### PR TITLE
feat: iap, revenuecat integration, service date fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ GOOGLE_IOS_CLIENT_ID="your-google-ios-client-id.apps.googleusercontent.com"
 # Apple Sign-In (mobile)
 APPLE_BUNDLE_ID="com.example.yourapp"
 
+# RevenueCat (IAP webhooks)
+REVENUECAT_WEBHOOK_AUTH_KEY="your-revenuecat-webhook-auth-key"
+
 # Auth
 JWT_SECRET="your-jwt-secret"
 SESSION_SECRET="your-session-secret"

--- a/apps/api/prisma/migrations/20260406_add_iap_subscription_fields/migration.sql
+++ b/apps/api/prisma/migrations/20260406_add_iap_subscription_fields/migration.sql
@@ -1,0 +1,9 @@
+-- CreateEnum
+CREATE TYPE "SubscriptionProvider" AS ENUM ('STRIPE', 'APPLE', 'GOOGLE');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "subscriptionProvider" "SubscriptionProvider",
+ADD COLUMN "revenuecatAppUserId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_revenuecatAppUserId_key" ON "User"("revenuecatAppUserId");

--- a/apps/api/prisma/migrations/20260408211117_add_revenuecat_trigger_source/migration.sql
+++ b/apps/api/prisma/migrations/20260408211117_add_revenuecat_trigger_source/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "TriggerSource" ADD VALUE 'revenuecat_webhook';

--- a/apps/api/prisma/migrations/20260408213119_remove_revenuecat_app_user_id/migration.sql
+++ b/apps/api/prisma/migrations/20260408213119_remove_revenuecat_app_user_id/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `revenuecatAppUserId` on the `User` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "User_revenuecatAppUserId_key";
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "revenuecatAppUserId";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -37,6 +37,8 @@ model User {
   stripeSubscriptionId String?            @unique
   referralCode        String?             @unique
   needsDowngradeSelection Boolean         @default(false)
+  subscriptionProvider    SubscriptionProvider?
+  revenuecatAppUserId     String?             @unique
   emailUnsubscribed   Boolean             @default(false)
   hoursDisplayPreference String?          @default("remaining")
   predictionMode         String?          @default("simple")
@@ -342,6 +344,12 @@ enum SubscriptionTier {
   FREE_LIGHT
   FREE_FULL
   PRO
+}
+
+enum SubscriptionProvider {
+  STRIPE
+  APPLE
+  GOOGLE
 }
 
 enum ReferralStatus {

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -449,6 +449,7 @@ enum TriggerSource {
   scheduled
   user_action
   stripe_webhook
+  revenuecat_webhook
 }
 
 enum EmailStatus {

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -38,7 +38,6 @@ model User {
   referralCode        String?             @unique
   needsDowngradeSelection Boolean         @default(false)
   subscriptionProvider    SubscriptionProvider?
-  revenuecatAppUserId     String?             @unique
   emailUnsubscribed   Boolean             @default(false)
   hoursDisplayPreference String?          @default("remaining")
   predictionMode         String?          @default("simple")

--- a/apps/api/src/auth/tier-access.ts
+++ b/apps/api/src/auth/tier-access.ts
@@ -6,13 +6,14 @@ type TierUser = {
   subscriptionTier: SubscriptionTier;
   isFoundingRider: boolean;
   needsDowngradeSelection?: boolean;
+  role?: string;
 };
 
 /**
- * Returns the effective tier, accounting for founding riders who always get PRO.
+ * Returns the effective tier, accounting for founding riders and admins who always get PRO.
  */
 export function getEffectiveTier(user: TierUser): SubscriptionTier {
-  if (user.isFoundingRider) return 'PRO';
+  if (user.isFoundingRider || user.role === 'ADMIN') return 'PRO';
   return user.subscriptionTier;
 }
 

--- a/apps/api/src/auth/tier-access.ts
+++ b/apps/api/src/auth/tier-access.ts
@@ -1,4 +1,4 @@
-import type { SubscriptionTier, ComponentType } from '@prisma/client';
+import type { SubscriptionTier, ComponentType, UserRole } from '@prisma/client';
 import { GraphQLError } from 'graphql';
 import { FREE_LIGHT_COMPONENT_TYPES, TIER_LIMITS, TIER_DISPLAY_NAMES } from '@loam/shared';
 
@@ -6,7 +6,7 @@ type TierUser = {
   subscriptionTier: SubscriptionTier;
   isFoundingRider: boolean;
   needsDowngradeSelection?: boolean;
-  role?: string;
+  role?: UserRole;
 };
 
 /**

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -41,4 +41,9 @@ export const config = {
    * iOS bundle identifier for Apple Sign-In token audience validation.
    */
   appleBundleId: process.env.APPLE_BUNDLE_ID,
+
+  /**
+   * RevenueCat webhook authorization key for verifying inbound IAP webhooks.
+   */
+  revenuecatWebhookAuthKey: process.env.REVENUECAT_WEBHOOK_AUTH_KEY,
 } as const;

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -249,7 +249,7 @@ describe('GraphQL Resolvers', () => {
         });
         expect(mockPrisma.component.update).toHaveBeenCalledWith({
           where: { id: 'comp-1' },
-          data: { hoursUsed: 0 },
+          data: { hoursUsed: 0, lastServicedAt: expect.any(Date) },
         });
         expect(result).toEqual({ id: 'comp-1', hoursUsed: 0 });
       });

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -2061,10 +2061,10 @@ export const resolvers = {
           },
         });
 
-        // Reset component hours
+        // Reset component hours and record service date
         return tx.component.update({
           where: { id },
-          data: { hoursUsed: 0 },
+          data: { hoursUsed: 0, lastServicedAt: serviceDate },
         });
       });
 
@@ -2132,10 +2132,10 @@ export const resolvers = {
           },
         });
 
-        // Reset component hours
+        // Reset component hours and record service date
         await tx.component.update({
           where: { id: input.componentId },
-          data: { hoursUsed: 0 },
+          data: { hoursUsed: 0, lastServicedAt: performedAt },
         });
 
         return log;
@@ -4132,6 +4132,10 @@ export const resolvers = {
   },
 
   Component: {
+    lastServicedAt: (component: ComponentModel & { lastServicedAt?: Date | string | null }) =>
+      component.lastServicedAt instanceof Date
+        ? component.lastServicedAt.toISOString()
+        : component.lastServicedAt ?? null,
     isSpare: (component: ComponentModel & { status?: string }) =>
       component.status === 'INVENTORY' || (component.status == null && component.bikeId == null),
     status: (component: ComponentModel & { status?: string }) => {
@@ -4206,24 +4210,23 @@ export const resolvers = {
         where: { userId: parent.id },
       });
     },
-    subscriptionTier: (parent: { subscriptionTier: string; isFoundingRider?: boolean }) => {
-      // Founding riders always appear as PRO
-      if (parent.isFoundingRider) return 'PRO';
+    subscriptionTier: (parent: { subscriptionTier: string; isFoundingRider?: boolean; role?: string }) => {
+      // Founding riders and admins always appear as PRO
+      if (parent.isFoundingRider || parent.role === 'ADMIN') return 'PRO';
       return parent.subscriptionTier;
     },
-    tierLimits: async (parent: { id: string; subscriptionTier: string; isFoundingRider?: boolean }) => {
-      const tier = getEffectiveTier({
+    tierLimits: async (parent: { id: string; subscriptionTier: string; isFoundingRider?: boolean; role?: string }) => {
+      const tierUser = {
         subscriptionTier: parent.subscriptionTier as 'FREE_LIGHT' | 'FREE_FULL' | 'PRO',
         isFoundingRider: parent.isFoundingRider ?? false,
-      });
+        role: parent.role,
+      };
+      const tier = getEffectiveTier(tierUser);
       const tierConfig = TIER_LIMITS[tier];
       const currentBikeCount = await prisma.bike.count({
         where: { userId: parent.id, status: 'ACTIVE' },
       });
-      const allowed = getAllowedComponentTypes({
-        subscriptionTier: parent.subscriptionTier as 'FREE_LIGHT' | 'FREE_FULL' | 'PRO',
-        isFoundingRider: parent.isFoundingRider ?? false,
-      });
+      const allowed = getAllowedComponentTypes(tierUser);
 
       return {
         maxBikes: tierConfig.maxBikes === Infinity ? null : tierConfig.maxBikes,
@@ -4231,10 +4234,7 @@ export const resolvers = {
           ? Object.values(ComponentTypeEnum)
           : allowed,
         currentBikeCount,
-        canAddBike: canCreateBike(
-          { subscriptionTier: parent.subscriptionTier as 'FREE_LIGHT' | 'FREE_FULL' | 'PRO', isFoundingRider: parent.isFoundingRider ?? false },
-          currentBikeCount
-        ),
+        canAddBike: canCreateBike(tierUser, currentBikeCount),
       };
     },
   },

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -89,6 +89,12 @@ export const typeDefs = gql`
     PRO
   }
 
+  enum SubscriptionProvider {
+    STRIPE
+    APPLE
+    GOOGLE
+  }
+
   enum StripePlan {
     MONTHLY
     ANNUAL
@@ -854,6 +860,7 @@ export const typeDefs = gql`
     needsReauthForSensitiveActions: Boolean!
     isFoundingRider: Boolean!
     subscriptionTier: SubscriptionTier!
+    subscriptionProvider: SubscriptionProvider
     referralCode: String
     needsDowngradeSelection: Boolean!
     tierLimits: TierLimits!

--- a/apps/api/src/lib/revenuecat.ts
+++ b/apps/api/src/lib/revenuecat.ts
@@ -1,0 +1,13 @@
+import { config } from '../config/env';
+
+export function validateRevenueCatConfig(): void {
+  if (!config.revenuecatWebhookAuthKey) {
+    throw new Error('Missing REVENUECAT_WEBHOOK_AUTH_KEY env var');
+  }
+}
+
+/** Map RevenueCat store identifiers to our SubscriptionProvider enum */
+export function storeToProvider(store: string): 'APPLE' | 'GOOGLE' {
+  if (store === 'APP_STORE' || store === 'MAC_APP_STORE') return 'APPLE';
+  return 'GOOGLE';
+}

--- a/apps/api/src/lib/revenuecat.ts
+++ b/apps/api/src/lib/revenuecat.ts
@@ -1,4 +1,5 @@
 import { config } from '../config/env';
+import { logger } from './logger';
 
 export function validateRevenueCatConfig(): void {
   if (!config.revenuecatWebhookAuthKey) {
@@ -9,5 +10,8 @@ export function validateRevenueCatConfig(): void {
 /** Map RevenueCat store identifiers to our SubscriptionProvider enum */
 export function storeToProvider(store: string): 'APPLE' | 'GOOGLE' {
   if (store === 'APP_STORE' || store === 'MAC_APP_STORE') return 'APPLE';
+  if (store !== 'PLAY_STORE') {
+    logger.warn({ store }, 'Unknown RevenueCat store, defaulting to GOOGLE');
+  }
   return 'GOOGLE';
 }

--- a/apps/api/src/lib/revenuecat.ts
+++ b/apps/api/src/lib/revenuecat.ts
@@ -1,11 +1,4 @@
-import { config } from '../config/env';
 import { logger } from './logger';
-
-export function validateRevenueCatConfig(): void {
-  if (!config.revenuecatWebhookAuthKey) {
-    throw new Error('Missing REVENUECAT_WEBHOOK_AUTH_KEY env var');
-  }
-}
 
 /** Map RevenueCat store identifiers to our SubscriptionProvider enum */
 export function storeToProvider(store: string): 'APPLE' | 'GOOGLE' {

--- a/apps/api/src/routes/webhooks.revenuecat.test.ts
+++ b/apps/api/src/routes/webhooks.revenuecat.test.ts
@@ -40,7 +40,6 @@ jest.mock('../config/env', () => ({
 
 jest.mock('../lib/revenuecat', () => ({
   storeToProvider: jest.fn((store: string) => store === 'APP_STORE' ? 'APPLE' : 'GOOGLE'),
-  validateRevenueCatConfig: jest.fn(),
 }));
 
 import router from './webhooks.revenuecat';

--- a/apps/api/src/routes/webhooks.revenuecat.test.ts
+++ b/apps/api/src/routes/webhooks.revenuecat.test.ts
@@ -1,0 +1,195 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+const mockUpgradeUser = jest.fn().mockResolvedValue(true);
+const mockDowngradeUser = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../services/subscription.service', () => ({
+  upgradeUser: (...args: unknown[]) => mockUpgradeUser(...args),
+  downgradeUser: (...args: unknown[]) => mockDowngradeUser(...args),
+}));
+
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+      updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+    },
+    emailSend: {
+      findFirst: jest.fn().mockResolvedValue(null),
+    },
+  },
+}));
+
+jest.mock('../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('../services/email.service', () => ({
+  sendEmailWithAudit: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../templates/emails/payment-failed', () => ({
+  getPaymentFailedEmailHtml: jest.fn().mockResolvedValue('<html>Payment failed</html>'),
+  getPaymentFailedEmailSubject: jest.fn().mockReturnValue('Payment Failed'),
+  PAYMENT_FAILED_TEMPLATE_VERSION: '1.0',
+}));
+
+jest.mock('../config/env', () => ({
+  config: { revenuecatWebhookAuthKey: 'test-webhook-key' },
+}));
+
+jest.mock('../lib/revenuecat', () => ({
+  storeToProvider: jest.fn((store: string) => store === 'APP_STORE' ? 'APPLE' : 'GOOGLE'),
+  validateRevenueCatConfig: jest.fn(),
+}));
+
+import router from './webhooks.revenuecat';
+
+interface RouteLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: RequestHandler }>;
+  };
+}
+
+function getHandler(path: string, method: string): RequestHandler | undefined {
+  const routerStack = (router as unknown as { stack: RouteLayer[] }).stack;
+  const layer = routerStack.find(
+    (l) => l.route?.path === path && l.route?.methods?.[method]
+  );
+  const handlers = layer?.route?.stack;
+  return handlers?.[handlers.length - 1]?.handle;
+}
+
+async function invokeHandler(
+  h: RequestHandler | undefined,
+  req: Request,
+  res: Response
+): Promise<void> {
+  if (!h) throw new Error('Handler not found');
+  await h(req, res, jest.fn() as NextFunction);
+}
+
+function createMockResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  };
+}
+
+function createWebhookRequest(eventType: string, overrides: Record<string, unknown> = {}) {
+  return {
+    headers: { authorization: 'Bearer test-webhook-key' },
+    body: {
+      event: {
+        type: eventType,
+        app_user_id: 'user-123',
+        store: 'APP_STORE',
+        ...overrides,
+      },
+    },
+  } as unknown as Request;
+}
+
+describe('POST /webhooks/revenuecat', () => {
+  let handler: RequestHandler | undefined;
+
+  beforeAll(() => {
+    handler = getHandler('/', 'post');
+    if (!handler) throw new Error('Handler not found for /');
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 401 for invalid authorization', async () => {
+    const req = {
+      headers: { authorization: 'Bearer wrong-key' },
+      body: { event: { type: 'INITIAL_PURCHASE', app_user_id: 'user-123' } },
+    } as unknown as Request;
+    const res = createMockResponse();
+
+    await invokeHandler(handler, req, res as unknown as Response);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.send).toHaveBeenCalledWith('Unauthorized');
+  });
+
+  it('should return 400 for missing event', async () => {
+    const req = {
+      headers: { authorization: 'Bearer test-webhook-key' },
+      body: {},
+    } as unknown as Request;
+    const res = createMockResponse();
+
+    await invokeHandler(handler, req, res as unknown as Response);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('should upgrade user on INITIAL_PURCHASE', async () => {
+    const req = createWebhookRequest('INITIAL_PURCHASE');
+    const res = createMockResponse();
+
+    await invokeHandler(handler, req, res as unknown as Response);
+
+    expect(mockUpgradeUser).toHaveBeenCalledWith('user-123', 'APPLE', 'revenuecat_webhook');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('should upgrade user on RENEWAL', async () => {
+    const req = createWebhookRequest('RENEWAL', { store: 'PLAY_STORE' });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, req, res as unknown as Response);
+
+    expect(mockUpgradeUser).toHaveBeenCalledWith('user-123', 'GOOGLE', 'revenuecat_webhook');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('should downgrade user on EXPIRATION', async () => {
+    const req = createWebhookRequest('EXPIRATION');
+    const res = createMockResponse();
+
+    await invokeHandler(handler, req, res as unknown as Response);
+
+    expect(mockDowngradeUser).toHaveBeenCalledWith('user-123', 'revenuecat_webhook');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('should not downgrade on CANCELLATION (access continues)', async () => {
+    const req = createWebhookRequest('CANCELLATION');
+    const res = createMockResponse();
+
+    await invokeHandler(handler, req, res as unknown as Response);
+
+    expect(mockDowngradeUser).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('should handle missing app_user_id gracefully', async () => {
+    const req = {
+      headers: { authorization: 'Bearer test-webhook-key' },
+      body: { event: { type: 'INITIAL_PURCHASE', store: 'APP_STORE' } },
+    } as unknown as Request;
+    const res = createMockResponse();
+
+    await invokeHandler(handler, req, res as unknown as Response);
+
+    expect(mockUpgradeUser).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('should return 500 on handler error', async () => {
+    mockUpgradeUser.mockRejectedValueOnce(new Error('DB connection failed'));
+    const req = createWebhookRequest('INITIAL_PURCHASE');
+    const res = createMockResponse();
+
+    await invokeHandler(handler, req, res as unknown as Response);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});

--- a/apps/api/src/routes/webhooks.revenuecat.test.ts
+++ b/apps/api/src/routes/webhooks.revenuecat.test.ts
@@ -44,6 +44,11 @@ jest.mock('../lib/revenuecat', () => ({
 }));
 
 import router from './webhooks.revenuecat';
+import { prisma } from '../lib/prisma';
+import { sendEmailWithAudit } from '../services/email.service';
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockSendEmailWithAudit = sendEmailWithAudit as jest.Mock;
 
 interface RouteLayer {
   route?: {
@@ -191,5 +196,70 @@ describe('POST /webhooks/revenuecat', () => {
     await invokeHandler(handler, req, res as unknown as Response);
 
     expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it('should upgrade user on UNCANCELLATION', async () => {
+    const req = createWebhookRequest('UNCANCELLATION');
+    const res = createMockResponse();
+
+    await invokeHandler(handler, req, res as unknown as Response);
+
+    expect(mockUpgradeUser).toHaveBeenCalledWith('user-123', 'APPLE', 'revenuecat_webhook');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  describe('BILLING_ISSUE', () => {
+    it('should send payment failed email', async () => {
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
+        id: 'user-123',
+        email: 'test@test.com',
+        name: 'Test User',
+      });
+      (mockPrisma.emailSend.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const req = createWebhookRequest('BILLING_ISSUE');
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req, res as unknown as Response);
+
+      expect(mockSendEmailWithAudit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'test@test.com',
+          emailType: 'payment_failed',
+          triggerSource: 'revenuecat_webhook',
+          bypassUnsubscribe: true,
+        })
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should skip email if one was sent in last 24h', async () => {
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
+        id: 'user-123',
+        email: 'test@test.com',
+        name: 'Test User',
+      });
+      (mockPrisma.emailSend.findFirst as jest.Mock).mockResolvedValue({ id: 'recent-email' });
+
+      const req = createWebhookRequest('BILLING_ISSUE');
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req, res as unknown as Response);
+
+      expect(mockSendEmailWithAudit).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should handle unknown user gracefully', async () => {
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const req = createWebhookRequest('BILLING_ISSUE');
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req, res as unknown as Response);
+
+      expect(mockSendEmailWithAudit).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
   });
 });

--- a/apps/api/src/routes/webhooks.revenuecat.ts
+++ b/apps/api/src/routes/webhooks.revenuecat.ts
@@ -41,16 +41,11 @@ router.post('/', async (req: Request, res: Response) => {
       case 'INITIAL_PURCHASE':
       case 'RENEWAL':
       case 'UNCANCELLATION': {
+        if (!store) {
+          logger.warn({ eventType, appUserId }, 'RevenueCat webhook missing store field');
+        }
         const provider = storeToProvider(store || 'PLAY_STORE');
         await upgradeUser(appUserId, provider, 'revenuecat_webhook');
-
-        // Store the RevenueCat app user ID for future lookups
-        await prisma.user.updateMany({
-          where: { id: appUserId, revenuecatAppUserId: null },
-          data: { revenuecatAppUserId: appUserId },
-        }).catch(() => {
-          // Ignore if already set or constraint violation
-        });
         break;
       }
 

--- a/apps/api/src/routes/webhooks.revenuecat.ts
+++ b/apps/api/src/routes/webhooks.revenuecat.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'crypto';
 import { Router, type Request, type Response } from 'express';
 import { prisma } from '../lib/prisma';
 import { logger } from '../lib/logger';
@@ -9,10 +10,16 @@ import { getPaymentFailedEmailHtml, getPaymentFailedEmailSubject, PAYMENT_FAILED
 
 const router = Router();
 
+function verifyWebhookAuth(authHeader: string | undefined): boolean {
+  const expected = Buffer.from(`Bearer ${config.revenuecatWebhookAuthKey}`);
+  const received = Buffer.from(authHeader ?? '');
+  if (expected.length !== received.length) return false;
+  return timingSafeEqual(expected, received);
+}
+
 router.post('/', async (req: Request, res: Response) => {
-  // Verify authorization
-  const authHeader = req.headers['authorization'];
-  if (authHeader !== `Bearer ${config.revenuecatWebhookAuthKey}`) {
+  // Verify authorization using constant-time comparison
+  if (!verifyWebhookAuth(req.headers['authorization'] as string | undefined)) {
     logger.warn('RevenueCat webhook: invalid authorization');
     res.status(401).send('Unauthorized');
     return;
@@ -25,6 +32,8 @@ router.post('/', async (req: Request, res: Response) => {
   }
 
   const eventType: string = event.type;
+  // app_user_id is set to the Loam Logger user.id during SDK initialization
+  // in the mobile app (src/lib/revenuecat.ts). This is the database primary key.
   const appUserId: string | undefined = event.app_user_id;
   const store: string | undefined = event.store;
 
@@ -83,18 +92,18 @@ router.post('/', async (req: Request, res: Response) => {
   res.status(200).json({ received: true });
 });
 
-async function handleBillingIssue(userId: string): Promise<void> {
+async function handleBillingIssue(appUserId: string): Promise<void> {
   const user = await prisma.user.findUnique({
-    where: { id: userId },
+    where: { id: appUserId },
     select: { id: true, email: true, name: true },
   });
 
   if (!user) {
-    logger.warn({ userId }, 'Billing issue for unknown user');
+    logger.warn({ appUserId }, 'Billing issue for unknown user (RevenueCat app_user_id not found in DB)');
     return;
   }
 
-  logger.warn({ userId }, 'IAP billing issue');
+  logger.warn({ userId: user.id }, 'IAP billing issue');
 
   // Dedup: only send one payment_failed email per 24-hour window per user
   const recentEmail = await prisma.emailSend.findFirst({
@@ -108,7 +117,7 @@ async function handleBillingIssue(userId: string): Promise<void> {
   });
 
   if (recentEmail) {
-    logger.info({ userId }, 'Payment failed email already sent in last 24h, skipping');
+    logger.info({ userId: user.id }, 'Payment failed email already sent in last 24h, skipping');
     return;
   }
 
@@ -125,7 +134,7 @@ async function handleBillingIssue(userId: string): Promise<void> {
       bypassUnsubscribe: true,
     });
   } catch (emailErr) {
-    logger.error({ error: emailErr instanceof Error ? emailErr.message : String(emailErr), userId }, 'Failed to send payment failed email');
+    logger.error({ error: emailErr instanceof Error ? emailErr.message : String(emailErr), userId: user.id }, 'Failed to send payment failed email');
   }
 }
 

--- a/apps/api/src/routes/webhooks.revenuecat.ts
+++ b/apps/api/src/routes/webhooks.revenuecat.ts
@@ -1,0 +1,137 @@
+import { Router, type Request, type Response } from 'express';
+import { prisma } from '../lib/prisma';
+import { logger } from '../lib/logger';
+import { config } from '../config/env';
+import { storeToProvider } from '../lib/revenuecat';
+import { upgradeUser, downgradeUser } from '../services/subscription.service';
+import { sendEmailWithAudit } from '../services/email.service';
+import { getPaymentFailedEmailHtml, getPaymentFailedEmailSubject, PAYMENT_FAILED_TEMPLATE_VERSION } from '../templates/emails/payment-failed';
+
+const router = Router();
+
+router.post('/', async (req: Request, res: Response) => {
+  // Verify authorization
+  const authHeader = req.headers['authorization'];
+  if (authHeader !== `Bearer ${config.revenuecatWebhookAuthKey}`) {
+    logger.warn('RevenueCat webhook: invalid authorization');
+    res.status(401).send('Unauthorized');
+    return;
+  }
+
+  const event = req.body?.event;
+  if (!event) {
+    res.status(400).send('Missing event');
+    return;
+  }
+
+  const eventType: string = event.type;
+  const appUserId: string | undefined = event.app_user_id;
+  const store: string | undefined = event.store;
+
+  logger.info({ eventType, appUserId, store }, 'RevenueCat webhook received');
+
+  if (!appUserId) {
+    logger.warn({ eventType }, 'RevenueCat webhook missing app_user_id');
+    res.status(200).json({ received: true });
+    return;
+  }
+
+  try {
+    switch (eventType) {
+      case 'INITIAL_PURCHASE':
+      case 'RENEWAL':
+      case 'UNCANCELLATION': {
+        const provider = storeToProvider(store || 'PLAY_STORE');
+        await upgradeUser(appUserId, provider, 'revenuecat_webhook');
+
+        // Store the RevenueCat app user ID for future lookups
+        await prisma.user.updateMany({
+          where: { id: appUserId, revenuecatAppUserId: null },
+          data: { revenuecatAppUserId: appUserId },
+        }).catch(() => {
+          // Ignore if already set or constraint violation
+        });
+        break;
+      }
+
+      case 'EXPIRATION':
+        await downgradeUser(appUserId, 'revenuecat_webhook');
+        break;
+
+      case 'BILLING_ISSUE':
+        await handleBillingIssue(appUserId);
+        break;
+
+      case 'CANCELLATION':
+        // User cancelled but still has access until period end. Log only.
+        logger.info({ appUserId, store }, 'Subscription cancelled (access continues until period end)');
+        break;
+
+      case 'PRODUCT_CHANGE':
+        // Monthly ↔ yearly switch. No tier change needed.
+        logger.info({ appUserId, store, newProductId: event.new_product_id }, 'Subscription product changed');
+        break;
+
+      case 'SUBSCRIBER_ALIAS':
+        logger.warn({ appUserId, aliases: event.aliases }, 'RevenueCat subscriber alias event — investigate if unexpected');
+        break;
+
+      default:
+        logger.info({ eventType, appUserId }, 'Unhandled RevenueCat event type');
+    }
+  } catch (err) {
+    logger.error({ error: err instanceof Error ? err.message : String(err), eventType, appUserId }, 'Error processing RevenueCat webhook');
+    res.status(500).json({ received: true, error: true });
+    return;
+  }
+
+  res.status(200).json({ received: true });
+});
+
+async function handleBillingIssue(userId: string): Promise<void> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, email: true, name: true },
+  });
+
+  if (!user) {
+    logger.warn({ userId }, 'Billing issue for unknown user');
+    return;
+  }
+
+  logger.warn({ userId }, 'IAP billing issue');
+
+  // Dedup: only send one payment_failed email per 24-hour window per user
+  const recentEmail = await prisma.emailSend.findFirst({
+    where: {
+      userId: user.id,
+      emailType: 'payment_failed',
+      status: 'sent',
+      createdAt: { gte: new Date(Date.now() - 24 * 60 * 60 * 1000) },
+    },
+    select: { id: true },
+  });
+
+  if (recentEmail) {
+    logger.info({ userId }, 'Payment failed email already sent in last 24h, skipping');
+    return;
+  }
+
+  try {
+    const firstName = user.name?.split(' ')[0] || undefined;
+    await sendEmailWithAudit({
+      to: user.email,
+      subject: getPaymentFailedEmailSubject(),
+      html: await getPaymentFailedEmailHtml({ name: firstName }),
+      userId: user.id,
+      emailType: 'payment_failed',
+      triggerSource: 'revenuecat_webhook',
+      templateVersion: PAYMENT_FAILED_TEMPLATE_VERSION,
+      bypassUnsubscribe: true,
+    });
+  } catch (emailErr) {
+    logger.error({ error: emailErr instanceof Error ? emailErr.message : String(emailErr), userId }, 'Failed to send payment failed email');
+  }
+}
+
+export default router;

--- a/apps/api/src/routes/webhooks.stripe.ts
+++ b/apps/api/src/routes/webhooks.stripe.ts
@@ -3,8 +3,7 @@ import { stripe, STRIPE_CONFIG } from '../lib/stripe';
 import { prisma } from '../lib/prisma';
 import { logger } from '../lib/logger';
 import { sendEmailWithAudit } from '../services/email.service';
-import { getUpgradeConfirmationEmailHtml, getUpgradeConfirmationEmailSubject, UPGRADE_CONFIRMATION_TEMPLATE_VERSION } from '../templates/emails/upgrade-confirmation';
-import { getDowngradeNoticeEmailHtml, getDowngradeNoticeEmailSubject, DOWNGRADE_NOTICE_TEMPLATE_VERSION } from '../templates/emails/downgrade-notice';
+import { upgradeUser, downgradeUser } from '../services/subscription.service';
 import { getPaymentFailedEmailHtml, getPaymentFailedEmailSubject, PAYMENT_FAILED_TEMPLATE_VERSION } from '../templates/emails/payment-failed';
 import type Stripe from 'stripe';
 
@@ -92,62 +91,10 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
     return;
   }
 
-  // Interactive transaction: only un-archive bikes if the upgrade actually happened.
-  const upgraded = await prisma.$transaction(async (tx) => {
-    const result = await tx.user.updateMany({
-      where: {
-        id: userId,
-        isFoundingRider: false,
-        stripeSubscriptionId: { not: subscriptionId },
-      },
-      data: {
-        subscriptionTier: 'PRO',
-        stripeCustomerId: customerId ?? null,
-        stripeSubscriptionId: subscriptionId,
-        needsDowngradeSelection: false,
-      },
-    });
-
-    if (result.count === 0) return false;
-
-    await tx.bike.updateMany({
-      where: { userId, status: 'ARCHIVED' },
-      data: { status: 'ACTIVE' },
-    });
-
-    return true;
+  await upgradeUser(userId, 'STRIPE', 'stripe_webhook', {
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscriptionId,
   });
-
-  if (!upgraded) {
-    logger.info({ userId, subscriptionId }, 'Checkout skipped (founding rider, already processed, or user not found)');
-    return;
-  }
-
-  logger.info({ userId, subscriptionId }, 'User upgraded to PRO via Stripe checkout');
-
-  // Fetch user for email (post-write, only on success)
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { email: true, name: true },
-  });
-
-  if (user) {
-    try {
-      const firstName = user.name?.split(' ')[0] || undefined;
-      await sendEmailWithAudit({
-        to: user.email,
-        subject: getUpgradeConfirmationEmailSubject(),
-        html: await getUpgradeConfirmationEmailHtml({ name: firstName }),
-        userId,
-        emailType: 'upgrade_confirmation',
-        triggerSource: 'stripe_webhook',
-        templateVersion: UPGRADE_CONFIRMATION_TEMPLATE_VERSION,
-        bypassUnsubscribe: true,
-      });
-    } catch (emailErr) {
-      logger.error({ error: emailErr instanceof Error ? emailErr.message : String(emailErr), userId }, 'Failed to send upgrade confirmation email');
-    }
-  }
 }
 
 async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
@@ -171,121 +118,15 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
   );
 
   if (subscription.status === 'active') {
-    // Interactive transaction: only un-archive bikes if the upgrade actually happened.
-    const didUpgrade = await prisma.$transaction(async (tx) => {
-      const result = await tx.user.updateMany({
-        where: { id: userId, subscriptionTier: { not: 'PRO' }, isFoundingRider: false },
-        data: {
-          subscriptionTier: 'PRO',
-          stripeSubscriptionId: subscription.id,
-          needsDowngradeSelection: false,
-        },
-      });
-
-      if (result.count === 0) return false;
-
-      await tx.bike.updateMany({
-        where: { userId, status: 'ARCHIVED' },
-        data: { status: 'ACTIVE' },
-      });
-
-      return true;
+    await upgradeUser(userId, 'STRIPE', 'stripe_webhook', {
+      stripeSubscriptionId: subscription.id,
     });
-
-    if (didUpgrade) {
-      logger.info({ userId }, 'Subscription resumed — user re-upgraded to PRO');
-
-      // Fetch fresh user data for email (post-write, only on success)
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: { email: true, name: true },
-      });
-
-      if (user) {
-        try {
-          const firstName = user.name?.split(' ')[0] || undefined;
-          await sendEmailWithAudit({
-            to: user.email,
-            subject: getUpgradeConfirmationEmailSubject(),
-            html: await getUpgradeConfirmationEmailHtml({ name: firstName }),
-            userId,
-            emailType: 'upgrade_confirmation',
-            triggerSource: 'stripe_webhook',
-            templateVersion: UPGRADE_CONFIRMATION_TEMPLATE_VERSION,
-            bypassUnsubscribe: true,
-          });
-        } catch (emailErr) {
-          logger.error({ error: emailErr instanceof Error ? emailErr.message : String(emailErr), userId }, 'Failed to send re-upgrade confirmation email');
-        }
-      }
-    }
   } else if (subscription.status === 'canceled') {
     // Stripe can fire updated with 'canceled' before or instead of the deleted event.
     // Trigger the same downgrade logic — it's idempotent.
-    await downgradeUser(userId);
+    await downgradeUser(userId, 'stripe_webhook');
   } else if (subscription.status === 'past_due') {
     logger.warn({ userId, subscriptionId: subscription.id }, 'Subscription is past due');
-  }
-}
-
-/**
- * Shared downgrade logic used by both handleSubscriptionDeleted and
- * handleSubscriptionUpdated (status === 'canceled'). Idempotent —
- * safe to call from both event paths.
- */
-async function downgradeUser(userId: string): Promise<void> {
-  const result = await prisma.$transaction(async (tx) => {
-    const user = await tx.user.findUnique({
-      where: { id: userId },
-      select: { isFoundingRider: true, subscriptionTier: true, email: true, name: true },
-    });
-
-    if (!user || user.isFoundingRider || user.subscriptionTier !== 'PRO') return null;
-
-    const [completedReferral, activeBikeCount] = await Promise.all([
-      tx.referral.findFirst({ where: { referrerUserId: userId, status: 'COMPLETED' }, select: { id: true } }),
-      tx.bike.count({ where: { userId, status: 'ACTIVE' } }),
-    ]);
-
-    const downgradeTier = completedReferral ? 'FREE_FULL' : 'FREE_LIGHT';
-    const needsSelection = activeBikeCount > 1;
-
-    await tx.user.update({
-      where: { id: userId },
-      data: {
-        subscriptionTier: downgradeTier,
-        stripeSubscriptionId: null,
-        needsDowngradeSelection: needsSelection,
-      },
-    });
-
-    return { email: user.email, name: user.name, downgradeTier, needsSelection };
-  });
-
-  if (!result) {
-    logger.info({ userId }, 'Downgrade skipped (founding rider, not PRO, or missing user)');
-    return;
-  }
-
-  logger.info(
-    { userId, downgradeTier: result.downgradeTier, needsDowngradeSelection: result.needsSelection },
-    'User downgraded from PRO'
-  );
-
-  try {
-    const firstName = result.name?.split(' ')[0] || undefined;
-    await sendEmailWithAudit({
-      to: result.email,
-      subject: getDowngradeNoticeEmailSubject(),
-      html: await getDowngradeNoticeEmailHtml({ name: firstName }),
-      userId,
-      emailType: 'downgrade_notice',
-      triggerSource: 'stripe_webhook',
-      templateVersion: DOWNGRADE_NOTICE_TEMPLATE_VERSION,
-      bypassUnsubscribe: true,
-    });
-  } catch (emailErr) {
-    logger.error({ error: emailErr instanceof Error ? emailErr.message : String(emailErr), userId }, 'Failed to send downgrade notice email');
   }
 }
 
@@ -296,7 +137,7 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
     return;
   }
 
-  await downgradeUser(userId);
+  await downgradeUser(userId, 'stripe_webhook');
 }
 
 async function handlePaymentFailed(invoice: Stripe.Invoice) {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -43,6 +43,8 @@ import spokesRouter from './routes/spokes';
 import emailUnsubscribeRouter from './routes/email.unsubscribe';
 import { googleRouter, emailRouter, deleteAccountRouter, passwordRouter, attachUser, verifyCsrf } from './auth/index';
 import webhooksStripe from './routes/webhooks.stripe';
+import webhooksRevenueCat from './routes/webhooks.revenuecat';
+import { validateRevenueCatConfig } from './lib/revenuecat';
 import { validateStripeConfig } from './lib/stripe';
 import { FRONTEND_URL } from './config/env';
 import referralRouter from './routes/referral';
@@ -142,6 +144,12 @@ const startServer = async () => {
   if (process.env.STRIPE_SECRET_KEY) {
     validateStripeConfig(); // Fail fast if any Stripe env vars are missing
     app.use('/webhooks/stripe', express.raw({ type: 'application/json' }), webhooksStripe);
+  }
+
+  // RevenueCat webhook uses standard JSON (no raw body signature like Stripe)
+  if (process.env.REVENUECAT_WEBHOOK_AUTH_KEY) {
+    validateRevenueCatConfig();
+    app.use('/webhooks/revenuecat', express.json(), webhooksRevenueCat);
   }
 
   app.use(express.json());

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -44,7 +44,6 @@ import emailUnsubscribeRouter from './routes/email.unsubscribe';
 import { googleRouter, emailRouter, deleteAccountRouter, passwordRouter, attachUser, verifyCsrf } from './auth/index';
 import webhooksStripe from './routes/webhooks.stripe';
 import webhooksRevenueCat from './routes/webhooks.revenuecat';
-import { validateRevenueCatConfig } from './lib/revenuecat';
 import { validateStripeConfig } from './lib/stripe';
 import { FRONTEND_URL } from './config/env';
 import referralRouter from './routes/referral';
@@ -148,7 +147,6 @@ const startServer = async () => {
 
   // RevenueCat webhook uses standard JSON (no raw body signature like Stripe)
   if (process.env.REVENUECAT_WEBHOOK_AUTH_KEY) {
-    validateRevenueCatConfig();
     app.use('/webhooks/revenuecat', express.json(), webhooksRevenueCat);
   }
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -145,7 +145,8 @@ const startServer = async () => {
     app.use('/webhooks/stripe', express.raw({ type: 'application/json' }), webhooksStripe);
   }
 
-  // RevenueCat webhook uses standard JSON (no raw body signature like Stripe)
+  // RevenueCat webhook registered before global express.json() — needs its own
+  // JSON parser since the global middleware hasn't been applied yet at this point.
   if (process.env.REVENUECAT_WEBHOOK_AUTH_KEY) {
     app.use('/webhooks/revenuecat', express.json(), webhooksRevenueCat);
   }

--- a/apps/api/src/services/notification.service.ts
+++ b/apps/api/src/services/notification.service.ts
@@ -70,7 +70,7 @@ export async function notifyRideUploaded(params: {
   bikeName?: string;
   user: NotificationUser;
 }): Promise<string | undefined> {
-  const { userId, rideId, durationSeconds, distanceMeters, bikeName, user } = params;
+  const { rideId, durationSeconds, distanceMeters, bikeName, user } = params;
 
   if (!user.notifyOnRideUpload) return;
 

--- a/apps/api/src/services/subscription.service.ts
+++ b/apps/api/src/services/subscription.service.ts
@@ -121,6 +121,7 @@ export async function downgradeUser(userId: string, triggerSource: string): Prom
         stripeSubscriptionId: null,
         subscriptionProvider: null,
         needsDowngradeSelection: needsSelection,
+        // stripeCustomerId intentionally preserved — reused if the user re-subscribes via Stripe
       },
     });
 

--- a/apps/api/src/services/subscription.service.ts
+++ b/apps/api/src/services/subscription.service.ts
@@ -1,0 +1,155 @@
+import { prisma } from '../lib/prisma';
+import { logger } from '../lib/logger';
+import { sendEmailWithAudit } from './email.service';
+import { getUpgradeConfirmationEmailHtml, getUpgradeConfirmationEmailSubject, UPGRADE_CONFIRMATION_TEMPLATE_VERSION } from '../templates/emails/upgrade-confirmation';
+import { getDowngradeNoticeEmailHtml, getDowngradeNoticeEmailSubject, DOWNGRADE_NOTICE_TEMPLATE_VERSION } from '../templates/emails/downgrade-notice';
+
+type SubscriptionProvider = 'STRIPE' | 'APPLE' | 'GOOGLE';
+
+interface UpgradeOptions {
+  stripeCustomerId?: string | null;
+  stripeSubscriptionId?: string;
+}
+
+/**
+ * Upgrade a user to PRO. Idempotent — safe to call from multiple webhook paths.
+ *
+ * Sets subscriptionTier to PRO, records the subscription provider, un-archives
+ * bikes, and sends a confirmation email. Skips founding riders and users already
+ * on PRO via the same provider+subscription. Returns true if the upgrade was applied.
+ */
+export async function upgradeUser(
+  userId: string,
+  provider: SubscriptionProvider,
+  triggerSource: string,
+  options: UpgradeOptions = {},
+): Promise<boolean> {
+  const upgraded = await prisma.$transaction(async (tx) => {
+    const result = await tx.user.updateMany({
+      where: {
+        id: userId,
+        isFoundingRider: false,
+        // Only upgrade if not already PRO, or if PRO via a different subscription
+        OR: [
+          { subscriptionTier: { not: 'PRO' } },
+          ...(options.stripeSubscriptionId
+            ? [{ stripeSubscriptionId: { not: options.stripeSubscriptionId } }]
+            : []),
+        ],
+      },
+      data: {
+        subscriptionTier: 'PRO',
+        subscriptionProvider: provider,
+        stripeCustomerId: options.stripeCustomerId ?? undefined,
+        stripeSubscriptionId: options.stripeSubscriptionId ?? undefined,
+        needsDowngradeSelection: false,
+      },
+    });
+
+    if (result.count === 0) return false;
+
+    await tx.bike.updateMany({
+      where: { userId, status: 'ARCHIVED' },
+      data: { status: 'ACTIVE' },
+    });
+
+    return true;
+  });
+
+  if (!upgraded) {
+    logger.info({ userId, provider }, 'Upgrade skipped (founding rider, already processed, or user not found)');
+    return false;
+  }
+
+  logger.info({ userId, provider }, 'User upgraded to PRO');
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { email: true, name: true },
+  });
+
+  if (user) {
+    try {
+      const firstName = user.name?.split(' ')[0] || undefined;
+      await sendEmailWithAudit({
+        to: user.email,
+        subject: getUpgradeConfirmationEmailSubject(),
+        html: await getUpgradeConfirmationEmailHtml({ name: firstName }),
+        userId,
+        emailType: 'upgrade_confirmation',
+        triggerSource,
+        templateVersion: UPGRADE_CONFIRMATION_TEMPLATE_VERSION,
+        bypassUnsubscribe: true,
+      });
+    } catch (emailErr) {
+      logger.error({ error: emailErr instanceof Error ? emailErr.message : String(emailErr), userId }, 'Failed to send upgrade confirmation email');
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Downgrade a user from PRO. Idempotent — safe to call from both Stripe and
+ * RevenueCat webhook paths.
+ *
+ * Determines downgrade tier based on referral status (FREE_FULL if referral,
+ * FREE_LIGHT otherwise). Sets needsDowngradeSelection if user has >1 active bikes.
+ * Clears provider-specific subscription fields and sends a downgrade email.
+ */
+export async function downgradeUser(userId: string, triggerSource: string): Promise<void> {
+  const result = await prisma.$transaction(async (tx) => {
+    const user = await tx.user.findUnique({
+      where: { id: userId },
+      select: { isFoundingRider: true, subscriptionTier: true, email: true, name: true },
+    });
+
+    if (!user || user.isFoundingRider || user.subscriptionTier !== 'PRO') return null;
+
+    const [completedReferral, activeBikeCount] = await Promise.all([
+      tx.referral.findFirst({ where: { referrerUserId: userId, status: 'COMPLETED' }, select: { id: true } }),
+      tx.bike.count({ where: { userId, status: 'ACTIVE' } }),
+    ]);
+
+    const downgradeTier = completedReferral ? 'FREE_FULL' : 'FREE_LIGHT';
+    const needsSelection = activeBikeCount > 1;
+
+    await tx.user.update({
+      where: { id: userId },
+      data: {
+        subscriptionTier: downgradeTier,
+        stripeSubscriptionId: null,
+        subscriptionProvider: null,
+        needsDowngradeSelection: needsSelection,
+      },
+    });
+
+    return { email: user.email, name: user.name, downgradeTier, needsSelection };
+  });
+
+  if (!result) {
+    logger.info({ userId }, 'Downgrade skipped (founding rider, not PRO, or missing user)');
+    return;
+  }
+
+  logger.info(
+    { userId, downgradeTier: result.downgradeTier, needsDowngradeSelection: result.needsSelection },
+    'User downgraded from PRO'
+  );
+
+  try {
+    const firstName = result.name?.split(' ')[0] || undefined;
+    await sendEmailWithAudit({
+      to: result.email,
+      subject: getDowngradeNoticeEmailSubject(),
+      html: await getDowngradeNoticeEmailHtml({ name: firstName }),
+      userId,
+      emailType: 'downgrade_notice',
+      triggerSource,
+      templateVersion: DOWNGRADE_NOTICE_TEMPLATE_VERSION,
+      bypassUnsubscribe: true,
+    });
+  } catch (emailErr) {
+    logger.error({ error: emailErr instanceof Error ? emailErr.message : String(emailErr), userId }, 'Failed to send downgrade notice email');
+  }
+}

--- a/apps/api/src/services/subscription.service.ts
+++ b/apps/api/src/services/subscription.service.ts
@@ -1,10 +1,9 @@
+import type { SubscriptionProvider, TriggerSource } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { logger } from '../lib/logger';
 import { sendEmailWithAudit } from './email.service';
 import { getUpgradeConfirmationEmailHtml, getUpgradeConfirmationEmailSubject, UPGRADE_CONFIRMATION_TEMPLATE_VERSION } from '../templates/emails/upgrade-confirmation';
 import { getDowngradeNoticeEmailHtml, getDowngradeNoticeEmailSubject, DOWNGRADE_NOTICE_TEMPLATE_VERSION } from '../templates/emails/downgrade-notice';
-
-type SubscriptionProvider = 'STRIPE' | 'APPLE' | 'GOOGLE';
 
 interface UpgradeOptions {
   stripeCustomerId?: string | null;
@@ -21,7 +20,7 @@ interface UpgradeOptions {
 export async function upgradeUser(
   userId: string,
   provider: SubscriptionProvider,
-  triggerSource: string,
+  triggerSource: TriggerSource,
   options: UpgradeOptions = {},
 ): Promise<boolean> {
   const upgraded = await prisma.$transaction(async (tx) => {
@@ -97,7 +96,7 @@ export async function upgradeUser(
  * FREE_LIGHT otherwise). Sets needsDowngradeSelection if user has >1 active bikes.
  * Clears provider-specific subscription fields and sends a downgrade email.
  */
-export async function downgradeUser(userId: string, triggerSource: string): Promise<void> {
+export async function downgradeUser(userId: string, triggerSource: TriggerSource): Promise<void> {
   const result = await prisma.$transaction(async (tx) => {
     const user = await tx.user.findUnique({
       where: { id: userId },


### PR DESCRIPTION
## Summary

- Add RevenueCat IAP webhook handler alongside existing Stripe billing, enabling Apple IAP and Google Play subscriptions
- Extract shared `upgradeUser`/`downgradeUser` logic from Stripe webhooks into `subscription.service.ts` so both providers use the same idempotent upgrade/downgrade flow
- Add `SubscriptionProvider` enum (STRIPE, APPLE, GOOGLE) and `subscriptionProvider`/`revenuecatAppUserId` fields to User model
- Fix `lastServicedAt` not being set when logging component service (both `logComponentService` and `logService` mutations)
- Fix admin accounts not receiving PRO-tier access in `getEffectiveTier` and `tierLimits` resolver

## Changes

- **New:** `subscription.service.ts` shared upgrade/downgrade service
- **New:** `webhooks.revenuecat.ts` handles INITIAL_PURCHASE, RENEWAL, EXPIRATION, BILLING_ISSUE, CANCELLATION events
- **New:** `lib/revenuecat.ts` config validation and store-to-provider mapping
- **Refactored:** `webhooks.stripe.ts` now delegates to shared subscription service
- **Schema:** Added `SubscriptionProvider` enum, `subscriptionProvider` and `revenuecatAppUserId` on User
- **Fix:** `logComponentService` and `logService` now set `lastServicedAt` on the component
- **Fix:** `getEffectiveTier` and `subscriptionTier` resolver treat `role === 'ADMIN'` as PRO
- **Fix:** `lastServicedAt` field resolver converts Date to ISO string for proper client parsing

## Test plan

- [ ] All 1109 existing API tests pass (including updated `logComponentService` test)
- [ ] 8 new RevenueCat webhook tests pass (auth, upgrade, downgrade, idempotency)
- [ ] Verify Stripe checkout on web still works unchanged
- [ ] Verify RevenueCat sandbox purchase triggers webhook and upgrades user
- [ ] Verify admin accounts see PRO tier limits and all component types
- [ ] Verify `lastServicedAt` displays correctly after logging service
