### PR TITLE
Add Year-Based Strava Import & Date Range Filtering

### DIFF
--- a/frontend/src/components/StravaImportModal.tsx
+++ b/frontend/src/components/StravaImportModal.tsx
@@ -15,7 +15,7 @@ type UnmappedGear = {
 
 export default function StravaImportModal({ open, onClose, onSuccess }: Props) {
   const [step, setStep] = useState<'period' | 'processing' | 'complete'>('period');
-  const [days, setDays] = useState(30);
+  const [year, setYear] = useState<string>('ytd');
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [importStats, setImportStats] = useState<{
@@ -30,7 +30,7 @@ export default function StravaImportModal({ open, onClose, onSuccess }: Props) {
     if (!open) {
       // Reset state when modal closes
       setStep('period');
-      setDays(30);
+      setYear('ytd');
       setError(null);
       setSuccessMessage(null);
       setImportStats(null);
@@ -45,7 +45,7 @@ export default function StravaImportModal({ open, onClose, onSuccess }: Props) {
 
     try {
       const res = await fetch(
-        `${import.meta.env.VITE_API_URL}/api/strava/backfill/fetch?days=${days}`,
+        `${import.meta.env.VITE_API_URL}/api/strava/backfill/fetch?year=${year}`,
         {
           credentials: 'include',
         }
@@ -99,31 +99,37 @@ export default function StravaImportModal({ open, onClose, onSuccess }: Props) {
 
             <h2 className="text-2xl font-bold mb-4">Import Strava Rides</h2>
 
-            {/* Step 1: Select Time Period */}
+            {/* Step 1: Select Year */}
             {step === 'period' && (
               <div className="space-y-6">
                 <div>
                   <p className="text-sm text-muted mb-4">
-                    Import your historical Strava cycling activities.
+                    Import your historical Strava cycling activities by year.
                     Activities will be fetched and imported immediately.
                   </p>
 
                   <label className="block text-sm font-medium mb-2">
-                    Import rides from the last:
+                    Select Year
                   </label>
                   <select
-                    value={days}
-                    onChange={(e) => setDays(parseInt(e.target.value))}
+                    value={year}
+                    onChange={(e) => setYear(e.target.value)}
                     className="w-full px-4 py-2 bg-surface-2 border border-app rounded-xl"
                   >
-                    <option value={7}>7 days</option>
-                    <option value={14}>14 days</option>
-                    <option value={30}>30 days</option>
-                    <option value={60}>60 days</option>
-                    <option value={90}>90 days</option>
-                    <option value={180}>6 months</option>
-                    <option value={365}>1 year</option>
+                    <option value="ytd">Year to Date ({new Date().getFullYear()})</option>
+                    <option value={new Date().getFullYear()}>{new Date().getFullYear()}</option>
+                    <option value={new Date().getFullYear() - 1}>{new Date().getFullYear() - 1}</option>
+                    <option value={new Date().getFullYear() - 2}>{new Date().getFullYear() - 2}</option>
+                    <option value={new Date().getFullYear() - 3}>{new Date().getFullYear() - 3}</option>
+                    <option value={new Date().getFullYear() - 4}>{new Date().getFullYear() - 4}</option>
+                    <option value={new Date().getFullYear() - 5}>{new Date().getFullYear() - 5}</option>
                   </select>
+                  <p className="text-xs text-muted mt-2">
+                    {year === 'ytd'
+                      ? `Import all rides from January 1, ${new Date().getFullYear()} to today`
+                      : `Import all rides from ${year}`
+                    }
+                  </p>
                 </div>
 
                 {error && (
@@ -162,9 +168,13 @@ export default function StravaImportModal({ open, onClose, onSuccess }: Props) {
                   </p>
                   {importStats && (
                     <div className="text-sm mt-3 text-green-200 space-y-1">
+                      <p className="font-medium">Import completed for {year === 'ytd' ? 'Year to Date' : year}</p>
                       <p>• Imported: {importStats.imported} rides</p>
                       <p>• Skipped (already exist): {importStats.skipped} rides</p>
                       <p>• Total cycling activities found: {importStats.total}</p>
+                      {unmappedGears.length > 0 && (
+                        <p className="text-yellow-300">• {unmappedGears.length} unmapped bike(s) - visit Gear page to map</p>
+                      )}
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
# Add Year-Based Strava Import & Date Range Filtering

## Overview
This PR adds two major features to improve ride data management:
1. **Year-based Strava import** - Import rides by specific calendar year instead of "days back"
2. **Date range filtering** - Filter rides list by date ranges (30 days, 3 months, 6 months, 1 year, all time)

## Problem Statement
Users were experiencing significant discrepancies between Strava's YTD totals and Loam Logger's reported statistics (35-40% lower). Investigation revealed two issues:
1. The Strava backfill only supported importing by "days back from now" (max 365 days), making it difficult to import specific calendar years
2. The rides query had a default limit of 20 rides, causing older rides to not display
3. No date filtering UI existed, making it hard to view rides from specific time periods

## Changes Made

### Backend Changes

#### 1. Year-Based Strava Import (`backend/src/routes/strava.backfill.ts`)
- **Replaced `days` parameter with `year` parameter**
  - Accepts `'ytd'` for Year-to-Date (Jan 1 of current year → today)
  - Accepts specific years: `'2025'`, `'2024'`, `'2023'`, etc.
  - Validates year is between 2000 and current year
  - Calculates proper date ranges for each option (Jan 1 - Dec 31 for full years)

- **Increased pagination limit**
  - Changed from 10 pages (500 activities) to 50 pages (2,500 activities)
  - Prevents incomplete imports for power users with many activities

#### 2. Date Range Filtering (`backend/src/graphql/schema.ts`, `backend/src/graphql/resolvers.ts`)
- **Added `RidesFilterInput` type** with `startDate` and `endDate` fields
- **Updated rides query** to accept optional `filter` parameter
- **Increased default limit** from 20 to 1000 rides
- **Implemented date filtering** using Prisma's `gte` and `lte` operators

### Frontend Changes

#### 1. Strava Import Modal (`frontend/src/components/StravaImportModal.tsx`)
- **Replaced days dropdown with year selection dropdown**
  - Year to Date (2025)
  - 2025, 2024, 2023, 2022, 2021, 2020 (going back 5 years)
  - Shows helpful description below dropdown explaining date range

- **Updated API call** to use `year` parameter instead of `days`

- **Enhanced success message**
  - Shows which year/period was imported
  - Displays import statistics clearly
  - Shows warning for unmapped bikes

#### 2. Rides Page Date Filtering (`frontend/src/pages/Rides.tsx`, `frontend/src/graphql/rides.ts`)
- **Added date range filter UI** with checkbox options:
  - All time (default)
  - Last 30 days
  - Last 3 months
  - Last 6 months
  - Last year

- **Added ride count display** showing number of rides in selected range

- **Updated GraphQL query** to support `RidesFilterInput` parameter

## API Changes

### Backend Endpoint Change
```diff
- GET /api/strava/backfill/fetch?days=30
+ GET /api/strava/backfill/fetch?year=ytd
+ GET /api/strava/backfill/fetch?year=2024
```

### GraphQL Schema Changes
```graphql
input RidesFilterInput {
  startDate: String
  endDate: String
}

type Query {
  rides(take: Int = 1000, after: ID, filter: RidesFilterInput): [Ride!]!
}
```

## Testing

### Manual Testing Completed
- ✅ Backend builds successfully with no TypeScript errors
- ✅ Frontend builds successfully with no TypeScript errors
- ✅ Year selection dropdown displays correctly
- ✅ Date range filter checkboxes display correctly

### Testing Checklist for Reviewer
- [ ] Test YTD import: Select "Year to Date" and verify all 2025 rides are imported
- [ ] Test specific year: Select "2024" and verify only 2024 rides are imported
- [ ] Test previous years: Select 2023, 2022 to verify historical imports work
- [ ] Verify no duplicates: Re-import same year and confirm rides are skipped
- [ ] Check totals: After importing YTD, verify Loam Logger totals match Strava's YTD stats
- [ ] Test date range filters: Verify each checkbox option filters correctly
- [ ] Test ride count: Verify ride count updates when selecting different date ranges

## Screenshots

### Before
- Strava import only allowed selecting "last X days" (7, 14, 30, 60, 90, 180, 365)
- No way to import all rides from a specific calendar year
- Rides page showed all rides with no filtering (limited to 20 by default)

### After
- Strava import allows selecting specific years or YTD
- Clear description of what date range will be imported
- Rides page has checkbox filters for common date ranges
- Rides page shows count of rides in selected range

## Migration Notes
No database migrations required. This is a pure API and UI change.

## Breaking Changes
⚠️ **Breaking Change**: The `/api/strava/backfill/fetch` endpoint parameter changed from `days` to `year`. Any external integrations calling this endpoint will need to be updated.

Old: `GET /api/strava/backfill/fetch?days=30`
New: `GET /api/strava/backfill/fetch?year=ytd`

## Performance Considerations
- Increased default rides query limit from 20 to 1000 may slightly increase initial page load time
- Date filtering happens at the database level (Prisma query), so performance should be good
- Increased Strava backfill pagination limit may cause longer import times for users with many activities

## Future Enhancements
- [ ] Add custom date range picker (select specific start/end dates)
- [ ] Add loading indicator showing import progress during backfill
- [ ] Add retry logic for failed Strava API calls with exponential backoff
- [ ] Add diagnostic endpoint showing import statistics

## Related Issues
Fixes discrepancy between Strava YTD totals and Loam Logger totals