### PR TITLE
 Auto-assign bike for Strava rides when only one bike exists

### DIFF
--- a/backend/src/routes/strava.backfill.ts
+++ b/backend/src/routes/strava.backfill.ts
@@ -134,6 +134,17 @@ r.get<Empty, void, Empty, { days?: string }>(
           bikeId = mapping?.bikeId ?? null;
         }
 
+        // If no bike assigned yet, check if user has exactly one bike (auto-assign)
+        if (!bikeId) {
+          const userBikes = await prisma.bike.findMany({
+            where: { userId },
+            select: { id: true },
+          });
+          if (userBikes.length === 1) {
+            bikeId = userBikes[0].id;
+          }
+        }
+
         // Convert activity to Ride format
         const distanceMiles = activity.distance * 0.000621371; // meters to miles
         const elevationGainFeet = activity.total_elevation_gain * 3.28084; // meters to feet

--- a/backend/src/routes/webhooks.strava.ts
+++ b/backend/src/routes/webhooks.strava.ts
@@ -277,6 +277,17 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
         bikeId = mapping?.bikeId ?? null;
       }
 
+      // If no bike assigned yet, check if user has exactly one bike (auto-assign)
+      if (!bikeId) {
+        const userBikes = await prisma.bike.findMany({
+          where: { userId: userAccount.userId },
+          select: { id: true },
+        });
+        if (userBikes.length === 1) {
+          bikeId = userBikes[0].id;
+        }
+      }
+
       // Upsert the ride
       await prisma.ride.upsert({
         where: {


### PR DESCRIPTION
## Auto-assign bike for Strava rides when only one bike exists

### Summary
This PR improves Strava ride imports by automatically assigning a bike when the user has exactly one bike in Loam Logger and the Strava ride does not resolve to a mapped bike.

This prevents missing component hour tracking for rides where:
- no `gear_id` is set in Strava, or
- a `gear_id` exists but has no Loam Logger mapping

The behavior now mirrors the existing manual ride creation flow.

---

### Problem
When importing or backfilling Strava rides, component hours were not tracked if:
- the user forgot to select a bike in Strava, or
- the Strava `gear_id` did not map to a Loam Logger bike

For users with a single bike, this resulted in dropped component usage despite the bike being unambiguous.

---

### Solution
If a Strava ride does not resolve to a mapped bike **and** the user has exactly one bike in Loam Logger, the ride is automatically assigned to that bike.

This ensures:
- consistent component hour tracking
- parity with manual ride creation behavior
- no ambiguity for multi-bike users

---

### Behavior Details
A bike is auto-assigned **only when all of the following are true**:
- The Strava ride has no `gear_id`, **or** the `gear_id` has no mapping
- The user has exactly one bike in Loam Logger

If the user has multiple bikes, no auto-assignment occurs.

---

### Files Changed
- **`webhooks.strava.ts`** (lines 280–289)  
  Added auto-assignment logic after Strava gear mapping lookup

- **`strava.backfill.ts`** (lines 137–146)  
  Applied the same auto-assignment logic during backfill

---

### Why This Is Safe
- Matches existing manual ride creation behavior
- Only applies when bike ownership is unambiguous
- Does not affect users with multiple bikes
- Improves data completeness without guessing

---

### Future Considerations
- Optional user setting to disable auto-assignment
- Logging or UI indicator when auto-assignment occurs
