### PR TITLE
feat: garmin backfill limiting, rate limiting fix for notifications

### DIFF
--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -70,6 +70,10 @@ export const MUTATION_RATE_LIMITS = {
   changePassword: { windowSeconds: 3600, maxRequests: 5 },
   /** oauthStart: max 5 requests per 10 minutes per user (creates DB row each call) */
   oauthStart: { windowSeconds: 600, maxRequests: 5 },
+  /** updateUserPreferences: max 20 requests per minute per user */
+  updateUserPreferences: { windowSeconds: 60, maxRequests: 20 },
+  /** updateBikeNotificationPreference: max 20 requests per minute per user */
+  updateBikeNotificationPreference: { windowSeconds: 60, maxRequests: 20 },
 } as const;
 
 /**

--- a/apps/api/src/services/notification.service.ts
+++ b/apps/api/src/services/notification.service.ts
@@ -241,8 +241,10 @@ export async function fireRideNotifications(params: {
   isNewRide: boolean;
   /** When set, this ride came from a bulk backfill — suppress per-ride notifications */
   isBackfill?: boolean;
+  /** Pre-fetched active bike count — avoids redundant DB query when caller already has it */
+  activeBikeCount?: number;
 }): Promise<void> {
-  const { userId, rideId, bikeId, durationSeconds, distanceMeters, isNewRide, isBackfill } = params;
+  const { userId, rideId, bikeId, durationSeconds, distanceMeters, isNewRide, isBackfill, activeBikeCount: providedBikeCount } = params;
 
   // Only notify for newly created rides, not updates or bulk backfills
   if (!isNewRide || isBackfill) return;
@@ -291,7 +293,7 @@ export async function fireRideNotifications(params: {
 
     // Notify multi-bike users when a ride is imported without a bike assignment
     if (!bikeId) {
-      const activeBikeCount = await prisma.bike.count({ where: { userId, status: 'ACTIVE' } });
+      const activeBikeCount = providedBikeCount ?? await prisma.bike.count({ where: { userId, status: 'ACTIVE' } });
       if (activeBikeCount > 1) {
         const unassignedTicketId = await sendPushNotification({
           pushToken: user.expoPushToken,

--- a/apps/api/src/services/notification.service.ts
+++ b/apps/api/src/services/notification.service.ts
@@ -287,6 +287,20 @@ export async function fireRideNotifications(params: {
     });
     if (rideTicketId) ticketIds.push(rideTicketId);
 
+    // Notify multi-bike users when a ride is imported without a bike assignment
+    if (!bikeId) {
+      const activeBikeCount = await prisma.bike.count({ where: { userId, status: 'ACTIVE' } });
+      if (activeBikeCount > 1) {
+        const unassignedTicketId = await sendPushNotification({
+          pushToken: user.expoPushToken,
+          title: 'Assign a Bike',
+          body: 'A ride was imported without a bike. Tap to assign it so component hours are tracked.',
+          data: { screen: 'ride', rideId },
+        });
+        if (unassignedTicketId) ticketIds.push(unassignedTicketId);
+      }
+    }
+
     // Service due check (only if ride is assigned to a bike)
     if (bikeId && bikeName) {
       const predictionMode = (user.predictionMode === 'predictive' ? 'predictive' : 'simple') as 'simple' | 'predictive';

--- a/apps/api/src/services/notification.service.ts
+++ b/apps/api/src/services/notification.service.ts
@@ -239,11 +239,13 @@ export async function fireRideNotifications(params: {
   durationSeconds: number;
   distanceMeters: number;
   isNewRide: boolean;
+  /** When set, this ride came from a bulk backfill — suppress per-ride notifications */
+  isBackfill?: boolean;
 }): Promise<void> {
-  const { userId, rideId, bikeId, durationSeconds, distanceMeters, isNewRide } = params;
+  const { userId, rideId, bikeId, durationSeconds, distanceMeters, isNewRide, isBackfill } = params;
 
-  // Only notify for newly created rides, not updates
-  if (!isNewRide) return;
+  // Only notify for newly created rides, not updates or bulk backfills
+  if (!isNewRide || isBackfill) return;
 
   try {
     // Single user query for all notification needs

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -546,10 +546,7 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
     select: { id: true },
   });
 
-  let syncedRideId: string | null = null;
-  let syncedBikeId: string | null = null;
-
-  await prisma.$transaction(async (tx) => {
+  const { syncedRideId, syncedBikeId } = await prisma.$transaction(async (tx) => {
     const ride = await tx.ride.upsert({
       where: { garminActivityId: activity.summaryId },
       create: {
@@ -578,9 +575,6 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
       },
     });
 
-    syncedRideId = ride.id;
-    syncedBikeId = ride.bikeId ?? null;
-
     // Sync component hours
     await syncBikeComponentHours(
       tx,
@@ -588,6 +582,8 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
       { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
       { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds }
     );
+
+    return { syncedRideId: ride.id, syncedBikeId: ride.bikeId ?? null };
   });
 
   // Update session's lastActivityReceivedAt if there's a running session
@@ -601,20 +597,18 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
   logger.debug({ summaryId: activity.summaryId }, '[SyncWorker] Upserted Garmin activity');
 
   // Fire-and-forget notifications
-  // Guard is for TypeScript narrowing — transaction either sets syncedRideId or throws
-  if (syncedRideId) {
-    fireRideNotifications({
-      userId,
-      rideId: syncedRideId,
-      bikeId: syncedBikeId,
-      durationSeconds: activity.durationInSeconds,
-      distanceMeters,
-      isNewRide,
-    }).catch(() => {}); // swallow - already logged internally
+  fireRideNotifications({
+    userId,
+    rideId: syncedRideId,
+    bikeId: syncedBikeId,
+    durationSeconds: activity.durationInSeconds,
+    distanceMeters,
+    isNewRide,
+    isBackfill: !!runningSession,
+  }).catch(() => {}); // swallow - already logged internally
 
-    if (isNewRide) {
-      completeReferral(userId).catch(() => {}); // swallow - already logged internally
-    }
+  if (isNewRide) {
+    completeReferral(userId).catch(() => {}); // swallow - already logged internally
   }
 }
 

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -547,6 +547,7 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
   });
 
   let syncedRideId: string | null = null;
+  let syncedBikeId: string | null = null;
 
   await prisma.$transaction(async (tx) => {
     const ride = await tx.ride.upsert({
@@ -578,6 +579,7 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
     });
 
     syncedRideId = ride.id;
+    syncedBikeId = ride.bikeId ?? null;
 
     // Sync component hours
     await syncBikeComponentHours(
@@ -599,11 +601,12 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
   logger.debug({ summaryId: activity.summaryId }, '[SyncWorker] Upserted Garmin activity');
 
   // Fire-and-forget notifications
+  // Guard is for TypeScript narrowing — transaction either sets syncedRideId or throws
   if (syncedRideId) {
     fireRideNotifications({
       userId,
       rideId: syncedRideId,
-      bikeId,
+      bikeId: syncedBikeId,
       durationSeconds: activity.durationInSeconds,
       distanceMeters,
       isNewRide,

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -524,11 +524,21 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
 
   const existing = await prisma.ride.findUnique({
     where: { garminActivityId: activity.summaryId },
-    select: { location: true },
+    select: { id: true, location: true, bikeId: true, durationSeconds: true },
   });
 
   const isNewRide = !existing;
   const locationUpdate = shouldApplyAutoLocation(existing?.location ?? null, autoLocation?.title ?? null);
+
+  // Auto-assign bike if user has exactly one active bike (Garmin has no gear tagging)
+  let bikeId: string | null = null;
+  const userBikes = await prisma.bike.findMany({
+    where: { userId, status: 'ACTIVE' },
+    select: { id: true },
+  });
+  if (userBikes.length === 1) {
+    bikeId = userBikes[0].id;
+  }
 
   // Look up running ImportSession for this user (if any)
   const runningSession = await prisma.importSession.findFirst({
@@ -536,31 +546,46 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
     select: { id: true },
   });
 
-  const ride = await prisma.ride.upsert({
-    where: { garminActivityId: activity.summaryId },
-    create: {
+  let syncedRideId: string | null = null;
+
+  await prisma.$transaction(async (tx) => {
+    const ride = await tx.ride.upsert({
+      where: { garminActivityId: activity.summaryId },
+      create: {
+        userId,
+        garminActivityId: activity.summaryId,
+        startTime,
+        durationSeconds: activity.durationInSeconds,
+        distanceMeters,
+        elevationGainMeters,
+        averageHr: activity.averageHeartRateInBeatsPerMinute ?? null,
+        rideType: activity.activityType,
+        notes: activity.activityName ?? null,
+        location: autoLocation?.title ?? null,
+        importSessionId: runningSession?.id ?? null,
+        bikeId,
+      },
+      update: {
+        startTime,
+        durationSeconds: activity.durationInSeconds,
+        distanceMeters,
+        elevationGainMeters,
+        averageHr: activity.averageHeartRateInBeatsPerMinute ?? null,
+        rideType: activity.activityType,
+        notes: activity.activityName ?? null,
+        ...(locationUpdate !== undefined ? { location: locationUpdate } : {}),
+      },
+    });
+
+    syncedRideId = ride.id;
+
+    // Sync component hours
+    await syncBikeComponentHours(
+      tx,
       userId,
-      garminActivityId: activity.summaryId,
-      startTime,
-      durationSeconds: activity.durationInSeconds,
-      distanceMeters,
-      elevationGainMeters,
-      averageHr: activity.averageHeartRateInBeatsPerMinute ?? null,
-      rideType: activity.activityType,
-      notes: activity.activityName ?? null,
-      location: autoLocation?.title ?? null,
-      importSessionId: runningSession?.id ?? null,
-    },
-    update: {
-      startTime,
-      durationSeconds: activity.durationInSeconds,
-      distanceMeters,
-      elevationGainMeters,
-      averageHr: activity.averageHeartRateInBeatsPerMinute ?? null,
-      rideType: activity.activityType,
-      notes: activity.activityName ?? null,
-      ...(locationUpdate !== undefined ? { location: locationUpdate } : {}),
-    },
+      { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
+      { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds }
+    );
   });
 
   // Update session's lastActivityReceivedAt if there's a running session
@@ -574,17 +599,19 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
   logger.debug({ summaryId: activity.summaryId }, '[SyncWorker] Upserted Garmin activity');
 
   // Fire-and-forget notifications
-  fireRideNotifications({
-    userId,
-    rideId: ride.id,
-    bikeId: ride.bikeId,
-    durationSeconds: activity.durationInSeconds,
-    distanceMeters,
-    isNewRide,
-  }).catch(() => {}); // swallow - already logged internally
+  if (syncedRideId) {
+    fireRideNotifications({
+      userId,
+      rideId: syncedRideId,
+      bikeId,
+      durationSeconds: activity.durationInSeconds,
+      distanceMeters,
+      isNewRide,
+    }).catch(() => {}); // swallow - already logged internally
 
-  if (isNewRide) {
-    completeReferral(userId).catch(() => {}); // swallow - already logged internally
+    if (isNewRide) {
+      completeReferral(userId).catch(() => {}); // swallow - already logged internally
+    }
   }
 }
 

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -530,14 +530,19 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
   const isNewRide = !existing;
   const locationUpdate = shouldApplyAutoLocation(existing?.location ?? null, autoLocation?.title ?? null);
 
-  // Auto-assign bike if user has exactly one active bike (Garmin has no gear tagging)
+  // Auto-assign bike if user has exactly one active bike (Garmin has no gear tagging).
+  // Only query on new rides — updates preserve the existing bikeId.
   let bikeId: string | null = null;
-  const userBikes = await prisma.bike.findMany({
-    where: { userId, status: 'ACTIVE' },
-    select: { id: true },
-  });
-  if (userBikes.length === 1) {
-    bikeId = userBikes[0].id;
+  let activeBikeCount = 0;
+  if (isNewRide) {
+    const userBikes = await prisma.bike.findMany({
+      where: { userId, status: 'ACTIVE' },
+      select: { id: true },
+    });
+    activeBikeCount = userBikes.length;
+    if (userBikes.length === 1) {
+      bikeId = userBikes[0].id;
+    }
   }
 
   // Look up running ImportSession for this user (if any)
@@ -546,45 +551,52 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
     select: { id: true },
   });
 
-  const { syncedRideId, syncedBikeId } = await prisma.$transaction(async (tx) => {
-    const ride = await tx.ride.upsert({
-      where: { garminActivityId: activity.summaryId },
-      create: {
-        userId,
-        garminActivityId: activity.summaryId,
-        startTime,
-        durationSeconds: activity.durationInSeconds,
-        distanceMeters,
-        elevationGainMeters,
-        averageHr: activity.averageHeartRateInBeatsPerMinute ?? null,
-        rideType: activity.activityType,
-        notes: activity.activityName ?? null,
-        location: autoLocation?.title ?? null,
-        importSessionId: runningSession?.id ?? null,
-        bikeId,
-      },
-      update: {
-        startTime,
-        durationSeconds: activity.durationInSeconds,
-        distanceMeters,
-        elevationGainMeters,
-        averageHr: activity.averageHeartRateInBeatsPerMinute ?? null,
-        rideType: activity.activityType,
-        notes: activity.activityName ?? null,
-        ...(locationUpdate !== undefined ? { location: locationUpdate } : {}),
-      },
-    });
-
-    // Sync component hours
-    await syncBikeComponentHours(
-      tx,
+  // Upsert ride first — this is the primary data, must not be lost
+  const ride = await prisma.ride.upsert({
+    where: { garminActivityId: activity.summaryId },
+    create: {
       userId,
-      { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
-      { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds }
-    );
-
-    return { syncedRideId: ride.id, syncedBikeId: ride.bikeId ?? null };
+      garminActivityId: activity.summaryId,
+      startTime,
+      durationSeconds: activity.durationInSeconds,
+      distanceMeters,
+      elevationGainMeters,
+      averageHr: activity.averageHeartRateInBeatsPerMinute ?? null,
+      rideType: activity.activityType,
+      notes: activity.activityName ?? null,
+      location: autoLocation?.title ?? null,
+      importSessionId: runningSession?.id ?? null,
+      bikeId,
+    },
+    update: {
+      startTime,
+      durationSeconds: activity.durationInSeconds,
+      distanceMeters,
+      elevationGainMeters,
+      averageHr: activity.averageHeartRateInBeatsPerMinute ?? null,
+      rideType: activity.activityType,
+      notes: activity.activityName ?? null,
+      ...(locationUpdate !== undefined ? { location: locationUpdate } : {}),
+    },
   });
+
+  const syncedRideId = ride.id;
+  const syncedBikeId = ride.bikeId ?? null;
+
+  // Sync component hours separately — secondary to recording the ride.
+  // A failure here should not roll back the ride (Garmin won't resend it).
+  try {
+    await prisma.$transaction(async (tx) => {
+      await syncBikeComponentHours(
+        tx,
+        userId,
+        { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
+        { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds }
+      );
+    });
+  } catch (err) {
+    logger.error({ err, userId, rideId: ride.id }, '[SyncWorker] Failed to sync component hours for Garmin activity');
+  }
 
   // Update session's lastActivityReceivedAt if there's a running session
   if (runningSession) {
@@ -605,6 +617,7 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
     distanceMeters,
     isNewRide,
     isBackfill: !!runningSession,
+    activeBikeCount,
   }).catch(() => {}); // swallow - already logged internally
 
   if (isNewRide) {

--- a/apps/web/src/components/GarminImportModal.tsx
+++ b/apps/web/src/components/GarminImportModal.tsx
@@ -22,15 +22,9 @@ interface BackfillRequest {
   completedAt: string | null;
 }
 
-const CURRENT_YEAR = new Date().getFullYear();
-
-// Generate year options: YTD + 5 previous years (current year is redundant with YTD)
-const YEAR_OPTIONS = [
-  { value: 'ytd', label: `Year to Date (${CURRENT_YEAR})` },
-  ...Array.from({ length: 5 }, (_, i) => ({
-    value: String(CURRENT_YEAR - 1 - i),
-    label: String(CURRENT_YEAR - 1 - i),
-  })),
+// Garmin's API only allows backfills for the past 30 days
+const GARMIN_YEAR_OPTIONS = [
+  { value: 'ytd', label: 'Last 30 Days' },
 ];
 
 export default function GarminImportModal({ open, onClose, onSuccess, onDuplicatesFound }: Props) {
@@ -213,13 +207,9 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
         <div className="space-y-6">
           <div>
             <p className="text-sm text-muted mb-4">
-              Select years to import your historical Garmin cycling activities.
+              Import your recent Garmin cycling activities.
               Garmin will send your rides via webhooks, and they'll appear automatically.
             </p>
-
-            <label className="block text-sm font-medium text-muted mb-2">
-              Years to import
-            </label>
 
             {historyLoading ? (
               <div className="flex items-center gap-2 text-sm text-muted py-4">
@@ -227,11 +217,9 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
                 Loading...
               </div>
             ) : (
-              <div className="grid grid-cols-2 gap-2">
-                {YEAR_OPTIONS.map((option) => {
-                  const isBackfilled = backfilledYears.has(option.value);
+              <div className="space-y-3">
+                {GARMIN_YEAR_OPTIONS.map((option) => {
                   const isInProgress = inProgressYears.has(option.value);
-                  const isDisabled = !canSelectYear(option.value);
                   const isSelected = selectedYears.has(option.value);
 
                   return (
@@ -239,8 +227,8 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
                       key={option.value}
                       className={`
                         flex items-center gap-2 p-2.5 rounded-lg border cursor-pointer transition-colors
-                        ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}
-                        ${isSelected && !isDisabled
+                        ${isInProgress ? 'opacity-50 cursor-not-allowed' : ''}
+                        ${isSelected && !isInProgress
                           ? 'border-accent bg-accent/10'
                           : 'border-app hover:border-accent/50'}
                       `}
@@ -248,22 +236,22 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
                       <input
                         type="checkbox"
                         checked={isSelected}
-                        disabled={isDisabled}
-                        onChange={() => !isDisabled && toggleYearSelection(option.value)}
+                        disabled={isInProgress}
+                        onChange={() => !isInProgress && toggleYearSelection(option.value)}
                         className="w-4 h-4 text-accent border-gray-500 focus:ring-accent rounded"
                       />
-                      <span className={`flex-1 text-sm ${isDisabled ? 'text-muted' : 'text-primary'}`}>
+                      <span className={`flex-1 text-sm ${isInProgress ? 'text-muted' : 'text-primary'}`}>
                         {option.label}
                       </span>
-                      {isBackfilled && (
-                        <span title="Already imported"><Check className="w-3 h-3 text-green-400" /></span>
-                      )}
-                      {isInProgress && !isBackfilled && (
+                      {isInProgress && (
                         <div className="w-3 h-3 border border-yellow-400 border-t-transparent rounded-full animate-spin" title="In progress" />
                       )}
                     </label>
                   );
                 })}
+                <p className="text-xs text-muted mt-2">
+                  Garmin limits historical data access to the past 30 days. New rides sync automatically going forward.
+                </p>
               </div>
             )}
 

--- a/apps/web/src/components/GarminImportModal.tsx
+++ b/apps/web/src/components/GarminImportModal.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useMemo } from 'react';
-import { Check } from 'lucide-react';
 import { Modal, Button } from './ui';
 import { getAuthHeaders } from '@/lib/csrf';
 
@@ -36,20 +35,6 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
   const [historyLoading, setHistoryLoading] = useState(true);
   const [duplicatesFound, setDuplicatesFound] = useState(0);
 
-  // Get years that are already backfilled (YTD is always allowed - incremental)
-  const backfilledYears = useMemo(() => {
-    return new Set(
-      backfillHistory
-        .filter(
-          (req) =>
-            req.provider === 'garmin' &&
-            req.year !== 'ytd' && // YTD is always allowed (incremental)
-            req.status !== 'failed' // Failed can be retried
-        )
-        .map((req) => req.year)
-    );
-  }, [backfillHistory]);
-
   // Get years that are in progress
   const inProgressYears = useMemo(() => {
     return new Set(
@@ -62,14 +47,6 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
         .map((req) => req.year)
     );
   }, [backfillHistory]);
-
-  // Helper to check if a year can be selected
-  const canSelectYear = (year: string): boolean => {
-    if (year === 'ytd') {
-      return !inProgressYears.has('ytd');
-    }
-    return !backfilledYears.has(year) && !inProgressYears.has(year);
-  };
 
   // Toggle year selection
   const toggleYearSelection = (year: string) => {

--- a/apps/web/src/components/onboarding/ImportRidesForm.test.tsx
+++ b/apps/web/src/components/onboarding/ImportRidesForm.test.tsx
@@ -157,80 +157,6 @@ describe('ImportRidesForm', () => {
         json: () => Promise.resolve({
           success: true,
           requests: [
-            { id: '1', provider: 'garmin', year: '2024', status: 'completed', ridesFound: 50 },
-            { id: '2', provider: 'garmin', year: 'ytd', status: 'in_progress', ridesFound: null },
-          ],
-        }),
-      });
-
-      render(<ImportRidesForm connectedProviders={['garmin']} />);
-
-      fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
-
-      await waitFor(() => {
-        // Check for the "Previously requested" section which contains history pills
-        expect(screen.getByText('Previously requested')).toBeInTheDocument();
-        // Use getAllByText since there are now multiple "2024" elements (checkbox label + history pill)
-        const elements2024 = screen.getAllByText('2024');
-        expect(elements2024.length).toBeGreaterThanOrEqual(2); // checkbox label + pill
-        // YTD appears in checkbox label and as history pill
-        const ytdElements = screen.getAllByText('YTD');
-        expect(ytdElements.length).toBeGreaterThanOrEqual(1);
-      });
-    });
-
-    it('shows checkmark for completed years (Garmin)', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({
-          success: true,
-          requests: [
-            { id: '1', provider: 'garmin', year: '2024', status: 'completed', ridesFound: 50 },
-          ],
-        }),
-      });
-
-      render(<ImportRidesForm connectedProviders={['garmin']} />);
-
-      fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
-
-      await waitFor(() => {
-        // Garmin uses checkboxes - completed year checkbox should be disabled
-        const checkbox2024 = screen.getByRole('checkbox', { name: /2024/i });
-        expect(checkbox2024).toBeDisabled();
-      });
-    });
-  });
-
-  describe('Duplicate Prevention (Garmin)', () => {
-    it('disables checkbox for already backfilled year', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({
-          success: true,
-          requests: [
-            { id: '1', provider: 'garmin', year: '2024', status: 'completed', ridesFound: 50 },
-          ],
-        }),
-      });
-
-      render(<ImportRidesForm connectedProviders={['garmin']} />);
-
-      fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
-
-      await waitFor(() => {
-        // Garmin uses checkboxes - completed year checkbox should be disabled
-        const checkbox2024 = screen.getByRole('checkbox', { name: /2024/i });
-        expect(checkbox2024).toBeDisabled();
-      });
-    });
-
-    it('allows YTD even if previously backfilled (incremental)', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({
-          success: true,
-          requests: [
             { id: '1', provider: 'garmin', year: 'ytd', status: 'completed', ridesFound: 50 },
           ],
         }),
@@ -241,13 +167,48 @@ describe('ImportRidesForm', () => {
       fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
 
       await waitFor(() => {
-        // YTD checkbox should be enabled even after previous backfill (incremental)
-        const ytdCheckbox = screen.getByRole('checkbox', { name: /Year to Date/i });
-        expect(ytdCheckbox).not.toBeDisabled();
+        expect(screen.getByText('Previously requested')).toBeInTheDocument();
       });
     });
 
-    it('disables YTD checkbox when already in progress', async () => {
+    it('shows Garmin restriction note', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true, requests: [] }),
+      });
+
+      render(<ImportRidesForm connectedProviders={['garmin']} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Garmin limits historical data access/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Garmin Last 30 Days', () => {
+    it('shows Last 30 Days as the only Garmin option', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true, requests: [] }),
+      });
+
+      render(<ImportRidesForm connectedProviders={['garmin']} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
+
+      await waitFor(() => {
+        const checkbox = screen.getByRole('checkbox', { name: /Last 30 Days/i });
+        expect(checkbox).toBeInTheDocument();
+      });
+
+      // Should not have year checkboxes
+      expect(screen.queryByRole('checkbox', { name: /2024/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('checkbox', { name: /2025/i })).not.toBeInTheDocument();
+    });
+
+    it('disables Last 30 Days checkbox when in progress', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({
@@ -263,19 +224,18 @@ describe('ImportRidesForm', () => {
       fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
 
       await waitFor(() => {
-        // YTD checkbox should be disabled when in progress
-        const ytdCheckbox = screen.getByRole('checkbox', { name: /Year to Date/i });
-        expect(ytdCheckbox).toBeDisabled();
+        const checkbox = screen.getByRole('checkbox', { name: /Last 30 Days/i });
+        expect(checkbox).toBeDisabled();
       });
     });
 
-    it('allows retry for failed backfills', async () => {
+    it('enables Last 30 Days checkbox when not in progress', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({
           success: true,
           requests: [
-            { id: '1', provider: 'garmin', year: '2024', status: 'failed', ridesFound: null },
+            { id: '1', provider: 'garmin', year: 'ytd', status: 'completed', ridesFound: 50 },
           ],
         }),
       });
@@ -285,9 +245,8 @@ describe('ImportRidesForm', () => {
       fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
 
       await waitFor(() => {
-        // Failed year checkbox should be enabled for retry
-        const checkbox2024 = screen.getByRole('checkbox', { name: /2024/i });
-        expect(checkbox2024).not.toBeDisabled();
+        const checkbox = screen.getByRole('checkbox', { name: /Last 30 Days/i });
+        expect(checkbox).not.toBeDisabled();
       });
     });
   });

--- a/apps/web/src/components/onboarding/ImportRidesForm.tsx
+++ b/apps/web/src/components/onboarding/ImportRidesForm.tsx
@@ -98,14 +98,6 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
     );
   }, [backfillHistory, selectedProvider, selectedYear]);
 
-  // Helper to check if a year can be selected for Garmin
-  const canSelectYear = (year: string): boolean => {
-    if (year === 'ytd') {
-      return !garminInProgressYears.has('ytd');
-    }
-    return !garminBackfilledYears.has(year) && !garminInProgressYears.has(year);
-  };
-
   // Toggle year selection for Garmin multi-select
   const toggleYearSelection = (year: string) => {
     setSelectedYears((prev) => {

--- a/apps/web/src/components/onboarding/ImportRidesForm.tsx
+++ b/apps/web/src/components/onboarding/ImportRidesForm.tsx
@@ -57,20 +57,6 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
   const [backfillHistory, setBackfillHistory] = useState<BackfillRequest[]>([]);
   const [historyLoading, setHistoryLoading] = useState(true);
 
-  // Get years that are already backfilled for Garmin (YTD is always allowed - incremental)
-  const garminBackfilledYears = useMemo(() => {
-    return new Set(
-      backfillHistory
-        .filter(
-          (req) =>
-            req.provider === 'garmin' &&
-            req.year !== 'ytd' && // YTD is always allowed (incremental)
-            req.status !== 'failed' // Failed can be retried
-        )
-        .map((req) => req.year)
-    );
-  }, [backfillHistory]);
-
   // Get years that are in progress for Garmin
   const garminInProgressYears = useMemo(() => {
     return new Set(
@@ -83,12 +69,6 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
         .map((req) => req.year)
     );
   }, [backfillHistory]);
-
-  // Check if the selected year is already backfilled (Garmin only, for single-select compatibility)
-  const isYearAlreadyBackfilled =
-    selectedProvider === 'garmin' &&
-    selectedYear !== 'ytd' &&
-    garminBackfilledYears.has(selectedYear);
 
   // Check if YTD is currently in progress (Garmin only - blocks re-triggering)
   const isYtdInProgress = useMemo(() => {
@@ -473,14 +453,14 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
               !selectedProvider ||
               importState === 'loading' ||
               (selectedProvider === 'garmin' && selectableYearsCount === 0) ||
-              (selectedProvider === 'strava' && (isYearAlreadyBackfilled || isYtdInProgress))
+              (selectedProvider === 'strava' && isYtdInProgress)
             }
             className={`
               w-full py-3 px-4 rounded-lg text-sm font-medium transition-all
               ${!selectedProvider ||
                 importState === 'loading' ||
                 (selectedProvider === 'garmin' && selectableYearsCount === 0) ||
-                (selectedProvider === 'strava' && (isYearAlreadyBackfilled || isYtdInProgress))
+                (selectedProvider === 'strava' && isYtdInProgress)
                 ? 'bg-gray-300 dark:bg-gray-700 text-gray-500 cursor-not-allowed'
                 : 'bg-accent text-white hover:bg-accent-hover'}
             `}
@@ -489,13 +469,11 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
               ? 'Importing...'
               : selectedProvider === 'garmin'
                 ? selectableYearsCount === 0
-                  ? 'Select years to import'
-                  : `Start Import (${selectableYearsCount} ${selectableYearsCount === 1 ? 'year' : 'years'})`
+                  ? 'Select a period to import'
+                  : 'Start Import'
                 : isYtdInProgress
                   ? 'Import In Progress'
-                  : isYearAlreadyBackfilled
-                    ? 'Already Imported'
-                    : 'Start Import'}
+                  : 'Start Import'}
           </button>
         </div>
       )}

--- a/apps/web/src/components/onboarding/ImportRidesForm.tsx
+++ b/apps/web/src/components/onboarding/ImportRidesForm.tsx
@@ -27,13 +27,18 @@ interface BackfillRequest {
 
 const CURRENT_YEAR = new Date().getFullYear();
 
-// Generate year options: YTD + 5 previous years (current year is redundant with YTD)
-const YEAR_OPTIONS = [
+// Strava allows full historical backfills
+const STRAVA_YEAR_OPTIONS = [
   { value: 'ytd', label: `Year to Date (${CURRENT_YEAR})` },
   ...Array.from({ length: 5 }, (_, i) => ({
     value: String(CURRENT_YEAR - 1 - i),
     label: String(CURRENT_YEAR - 1 - i),
   })),
+];
+
+// Garmin limits historical data access to the past 30 days
+const GARMIN_YEAR_OPTIONS = [
+  { value: 'ytd', label: 'Last 30 Days' },
 ];
 
 const PROVIDER_LABELS: Record<string, string> = {
@@ -352,16 +357,15 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
           {/* Year selector - Garmin uses multi-select checkboxes, Strava uses dropdown */}
           <div className="space-y-2">
             <label className="block text-sm font-medium text-muted">
-              {selectedProvider === 'garmin' ? 'Years to import' : 'Year to import'}
+              {selectedProvider === 'garmin' ? 'Import period' : 'Year to import'}
             </label>
 
             {selectedProvider === 'garmin' ? (
-              // Multi-select checkbox grid for Garmin
-              <div className="grid grid-cols-2 gap-2">
-                {YEAR_OPTIONS.map((option) => {
-                  const isBackfilled = garminBackfilledYears.has(option.value);
+              // Garmin: restricted to last 30 days
+              <div className="space-y-3">
+                {GARMIN_YEAR_OPTIONS.map((option) => {
                   const isInProgress = garminInProgressYears.has(option.value);
-                  const isDisabled = !canSelectYear(option.value) || importState === 'loading';
+                  const isDisabled = isInProgress || importState === 'loading';
                   const isSelected = selectedYears.has(option.value);
 
                   return (
@@ -385,25 +389,25 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
                       <span className={`flex-1 text-sm ${isDisabled ? 'text-muted' : 'text-primary'}`}>
                         {option.label}
                       </span>
-                      {isBackfilled && (
-                        <span title="Already imported"><Check className="w-3 h-3 text-green-400" /></span>
-                      )}
-                      {isInProgress && !isBackfilled && (
+                      {isInProgress && (
                         <div className="w-3 h-3 border border-yellow-400 border-t-transparent rounded-full animate-spin" title="In progress" />
                       )}
                     </label>
                   );
                 })}
+                <p className="text-xs text-muted">
+                  Garmin limits historical data access to the past 30 days. New rides sync automatically going forward.
+                </p>
               </div>
             ) : (
-              // Single-select dropdown for Strava
+              // Strava: full year selection
               <select
                 value={selectedYear}
                 onChange={(e) => setSelectedYear(e.target.value)}
                 className="w-full input-soft"
                 disabled={importState === 'loading'}
               >
-                {YEAR_OPTIONS.map((option) => (
+                {STRAVA_YEAR_OPTIONS.map((option) => (
                   <option key={option.value} value={option.value}>
                     {option.label}
                   </option>


### PR DESCRIPTION
## Summary

Fix Garmin ride import to match Strava/WHOOP behavior (auto-assign bikes, track component hours), add push notification for unassigned rides, and restore missing rate limit configs.

## Changes

### Garmin auto-assignment and component hours
- Add single-bike auto-assignment to `upsertGarminActivity` in sync worker. Users with one active bike now get Garmin rides automatically assigned, matching Strava and WHOOP behavior.
- Wrap Garmin upsert in a transaction with `syncBikeComponentHours` so component wear hours are tracked when a bike is assigned. Previously Garmin rides never contributed to component hours.
- Expand the existing ride select to include `bikeId` and `durationSeconds` for the component hours sync.

### Unassigned ride notification
- Add push notification in `fireRideNotifications` for multi-bike users when a ride is imported without a bike. Sends "Assign a Bike" with a deep link to the ride screen.
- Only fires for users with >1 active bikes (single-bike users get auto-assignment instead).

### Rate limit config fix
- Restore `updateUserPreferences` and `updateBikeNotificationPreference` rate limit entries that were accidentally removed. Without these, the resolvers crashed with `Cannot read properties of undefined (reading 'maxRequests')` when updating notification preferences.

## Test plan

- [ ] All 1113 API tests pass
- [ ] Garmin ride syncs with single bike: ride auto-assigned, component hours updated
- [ ] Garmin ride syncs with multiple bikes: ride unassigned, push notification sent
- [ ] Notification preferences toggle works without error in mobile settings
- [ ] User preferences update works without error
