### PR TITLE
feat: add ride source badges and auto-populate locations from Garmin/…

### DIFF
--- a/backend/src/lib/location.ts
+++ b/backend/src/lib/location.ts
@@ -1,0 +1,50 @@
+export const buildLocationString = (
+  parts: Array<string | null | undefined>
+): string | null => {
+  const cleaned = parts
+    .map((part) => (typeof part === 'string' ? part.trim() : part))
+    .filter((part): part is string => Boolean(part && part.length > 0));
+
+  return cleaned.length ? cleaned.join(', ') : null;
+};
+
+export const formatLatLon = (
+  lat?: number | null,
+  lon?: number | null
+): string | null => {
+  if (!Number.isFinite(lat ?? NaN) || !Number.isFinite(lon ?? NaN)) {
+    return null;
+  }
+
+  const latStr = (lat as number).toFixed(3);
+  const lonStr = (lon as number).toFixed(3);
+  return `Lat ${latStr}, Lon ${lonStr}`;
+};
+
+export const deriveLocation = (opts: {
+  city?: string | null;
+  state?: string | null;
+  country?: string | null;
+  fallback?: string | null;
+  lat?: number | null;
+  lon?: number | null;
+}): string | null => {
+  const singleValue = opts.city ?? opts.state ?? opts.country ?? opts.fallback ?? null;
+
+  return (
+    buildLocationString([opts.city, opts.state]) ??
+    buildLocationString([opts.city, opts.country]) ??
+    buildLocationString([opts.state, opts.country]) ??
+    (singleValue?.trim() || null) ??
+    formatLatLon(opts.lat, opts.lon)
+  );
+};
+
+export const shouldApplyAutoLocation = (
+  existing: string | null | undefined,
+  incoming: string | null
+): string | undefined => {
+  if (!incoming) return undefined;
+  if (existing && existing.trim().length > 0) return undefined;
+  return incoming;
+};

--- a/frontend/src/graphql/rides.ts
+++ b/frontend/src/graphql/rides.ts
@@ -5,6 +5,7 @@ export const RIDES = gql`
     rides(take: $take, after: $after) {
       id
       garminActivityId
+      stravaActivityId
       startTime
       durationSeconds
       distanceMiles


### PR DESCRIPTION
- Add Strava ride IDs to the RIDES GraphQL query and teach RideCard to detect each ride’s source, render the appropriate Garmin/Strava/manual badge, and reformat titles to prioritize locations
- Introduce shared helpers for formatting auto-populated locations and respecting manual overrides, then wire Strava webhook/backfill + Garmin webhook to capture city/state/country/lat-lon data and persist it on rides without clobbering user edits
- Ensure Strava imports (webhook + backfill) still update component hours inside a transaction while now saving derived locations alongside other ride fields