### PR TITLE
feat: error handling for history import

### DIFF
--- a/backend/src/lib/garmin-token.ts
+++ b/backend/src/lib/garmin-token.ts
@@ -1,0 +1,100 @@
+import { prisma } from './prisma.ts';
+import { addSeconds } from 'date-fns';
+
+/**
+ * Get a valid Garmin access token for a user
+ * Automatically refreshes the token if it's expired
+ */
+export async function getValidGarminToken(userId: string): Promise<string | null> {
+  const token = await prisma.oauthToken.findUnique({
+    where: {
+      userId_provider: {
+        userId,
+        provider: 'garmin',
+      },
+    },
+  });
+
+  if (!token) {
+    return null;
+  }
+
+  // Check if token is expired or about to expire (within 5 minutes)
+  const now = new Date();
+  const expiryBuffer = new Date(token.expiresAt.getTime() - 5 * 60 * 1000);
+
+  if (now < expiryBuffer) {
+    // Token is still valid
+    return token.accessToken;
+  }
+
+  // Token is expired or about to expire, try to refresh it
+  if (!token.refreshToken) {
+    console.error('[Garmin Token] No refresh token available');
+    return null;
+  }
+
+  try {
+    const TOKEN_URL = process.env.GARMIN_TOKEN_URL;
+    const CLIENT_ID = process.env.GARMIN_CLIENT_ID;
+
+    if (!TOKEN_URL || !CLIENT_ID) {
+      console.error('[Garmin Token] Missing GARMIN_TOKEN_URL or GARMIN_CLIENT_ID');
+      return null;
+    }
+
+    console.log('[Garmin Token] Refreshing expired token for user:', userId);
+
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: token.refreshToken,
+      client_id: CLIENT_ID,
+    });
+
+    if (process.env.GARMIN_CLIENT_SECRET) {
+      body.set('client_secret', process.env.GARMIN_CLIENT_SECRET);
+    }
+
+    const refreshRes = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+
+    if (!refreshRes.ok) {
+      const text = await refreshRes.text();
+      console.error(`[Garmin Token] Refresh failed: ${refreshRes.status} ${text}`);
+      return null;
+    }
+
+    type TokenResp = {
+      access_token: string;
+      refresh_token?: string;
+      expires_in?: number;
+    };
+
+    const newTokens = (await refreshRes.json()) as TokenResp;
+    const newExpiresAt = addSeconds(new Date(), newTokens.expires_in ?? 3600);
+
+    // Update token in database
+    await prisma.oauthToken.update({
+      where: {
+        userId_provider: {
+          userId,
+          provider: 'garmin',
+        },
+      },
+      data: {
+        accessToken: newTokens.access_token,
+        expiresAt: newExpiresAt,
+        ...(newTokens.refresh_token ? { refreshToken: newTokens.refresh_token } : {}),
+      },
+    });
+
+    console.log('[Garmin Token] Token refreshed successfully');
+    return newTokens.access_token;
+  } catch (error) {
+    console.error('[Garmin Token] Error refreshing token:', error);
+    return null;
+  }
+}

--- a/backend/src/routes/garmin.backfill.ts
+++ b/backend/src/routes/garmin.backfill.ts
@@ -1,0 +1,133 @@
+import { Router as createRouter, type Router, type Request, type Response } from 'express';
+import { getValidGarminToken } from '../lib/garmin-token.ts';
+import { subDays } from 'date-fns';
+
+type Empty = Record<string, never>;
+const r: Router = createRouter();
+
+/**
+ * Fetch historical activities from Garmin for a given time period
+ * Returns activities that need bike assignment
+ */
+r.get<Empty, void, Empty, { days?: string }>(
+  '/garmin/backfill/fetch',
+  async (req: Request<Empty, void, Empty, { days?: string }>, res: Response) => {
+    const userId = req.user?.id || req.sessionUser?.uid;
+    if (!userId) {
+      return res.status(401).json({ error: 'Not authenticated' });
+    }
+
+    try {
+      const days = parseInt(req.query.days || '30', 10);
+      if (isNaN(days) || days < 1 || days > 365) {
+        return res.status(400).json({ error: 'Days must be between 1 and 365' });
+      }
+
+      // Get valid OAuth token (auto-refreshes if expired)
+      const accessToken = await getValidGarminToken(userId);
+
+      if (!accessToken) {
+        return res.status(400).json({ error: 'Garmin not connected or token expired. Please reconnect your Garmin account.' });
+      }
+
+      // Calculate date range
+      const endDate = new Date();
+      const startDate = subDays(endDate, days);
+
+      const startDateStr = startDate.toISOString().split('T')[0]; // YYYY-MM-DD
+      const endDateStr = endDate.toISOString().split('T')[0];
+
+      console.log(`[Garmin Backfill] Triggering backfill for ${startDateStr} to ${endDateStr}`);
+
+      // Garmin Wellness API: Use the async backfill endpoint
+      // This triggers Garmin to send activities via webhooks
+      const API_BASE = process.env.GARMIN_API_BASE || 'https://apis.garmin.com/wellness-api';
+
+      // Wellness API: Trigger backfill in 30-day chunks (API limit)
+      const CHUNK_DAYS = 30;
+      let currentStartDate = new Date(startDate);
+      let totalChunks = 0;
+      const errors: string[] = [];
+
+      console.log(`[Garmin Backfill] Triggering async backfill requests`);
+
+      while (currentStartDate < endDate) {
+        // Calculate chunk end date (30 days from chunk start, or endDate if sooner)
+        const chunkEndDate = new Date(currentStartDate);
+        chunkEndDate.setDate(chunkEndDate.getDate() + CHUNK_DAYS);
+        const actualChunkEndDate = chunkEndDate > endDate ? endDate : chunkEndDate;
+
+        const chunkStartSeconds = Math.floor(currentStartDate.getTime() / 1000);
+        const chunkEndSeconds = Math.floor(actualChunkEndDate.getTime() / 1000);
+
+        console.log(`[Garmin Backfill] Triggering backfill chunk: ${currentStartDate.toISOString()} to ${actualChunkEndDate.toISOString()}`);
+
+        const url = `${API_BASE}/rest/backfill/activities?summaryStartTimeInSeconds=${chunkStartSeconds}&summaryEndTimeInSeconds=${chunkEndSeconds}`;
+
+        try {
+          const backfillRes = await fetch(url, {
+            headers: {
+              'Authorization': `Bearer ${accessToken}`,
+              'Accept': 'application/json',
+            },
+          });
+
+          if (backfillRes.status === 202) {
+            // 202 Accepted - backfill request accepted
+            console.log(`[Garmin Backfill] Backfill request accepted for chunk ${totalChunks + 1}`);
+            totalChunks++;
+          } else if (backfillRes.status === 409) {
+            // 409 Conflict - duplicate request (already requested this time period)
+            console.log(`[Garmin Backfill] Backfill already in progress for this time period`);
+            errors.push(`Duplicate request for period ${currentStartDate.toISOString().split('T')[0]}`);
+          } else {
+            const text = await backfillRes.text();
+            console.error(`[Garmin Backfill] Failed to trigger backfill chunk: ${backfillRes.status} ${text}`);
+            errors.push(`Failed for period ${currentStartDate.toISOString().split('T')[0]}: ${backfillRes.status}`);
+          }
+        } catch (error) {
+          console.error(`[Garmin Backfill] Error triggering backfill chunk:`, error);
+          errors.push(`Error for period ${currentStartDate.toISOString().split('T')[0]}`);
+        }
+
+        // Move to next chunk
+        currentStartDate = new Date(actualChunkEndDate);
+        currentStartDate.setDate(currentStartDate.getDate() + 1);
+      }
+
+      console.log(`[Garmin Backfill] Triggered ${totalChunks} backfill request(s)`);
+
+      // Check if all requests were duplicates (backfill already in progress)
+      const duplicateErrors = errors.filter(e => e.includes('Duplicate request'));
+      const allDuplicates = duplicateErrors.length === errors.length && errors.length > 0;
+
+      if (totalChunks === 0 && allDuplicates) {
+        return res.status(409).json({
+          error: 'Backfill already in progress',
+          message: `A backfill for this time period is already in progress. Your rides will sync automatically when it completes.`,
+          details: errors,
+        });
+      }
+
+      if (totalChunks === 0) {
+        return res.status(400).json({
+          error: 'Failed to trigger any backfill requests',
+          details: errors,
+        });
+      }
+
+      // Return success - activities will arrive via webhooks
+      return res.json({
+        success: true,
+        message: `Backfill triggered for ${days} days. Your rides will sync automatically via webhooks.`,
+        chunksRequested: totalChunks,
+        warnings: errors.length > 0 ? errors : undefined,
+      });
+    } catch (error) {
+      console.error('[Garmin Backfill] Error:', error);
+      return res.status(500).json({ error: 'Failed to fetch activities' });
+    }
+  }
+);
+
+export default r;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,6 +8,7 @@ import { typeDefs } from './graphql/schema.ts';
 import { resolvers } from './graphql/resolvers.ts';
 import authGarmin from './routes/auth.garmin.ts';
 import webhooksGarmin from './routes/webhooks.garmin.ts';
+import garminBackfill from './routes/garmin.backfill.ts';
 import garminTest from './routes/garmin.test.ts';
 import mockGarmin from './routes/mock.garmin.ts';
 import onboardingRouter from './routes/onboarding.ts';
@@ -82,6 +83,7 @@ const startServer = async () => {
   app.use('/auth', emailRouter);        // POST /auth/signup, /auth/login
   app.use('/auth', deleteAccountRouter); // DELETE /auth/delete-account
   app.use('/auth', authGarmin);         // Garmin OAuth
+  app.use('/api', garminBackfill);      // Garmin backfill (import historical rides)
   app.use(webhooksGarmin);              // Garmin webhooks (deregistration, permissions, activities)
   app.use('/onboarding', onboardingRouter); // POST /onboarding/complete
   app.use(garminTest);            // test route

--- a/frontend/src/components/GarminImportModal.tsx
+++ b/frontend/src/components/GarminImportModal.tsx
@@ -1,0 +1,169 @@
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+};
+
+export default function GarminImportModal({ open, onClose, onSuccess }: Props) {
+  const [step, setStep] = useState<'period' | 'processing' | 'complete'>('period');
+  const [days, setDays] = useState(30);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [isDuplicate, setIsDuplicate] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      // Reset state when modal closes
+      setStep('period');
+      setDays(30);
+      setError(null);
+      setSuccessMessage(null);
+      setIsDuplicate(false);
+    }
+  }, [open]);
+
+  const handleTriggerBackfill = async () => {
+    setError(null);
+    setStep('processing');
+
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_API_URL}/api/garmin/backfill/fetch?days=${days}`,
+        {
+          credentials: 'include',
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await res.json();
+
+        // Handle 409 Conflict (duplicate backfill request) specially
+        if (res.status === 409) {
+          setSuccessMessage(errorData.message || 'A backfill for this time period is already in progress.');
+          setIsDuplicate(true);
+          setStep('complete');
+          onSuccess();
+          return;
+        }
+
+        throw new Error(errorData.error || 'Failed to trigger backfill');
+      }
+
+      const data = await res.json();
+      setSuccessMessage(data.message || `Backfill triggered for ${days} days. Your rides will sync automatically.`);
+      setStep('complete');
+
+      // Call onSuccess to show toast in parent
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to trigger backfill');
+      setStep('period');
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.95 }}
+            className="relative w-full max-w-2xl bg-surface border border-app rounded-3xl p-6 shadow-xl"
+          >
+            <button
+              onClick={onClose}
+              className="absolute top-4 right-4 text-2xl text-muted hover:text-white"
+              disabled={step === 'processing'}
+            >
+              ×
+            </button>
+
+            <h2 className="text-2xl font-bold mb-4">Import Garmin Rides</h2>
+
+            {/* Step 1: Select Time Period */}
+            {step === 'period' && (
+              <div className="space-y-6">
+                <div>
+                  <p className="text-sm text-muted mb-4">
+                    Trigger a backfill to import your historical Garmin cycling activities.
+                    Garmin will send your rides via webhooks, and they'll appear automatically.
+                  </p>
+
+                  <label className="block text-sm font-medium mb-2">
+                    Import rides from the last:
+                  </label>
+                  <select
+                    value={days}
+                    onChange={(e) => setDays(parseInt(e.target.value))}
+                    className="w-full px-4 py-2 bg-surface-2 border border-app rounded-xl"
+                  >
+                    <option value={7}>7 days</option>
+                    <option value={14}>14 days</option>
+                    <option value={30}>30 days</option>
+                    <option value={60}>60 days</option>
+                    <option value={90}>90 days</option>
+                    <option value={180}>6 months</option>
+                    <option value={365}>1 year</option>
+                  </select>
+                </div>
+
+                {error && (
+                  <div className="p-4 bg-red-950/30 border border-red-600/50 rounded-xl">
+                    <p className="text-sm text-red-200">{error}</p>
+                  </div>
+                )}
+
+                <div className="flex justify-end gap-3">
+                  <button onClick={onClose} className="btn-secondary">
+                    Cancel
+                  </button>
+                  <button onClick={handleTriggerBackfill} className="btn-primary">
+                    Trigger Import
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* Step 2: Processing */}
+            {step === 'processing' && (
+              <div className="space-y-6">
+                <div className="flex flex-col items-center justify-center py-8">
+                  <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mb-4"></div>
+                  <p className="text-muted">Triggering backfill request...</p>
+                </div>
+              </div>
+            )}
+
+            {/* Step 3: Complete */}
+            {step === 'complete' && (
+              <div className="space-y-6">
+                <div className={`p-4 rounded-xl ${
+                  isDuplicate
+                    ? 'bg-yellow-950/30 border border-yellow-600/50'
+                    : 'bg-green-950/30 border border-green-600/50'
+                }`}>
+                  <p className={isDuplicate ? 'text-yellow-100' : 'text-green-100'}>
+                    {isDuplicate ? '⚠' : '✓'} {successMessage}
+                  </p>
+                  <p className={`text-sm mt-2 ${isDuplicate ? 'text-yellow-200' : 'text-green-200'}`}>
+                    Your rides will appear in the Rides page as Garmin processes them. This may take a few minutes.
+                  </p>
+                </div>
+
+                <div className="flex justify-end">
+                  <button onClick={onClose} className="btn-primary">
+                    Done
+                  </button>
+                </div>
+              </div>
+            )}
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -6,6 +6,7 @@ import { formatDistanceToNow } from "date-fns";
 import ThemeToggle from "../components/ThemeToggleButton";
 import DeleteAccountModal from "../components/DeleteAccountModal";
 import ConnectGarminLink from "../components/ConnectGarminLink";
+import GarminImportModal from "../components/GarminImportModal";
 import { useCurrentUser } from "../hooks/useCurrentUser";
 
 const CONNECTED_ACCOUNTS_QUERY = gql`
@@ -26,6 +27,7 @@ export default function Settings() {
   const { data: accountsData, refetch: refetchAccounts } = useQuery(CONNECTED_ACCOUNTS_QUERY);
   const [hoursDisplay, setHoursDisplay] = useState<"total" | "remaining">("total");
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [importModalOpen, setImportModalOpen] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   // Check for Garmin connection success from OAuth redirect
@@ -138,12 +140,20 @@ export default function Settings() {
                       </p>
                     </div>
                   </div>
-                  <button
-                    onClick={handleDisconnectGarmin}
-                    className="rounded-xl px-3 py-1.5 text-xs font-medium text-red-400/80 bg-surface-2/50 border border-red-400/30 hover:bg-surface-2 hover:text-red-400 hover:border-red-400/50 hover:cursor-pointer transition"
-                  >
-                    Disconnect
-                  </button>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => setImportModalOpen(true)}
+                      className="rounded-xl px-3 py-1.5 text-xs font-medium text-blue-400/80 bg-surface-2/50 border border-blue-400/30 hover:bg-surface-2 hover:text-blue-400 hover:border-blue-400/50 hover:cursor-pointer transition"
+                    >
+                      Import Rides
+                    </button>
+                    <button
+                      onClick={handleDisconnectGarmin}
+                      className="rounded-xl px-3 py-1.5 text-xs font-medium text-red-400/80 bg-surface-2/50 border border-red-400/30 hover:bg-surface-2 hover:text-red-400 hover:border-red-400/50 hover:cursor-pointer transition"
+                    >
+                      Disconnect
+                    </button>
+                  </div>
                 </div>
               </div>
             ) : (
@@ -261,6 +271,15 @@ export default function Settings() {
         open={deleteModalOpen}
         onClose={() => setDeleteModalOpen(false)}
         onConfirm={handleDeleteAccount}
+      />
+
+      <GarminImportModal
+        open={importModalOpen}
+        onClose={() => setImportModalOpen(false)}
+        onSuccess={() => {
+          setSuccessMessage('Backfill triggered! Your rides will sync automatically via Garmin webhooks.');
+          setTimeout(() => setSuccessMessage(null), 8000);
+        }}
       />
     </div>
   );


### PR DESCRIPTION
# Pull Request: Garmin Historical Activity Import via Async Backfill

## Summary
Implements a user-initiated import feature for historical Garmin cycling activities using Garmin's asynchronous backfill API. Users can trigger imports for custom time periods (7-365 days), and activities automatically sync via existing webhooks.

## Motivation
Previously, users could only sync new Garmin activities going forward. This feature allows users to import their historical ride data when first connecting Garmin or to backfill missing rides from specific time periods.

## Changes

### Backend

#### New Files
- **`backend/src/routes/garmin.backfill.ts`** - Backfill endpoint handler
  - `GET /api/garmin/backfill/fetch?days={number}` - Triggers async backfill
  - Splits requests into 30-day chunks (Garmin API limit)
  - Returns HTTP 202 when successful, 409 for duplicates
  - Comprehensive error handling with detailed logging

- **`backend/src/lib/garmin-token.ts`** - OAuth token management utility
  - `getValidGarminToken(userId)` - Auto-refreshes expired tokens
  - 5-minute expiry buffer to prevent mid-request expiration
  - Used across all Garmin API calls

#### Modified Files
- **`backend/src/routes/webhooks.garmin.ts`**
  - Updated to use `getValidGarminToken()` for automatic token refresh
  - Added comprehensive cycling activity type filtering (17 types)
  - Supports: BMX, cyclocross, downhill biking, e-bikes, gravel, MTB, road, track, virtual, handcycling, etc.

- **`backend/src/server.ts`**
  - Registered `/api/garmin/backfill` routes

### Frontend

#### New Files
- **`frontend/src/components/GarminImportModal.tsx`** - Import wizard modal
  - 3-step flow: Period selection → Processing → Complete
  - Dropdown for time periods (7 days to 1 year)
  - Green success UI for new backfills
  - Yellow warning UI for duplicate requests (backfill already in progress)
  - Animated transitions with Framer Motion

#### Modified Files
- **`frontend/src/pages/Settings.tsx`**
  - Added "Import Rides" button next to Garmin disconnect
  - Toast notification on successful backfill trigger
  - 8-second display for async process explanation

## Technical Implementation

### API Flow
1. User selects time period and clicks "Trigger Import"
2. Backend splits range into 30-day chunks (Garmin API limit)
3. Makes async backfill requests to `GET /wellness-api/rest/backfill/activities`
4. Garmin returns HTTP 202 (Accepted) for each chunk
5. Garmin processes in background and sends activities via PING webhooks
6. Existing webhook handler (`/webhooks/garmin/activities-ping`) receives activities
7. Rides automatically appear in app (filtered for cycling only)

### Error Handling
- **HTTP 409 (Conflict)**: Duplicate backfill request → Shows warning, not error
- **HTTP 400 (Bad Request)**: All chunks failed → Shows error with details
- **HTTP 500 (Internal Server Error)**: Server error → Generic error message
- **Partial success**: Some chunks succeed → Returns success with warnings

### Activity Filtering
Only imports cycling activities (17 types):
CYCLING, BMX, CYCLOCROSS, DOWNHILL_BIKING, E_BIKE_FITNESS, E_BIKE_MOUNTAIN, E_ENDURO_MTB, ENDURO_MTB, GRAVEL_CYCLING, INDOOR_CYCLING, MOUNTAIN_BIKING, RECUMBENT_CYCLING, ROAD_BIKING, TRACK_CYCLING, VIRTUAL_RIDE, HANDCYCLING, INDOOR_HANDCYCLING

### Token Management
- Automatic OAuth token refresh before expiration
- 5-minute expiry buffer
- Reused across all Garmin API endpoints (backfill, webhooks)
- Handles refresh token rotation

## Testing

### Manual Testing Checklist
- [ ] Trigger backfill for 30 days
- [ ] Verify activities arrive via webhooks
- [ ] Trigger duplicate backfill → Verify 409 warning
- [ ] Test with expired token → Verify auto-refresh
- [ ] Test with 365 days → Verify chunking works (12 chunks)
- [ ] Verify only cycling activities imported
- [ ] Test error states (disconnected Garmin, network errors)

### Edge Cases Handled
- Token expiration during multi-chunk requests
- Duplicate backfill requests (409 Conflict)
- Partial chunk failures (some succeed, some fail)
- Activities that aren't cycling (filtered out)
- Rides that already exist (webhook deduplication)

## Security Considerations
- User authentication required (`req.user?.id || req.sessionUser?.uid`)
- OAuth token stored securely in database
- No sensitive data logged
- CORS and credentials properly configured

## Performance Considerations
- Async backfill prevents blocking requests
- Chunking prevents API rate limits
- Token refresh minimizes API calls
- Webhook handler processes activities asynchronously

## User Experience
- Clear messaging about async process
- Visual distinction between success and duplicate states
- Toast notifications for feedback
- Non-blocking modal workflow
- Automatic modal state reset on close

## Future Enhancements
- [ ] Add progress tracking for backfill completion
- [ ] Email notification when backfill completes
- [ ] Bike auto-assignment based on activity type
- [ ] Backfill status dashboard
- [ ] Retry failed chunks

## Breaking Changes
None - This is a new feature with no impact on existing functionality.

## Dependencies
No new dependencies added.