### PR TITLE
 Strava Data Import Enhancement: Moving Time & Bike Mapping

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -40,6 +40,7 @@ model User {
   bikes Bike[]
   components Component[]
   accounts       UserAccount[]
+  stravaGearMappings StravaGearMapping[]
 
   createdAt DateTime     @default(now())
   updatedAt DateTime     @updatedAt
@@ -80,6 +81,7 @@ model Ride {
 
   garminActivityId  String?   @unique
   stravaActivityId  String?   @unique  // Strava activity ID
+  stravaGearId      String?   // Strava gear_id from API
   startTime         DateTime
   durationSeconds   Int
   distanceMiles     Float
@@ -118,10 +120,30 @@ model Bike {
   notes         String?
 
   components Component[]
+  stravaGearMappings StravaGearMapping[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   Ride      Ride[]
+}
+
+model StravaGearMapping {
+  id              String   @id @default(uuid())
+  userId          String
+  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  stravaGearId    String   // e.g., "b12345678"
+  stravaGearName  String?  // e.g., "Trek Slash 9.9"
+
+  bikeId          String
+  bike            Bike     @relation(fields: [bikeId], references: [id], onDelete: Cascade)
+
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  @@unique([userId, stravaGearId])
+  @@index([userId])
+  @@index([bikeId])
 }
 
 model Component {

--- a/backend/src/graphql/schema.ts
+++ b/backend/src/graphql/schema.ts
@@ -30,6 +30,8 @@ export const typeDefs = gql`
     id: ID!
     userId: ID!
     garminActivityId: String
+    stravaActivityId: String
+    stravaGearId: String
     startTime: String!
     durationSeconds: Int!
     distanceMiles: Float!
@@ -77,6 +79,28 @@ export const typeDefs = gql`
     components: [Component!]!
     createdAt: String!
     updatedAt: String!
+  }
+
+  type StravaGearMapping {
+    id: ID!
+    stravaGearId: String!
+    stravaGearName: String
+    bikeId: ID!
+    bike: Bike!
+    createdAt: String!
+  }
+
+  type StravaGearInfo {
+    gearId: String!
+    gearName: String
+    rideCount: Int!
+    isMapped: Boolean!
+  }
+
+  input CreateStravaGearMappingInput {
+    stravaGearId: String!
+    stravaGearName: String
+    bikeId: ID!
   }
 
   input UpdateRideInput {
@@ -184,6 +208,8 @@ export const typeDefs = gql`
     updateComponent(id: ID!, input: UpdateComponentInput!): Component!
     deleteComponent(id: ID!): DeleteResult!
     logComponentService(id: ID!): Component!
+    createStravaGearMapping(input: CreateStravaGearMappingInput!): StravaGearMapping!
+    deleteStravaGearMapping(id: ID!): DeleteResult!
   }
 
   type ConnectedAccount {
@@ -211,5 +237,7 @@ export const typeDefs = gql`
     rideTypes: [RideType!]!
     bikes: [Bike!]!
     components(filter: ComponentFilterInput): [Component!]!
+    stravaGearMappings: [StravaGearMapping!]!
+    unmappedStravaGears: [StravaGearInfo!]!
   }
 `;

--- a/frontend/src/components/StravaGearMappingModal.tsx
+++ b/frontend/src/components/StravaGearMappingModal.tsx
@@ -1,0 +1,214 @@
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { useQuery, useMutation } from '@apollo/client';
+import { BIKES } from '../graphql/bikes';
+import { CREATE_STRAVA_GEAR_MAPPING } from '../graphql/stravaGear';
+
+type UnmappedGear = {
+  gearId: string;
+  gearName?: string | null;
+  rideCount: number;
+};
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  unmappedGears: UnmappedGear[];
+  trigger: 'import' | 'webhook';
+};
+
+type Bike = {
+  id: string;
+  nickname?: string | null;
+  manufacturer: string;
+  model: string;
+};
+
+export default function StravaGearMappingModal({
+  open,
+  onClose,
+  onSuccess,
+  unmappedGears,
+  trigger,
+}: Props) {
+  const [currentGearIndex, setCurrentGearIndex] = useState(0);
+  const [selectedBikeId, setSelectedBikeId] = useState<string>('');
+  const [gearNames, setGearNames] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const { data: bikesData } = useQuery(BIKES);
+  const [createMapping, { loading: creatingMapping }] = useMutation(CREATE_STRAVA_GEAR_MAPPING);
+
+  const bikes: Bike[] = bikesData?.bikes || [];
+  const currentGear = unmappedGears[currentGearIndex];
+
+  useEffect(() => {
+    if (!open) {
+      setCurrentGearIndex(0);
+      setSelectedBikeId('');
+      setGearNames({});
+      setError(null);
+    }
+  }, [open]);
+
+  // Fetch gear names from Strava API
+  useEffect(() => {
+    if (open && currentGear && !gearNames[currentGear.gearId]) {
+      fetchGearName(currentGear.gearId);
+    }
+  }, [open, currentGear?.gearId]);
+
+  const fetchGearName = async (gearId: string) => {
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_API_URL}/api/strava/gear/${gearId}`,
+        { credentials: 'include' }
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setGearNames((prev) => ({
+          ...prev,
+          [gearId]: data.name || gearId,
+        }));
+      }
+    } catch (err) {
+      console.error('Failed to fetch gear name:', err);
+    }
+  };
+
+  const handleMapBike = async () => {
+    if (!selectedBikeId || !currentGear) return;
+
+    setError(null);
+    try {
+      await createMapping({
+        variables: {
+          input: {
+            stravaGearId: currentGear.gearId,
+            stravaGearName: gearNames[currentGear.gearId] || null,
+            bikeId: selectedBikeId,
+          },
+        },
+      });
+
+      // Move to next gear or close if done
+      if (currentGearIndex < unmappedGears.length - 1) {
+        setCurrentGearIndex(currentGearIndex + 1);
+        setSelectedBikeId('');
+      } else {
+        onSuccess();
+        onClose();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create mapping');
+    }
+  };
+
+  const handleSkip = () => {
+    if (currentGearIndex < unmappedGears.length - 1) {
+      setCurrentGearIndex(currentGearIndex + 1);
+      setSelectedBikeId('');
+    } else {
+      onClose();
+    }
+  };
+
+  if (!currentGear) return null;
+
+  const gearDisplayName = gearNames[currentGear.gearId] || currentGear.gearId;
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.95 }}
+            className="relative w-full max-w-2xl bg-surface border border-app rounded-3xl p-6 shadow-xl"
+          >
+            <button
+              onClick={onClose}
+              className="absolute top-4 right-4 text-2xl text-muted hover:text-white"
+            >
+              ×
+            </button>
+
+            <h2 className="text-2xl font-bold text-white mb-4">
+              Map Strava Bikes
+            </h2>
+
+            <div className="mb-6">
+              <p className="text-muted mb-2">
+                {trigger === 'import'
+                  ? 'Your Strava import includes bikes that need to be mapped to your Loam Logger bikes.'
+                  : 'New rides from Strava include bikes that need to be mapped to your Loam Logger bikes.'}
+              </p>
+              <p className="text-sm text-muted">
+                Progress: {currentGearIndex + 1} of {unmappedGears.length}
+              </p>
+            </div>
+
+            <div className="bg-highlight/30 border border-app rounded-2xl p-4 mb-6">
+              <h3 className="text-lg font-semibold text-white mb-2">
+                Strava Bike: {gearDisplayName}
+              </h3>
+              <p className="text-sm text-muted">
+                Used in {currentGear.rideCount} {currentGear.rideCount === 1 ? 'ride' : 'rides'}
+              </p>
+            </div>
+
+            {error && (
+              <div className="mb-4 p-4 bg-red-500/20 border border-red-500/50 rounded-xl text-red-200">
+                {error}
+              </div>
+            )}
+
+            <div className="mb-6">
+              <label className="block text-sm font-medium text-muted mb-2">
+                Map to Loam Logger Bike
+              </label>
+              <select
+                value={selectedBikeId}
+                onChange={(e) => setSelectedBikeId(e.target.value)}
+                className="w-full bg-highlight border border-app rounded-xl px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-accent"
+              >
+                <option value="">Select a bike...</option>
+                {bikes.map((bike) => (
+                  <option key={bike.id} value={bike.id}>
+                    {bike.nickname || `${bike.manufacturer} ${bike.model}`}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex gap-3">
+              <button
+                onClick={handleSkip}
+                className="flex-1 bg-highlight hover:bg-highlight-hover border border-app rounded-xl px-6 py-3 text-white font-medium transition-colors"
+                disabled={creatingMapping}
+              >
+                {currentGearIndex < unmappedGears.length - 1 ? 'Skip for Now' : 'Done'}
+              </button>
+              <button
+                onClick={handleMapBike}
+                disabled={!selectedBikeId || creatingMapping}
+                className="flex-1 bg-accent hover:bg-accent-hover text-white font-medium px-6 py-3 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {creatingMapping ? 'Mapping...' : 'Map Bike'}
+              </button>
+            </div>
+
+            <div className="mt-4 text-sm text-muted">
+              <p>
+                Mapping this bike will automatically assign all past rides with this Strava bike
+                to your Loam Logger bike and update component hours.
+              </p>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/StravaImportModal.tsx
+++ b/frontend/src/components/StravaImportModal.tsx
@@ -1,10 +1,16 @@
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
+import StravaGearMappingModal from './StravaGearMappingModal';
 
 type Props = {
   open: boolean;
   onClose: () => void;
   onSuccess: () => void;
+};
+
+type UnmappedGear = {
+  gearId: string;
+  rideCount: number;
 };
 
 export default function StravaImportModal({ open, onClose, onSuccess }: Props) {
@@ -17,6 +23,8 @@ export default function StravaImportModal({ open, onClose, onSuccess }: Props) {
     skipped: number;
     total: number;
   } | null>(null);
+  const [unmappedGears, setUnmappedGears] = useState<UnmappedGear[]>([]);
+  const [showGearMapping, setShowGearMapping] = useState(false);
 
   useEffect(() => {
     if (!open) {
@@ -26,6 +34,8 @@ export default function StravaImportModal({ open, onClose, onSuccess }: Props) {
       setError(null);
       setSuccessMessage(null);
       setImportStats(null);
+      setUnmappedGears([]);
+      setShowGearMapping(false);
     }
   }, [open]);
 
@@ -54,6 +64,12 @@ export default function StravaImportModal({ open, onClose, onSuccess }: Props) {
         total: data.cyclingActivities || 0,
       });
       setStep('complete');
+
+      // Check for unmapped gears
+      if (data.unmappedGears && data.unmappedGears.length > 0) {
+        setUnmappedGears(data.unmappedGears);
+        setShowGearMapping(true);
+      }
 
       // Call onSuccess to trigger parent refresh
       onSuccess();
@@ -162,6 +178,18 @@ export default function StravaImportModal({ open, onClose, onSuccess }: Props) {
             )}
           </motion.div>
         </div>
+      )}
+      {showGearMapping && unmappedGears.length > 0 && (
+        <StravaGearMappingModal
+          open={showGearMapping}
+          onClose={() => setShowGearMapping(false)}
+          onSuccess={() => {
+            onSuccess();
+            setUnmappedGears([]);
+          }}
+          unmappedGears={unmappedGears}
+          trigger="import"
+        />
       )}
     </AnimatePresence>
   );

--- a/frontend/src/graphql/stravaGear.ts
+++ b/frontend/src/graphql/stravaGear.ts
@@ -1,0 +1,50 @@
+import { gql } from '@apollo/client';
+
+export const UNMAPPED_STRAVA_GEARS = gql`
+  query UnmappedStravaGears {
+    unmappedStravaGears {
+      gearId
+      gearName
+      rideCount
+      isMapped
+    }
+  }
+`;
+
+export const STRAVA_GEAR_MAPPINGS = gql`
+  query StravaGearMappings {
+    stravaGearMappings {
+      id
+      stravaGearId
+      stravaGearName
+      bikeId
+      bike {
+        id
+        nickname
+        manufacturer
+        model
+      }
+      createdAt
+    }
+  }
+`;
+
+export const CREATE_STRAVA_GEAR_MAPPING = gql`
+  mutation CreateStravaGearMapping($input: CreateStravaGearMappingInput!) {
+    createStravaGearMapping(input: $input) {
+      id
+      stravaGearId
+      stravaGearName
+      bikeId
+    }
+  }
+`;
+
+export const DELETE_STRAVA_GEAR_MAPPING = gql`
+  mutation DeleteStravaGearMapping($id: ID!) {
+    deleteStravaGearMapping(id: $id) {
+      ok
+      id
+    }
+  }
+`;


### PR DESCRIPTION
# Strava Data Import Enhancement: Moving Time & Bike Mapping

## Overview
This PR enhances the Strava integration to use accurate ride duration (moving time) and implements an intelligent bike mapping system that automatically assigns Strava bikes to Loam Logger bikes, enabling proper component tracking for imported rides.

## Features

### 1. **Moving Time vs Elapsed Time** ⏱️
- Switched from `elapsed_time` to `moving_time` for all Strava ride imports
- Provides accurate ride duration by excluding stopped time (breaks, traffic lights, etc.)
- Applied to both webhook imports and historical backfill

### 2. **Bike Mapping System** 🚴
- **One-to-one mapping**: Link Strava bikes (via `gear_id`) to Loam Logger bikes
- **Automatic prompting**: 
  - After historical import → Shows mapping modal on Settings page
  - After webhook import → Shows mapping modal on Dashboard
- **Retroactive updates**: When a mapping is created, all past rides with that Strava bike are automatically assigned to the mapped Loam Logger bike
- **Component hour tracking**: Automatically updates component hours when mappings are created or deleted

### 3. **Smart Detection** 🔍
- Detects unmapped Strava bikes during import and after webhook events
- Dashboard polls every 60 seconds for new unmapped bikes from real-time Strava webhooks
- Fetches bike names from Strava API for better UX

## Technical Changes

### Backend
- **Database**: Added `StravaGearMapping` table with unique constraint on `[userId, stravaGearId]`
- **Schema**: Added `stravaGearId` field to `Ride` model
- **API Endpoints**: 
  - New `/api/strava/gear/:gearId` endpoint to fetch Strava gear details
  - Updated backfill endpoint to return `unmappedGears` in response
- **GraphQL**:
  - New types: `StravaGearMapping`, `StravaGearInfo`
  - New queries: `stravaGearMappings`, `unmappedStravaGears`
  - New mutations: `createStravaGearMapping`, `deleteStravaGearMapping`
- **Webhooks**: Updated to capture `gear_id` and apply mappings automatically

### Frontend
- **New Component**: `StravaGearMappingModal` - Guides users through mapping Strava bikes
- **Updated Components**:
  - `StravaImportModal`: Triggers gear mapping after import
  - `Dashboard`: Polls for unmapped gears and shows mapping modal
- **GraphQL Queries**: New `stravaGear.ts` file with all bike mapping queries/mutations

## Files Changed

### Backend
- `backend/prisma/schema.prisma` - Database schema
- `backend/src/routes/webhooks.strava.ts` - Webhook handler
- `backend/src/routes/strava.backfill.ts` - Backfill handler + gear endpoint
- `backend/src/graphql/schema.ts` - GraphQL schema
- `backend/src/graphql/resolvers.ts` - GraphQL resolvers

### Frontend
- `frontend/src/components/StravaGearMappingModal.tsx` - NEW
- `frontend/src/graphql/stravaGear.ts` - NEW
- `frontend/src/components/StravaImportModal.tsx` - Updated
- `frontend/src/pages/Dashboard.tsx` - Updated

## Testing Checklist
- [ ] Historical import detects unmapped bikes
- [ ] Mapping modal appears with correct bike names
- [ ] Mapping creation updates all historical rides
- [ ] Component hours increment correctly
- [ ] Dashboard polling detects webhook imports
- [ ] Delete mapping unmaps rides and decrements hours
- [ ] One-to-one constraint prevents duplicate mappings

## Notes
- Existing rides will continue to use `elapsed_time` (only new imports use `moving_time`)
- Database changes applied via `prisma db push` (no migration file)
- Component hour calculations use transactions for atomicity