### PR TITLE
Feat/mobile launch prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,19 @@ jobs:
       - name: Type check affected projects
         run: npx nx affected -t type-check --parallel=3 || echo "No type-check target defined"
 
+      - name: Compute Sentry release (short git SHA)
+        id: sentry-release
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Build affected projects
+        # SENTRY_AUTH_TOKEN enables @sentry/vite-plugin to upload source maps
+        # during the build. Without it the plugin is a no-op (disable: !token).
+        # SENTRY_RELEASE tags the uploaded maps so they bind to the matching
+        # runtime release in each app's Sentry.init.
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_RELEASE: ${{ steps.sentry-release.outputs.sha }}
+          VITE_SENTRY_RELEASE: ${{ steps.sentry-release.outputs.sha }}
         run: npx nx affected -t build --parallel=3 --verbose
 
       - name: Verify API build has no orphan SSR chunks

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -58,6 +58,7 @@
     "@eslint/js": "^9.39.4",
     "@nx/esbuild": "^22.6.1",
     "@nx/vite": "^22.6.1",
+    "@sentry/vite-plugin": "^5.2.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/body-parser": "^1.19.6",
     "@types/cookie-parser": "^1.4.10",

--- a/apps/api/prisma/migrations/20260413192202_add_password_reset_tokens/migration.sql
+++ b/apps/api/prisma/migrations/20260413192202_add_password_reset_tokens/migration.sql
@@ -1,0 +1,29 @@
+-- AlterEnum
+ALTER TYPE "EmailType" ADD VALUE 'password_reset';
+
+-- AlterEnum
+ALTER TYPE "TriggerSource" ADD VALUE 'admin_password_reset';
+
+-- CreateTable
+CREATE TABLE "PasswordResetToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PasswordResetToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PasswordResetToken_tokenHash_key" ON "PasswordResetToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "PasswordResetToken_userId_idx" ON "PasswordResetToken"("userId");
+
+-- CreateIndex
+CREATE INDEX "PasswordResetToken_expiresAt_idx" ON "PasswordResetToken"("expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "PasswordResetToken" ADD CONSTRAINT "PasswordResetToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
   whoopUserId         String?             @unique
   role                UserRole            @default(WAITLIST)
   mustChangePassword  Boolean             @default(false)
+  sessionTokenVersion Int                 @default(0)
   activatedAt         DateTime?
   activatedBy         String?
   isFoundingRider     Boolean             @default(false)
@@ -63,6 +64,7 @@ model User {
   notificationLogs    NotificationLog[]
   referralsMade       Referral[]          @relation("ReferralsMade")
   referralReceived    Referral?           @relation("ReferralReceived")
+  passwordResetTokens PasswordResetToken[]
 
   // Push notification preferences
   expoPushToken       String?
@@ -435,6 +437,7 @@ enum EmailType {
   beta_feature_roundup
   password_added
   password_changed
+  password_reset
   upgrade_confirmation
   downgrade_notice
   payment_failed
@@ -444,6 +447,7 @@ enum EmailType {
 
 enum TriggerSource {
   admin_manual
+  admin_password_reset
   system_activation
   system_welcome_series
   scheduled
@@ -675,6 +679,19 @@ model NotificationLog {
   @@index([userId])
   @@index([componentId])
   @@index([bikeId])
+}
+
+model PasswordResetToken {
+  id        String    @id @default(cuid())
+  userId    String
+  tokenHash String    @unique
+  expiresAt DateTime
+  usedAt    DateTime?
+  createdAt DateTime  @default(now())
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([expiresAt])
 }
 
 model Referral {

--- a/apps/api/src/auth/email.route.test.ts
+++ b/apps/api/src/auth/email.route.test.ts
@@ -1,0 +1,427 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+// Mock dependencies BEFORE importing the router
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    user: { findUnique: jest.fn(), update: jest.fn() },
+  },
+}));
+
+jest.mock('../lib/rate-limit', () => ({
+  checkAuthRateLimit: jest.fn().mockResolvedValue({ allowed: true, redisAvailable: true }),
+  checkMutationRateLimit: jest.fn().mockResolvedValue({ allowed: true, redisAvailable: true }),
+}));
+
+jest.mock('./password.utils', () => ({
+  validatePassword: jest.fn().mockReturnValue({ isValid: true }),
+  hashPassword: jest.fn().mockResolvedValue('hashed_new_password'),
+  verifyPassword: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('./email.utils', () => ({
+  validateEmailFormat: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('./utils', () => ({
+  normalizeEmail: jest.fn((e: string) => e.trim().toLowerCase()),
+  getClientIp: jest.fn().mockReturnValue('1.2.3.4'),
+}));
+
+jest.mock('./session', () => ({
+  setSessionCookie: jest.fn(),
+  clearSessionCookie: jest.fn(),
+}));
+
+jest.mock('./session-issuer', () => ({
+  issueWebSession: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('./csrf', () => ({
+  setCsrfCookie: jest.fn().mockReturnValue('csrf_token'),
+}));
+
+jest.mock('./recent-auth', () => ({
+  updateLastAuthAt: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('./requireRecentAuth', () => ({
+  requireRecentAuth: (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+jest.mock('../services/password-notification.service', () => ({
+  sendPasswordChangedNotification: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../services/password-reset.service', () => ({
+  consumePasswordResetToken: jest.fn(),
+  createPasswordResetToken: jest.fn(),
+  sendPasswordResetEmail: jest.fn(),
+}));
+
+jest.mock('../services/signup.service', () => ({
+  createNewUser: jest.fn(),
+  verifyEmailAvailable: jest.fn(),
+}));
+
+jest.mock('../lib/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+import router from './email.route';
+import { prisma } from '../lib/prisma';
+import { checkAuthRateLimit } from '../lib/rate-limit';
+import {
+  consumePasswordResetToken,
+  createPasswordResetToken,
+  sendPasswordResetEmail,
+} from '../services/password-reset.service';
+import { validateEmailFormat } from './email.utils';
+import { hashPassword, validatePassword } from './password.utils';
+import { logger } from '../lib/logger';
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockUserFindUnique = mockPrisma.user.findUnique as unknown as jest.Mock;
+const mockUserUpdate = mockPrisma.user.update as unknown as jest.Mock;
+const mockCheckAuthRateLimit = checkAuthRateLimit as jest.Mock;
+const mockConsumeToken = consumePasswordResetToken as jest.Mock;
+const mockCreateToken = createPasswordResetToken as jest.Mock;
+const mockSendEmail = sendPasswordResetEmail as jest.Mock;
+const mockValidateEmailFormat = validateEmailFormat as jest.Mock;
+const mockHashPassword = hashPassword as jest.Mock;
+const mockValidatePassword = validatePassword as jest.Mock;
+const mockLoggerWarn = logger.warn as unknown as jest.Mock;
+const mockLoggerDebug = logger.debug as unknown as jest.Mock;
+
+interface RouteLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: RequestHandler }>;
+  };
+}
+
+function getHandler(path: string, method: string): RequestHandler | undefined {
+  const routerStack = (router as unknown as { stack: RouteLayer[] }).stack;
+  const layer = routerStack.find((l) => l.route?.path === path && l.route?.methods?.[method]);
+  const handlers = layer?.route?.stack;
+  return handlers?.[handlers.length - 1]?.handle;
+}
+
+async function invokeHandler(
+  h: RequestHandler | undefined,
+  req: Request,
+  res: Response,
+): Promise<void> {
+  if (!h) throw new Error('Handler not found');
+  await h(req, res, jest.fn() as NextFunction);
+}
+
+function createMockResponse() {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+    cookie: jest.fn().mockReturnThis(),
+    clearCookie: jest.fn().mockReturnThis(),
+  };
+  return res;
+}
+
+function createMockRequest(overrides: Partial<Request> = {}): Partial<Request> {
+  return {
+    body: {},
+    headers: {},
+    cookies: {},
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCheckAuthRateLimit.mockResolvedValue({ allowed: true });
+  mockValidateEmailFormat.mockReturnValue(true);
+  mockValidatePassword.mockReturnValue({ isValid: true });
+  mockHashPassword.mockResolvedValue('hashed_new_password');
+});
+
+// ============================================================================
+// POST /forgot-password
+// ============================================================================
+
+describe('POST /forgot-password', () => {
+  let handler: RequestHandler | undefined;
+
+  beforeAll(() => {
+    handler = getHandler('/forgot-password', 'post');
+    if (!handler) throw new Error('Handler not found for /forgot-password');
+  });
+
+  describe('Rate limiting', () => {
+    it('returns 429 when per-IP rate limit is exceeded', async () => {
+      mockCheckAuthRateLimit.mockResolvedValue({ allowed: false, retryAfter: 60 });
+      const req = createMockRequest({ body: { email: 'rider@example.com' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(429);
+      expect(mockCreateToken).not.toHaveBeenCalled();
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Enumeration resistance (always 200)', () => {
+    it('returns 200 + no email send when the email does not match any user', async () => {
+      mockUserFindUnique.mockResolvedValue(null);
+      const req = createMockRequest({ body: { email: 'nobody@example.com' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.json).toHaveBeenCalledWith({ ok: true });
+      expect(mockCreateToken).not.toHaveBeenCalled();
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 when the email fails format validation (no token created)', async () => {
+      mockValidateEmailFormat.mockReturnValue(false);
+      const req = createMockRequest({ body: { email: 'not-an-email' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.json).toHaveBeenCalledWith({ ok: true });
+      expect(mockUserFindUnique).not.toHaveBeenCalled();
+      expect(mockCreateToken).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 even if the email-send step throws (no leak of failure state)', async () => {
+      mockUserFindUnique.mockResolvedValue({
+        id: 'user_1',
+        email: 'rider@example.com',
+        name: 'Alex',
+      });
+      mockCreateToken.mockResolvedValue('raw-token');
+      mockSendEmail.mockRejectedValue(new Error('Resend down'));
+
+      const req = createMockRequest({ body: { email: 'rider@example.com' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.json).toHaveBeenCalledWith({ ok: true });
+    });
+  });
+
+  describe('Validation', () => {
+    it('returns 400 when email is missing from body', async () => {
+      const req = createMockRequest({ body: {} });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('Happy path', () => {
+    it('creates a token, sends the email, and returns 200 for a known user', async () => {
+      mockUserFindUnique.mockResolvedValue({
+        id: 'user_1',
+        email: 'rider@example.com',
+        name: 'Alex Example',
+      });
+      mockCreateToken.mockResolvedValue('raw-token-abc');
+
+      const req = createMockRequest({ body: { email: 'rider@example.com' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(mockCreateToken).toHaveBeenCalledWith('user_1');
+      expect(mockSendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'user_1', email: 'rider@example.com' }),
+        'raw-token-abc',
+        'user_action',
+      );
+      expect(res.json).toHaveBeenCalledWith({ ok: true });
+    });
+  });
+});
+
+// ============================================================================
+// POST /reset-password
+// ============================================================================
+
+describe('POST /reset-password', () => {
+  let handler: RequestHandler | undefined;
+
+  beforeAll(() => {
+    handler = getHandler('/reset-password', 'post');
+    if (!handler) throw new Error('Handler not found for /reset-password');
+  });
+
+  describe('Rate limiting', () => {
+    it('returns 429 when per-IP rate limit is exceeded', async () => {
+      mockCheckAuthRateLimit.mockResolvedValue({ allowed: false, retryAfter: 60 });
+      const req = createMockRequest({ body: { token: 't', newPassword: 'NewPass123!' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(429);
+      expect(mockConsumeToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Validation', () => {
+    it('returns 400 when the token is missing', async () => {
+      const req = createMockRequest({ body: { newPassword: 'NewPass123!' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockConsumeToken).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the new password is missing', async () => {
+      const req = createMockRequest({ body: { token: 't' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockConsumeToken).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the password fails strength validation (before touching the token)', async () => {
+      mockValidatePassword.mockReturnValue({ isValid: false, error: 'Too short' });
+      const req = createMockRequest({ body: { token: 't', newPassword: 'weak' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockConsumeToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Token states', () => {
+    it('returns TOKEN_INVALID (400) when the token is not found — no warn log', async () => {
+      mockConsumeToken.mockResolvedValue({ ok: false, reason: 'not_found' });
+      const req = createMockRequest({ body: { token: 't', newPassword: 'NewPass123!' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'TOKEN_INVALID' }),
+      );
+      expect(mockLoggerWarn).not.toHaveBeenCalled();
+    });
+
+    it('returns TOKEN_INVALID (400) when the token was already used — warns with userId + clientIp', async () => {
+      mockConsumeToken.mockResolvedValue({
+        ok: false,
+        reason: 'already_used',
+        userId: 'user_42',
+      });
+      const req = createMockRequest({ body: { token: 't', newPassword: 'NewPass123!' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      // Client-side code stays generic — no enumeration leak.
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'TOKEN_INVALID' }),
+      );
+      // Server-side: security audit log fires.
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user_42', clientIp: '1.2.3.4' }),
+        expect.stringContaining('reuse'),
+      );
+    });
+
+    it('returns TOKEN_EXPIRED (400) when the token is past its expiry — no warn log', async () => {
+      mockConsumeToken.mockResolvedValue({ ok: false, reason: 'expired' });
+      const req = createMockRequest({ body: { token: 't', newPassword: 'NewPass123!' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'TOKEN_EXPIRED' }),
+      );
+      expect(mockLoggerWarn).not.toHaveBeenCalled();
+    });
+
+    it('returns TOKEN_EXPIRED (400) for race_expired and logs at debug (not warn)', async () => {
+      mockConsumeToken.mockResolvedValue({
+        ok: false,
+        reason: 'race_expired',
+        userId: 'user_11',
+      });
+      const req = createMockRequest({ body: { token: 't', newPassword: 'NewPass123!' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'TOKEN_EXPIRED' }),
+      );
+      // Benign case — should NOT trigger the security-alert warn log.
+      expect(mockLoggerWarn).not.toHaveBeenCalled();
+      expect(mockLoggerDebug).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user_11' }),
+        expect.any(String),
+      );
+    });
+  });
+
+  describe('Happy path', () => {
+    it('hashes the new password, bumps sessionTokenVersion, and returns 200', async () => {
+      mockConsumeToken.mockResolvedValue({ ok: true, userId: 'user_1' });
+      mockUserFindUnique.mockResolvedValue({
+        id: 'user_1',
+        email: 'rider@example.com',
+        name: 'Alex',
+      });
+      mockUserUpdate.mockResolvedValue({});
+
+      const req = createMockRequest({ body: { token: 't', newPassword: 'NewPass123!' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(mockHashPassword).toHaveBeenCalledWith('NewPass123!');
+      expect(mockUserUpdate).toHaveBeenCalledWith({
+        where: { id: 'user_1' },
+        data: {
+          passwordHash: 'hashed_new_password',
+          mustChangePassword: false,
+          sessionTokenVersion: { increment: 1 },
+        },
+      });
+      expect(res.json).toHaveBeenCalledWith({ ok: true });
+    });
+
+    it('defensively rejects if the user has vanished between token consumption and update', async () => {
+      mockConsumeToken.mockResolvedValue({ ok: true, userId: 'ghost_user' });
+      mockUserFindUnique.mockResolvedValue(null);
+
+      const req = createMockRequest({ body: { token: 't', newPassword: 'NewPass123!' } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockUserUpdate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/auth/email.route.test.ts
+++ b/apps/api/src/auth/email.route.test.ts
@@ -90,7 +90,7 @@ const mockValidateEmailFormat = validateEmailFormat as jest.Mock;
 const mockHashPassword = hashPassword as jest.Mock;
 const mockValidatePassword = validatePassword as jest.Mock;
 const mockLoggerWarn = logger.warn as unknown as jest.Mock;
-const mockLoggerDebug = logger.debug as unknown as jest.Mock;
+const mockLoggerInfo = logger.info as unknown as jest.Mock;
 
 interface RouteLayer {
   route?: {
@@ -360,7 +360,7 @@ describe('POST /reset-password', () => {
       expect(mockLoggerWarn).not.toHaveBeenCalled();
     });
 
-    it('returns TOKEN_EXPIRED (400) for race_expired and logs at debug (not warn)', async () => {
+    it('returns TOKEN_EXPIRED (400) for race_expired and logs at info (not warn, not debug)', async () => {
       mockConsumeToken.mockResolvedValue({
         ok: false,
         reason: 'race_expired',
@@ -375,9 +375,10 @@ describe('POST /reset-password', () => {
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({ code: 'TOKEN_EXPIRED' }),
       );
-      // Benign case — should NOT trigger the security-alert warn log.
+      // Benign case — should NOT trigger the security-alert warn log, but
+      // should still be visible in production log pipelines (hence info, not debug).
       expect(mockLoggerWarn).not.toHaveBeenCalled();
-      expect(mockLoggerDebug).toHaveBeenCalledWith(
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
         expect.objectContaining({ userId: 'user_11' }),
         expect.any(String),
       );

--- a/apps/api/src/auth/email.route.ts
+++ b/apps/api/src/auth/email.route.ts
@@ -349,16 +349,23 @@ router.post('/reset-password', express.json(), async (req, res) => {
     if (!result.ok) {
       // Reuse of an already-consumed token is a signal the reset email may have
       // leaked — log it server-side without tipping off the client.
+      // `race_expired` is the benign "expired between read and write" case,
+      // logged at debug rather than warn to avoid false-positive alerts.
       if (result.reason === 'already_used') {
         logger.warn(
           { userId: result.userId, clientIp },
           '[EmailAuth] Password reset token reuse attempted',
         );
+      } else if (result.reason === 'race_expired') {
+        logger.debug(
+          { userId: result.userId, clientIp },
+          '[EmailAuth] Password reset token expired during consumption',
+        );
       }
       // Distinguish expired vs invalid so the client can show a dedicated
       // "request a new link" screen for expired tokens. not_found and
       // already_used collapse into a single generic code to avoid enumeration.
-      if (result.reason === 'expired') {
+      if (result.reason === 'expired' || result.reason === 'race_expired') {
         return sendBadRequest(res, 'Reset link has expired', 'TOKEN_EXPIRED');
       }
       return sendBadRequest(res, 'Reset link is invalid or has expired', 'TOKEN_INVALID');

--- a/apps/api/src/auth/email.route.ts
+++ b/apps/api/src/auth/email.route.ts
@@ -10,7 +10,11 @@ import { prisma } from '../lib/prisma';
 import { sendBadRequest, sendUnauthorized, sendForbidden, sendConflict, sendInternalError, sendTooManyRequests } from '../lib/api-response';
 import { checkAuthRateLimit, checkMutationRateLimit } from '../lib/rate-limit';
 import { sendPasswordChangedNotification } from '../services/password-notification.service';
-import { consumePasswordResetToken } from '../services/password-reset.service';
+import {
+  consumePasswordResetToken,
+  createPasswordResetToken,
+  sendPasswordResetEmail,
+} from '../services/password-reset.service';
 import { logger } from '../lib/logger';
 import { config } from '../config/env';
 import { createNewUser, verifyEmailAvailable } from '../services/signup.service';
@@ -263,6 +267,58 @@ router.post('/change-password', express.json(), requireRecentAuth, async (req, r
 });
 
 /**
+ * POST /auth/forgot-password
+ * Start a self-service password reset. Emails a reset link to the user if the
+ * address is on file.
+ *
+ * Always returns 200 regardless of whether the email matches a user — this
+ * prevents email enumeration via the response.
+ */
+router.post('/forgot-password', express.json(), async (req, res) => {
+  try {
+    const clientIp = getClientIp(req);
+    const rateLimit = await checkAuthRateLimit('forgot-password', clientIp);
+    if (!rateLimit.allowed) {
+      return sendTooManyRequests(res, 'Too many attempts. Please try again later.', rateLimit.retryAfter);
+    }
+
+    const { email: rawEmail } = req.body as { email?: string };
+
+    if (!rawEmail) {
+      return sendBadRequest(res, 'Email is required');
+    }
+
+    const email = normalizeEmail(rawEmail);
+    if (!email || !validateEmailFormat(email)) {
+      // Still return 200 to avoid leaking which strings are valid emails on file.
+      return res.json({ ok: true });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { email },
+      select: { id: true, email: true, name: true },
+    });
+
+    if (user) {
+      try {
+        const rawToken = await createPasswordResetToken(user.id);
+        await sendPasswordResetEmail(user, rawToken, 'user_action');
+      } catch (err) {
+        // Log but still return 200 — we don't want the client to infer anything
+        // from timing or error state.
+        logger.error({ err, userId: user.id }, '[EmailAuth] Forgot password email send failed');
+      }
+    }
+
+    res.json({ ok: true });
+  } catch (e) {
+    logger.error({ err: e }, '[EmailAuth] Forgot password failed');
+    // Return 200 anyway — failure modes here shouldn't be distinguishable from success.
+    res.json({ ok: true });
+  }
+});
+
+/**
  * POST /auth/reset-password
  * Complete a password reset using a token emailed to the user.
  * This endpoint is unauthenticated — the reset token is the authorization.
@@ -291,7 +347,21 @@ router.post('/reset-password', express.json(), async (req, res) => {
 
     const result = await consumePasswordResetToken(token);
     if (!result.ok) {
-      return sendBadRequest(res, 'Reset link is invalid or has expired');
+      // Reuse of an already-consumed token is a signal the reset email may have
+      // leaked — log it server-side without tipping off the client.
+      if (result.reason === 'already_used') {
+        logger.warn(
+          { userId: result.userId, clientIp: getClientIp(req) },
+          '[EmailAuth] Password reset token reuse attempted',
+        );
+      }
+      // Distinguish expired vs invalid so the client can show a dedicated
+      // "request a new link" screen for expired tokens. not_found and
+      // already_used collapse into a single generic code to avoid enumeration.
+      if (result.reason === 'expired') {
+        return sendBadRequest(res, 'Reset link has expired', 'TOKEN_EXPIRED');
+      }
+      return sendBadRequest(res, 'Reset link is invalid or has expired', 'TOKEN_INVALID');
     }
 
     const user = await prisma.user.findUnique({

--- a/apps/api/src/auth/email.route.ts
+++ b/apps/api/src/auth/email.route.ts
@@ -347,17 +347,18 @@ router.post('/reset-password', express.json(), async (req, res) => {
 
     const result = await consumePasswordResetToken(token);
     if (!result.ok) {
-      // Reuse of an already-consumed token is a signal the reset email may have
-      // leaked — log it server-side without tipping off the client.
-      // `race_expired` is the benign "expired between read and write" case,
-      // logged at debug rather than warn to avoid false-positive alerts.
+      // Reuse of an already-consumed token is a signal the reset email may
+      // have leaked — warn-level so it surfaces on the security channel.
+      // `race_expired` is the benign "expired between read and write" case —
+      // info-level so it's visible for debugging concurrent-submission
+      // behavior without triggering on-call alerts.
       if (result.reason === 'already_used') {
         logger.warn(
           { userId: result.userId, clientIp },
           '[EmailAuth] Password reset token reuse attempted',
         );
       } else if (result.reason === 'race_expired') {
-        logger.debug(
+        logger.info(
           { userId: result.userId, clientIp },
           '[EmailAuth] Password reset token expired during consumption',
         );

--- a/apps/api/src/auth/email.route.ts
+++ b/apps/api/src/auth/email.route.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import { normalizeEmail, getClientIp } from './utils';
 import { hashPassword, verifyPassword, validatePassword } from './password.utils';
 import { validateEmailFormat } from './email.utils';
-import { setSessionCookie } from './session';
+import { issueWebSession } from './session-issuer';
 import { setCsrfCookie } from './csrf'; // Used by /auth/csrf-token endpoint
 import { updateLastAuthAt } from './recent-auth';
 import { requireRecentAuth } from './requireRecentAuth';
@@ -10,6 +10,7 @@ import { prisma } from '../lib/prisma';
 import { sendBadRequest, sendUnauthorized, sendForbidden, sendConflict, sendInternalError, sendTooManyRequests } from '../lib/api-response';
 import { checkAuthRateLimit, checkMutationRateLimit } from '../lib/rate-limit';
 import { sendPasswordChangedNotification } from '../services/password-notification.service';
+import { consumePasswordResetToken } from '../services/password-reset.service';
 import { logger } from '../lib/logger';
 import { config } from '../config/env';
 import { createNewUser, verifyEmailAvailable } from '../services/signup.service';
@@ -81,7 +82,7 @@ router.post('/signup', express.json(), async (req, res) => {
       const passwordHash = await hashPassword(password);
       const { user } = await createNewUser({ email: verifiedEmail, name: name.trim(), passwordHash, ref });
 
-      setSessionCookie(res, { uid: user.id, email: user.email, authAt: Date.now() });
+      await issueWebSession(res, { id: user.id, email: user.email });
       const csrfToken = setCsrfCookie(res);
 
       return res.status(201).json({ ok: true, waitlist: false, csrfToken });
@@ -157,7 +158,7 @@ router.post('/login', express.json(), async (req, res) => {
 
     // Set session and CSRF cookies, return CSRF token for immediate use
     // Include authAt as fallback in case DB lastAuthAt write failed
-    setSessionCookie(res, { uid: user.id, email: user.email, authAt: Date.now() });
+    await issueWebSession(res, { id: user.id, email: user.email });
     const csrfToken = setCsrfCookie(res);
 
     // Return success with mustChangePassword flag and CSRF token
@@ -233,15 +234,21 @@ router.post('/change-password', express.json(), requireRecentAuth, async (req, r
       return sendUnauthorized(res, 'Current password is incorrect');
     }
 
-    // Hash and save new password, clear mustChangePassword flag
+    // Hash and save new password, clear mustChangePassword flag, and bump the
+    // session token version to invalidate all other active sessions. We re-issue
+    // the current session cookie below so the caller stays logged in on this device.
     const newHash = await hashPassword(newPassword);
     await prisma.user.update({
       where: { id: userId },
       data: {
         passwordHash: newHash,
         mustChangePassword: false,
+        sessionTokenVersion: { increment: 1 },
       },
     });
+
+    // Re-issue the web session cookie stamped with the new sessionTokenVersion
+    await issueWebSession(res, { id: user.id, email: user.email });
 
     // Send notification email (non-blocking)
     sendPasswordChangedNotification({ id: user.id, email: user.email, name: user.name }).catch(() => {
@@ -252,6 +259,70 @@ router.post('/change-password', express.json(), requireRecentAuth, async (req, r
   } catch (e) {
     logger.error({ err: e }, '[EmailAuth] Change password failed');
     return sendInternalError(res, 'Failed to change password');
+  }
+});
+
+/**
+ * POST /auth/reset-password
+ * Complete a password reset using a token emailed to the user.
+ * This endpoint is unauthenticated — the reset token is the authorization.
+ */
+router.post('/reset-password', express.json(), async (req, res) => {
+  try {
+    const clientIp = getClientIp(req);
+    const rateLimit = await checkAuthRateLimit('reset-password', clientIp);
+    if (!rateLimit.allowed) {
+      return sendTooManyRequests(res, 'Too many attempts. Please try again later.', rateLimit.retryAfter);
+    }
+
+    const { token, newPassword } = req.body as {
+      token?: string;
+      newPassword?: string;
+    };
+
+    if (!token || !newPassword) {
+      return sendBadRequest(res, 'Token and new password are required');
+    }
+
+    const validation = validatePassword(newPassword);
+    if (!validation.isValid) {
+      return sendBadRequest(res, validation.error || 'Password does not meet requirements');
+    }
+
+    const result = await consumePasswordResetToken(token);
+    if (!result.ok) {
+      return sendBadRequest(res, 'Reset link is invalid or has expired');
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: result.userId },
+      select: { id: true, email: true, name: true },
+    });
+
+    if (!user) {
+      return sendBadRequest(res, 'Reset link is invalid or has expired');
+    }
+
+    const passwordHash = await hashPassword(newPassword);
+    await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        passwordHash,
+        mustChangePassword: false,
+        // Invalidate all existing sessions — any active cookie/token issued before
+        // this reset will fail the version check in attachUser.
+        sessionTokenVersion: { increment: 1 },
+      },
+    });
+
+    sendPasswordChangedNotification({ id: user.id, email: user.email, name: user.name }).catch(() => {
+      // Already logged in the service
+    });
+
+    res.json({ ok: true });
+  } catch (e) {
+    logger.error({ err: e }, '[EmailAuth] Reset password failed');
+    return sendInternalError(res, 'Failed to reset password');
   }
 });
 

--- a/apps/api/src/auth/email.route.ts
+++ b/apps/api/src/auth/email.route.ts
@@ -351,7 +351,7 @@ router.post('/reset-password', express.json(), async (req, res) => {
       // leaked — log it server-side without tipping off the client.
       if (result.reason === 'already_used') {
         logger.warn(
-          { userId: result.userId, clientIp: getClientIp(req) },
+          { userId: result.userId, clientIp },
           '[EmailAuth] Password reset token reuse attempted',
         );
       }

--- a/apps/api/src/auth/google.route.ts
+++ b/apps/api/src/auth/google.route.ts
@@ -1,7 +1,8 @@
 import express from 'express';
 import { OAuth2Client } from 'google-auth-library';
 import { ensureUserFromGoogle } from './ensureUserFromGoogle';
-import { setSessionCookie, clearSessionCookie } from './session';
+import { clearSessionCookie } from './session';
+import { issueWebSession } from './session-issuer';
 import { setCsrfCookie, clearCsrfCookie } from './csrf';
 import { updateLastAuthAt } from './recent-auth';
 import { logger } from '../lib/logger';
@@ -53,7 +54,7 @@ router.post('/google/code', express.json(), async (req, res) => {
 
     // Set session and CSRF cookies, return CSRF token for immediate use
     // Include authAt as fallback in case DB lastAuthAt write failed
-    setSessionCookie(res, { uid: user.id, email: user.email, authAt: Date.now() });
+    await issueWebSession(res, { id: user.id, email: user.email });
     const csrfToken = setCsrfCookie(res);
     res.status(200).json({ ok: true, csrfToken });
   } catch (e) {

--- a/apps/api/src/auth/mobile-password.route.test.ts
+++ b/apps/api/src/auth/mobile-password.route.test.ts
@@ -51,6 +51,13 @@ jest.mock('./token', () => ({
   verifyToken: jest.fn(),
 }));
 
+jest.mock('./session-issuer', () => ({
+  issueMobileTokens: jest.fn().mockResolvedValue({
+    accessToken: 'new_access_token',
+    refreshToken: 'new_refresh_token',
+  }),
+}));
+
 jest.mock('./recent-auth', () => ({
   updateLastAuthAt: jest.fn().mockResolvedValue(undefined),
 }));
@@ -473,9 +480,14 @@ describe('POST /mobile/password/change', () => {
         data: {
           passwordHash: 'new_hashed_password',
           mustChangePassword: false,
+          sessionTokenVersion: { increment: 1 },
         },
       });
-      expect(res.json).toHaveBeenCalledWith({ ok: true });
+      expect(res.json).toHaveBeenCalledWith({
+        ok: true,
+        accessToken: 'new_access_token',
+        refreshToken: 'new_refresh_token',
+      });
     });
 
     it('should send notification email on success', async () => {

--- a/apps/api/src/auth/mobile.route.ts
+++ b/apps/api/src/auth/mobile.route.ts
@@ -6,7 +6,8 @@ import { verifyAppleIdentityToken } from './appleTokenVerifier';
 import { normalizeEmail, getClientIp } from './utils';
 import { validateEmailFormat } from './email.utils';
 import { verifyPassword, validatePassword, hashPassword } from './password.utils';
-import { generateAccessToken, generateRefreshToken, verifyToken } from './token';
+import { generateAccessToken, verifyToken } from './token';
+import { issueMobileTokens } from './session-issuer';
 import { updateLastAuthAt } from './recent-auth';
 import { prisma } from '../lib/prisma';
 import { checkAuthRateLimit, checkMutationRateLimit } from '../lib/rate-limit';
@@ -109,8 +110,7 @@ router.post('/mobile/signup', express.json(), async (req, res) => {
 
       const { user } = await createNewUser({ email: verifiedEmail, name: trimmedName, passwordHash, ref });
 
-      const accessToken = generateAccessToken({ uid: user.id, email: user.email });
-      const refreshToken = generateRefreshToken({ uid: user.id, email: user.email });
+      const { accessToken, refreshToken } = await issueMobileTokens({ id: user.id, email: user.email });
 
       return res.status(201).json({
         ok: true,
@@ -177,8 +177,7 @@ router.post('/mobile/google', express.json(), async (req, res) => {
     );
 
     // Generate tokens for mobile
-    const accessToken = generateAccessToken({ uid: user.id, email: user.email });
-    const refreshToken = generateRefreshToken({ uid: user.id, email: user.email });
+    const { accessToken, refreshToken } = await issueMobileTokens({ id: user.id, email: user.email });
 
     res.status(200).json({
       accessToken,
@@ -267,8 +266,7 @@ router.post('/mobile/apple', express.json(), async (req, res) => {
     );
 
     // Generate tokens for mobile
-    const accessToken = generateAccessToken({ uid: user.id, email: user.email });
-    const refreshToken = generateRefreshToken({ uid: user.id, email: user.email });
+    const { accessToken, refreshToken } = await issueMobileTokens({ id: user.id, email: user.email });
 
     res.status(200).json({
       accessToken,
@@ -348,8 +346,7 @@ router.post('/mobile/login', express.json(), async (req, res) => {
     );
 
     // Generate tokens for mobile
-    const accessToken = generateAccessToken({ uid: user.id, email: user.email });
-    const refreshToken = generateRefreshToken({ uid: user.id, email: user.email });
+    const { accessToken, refreshToken } = await issueMobileTokens({ id: user.id, email: user.email });
 
     res.status(200).json({
       accessToken,
@@ -390,14 +387,24 @@ router.post('/mobile/refresh', express.json(), async (req, res) => {
     // Verify user still exists
     const user = await prisma.user.findUnique({
       where: { id: payload.uid },
+      select: { id: true, email: true, sessionTokenVersion: true },
     });
 
     if (!user) {
       return res.status(401).send('User not found');
     }
 
-    // Generate new access token
-    const accessToken = generateAccessToken({ uid: user.id, email: user.email });
+    // Reject refresh tokens issued before a session invalidation (e.g. password reset)
+    if ((payload.v ?? 0) !== user.sessionTokenVersion) {
+      return res.status(401).send('Refresh token has been revoked');
+    }
+
+    // Generate new access token stamped with the current token version
+    const accessToken = generateAccessToken({
+      uid: user.id,
+      email: user.email,
+      v: user.sessionTokenVersion,
+    });
 
     res.status(200).json({ accessToken });
   } catch (e) {
@@ -557,14 +564,23 @@ router.post('/mobile/password/change', express.json(), async (req, res) => {
       return sendUnauthorized(res, 'Current password is incorrect');
     }
 
-    // Hash and save new password, clear mustChangePassword flag
+    // Hash and save new password, clear mustChangePassword flag, and bump
+    // sessionTokenVersion to invalidate all other active sessions. We issue a
+    // fresh token pair below so this device stays logged in.
     const newHash = await hashPassword(newPassword);
     await prisma.user.update({
       where: { id: sessionUser.uid },
       data: {
         passwordHash: newHash,
         mustChangePassword: false,
+        sessionTokenVersion: { increment: 1 },
       },
+    });
+
+    // Issue fresh tokens stamped with the new version so the caller stays logged in
+    const { accessToken, refreshToken } = await issueMobileTokens({
+      id: user.id,
+      email: user.email,
     });
 
     // Send notification email (non-blocking)
@@ -572,7 +588,7 @@ router.post('/mobile/password/change', express.json(), async (req, res) => {
       // Already logged in the service
     });
 
-    res.json({ ok: true });
+    res.json({ ok: true, accessToken, refreshToken });
   } catch (e) {
     logger.error({ err: e }, '[MobileAuth] Change password failed');
     return sendInternalError(res, 'Failed to change password');

--- a/apps/api/src/auth/session-issuer.ts
+++ b/apps/api/src/auth/session-issuer.ts
@@ -1,0 +1,48 @@
+import type { Response } from 'express';
+import { prisma } from '../lib/prisma';
+import { setSessionCookie } from './session';
+import { generateAccessToken, generateRefreshToken } from './token';
+
+/**
+ * Fetch the user's current sessionTokenVersion. Used to stamp tokens at issue time
+ * so we can reject tokens issued before a password reset or other revocation event.
+ */
+async function getSessionTokenVersion(userId: string): Promise<number> {
+  const row = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { sessionTokenVersion: true },
+  });
+  return row?.sessionTokenVersion ?? 0;
+}
+
+/**
+ * Issue a web session cookie for the given user, stamped with their current
+ * sessionTokenVersion so the session can be revoked by bumping the version.
+ */
+export async function issueWebSession(
+  res: Response,
+  user: { id: string; email: string },
+): Promise<void> {
+  const v = await getSessionTokenVersion(user.id);
+  setSessionCookie(res, { uid: user.id, email: user.email, authAt: Date.now(), v });
+}
+
+export type MobileTokenPair = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+/**
+ * Issue a mobile access + refresh token pair stamped with the user's current
+ * sessionTokenVersion.
+ */
+export async function issueMobileTokens(user: {
+  id: string;
+  email: string;
+}): Promise<MobileTokenPair> {
+  const v = await getSessionTokenVersion(user.id);
+  return {
+    accessToken: generateAccessToken({ uid: user.id, email: user.email, v }),
+    refreshToken: generateRefreshToken({ uid: user.id, email: user.email, v }),
+  };
+}

--- a/apps/api/src/auth/session.test.ts
+++ b/apps/api/src/auth/session.test.ts
@@ -1,0 +1,227 @@
+import type { Request, Response, NextFunction } from 'express';
+
+// Set env before importing the module under test
+const originalEnv = process.env;
+process.env = { ...originalEnv, SESSION_SECRET: 'test-secret' };
+
+// Mock dependencies BEFORE importing session.ts
+jest.mock('jsonwebtoken');
+jest.mock('./token', () => ({
+  extractBearerToken: jest.fn(),
+  verifyToken: jest.fn(),
+}));
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+jest.mock('../lib/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+import * as jwt from 'jsonwebtoken';
+import { attachUser, type SessionUser } from './session';
+import { extractBearerToken, verifyToken } from './token';
+import { prisma } from '../lib/prisma';
+
+const mockedJwt = jwt as jest.Mocked<typeof jwt>;
+const mockExtractBearerToken = extractBearerToken as jest.Mock;
+const mockVerifyToken = verifyToken as jest.Mock;
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockUserFindUnique = mockPrisma.user.findUnique as unknown as jest.Mock;
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+type MockReq = Partial<Request> & { sessionUser?: SessionUser; cookies?: Record<string, string> };
+
+function makeReq(overrides: Partial<MockReq> = {}): MockReq {
+  return { cookies: {}, headers: {}, ...overrides } as MockReq;
+}
+
+/** attachUser is a sync wrapper that kicks off an async IIFE; this helper waits for it to resolve. */
+async function runAttachUser(req: MockReq): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const next: NextFunction = () => resolve();
+    attachUser(req as Request, {} as Response, next);
+  });
+}
+
+describe('attachUser — cookie session (web)', () => {
+  it('attaches sessionUser when cookie is valid and token version matches DB', async () => {
+    const payload: SessionUser = { uid: 'user_1', email: 'a@b.com', v: 5 };
+    mockedJwt.verify.mockReturnValue(payload as never);
+    mockUserFindUnique.mockResolvedValue({ sessionTokenVersion: 5 });
+
+    const req = makeReq({ cookies: { ll_session: 'signed-jwt' } });
+    await runAttachUser(req);
+
+    expect(req.sessionUser).toEqual(payload);
+  });
+
+  it('rejects a cookie whose v is stale (less than current sessionTokenVersion)', async () => {
+    // Attacker token minted when version was 3; DB is now 4 after a password reset.
+    const stalePayload: SessionUser = { uid: 'user_1', email: 'a@b.com', v: 3 };
+    mockedJwt.verify.mockReturnValue(stalePayload as never);
+    mockUserFindUnique.mockResolvedValue({ sessionTokenVersion: 4 });
+
+    const req = makeReq({ cookies: { ll_session: 'signed-jwt' } });
+    await runAttachUser(req);
+
+    expect(req.sessionUser).toBeUndefined();
+  });
+
+  it('rejects a cookie whose v is ahead of DB (forged/mismatched)', async () => {
+    const forgedPayload: SessionUser = { uid: 'user_1', v: 99 };
+    mockedJwt.verify.mockReturnValue(forgedPayload as never);
+    mockUserFindUnique.mockResolvedValue({ sessionTokenVersion: 4 });
+
+    const req = makeReq({ cookies: { ll_session: 'signed-jwt' } });
+    await runAttachUser(req);
+
+    expect(req.sessionUser).toBeUndefined();
+  });
+
+  it('treats a missing v claim as v=0 (backwards compat with pre-bump tokens)', async () => {
+    // Old token from before the sessionTokenVersion work — no v field.
+    const legacyPayload = { uid: 'user_1', email: 'a@b.com' } as SessionUser;
+    mockedJwt.verify.mockReturnValue(legacyPayload as never);
+    mockUserFindUnique.mockResolvedValue({ sessionTokenVersion: 0 });
+
+    const req = makeReq({ cookies: { ll_session: 'signed-jwt' } });
+    await runAttachUser(req);
+
+    expect(req.sessionUser).toEqual(legacyPayload);
+  });
+
+  it('rejects a legacy (no-v) token once the user has had a revocation event', async () => {
+    const legacyPayload = { uid: 'user_1' } as SessionUser;
+    mockedJwt.verify.mockReturnValue(legacyPayload as never);
+    mockUserFindUnique.mockResolvedValue({ sessionTokenVersion: 1 });
+
+    const req = makeReq({ cookies: { ll_session: 'signed-jwt' } });
+    await runAttachUser(req);
+
+    expect(req.sessionUser).toBeUndefined();
+  });
+
+  it('rejects the cookie and falls through to bearer when JWT verification fails', async () => {
+    mockedJwt.verify.mockImplementation(() => {
+      throw new Error('invalid signature');
+    });
+    mockExtractBearerToken.mockReturnValue(null);
+
+    const req = makeReq({ cookies: { ll_session: 'bad-jwt' } });
+    await runAttachUser(req);
+
+    expect(req.sessionUser).toBeUndefined();
+    // Falls through to check bearer auth
+    expect(mockExtractBearerToken).toHaveBeenCalled();
+  });
+
+  it('rejects the cookie when the user no longer exists (fail-closed)', async () => {
+    mockedJwt.verify.mockReturnValue({ uid: 'deleted_user', v: 0 } as never);
+    mockUserFindUnique.mockResolvedValue(null);
+
+    const req = makeReq({ cookies: { ll_session: 'signed-jwt' } });
+    await runAttachUser(req);
+
+    expect(req.sessionUser).toBeUndefined();
+  });
+
+  it('rejects the cookie when the DB lookup errors (fail-closed)', async () => {
+    mockedJwt.verify.mockReturnValue({ uid: 'user_1', v: 0 } as never);
+    mockUserFindUnique.mockRejectedValue(new Error('DB unavailable'));
+
+    const req = makeReq({ cookies: { ll_session: 'signed-jwt' } });
+    await runAttachUser(req);
+
+    expect(req.sessionUser).toBeUndefined();
+  });
+});
+
+describe('attachUser — bearer token (mobile)', () => {
+  it('attaches sessionUser when bearer token is valid and version matches', async () => {
+    const payload = { uid: 'user_1', email: 'a@b.com', v: 2 };
+    mockExtractBearerToken.mockReturnValue('mobile-access-token');
+    mockVerifyToken.mockReturnValue(payload);
+    mockUserFindUnique.mockResolvedValue({ sessionTokenVersion: 2 });
+
+    const req = makeReq();
+    await runAttachUser(req);
+
+    expect(req.sessionUser).toEqual(payload);
+  });
+
+  it('rejects a bearer token whose v is stale (mobile device still holding pre-reset token)', async () => {
+    const stalePayload = { uid: 'user_1', v: 0 };
+    mockExtractBearerToken.mockReturnValue('stale-mobile-token');
+    mockVerifyToken.mockReturnValue(stalePayload);
+    mockUserFindUnique.mockResolvedValue({ sessionTokenVersion: 1 });
+
+    const req = makeReq();
+    await runAttachUser(req);
+
+    expect(req.sessionUser).toBeUndefined();
+  });
+
+  it('does not attach a user when bearer token itself is invalid', async () => {
+    mockExtractBearerToken.mockReturnValue('garbage-token');
+    mockVerifyToken.mockReturnValue(null);
+
+    const req = makeReq();
+    await runAttachUser(req);
+
+    expect(req.sessionUser).toBeUndefined();
+    expect(mockUserFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('calls next even when no cookie and no bearer token is present', async () => {
+    mockExtractBearerToken.mockReturnValue(null);
+
+    const req = makeReq();
+    await runAttachUser(req);
+
+    expect(req.sessionUser).toBeUndefined();
+  });
+});
+
+describe('attachUser — revocation after sessionTokenVersion bump', () => {
+  it('accepts a freshly-issued token then rejects it after a version bump (password reset scenario)', async () => {
+    // Token issued with v=0
+    const payload = { uid: 'user_1', email: 'a@b.com', v: 0 };
+    mockedJwt.verify.mockReturnValue(payload as never);
+
+    // First request: DB is still at v=0 — token valid.
+    mockUserFindUnique.mockResolvedValueOnce({ sessionTokenVersion: 0 });
+    const req1 = makeReq({ cookies: { ll_session: 'signed-jwt' } });
+    await runAttachUser(req1);
+    expect(req1.sessionUser).toEqual(payload);
+
+    // User completes a password reset → sessionTokenVersion becomes 1.
+    // Next request with the same old cookie should be rejected.
+    mockUserFindUnique.mockResolvedValueOnce({ sessionTokenVersion: 1 });
+    const req2 = makeReq({ cookies: { ll_session: 'signed-jwt' } });
+    await runAttachUser(req2);
+    expect(req2.sessionUser).toBeUndefined();
+  });
+
+  it('accepts a newly-issued token after the bump (new login works)', async () => {
+    // After a reset, user logs in fresh; new token carries v=1.
+    const freshPayload = { uid: 'user_1', email: 'a@b.com', v: 1 };
+    mockedJwt.verify.mockReturnValue(freshPayload as never);
+    mockUserFindUnique.mockResolvedValue({ sessionTokenVersion: 1 });
+
+    const req = makeReq({ cookies: { ll_session: 'fresh-jwt' } });
+    await runAttachUser(req);
+
+    expect(req.sessionUser).toEqual(freshPayload);
+  });
+});

--- a/apps/api/src/auth/session.test.ts
+++ b/apps/api/src/auth/session.test.ts
@@ -18,19 +18,27 @@ jest.mock('../lib/prisma', () => ({
   },
 }));
 jest.mock('../lib/logger', () => ({
-  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
 }));
 
 import * as jwt from 'jsonwebtoken';
+import * as Sentry from '@sentry/node';
 import { attachUser, type SessionUser } from './session';
 import { extractBearerToken, verifyToken } from './token';
 import { prisma } from '../lib/prisma';
+import { logger } from '../lib/logger';
 
 const mockedJwt = jwt as jest.Mocked<typeof jwt>;
 const mockExtractBearerToken = extractBearerToken as jest.Mock;
 const mockVerifyToken = verifyToken as jest.Mock;
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockUserFindUnique = mockPrisma.user.findUnique as unknown as jest.Mock;
+const mockSentryCapture = Sentry.captureException as jest.Mock;
+const mockLoggerError = logger.error as unknown as jest.Mock;
+const mockLoggerDebug = logger.debug as unknown as jest.Mock;
 
 afterAll(() => {
   process.env = originalEnv;
@@ -136,14 +144,79 @@ describe('attachUser — cookie session (web)', () => {
     expect(req.sessionUser).toBeUndefined();
   });
 
-  it('rejects the cookie when the DB lookup errors (fail-closed)', async () => {
+  it('rejects the cookie when the DB lookup errors (fail-closed) and alerts Sentry + error log', async () => {
     mockedJwt.verify.mockReturnValue({ uid: 'user_1', v: 0 } as never);
-    mockUserFindUnique.mockRejectedValue(new Error('DB unavailable'));
+    const dbErr = new Error('DB unavailable');
+    mockUserFindUnique.mockRejectedValue(dbErr);
 
     const req = makeReq({ cookies: { ll_session: 'signed-jwt' } });
     await runAttachUser(req);
 
     expect(req.sessionUser).toBeUndefined();
+    // Auth failing closed is critical — on-call needs to see this immediately.
+    expect(mockSentryCapture).toHaveBeenCalledWith(dbErr, expect.objectContaining({
+      tags: expect.objectContaining({ component: 'auth', severity: 'critical' }),
+    }));
+    expect(mockLoggerError).toHaveBeenCalled();
+  });
+
+  it('rate-limits Sentry alerts during a sustained DB outage (first fires, bursts suppressed)', async () => {
+    // Fresh module load so the alert-cooldown state is zeroed for this test.
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('@sentry/node', () => ({ captureException: jest.fn() }));
+      jest.doMock('jsonwebtoken');
+      jest.doMock('./token', () => ({
+        extractBearerToken: jest.fn().mockReturnValue(null),
+        verifyToken: jest.fn(),
+      }));
+      jest.doMock('../lib/prisma', () => ({
+        prisma: { user: { findUnique: jest.fn() } },
+      }));
+      jest.doMock('../lib/logger', () => ({
+        logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+      }));
+
+      const freshJwt = (await import('jsonwebtoken')) as jest.Mocked<typeof import('jsonwebtoken')>;
+      const freshSentry = (await import('@sentry/node')) as unknown as {
+        captureException: jest.Mock;
+      };
+      const freshLogger = ((await import('../lib/logger')) as unknown as {
+        logger: { error: jest.Mock; debug: jest.Mock };
+      }).logger;
+      const freshPrismaFindUnique = ((await import('../lib/prisma')) as unknown as {
+        prisma: { user: { findUnique: jest.Mock } };
+      }).prisma.user.findUnique;
+      const { attachUser: freshAttachUser } = await import('./session');
+
+      freshJwt.verify.mockReturnValue({ uid: 'user_x', v: 0 } as never);
+      freshPrismaFindUnique.mockRejectedValue(new Error('DB down'));
+
+      const run = () =>
+        new Promise<void>((resolve) => {
+          const next: NextFunction = () => resolve();
+          freshAttachUser(
+            { cookies: { ll_session: 'jwt' }, headers: {} } as Request,
+            {} as Response,
+            next,
+          );
+        });
+
+      // First hit during the outage should alert.
+      await run();
+      expect(freshSentry.captureException).toHaveBeenCalledTimes(1);
+      expect(freshLogger.error).toHaveBeenCalledTimes(1);
+
+      // Next several hits within the cooldown window should stay silent on
+      // Sentry/error, going to debug instead — otherwise a DB outage floods the
+      // alert channel with thousands of duplicates per minute.
+      await run();
+      await run();
+      await run();
+
+      expect(freshSentry.captureException).toHaveBeenCalledTimes(1);
+      expect(freshLogger.error).toHaveBeenCalledTimes(1);
+      expect(freshLogger.debug).toHaveBeenCalledTimes(3);
+    });
   });
 });
 

--- a/apps/api/src/auth/session.ts
+++ b/apps/api/src/auth/session.ts
@@ -1,6 +1,8 @@
 import type { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { extractBearerToken, verifyToken } from './token';
+import { prisma } from '../lib/prisma';
+import { logger } from '../lib/logger';
 
 const { SESSION_SECRET } = process.env;
 
@@ -9,6 +11,8 @@ export type SessionUser = {
   email?: string;
   /** Timestamp when this session was created (login time) */
   authAt?: number;
+  /** User's sessionTokenVersion at token issue time — used to revoke sessions after password reset */
+  v?: number;
 }
 
 export function setSessionCookie(res: Response, payload: SessionUser) {
@@ -31,27 +35,60 @@ export function clearSessionCookie(res: Response) {
   });
 }
 
+/**
+ * Verify that a parsed token's version claim matches the user's current
+ * sessionTokenVersion in the DB. Tokens issued before a revocation event
+ * (e.g. password reset) will have a stale `v` and be rejected.
+ *
+ * Returns true if the token is still valid, false if it has been revoked
+ * or the user no longer exists.
+ */
+async function isTokenVersionCurrent(payload: { uid: string; v?: number }): Promise<boolean> {
+  try {
+    const row = await prisma.user.findUnique({
+      where: { id: payload.uid },
+      select: { sessionTokenVersion: true },
+    });
+    if (!row) return false;
+    return (payload.v ?? 0) === row.sessionTokenVersion;
+  } catch (err) {
+    logger.error({ err, uid: payload.uid }, '[Session] Failed to validate token version');
+    // Fail closed — if we can't verify the version, don't trust the token
+    return false;
+  }
+}
+
 export function attachUser(req: Request, _res: Response, next: NextFunction) {
-  // First, try cookie-based session (for web)
-  const cookieToken = req.cookies?.ll_session;
-  if (cookieToken) {
+  // Wrap the async body so middleware errors don't leave Express 4 hanging
+  void (async () => {
     try {
-      const user = jwt.verify(cookieToken, SESSION_SECRET!) as SessionUser;
-      req.sessionUser = user;
-      return next();
-    } catch {
-      // ignore invalid/expired cookie token
-    }
-  }
+      // First, try cookie-based session (for web)
+      const cookieToken = req.cookies?.ll_session;
+      if (cookieToken) {
+        try {
+          const user = jwt.verify(cookieToken, SESSION_SECRET!) as SessionUser;
+          if (await isTokenVersionCurrent(user)) {
+            req.sessionUser = user;
+          }
+          return next();
+        } catch {
+          // ignore invalid/expired cookie token
+        }
+      }
 
-  // If no cookie, try bearer token (for mobile)
-  const bearerToken = extractBearerToken(req);
-  if (bearerToken) {
-    const user = verifyToken(bearerToken);
-    if (user) {
-      req.sessionUser = user;
-    }
-  }
+      // If no cookie, try bearer token (for mobile)
+      const bearerToken = extractBearerToken(req);
+      if (bearerToken) {
+        const user = verifyToken(bearerToken);
+        if (user && (await isTokenVersionCurrent(user))) {
+          req.sessionUser = user;
+        }
+      }
 
-  next();
+      next();
+    } catch (err) {
+      logger.error({ err }, '[Session] attachUser failed');
+      next();
+    }
+  })();
 }

--- a/apps/api/src/auth/session.ts
+++ b/apps/api/src/auth/session.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
+import * as Sentry from '@sentry/node';
 import { extractBearerToken, verifyToken } from './token';
 import { prisma } from '../lib/prisma';
 import { logger } from '../lib/logger';
@@ -35,6 +36,32 @@ export function clearSessionCookie(res: Response) {
   });
 }
 
+// DB-error alerting state. `isTokenVersionCurrent` is on the hot path for every
+// authenticated request, so a DB outage would produce millions of log lines
+// and Sentry events per minute. Throttle so the *first* failure after a period
+// of health still pages on-call, without burying everything else.
+const ALERT_COOLDOWN_MS = 60_000;
+let lastDbErrorAlertAt = 0;
+
+function alertOnDbFailure(err: unknown, uid: string): void {
+  const now = Date.now();
+  if (now - lastDbErrorAlertAt < ALERT_COOLDOWN_MS) {
+    // Still log at debug so the full volume is inspectable if needed,
+    // but don't spam Sentry or the error channel.
+    logger.debug({ err, uid }, '[Session] Token version validation failed (rate-limited)');
+    return;
+  }
+  lastDbErrorAlertAt = now;
+  logger.error(
+    { err, uid },
+    '[Session] Token version validation failed — authentication is failing closed. Investigate DB connectivity immediately.',
+  );
+  Sentry.captureException(err, {
+    tags: { component: 'auth', severity: 'critical' },
+    extra: { reason: 'token_version_validation_failed', uid },
+  });
+}
+
 /**
  * Verify that a parsed token's version claim matches the user's current
  * sessionTokenVersion in the DB. Tokens issued before a revocation event
@@ -42,6 +69,11 @@ export function clearSessionCookie(res: Response) {
  *
  * Returns true if the token is still valid, false if it has been revoked
  * or the user no longer exists.
+ *
+ * **Fail-closed on DB error:** if the lookup throws, this returns false so an
+ * attacker with a stale token can't bypass revocation by disrupting the DB.
+ * The trade-off is that a DB outage denies auth for everyone — we surface
+ * that loudly via Sentry + error logs (rate-limited to avoid a firehose).
  */
 async function isTokenVersionCurrent(payload: { uid: string; v?: number }): Promise<boolean> {
   try {
@@ -52,43 +84,43 @@ async function isTokenVersionCurrent(payload: { uid: string; v?: number }): Prom
     if (!row) return false;
     return (payload.v ?? 0) === row.sessionTokenVersion;
   } catch (err) {
-    logger.error({ err, uid: payload.uid }, '[Session] Failed to validate token version');
-    // Fail closed — if we can't verify the version, don't trust the token
+    alertOnDbFailure(err, payload.uid);
     return false;
   }
 }
 
-export function attachUser(req: Request, _res: Response, next: NextFunction) {
-  // Wrap the async body so middleware errors don't leave Express 4 hanging
-  void (async () => {
-    try {
-      // First, try cookie-based session (for web)
-      const cookieToken = req.cookies?.ll_session;
-      if (cookieToken) {
-        try {
-          const user = jwt.verify(cookieToken, SESSION_SECRET!) as SessionUser;
-          if (await isTokenVersionCurrent(user)) {
-            req.sessionUser = user;
-          }
-          return next();
-        } catch {
-          // ignore invalid/expired cookie token
-        }
-      }
-
-      // If no cookie, try bearer token (for mobile)
-      const bearerToken = extractBearerToken(req);
-      if (bearerToken) {
-        const user = verifyToken(bearerToken);
-        if (user && (await isTokenVersionCurrent(user))) {
+export async function attachUser(req: Request, _res: Response, next: NextFunction): Promise<void> {
+  try {
+    // First, try cookie-based session (for web)
+    const cookieToken = req.cookies?.ll_session;
+    if (cookieToken) {
+      try {
+        const user = jwt.verify(cookieToken, SESSION_SECRET!) as SessionUser;
+        if (await isTokenVersionCurrent(user)) {
           req.sessionUser = user;
         }
+        return next();
+      } catch {
+        // ignore invalid/expired cookie token — fall through to bearer
       }
-
-      next();
-    } catch (err) {
-      logger.error({ err }, '[Session] attachUser failed');
-      next();
     }
-  })();
+
+    // If no cookie, try bearer token (for mobile)
+    const bearerToken = extractBearerToken(req);
+    if (bearerToken) {
+      const user = verifyToken(bearerToken);
+      if (user && (await isTokenVersionCurrent(user))) {
+        req.sessionUser = user;
+      }
+    }
+
+    next();
+  } catch (err) {
+    // Pass unexpected errors to Express's error handler rather than hanging
+    // the request. `isTokenVersionCurrent` already swallows DB errors itself,
+    // so this branch should be rare — but if it fires, the request completes
+    // deterministically with an error response instead of timing out.
+    logger.error({ err }, '[Session] attachUser failed unexpectedly');
+    next(err);
+  }
 }

--- a/apps/api/src/auth/token.ts
+++ b/apps/api/src/auth/token.ts
@@ -6,6 +6,8 @@ const { SESSION_SECRET } = process.env;
 export type TokenPayload = {
   uid: string;
   email?: string;
+  /** User's sessionTokenVersion at token issue time — used to revoke tokens after password reset */
+  v?: number;
 };
 
 /**

--- a/apps/api/src/instrument.ts
+++ b/apps/api/src/instrument.ts
@@ -1,9 +1,21 @@
 import 'dotenv/config';
 import * as Sentry from '@sentry/node';
+import { scrubKnownSecrets } from './lib/sentry-scrub';
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
+  // Tag every event with the deploy SHA so Sentry can group errors by release
+  // and surface regressions. Falls back to 'unknown' if the build didn't inject
+  // it — prefer that over leaving it undefined, which disables release tracking.
+  release: process.env.SENTRY_RELEASE || 'unknown',
   environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'development',
   tracesSampleRate: 0.05,
   enabled: process.env.NODE_ENV === 'production',
+  // Strip noisy health-check errors and scrub secrets from every event
+  // (request bodies, breadcrumb data, contexts) before transmission.
+  beforeSend(event) {
+    const url = event.request?.url;
+    if (url && (url.endsWith('/health') || url.endsWith('/healthz'))) return null;
+    return scrubKnownSecrets(event);
+  },
 });

--- a/apps/api/src/lib/prisma.ts
+++ b/apps/api/src/lib/prisma.ts
@@ -1,4 +1,47 @@
 import { PrismaClient } from '@prisma/client';
+import * as Sentry from '@sentry/node';
+
 declare global { var __prisma__: PrismaClient | undefined; }
-export const prisma = global.__prisma__ ?? new PrismaClient();
+
+function createPrismaClient(): PrismaClient {
+  const base = new PrismaClient();
+
+  // Emit a Sentry breadcrumb per Prisma operation so error events can show
+  // the last few DB calls as context. Never includes `args` — parameters may
+  // contain PII and we don't want to ship them to Sentry.
+  //
+  // Uses the $extends query hook rather than the deprecated $use middleware.
+  // Note: $extends returns a new client; callers get the extended one.
+  return base.$extends({
+    query: {
+      $allOperations({ model, operation, query, args }) {
+        const start = Date.now();
+        const result = query(args);
+        // Fire-and-forget: don't wait on the query to resolve before returning.
+        Promise.resolve(result)
+          .then(() => {
+            Sentry.addBreadcrumb({
+              category: 'prisma',
+              type: 'query',
+              level: 'info',
+              message: `${model ?? 'raw'}.${operation}`,
+              data: { durationMs: Date.now() - start },
+            });
+          })
+          .catch(() => {
+            Sentry.addBreadcrumb({
+              category: 'prisma',
+              type: 'query',
+              level: 'warning',
+              message: `${model ?? 'raw'}.${operation} (failed)`,
+              data: { durationMs: Date.now() - start },
+            });
+          });
+        return result;
+      },
+    },
+  }) as unknown as PrismaClient;
+}
+
+export const prisma = global.__prisma__ ?? createPrismaClient();
 if (process.env.NODE_ENV !== 'production') global.__prisma__ = prisma;

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -167,6 +167,8 @@ export const ADMIN_RATE_LIMITS = {
   createUser: 5 * SECONDS,
   /** User demotion cooldown: 5 seconds per target user (prevents accidental spam) */
   demoteUser: 5 * SECONDS,
+  /** Password reset email cooldown: 30 seconds per target user (prevents accidental double-click + email spam) */
+  sendPasswordReset: 30 * SECONDS,
   /** Bulk email cooldown: 60 seconds per admin (prevents spam) */
   bulkEmail: 60 * SECONDS,
   /** Waitlist import cooldown: 60 seconds per admin (prevents spam) */
@@ -184,6 +186,8 @@ export const AUTH_RATE_LIMITS = {
   'oauth-login': { windowSeconds: 60, maxRequests: 10 },
   /** public-stats: max 30 requests per minute per IP (cached endpoint, prevent abuse) */
   'public-stats': { windowSeconds: 60, maxRequests: 30 },
+  /** reset-password: max 10 requests per minute per IP (prevents token-guessing floods) */
+  'reset-password': { windowSeconds: 60, maxRequests: 10 },
 } as const;
 
 export type AuthRateLimitType = keyof typeof AUTH_RATE_LIMITS;

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -188,6 +188,8 @@ export const AUTH_RATE_LIMITS = {
   'public-stats': { windowSeconds: 60, maxRequests: 30 },
   /** reset-password: max 10 requests per minute per IP (prevents token-guessing floods) */
   'reset-password': { windowSeconds: 60, maxRequests: 10 },
+  /** forgot-password: max 5 requests per minute per IP (public; prevents email-blast abuse) */
+  'forgot-password': { windowSeconds: 60, maxRequests: 5 },
 } as const;
 
 export type AuthRateLimitType = keyof typeof AUTH_RATE_LIMITS;

--- a/apps/api/src/lib/sentry-apollo-plugin.test.ts
+++ b/apps/api/src/lib/sentry-apollo-plugin.test.ts
@@ -1,0 +1,159 @@
+// Mock @sentry/node before importing the plugin so its withScope/captureException calls are spies
+jest.mock('@sentry/node', () => {
+  const scope = {
+    setTag: jest.fn(),
+    setContext: jest.fn(),
+  };
+  return {
+    withScope: jest.fn((fn: (s: typeof scope) => void) => fn(scope)),
+    captureException: jest.fn(),
+    __testScope: scope,
+  };
+});
+
+import * as Sentry from '@sentry/node';
+import { sentryApolloPlugin } from './sentry-apollo-plugin';
+import { GraphQLError } from 'graphql';
+
+const mockedSentry = Sentry as unknown as {
+  withScope: jest.Mock;
+  captureException: jest.Mock;
+  __testScope: { setTag: jest.Mock; setContext: jest.Mock };
+};
+
+type MinimalCtx = {
+  request: {
+    operationName?: string | null;
+    variables?: Record<string, unknown> | null;
+    query?: string | null;
+  };
+  errors: readonly GraphQLError[];
+};
+
+async function runDidEncounterErrors(ctx: MinimalCtx): Promise<void> {
+  const plugin = sentryApolloPlugin();
+  const started = await plugin.requestDidStart!({} as never);
+  await started?.didEncounterErrors?.(ctx as never);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('sentryApolloPlugin — didEncounterErrors', () => {
+  it('captures resolver errors to Sentry with operation name and query context', async () => {
+    const resolverErr = new GraphQLError('Boom inside resolver');
+    await runDidEncounterErrors({
+      request: { operationName: 'GetRides', variables: { limit: 10 }, query: 'query GetRides { rides }' },
+      errors: [resolverErr],
+    });
+
+    expect(mockedSentry.captureException).toHaveBeenCalledTimes(1);
+    expect(mockedSentry.__testScope.setTag).toHaveBeenCalledWith('graphql.operation', 'GetRides');
+    expect(mockedSentry.__testScope.setTag).toHaveBeenCalledWith('graphql.source', 'apollo-plugin');
+    expect(mockedSentry.__testScope.setContext).toHaveBeenCalledWith(
+      'graphql',
+      expect.objectContaining({
+        operationName: 'GetRides',
+        variables: { limit: 10 },
+        query: 'query GetRides { rides }',
+      }),
+    );
+  });
+
+  it('uses the originalError (not the Apollo wrapper) so the real stack is preserved', async () => {
+    const root = new Error('DB connection refused');
+    const wrapped = new GraphQLError('Internal server error', {
+      extensions: { originalError: root },
+    });
+    await runDidEncounterErrors({
+      request: { operationName: 'Anything', variables: null, query: null },
+      errors: [wrapped],
+    });
+
+    expect(mockedSentry.captureException).toHaveBeenCalledWith(root);
+  });
+
+  it('does NOT capture BAD_USER_INPUT client errors', async () => {
+    const clientErr = new GraphQLError('Invalid input', {
+      extensions: { code: 'BAD_USER_INPUT' },
+    });
+    await runDidEncounterErrors({
+      request: { operationName: 'Op', variables: null, query: null },
+      errors: [clientErr],
+    });
+
+    expect(mockedSentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('does NOT capture UNAUTHENTICATED errors', async () => {
+    const authErr = new GraphQLError('Must log in', {
+      extensions: { code: 'UNAUTHENTICATED' },
+    });
+    await runDidEncounterErrors({
+      request: { operationName: 'Op', variables: null, query: null },
+      errors: [authErr],
+    });
+
+    expect(mockedSentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('does NOT capture FORBIDDEN errors', async () => {
+    const forbidden = new GraphQLError('Not allowed', {
+      extensions: { code: 'FORBIDDEN' },
+    });
+    await runDidEncounterErrors({
+      request: { operationName: 'Op', variables: null, query: null },
+      errors: [forbidden],
+    });
+
+    expect(mockedSentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('does NOT capture validation errors', async () => {
+    const validation = new GraphQLError('bad query syntax', {
+      extensions: { code: 'GRAPHQL_VALIDATION_FAILED' },
+    });
+    await runDidEncounterErrors({
+      request: { operationName: 'Op', variables: null, query: null },
+      errors: [validation],
+    });
+
+    expect(mockedSentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('captures each non-client error when multiple are in a single response', async () => {
+    const client = new GraphQLError('bad input', { extensions: { code: 'BAD_USER_INPUT' } });
+    const serverA = new GraphQLError('Boom A');
+    const serverB = new GraphQLError('Boom B');
+
+    await runDidEncounterErrors({
+      request: { operationName: 'Batch', variables: null, query: null },
+      errors: [client, serverA, serverB],
+    });
+
+    // Client error skipped, both server errors captured.
+    expect(mockedSentry.captureException).toHaveBeenCalledTimes(2);
+  });
+
+  it('truncates large query strings to keep event size bounded', async () => {
+    const hugeQuery = 'query X { x }'.repeat(500); // ~6000+ chars
+    await runDidEncounterErrors({
+      request: { operationName: 'Huge', variables: null, query: hugeQuery },
+      errors: [new GraphQLError('Boom')],
+    });
+
+    const setContextCall = mockedSentry.__testScope.setContext.mock.calls[0];
+    const gqlContext = setContextCall[1] as { query: string };
+    expect(gqlContext.query.length).toBeLessThanOrEqual(2000);
+  });
+
+  it('falls back to "anonymous" when operation has no name', async () => {
+    await runDidEncounterErrors({
+      request: { operationName: null, variables: null, query: null },
+      errors: [new GraphQLError('Boom')],
+    });
+
+    expect(mockedSentry.__testScope.setTag).toHaveBeenCalledWith('graphql.operation', 'anonymous');
+  });
+});

--- a/apps/api/src/lib/sentry-apollo-plugin.ts
+++ b/apps/api/src/lib/sentry-apollo-plugin.ts
@@ -1,0 +1,69 @@
+import * as Sentry from '@sentry/node';
+import type { ApolloServerPlugin, GraphQLRequestContext } from '@apollo/server';
+import type { GraphQLFormattedError } from 'graphql';
+import type { GraphQLContext } from '../server';
+
+/**
+ * Extension codes that indicate *client-side* issues — bad input, missing auth,
+ * forbidden access. These are expected and don't warrant a Sentry alert.
+ * Anything else (thrown resolver, Prisma error, network timeout) should surface.
+ */
+const CLIENT_ERROR_CODES = new Set([
+  'BAD_USER_INPUT',
+  'GRAPHQL_VALIDATION_FAILED',
+  'GRAPHQL_PARSE_FAILED',
+  'PERSISTED_QUERY_NOT_FOUND',
+  'PERSISTED_QUERY_NOT_SUPPORTED',
+  'UNAUTHENTICATED',
+  'FORBIDDEN',
+]);
+
+function isClientError(err: GraphQLFormattedError): boolean {
+  const code = err.extensions?.code;
+  return typeof code === 'string' && CLIENT_ERROR_CODES.has(code);
+}
+
+/**
+ * Apollo Server plugin that turns GraphQL errors into first-class Sentry
+ * events with operation name, query (truncated), and variables as context.
+ *
+ * `beforeSend` in instrument.ts scrubs sensitive keys from variables before
+ * transmission, so `{ newPassword: '...' }` lands in Sentry as `[Filtered]`.
+ *
+ * Client errors (validation, auth failures) are skipped — those are expected
+ * and just noise in the alerting channel.
+ */
+export function sentryApolloPlugin(): ApolloServerPlugin<GraphQLContext> {
+  return {
+    async requestDidStart() {
+      return {
+        async didEncounterErrors(ctx: GraphQLRequestContext<GraphQLContext>) {
+          if (!ctx.errors) return;
+          for (const err of ctx.errors) {
+            if (isClientError(err)) continue;
+
+            Sentry.withScope((scope) => {
+              scope.setTag('graphql.operation', ctx.request.operationName ?? 'anonymous');
+              scope.setTag('graphql.source', 'apollo-plugin');
+              scope.setContext('graphql', {
+                operationName: ctx.request.operationName ?? null,
+                // Variables may contain sensitive input (e.g. newPassword for
+                // reset-password); beforeSend scrubs those keys before send.
+                variables: ctx.request.variables ?? null,
+                // Truncate the query so we don't ship massive documents on
+                // every error.
+                query: ctx.request.query?.slice(0, 2000) ?? null,
+              });
+              // Prefer the original error (with its real stack) over Apollo's
+              // wrapper, which otherwise swallows the useful trace.
+              const originalError = err.extensions?.originalError;
+              const toCapture =
+                originalError instanceof Error ? originalError : err;
+              Sentry.captureException(toCapture);
+            });
+          }
+        },
+      };
+    },
+  };
+}

--- a/apps/api/src/lib/sentry-scrub.test.ts
+++ b/apps/api/src/lib/sentry-scrub.test.ts
@@ -1,0 +1,123 @@
+import { scrubKnownSecrets } from './sentry-scrub';
+
+describe('scrubKnownSecrets', () => {
+  it('replaces sensitive-keyed values in request.data with [Filtered]', () => {
+    const event = {
+      request: {
+        data: { email: 'a@b.com', password: 'hunter2', newPassword: 'also-secret' },
+      },
+    };
+    scrubKnownSecrets(event);
+    expect(event.request.data).toEqual({
+      email: 'a@b.com',
+      password: '[Filtered]',
+      newPassword: '[Filtered]',
+    });
+  });
+
+  it('scrubs recursively through nested objects', () => {
+    const event = {
+      request: {
+        data: {
+          user: {
+            profile: { name: 'Alex', token: 'should-be-gone' },
+          },
+        },
+      },
+    };
+    scrubKnownSecrets(event);
+    const nested = (event.request.data as { user: { profile: Record<string, unknown> } }).user.profile;
+    expect(nested.name).toBe('Alex');
+    expect(nested.token).toBe('[Filtered]');
+  });
+
+  it('scrubs values inside array elements', () => {
+    const event = {
+      extra: {
+        items: [
+          { id: 1, resetToken: 'r1' },
+          { id: 2, resetToken: 'r2' },
+        ],
+      },
+    };
+    scrubKnownSecrets(event);
+    expect((event.extra.items as Array<{ resetToken: string }>)[0].resetToken).toBe('[Filtered]');
+    expect((event.extra.items as Array<{ resetToken: string }>)[1].resetToken).toBe('[Filtered]');
+  });
+
+  it('is case-insensitive on key names', () => {
+    const event = {
+      request: {
+        data: { Password: 'x', AUTHORIZATION: 'Bearer y', Cookie: 'z' },
+      },
+    };
+    scrubKnownSecrets(event);
+    expect(event.request.data).toEqual({
+      Password: '[Filtered]',
+      AUTHORIZATION: '[Filtered]',
+      Cookie: '[Filtered]',
+    });
+  });
+
+  it('scrubs breadcrumb data entries', () => {
+    const event = {
+      breadcrumbs: [
+        { message: 'login', data: { email: 'a@b.com', password: 'secret' } },
+        { message: 'reset', data: { token: 'reset-token' } },
+      ],
+    };
+    scrubKnownSecrets(event);
+    expect(event.breadcrumbs[0].data?.password).toBe('[Filtered]');
+    expect(event.breadcrumbs[1].data?.token).toBe('[Filtered]');
+    // Non-sensitive keys untouched
+    expect(event.breadcrumbs[0].data?.email).toBe('a@b.com');
+  });
+
+  it('does not touch unrelated keys', () => {
+    const event = {
+      request: {
+        data: { id: 'user_1', name: 'Alex', location: 'here' },
+      },
+    };
+    scrubKnownSecrets(event);
+    expect(event.request.data).toEqual({ id: 'user_1', name: 'Alex', location: 'here' });
+  });
+
+  it('handles null/undefined/missing sections gracefully', () => {
+    expect(() => scrubKnownSecrets({})).not.toThrow();
+    expect(() => scrubKnownSecrets({ request: undefined })).not.toThrow();
+    expect(() => scrubKnownSecrets({ extra: undefined })).not.toThrow();
+  });
+
+  it('does not loop forever on circular references', () => {
+    const data: Record<string, unknown> = { name: 'loopy' };
+    data.self = data;
+    const event = { extra: { data } };
+    expect(() => scrubKnownSecrets(event)).not.toThrow();
+  });
+
+  it('stops at a reasonable max depth to bound work', () => {
+    // Build a deeply nested object; scrubber must not throw or hang.
+    let deep: Record<string, unknown> = { password: 'leak' };
+    for (let i = 0; i < 50; i++) deep = { next: deep };
+    const event = { extra: { deep } };
+    expect(() => scrubKnownSecrets(event)).not.toThrow();
+  });
+
+  it('scrubs headers.authorization in request', () => {
+    const event = {
+      request: {
+        headers: { Authorization: 'Bearer abc', 'User-Agent': 'test' },
+      },
+    };
+    scrubKnownSecrets(event);
+    expect(event.request.headers.Authorization).toBe('[Filtered]');
+    expect(event.request.headers['User-Agent']).toBe('test');
+  });
+
+  it('returns the same event object (in-place mutation)', () => {
+    const event = { request: { data: { password: 'x' } } };
+    const result = scrubKnownSecrets(event);
+    expect(result).toBe(event);
+  });
+});

--- a/apps/api/src/lib/sentry-scrub.ts
+++ b/apps/api/src/lib/sentry-scrub.ts
@@ -1,0 +1,86 @@
+/**
+ * Sentry event scrubbing helpers.
+ *
+ * The Pino logger in `./logger.ts` has its own redact list, but Sentry captures
+ * request bodies, breadcrumb data, and context payloads that the logger never
+ * touches. This module keeps the secret-stripping logic consistent across both.
+ *
+ * The shape used by Sentry events is loosely typed here to avoid coupling to
+ * @sentry/types (which differs between @sentry/node and @sentry/react). Event
+ * objects are plain JSON and we mutate them in place.
+ */
+
+/**
+ * Keys whose values should be replaced with [Filtered] anywhere they appear
+ * in a Sentry event. Matched case-insensitively on the key name, substring.
+ * Deliberately broad — false positives here are safe (a scrubbed non-secret is
+ * harmless), false negatives can leak credentials.
+ */
+const SENSITIVE_KEY_PATTERN = /password|token|secret|cookie|authorization|bearer|apiKey|api_key|resetToken|sessionToken/i;
+
+const FILTERED = '[Filtered]';
+
+// Prevent runaway recursion on circular refs or giant structures
+const MAX_DEPTH = 8;
+
+type Scrubable = Record<string, unknown> | unknown[] | null | undefined;
+
+function scrubInPlace(value: Scrubable, depth: number, seen: WeakSet<object>): void {
+  if (value === null || value === undefined) return;
+  if (typeof value !== 'object') return;
+  if (depth > MAX_DEPTH) return;
+  if (seen.has(value)) return;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (item && typeof item === 'object') {
+        scrubInPlace(item as Scrubable, depth + 1, seen);
+      }
+    }
+    return;
+  }
+
+  const obj = value as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      obj[key] = FILTERED;
+      continue;
+    }
+    const child = obj[key];
+    if (child && typeof child === 'object') {
+      scrubInPlace(child as Scrubable, depth + 1, seen);
+    }
+  }
+}
+
+/** Shape of the parts of a Sentry event we know how to scrub. */
+export type ScrubbableSentryEvent = {
+  request?: {
+    data?: unknown;
+    headers?: Record<string, unknown>;
+    cookies?: unknown;
+    query_string?: unknown;
+  };
+  contexts?: Record<string, unknown>;
+  extra?: Record<string, unknown>;
+  breadcrumbs?: Array<{ data?: unknown; message?: string }>;
+  tags?: Record<string, unknown>;
+};
+
+/**
+ * Walk a Sentry event in place, replacing values at any sensitive-named key
+ * with [Filtered]. Returns the same event for convenience.
+ */
+export function scrubKnownSecrets<T extends ScrubbableSentryEvent>(event: T): T {
+  const seen = new WeakSet<object>();
+  if (event.request) scrubInPlace(event.request as Scrubable, 0, seen);
+  if (event.contexts) scrubInPlace(event.contexts as Scrubable, 0, seen);
+  if (event.extra) scrubInPlace(event.extra as Scrubable, 0, seen);
+  if (event.breadcrumbs) {
+    for (const bc of event.breadcrumbs) {
+      if (bc.data) scrubInPlace(bc.data as Scrubable, 0, seen);
+    }
+  }
+  return event;
+}

--- a/apps/api/src/routes/admin.send-password-reset.test.ts
+++ b/apps/api/src/routes/admin.send-password-reset.test.ts
@@ -1,0 +1,254 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+// Mock dependencies BEFORE importing the router
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    user: { findUnique: jest.fn(), findMany: jest.fn(), count: jest.fn() },
+  },
+}));
+
+jest.mock('../lib/rate-limit', () => ({
+  checkAdminRateLimit: jest.fn().mockResolvedValue({ allowed: true, redisAvailable: true }),
+}));
+
+jest.mock('../services/password-reset.service', () => ({
+  createPasswordResetToken: jest.fn(),
+  sendPasswordResetEmail: jest.fn(),
+}));
+
+// The service layer we care about for this test. Everything else the admin
+// router imports just needs to not explode during module load.
+jest.mock('../services/activation.service', () => ({
+  activateWaitlistUser: jest.fn(),
+  generateTempPassword: jest.fn(),
+}));
+jest.mock('../auth/password.utils', () => ({
+  hashPassword: jest.fn(),
+}));
+jest.mock('../services/email.service', () => ({
+  sendEmail: jest.fn(),
+  sendReactEmailWithAudit: jest.fn(),
+}));
+jest.mock('@react-email/render', () => ({
+  render: jest.fn().mockResolvedValue('<html></html>'),
+}));
+jest.mock('../lib/unsubscribe-token', () => ({
+  generateUnsubscribeToken: jest.fn().mockReturnValue('tok'),
+}));
+
+// Mock the admin middleware — we track that the router wires it up, but for
+// handler-level tests we just pass through.
+jest.mock('../auth/adminMiddleware', () => ({
+  requireAdmin: jest.fn((_req: Request, _res: Response, next: NextFunction) => next()),
+}));
+
+jest.mock('../lib/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+  logError: jest.fn(),
+  createLogger: jest.fn(() => ({
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  })),
+}));
+
+import router from './admin';
+import { prisma } from '../lib/prisma';
+import { checkAdminRateLimit } from '../lib/rate-limit';
+import {
+  createPasswordResetToken,
+  sendPasswordResetEmail,
+} from '../services/password-reset.service';
+import { requireAdmin } from '../auth/adminMiddleware';
+import { logger } from '../lib/logger';
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockUserFindUnique = mockPrisma.user.findUnique as unknown as jest.Mock;
+const mockCheckAdminRateLimit = checkAdminRateLimit as jest.Mock;
+const mockCreateToken = createPasswordResetToken as jest.Mock;
+const mockSendEmail = sendPasswordResetEmail as jest.Mock;
+const mockRequireAdmin = requireAdmin as unknown as jest.Mock;
+const mockLoggerInfo = logger.info as unknown as jest.Mock;
+
+interface RouteLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: RequestHandler }>;
+  };
+  name?: string;
+  handle?: RequestHandler;
+}
+
+function getHandler(path: string, method: string): RequestHandler | undefined {
+  const routerStack = (router as unknown as { stack: RouteLayer[] }).stack;
+  const layer = routerStack.find((l) => l.route?.path === path && l.route?.methods?.[method]);
+  const handlers = layer?.route?.stack;
+  return handlers?.[handlers.length - 1]?.handle;
+}
+
+async function invokeHandler(
+  h: RequestHandler | undefined,
+  req: Request,
+  res: Response,
+): Promise<void> {
+  if (!h) throw new Error('Handler not found');
+  await h(req, res, jest.fn() as NextFunction);
+}
+
+function createMockResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+  };
+}
+
+function createMockRequest(overrides: Partial<Request> = {}): Partial<Request> {
+  return {
+    sessionUser: { uid: 'admin_1', email: 'admin@loamlogger.app' },
+    params: { userId: '11111111-1111-1111-1111-111111111111' },
+    body: {},
+    headers: {},
+    cookies: {},
+    ...overrides,
+  } as Partial<Request>;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCheckAdminRateLimit.mockResolvedValue({ allowed: true });
+});
+
+describe('admin router — middleware wiring', () => {
+  it('installs requireAdmin as a Router-level guard before any route handler', () => {
+    // A Router-level middleware (via router.use) registers as a stack layer
+    // with no `.route` and a direct `.handle` reference. If someone removes
+    // `router.use(requireAdmin)`, this test fails loudly.
+    const routerStack = (router as unknown as { stack: RouteLayer[] }).stack;
+    const middlewareLayers = routerStack.filter((l) => !l.route);
+    const hasRequireAdminGuard = middlewareLayers.some((l) => l.handle === mockRequireAdmin);
+    expect(hasRequireAdminGuard).toBe(true);
+  });
+});
+
+describe('POST /users/:userId/send-password-reset', () => {
+  let handler: RequestHandler | undefined;
+
+  beforeAll(() => {
+    handler = getHandler('/users/:userId/send-password-reset', 'post');
+    if (!handler) {
+      throw new Error('Handler not found for /users/:userId/send-password-reset');
+    }
+  });
+
+  describe('Authentication', () => {
+    it('returns 401 when sessionUser is missing (safety net behind requireAdmin)', async () => {
+      const req = createMockRequest({ sessionUser: undefined });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(mockCreateToken).not.toHaveBeenCalled();
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Input validation', () => {
+    it('returns 400 when userId is not a valid UUID/CUID', async () => {
+      const req = createMockRequest({ params: { userId: "' OR 1=1 --" } });
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockUserFindUnique).not.toHaveBeenCalled();
+      expect(mockCreateToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Rate limiting', () => {
+    it('returns 429 when the per-target admin rate limit is exceeded', async () => {
+      mockCheckAdminRateLimit.mockResolvedValue({ allowed: false, retryAfter: 30 });
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(429);
+      expect(res.setHeader).toHaveBeenCalledWith('Retry-After', '30');
+      expect(mockCreateToken).not.toHaveBeenCalled();
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it('keys the rate limit by target user (not by admin)', async () => {
+      mockUserFindUnique.mockResolvedValue({
+        id: '11111111-1111-1111-1111-111111111111',
+        email: 'target@example.com',
+        name: 'Target',
+      });
+      mockCreateToken.mockResolvedValue('raw');
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(mockCheckAdminRateLimit).toHaveBeenCalledWith(
+        'sendPasswordReset',
+        '11111111-1111-1111-1111-111111111111',
+      );
+    });
+  });
+
+  describe('User lookup', () => {
+    it('returns 400 when the target user does not exist', async () => {
+      mockUserFindUnique.mockResolvedValue(null);
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockCreateToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Happy path', () => {
+    it('creates a token, sends the email, logs the action, and returns 200', async () => {
+      mockUserFindUnique.mockResolvedValue({
+        id: '11111111-1111-1111-1111-111111111111',
+        email: 'target@example.com',
+        name: 'Target User',
+      });
+      mockCreateToken.mockResolvedValue('raw-token-xyz');
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      await invokeHandler(handler, req as Request, res as unknown as Response);
+
+      expect(mockCreateToken).toHaveBeenCalledWith('11111111-1111-1111-1111-111111111111');
+      expect(mockSendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: '11111111-1111-1111-1111-111111111111',
+          email: 'target@example.com',
+        }),
+        'raw-token-xyz',
+        'admin_password_reset',
+      );
+      // Structured log, no PII in the message string.
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: '11111111-1111-1111-1111-111111111111',
+          adminUserId: 'admin_1',
+        }),
+        expect.any(String),
+      );
+      expect(res.json).toHaveBeenCalledWith({ success: true });
+    });
+  });
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -725,13 +725,26 @@ router.get('/users', async (req, res) => {
           activatedAt: true,
           emailUnsubscribed: true,
           isFoundingRider: true,
+          emailSends: {
+            where: { emailType: 'password_reset', status: 'sent' },
+            orderBy: { createdAt: 'desc' },
+            take: 1,
+            select: { createdAt: true },
+          },
         },
       }),
       prisma.user.count({ where: { role: { in: ['FREE', 'PRO', 'ADMIN'] } } }),
     ]);
 
+    // Flatten the relation into a single timestamp field so the frontend
+    // doesn't need to know about the EmailSend table.
+    const usersWithResetTimestamp = users.map(({ emailSends, ...user }) => ({
+      ...user,
+      lastPasswordResetEmailAt: emailSends[0]?.createdAt ?? null,
+    }));
+
     res.json({
-      users,
+      users: usersWithResetTimestamp,
       pagination: {
         page,
         limit,

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -20,7 +20,7 @@ import React from 'react';
 import { generateUnsubscribeToken } from '../lib/unsubscribe-token';
 import { sendUnauthorized, sendBadRequest, sendInternalError } from '../lib/api-response';
 import { checkAdminRateLimit } from '../lib/rate-limit';
-import { logError } from '../lib/logger';
+import { logError, logger } from '../lib/logger';
 import { escapeHtml } from '../lib/html';
 import type { UserRole } from '@prisma/client';
 import { getActivationEmailHtml, getActivationEmailSubject } from '../templates/emails/activation';
@@ -463,7 +463,7 @@ router.post('/users/:userId/send-password-reset', async (req, res) => {
     const rawToken = await createPasswordResetToken(user.id);
     await sendPasswordResetEmail(user, rawToken, 'admin_password_reset');
 
-    console.log(`[Admin] Password reset emailed to ${user.email} by ${adminUserId}`);
+    logger.info({ userId: user.id, adminUserId }, '[Admin] Password reset emailed');
 
     res.json({ success: true });
   } catch (error) {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -3,6 +3,10 @@ import { prisma } from '../lib/prisma';
 import { requireAdmin } from '../auth/adminMiddleware';
 import { activateWaitlistUser, generateTempPassword } from '../services/activation.service';
 import { hashPassword } from '../auth/password.utils';
+import {
+  createPasswordResetToken,
+  sendPasswordResetEmail,
+} from '../services/password-reset.service';
 import { sendEmail, sendReactEmailWithAudit } from '../services/email.service';
 import {
   getTemplateListForAPI,
@@ -392,7 +396,8 @@ router.post('/users/:userId/demote', async (req, res) => {
       }
     }
 
-    // Demote user to WAITLIST and clear activation fields
+    // Demote user to WAITLIST, clear activation fields, and invalidate any
+    // active sessions so the demoted user is logged out everywhere.
     const updated = await prisma.user.update({
       where: { id: userId },
       data: {
@@ -401,6 +406,7 @@ router.post('/users/:userId/demote', async (req, res) => {
         activatedBy: null,
         mustChangePassword: false,
         passwordHash: null,
+        sessionTokenVersion: { increment: 1 },
       },
       select: {
         id: true,
@@ -415,6 +421,54 @@ router.post('/users/:userId/demote', async (req, res) => {
   } catch (error) {
     logError('Admin demote user', error);
     return sendInternalError(res, 'Failed to demote user');
+  }
+});
+
+/**
+ * POST /api/admin/users/:userId/send-password-reset
+ * Email a password reset link to the user.
+ */
+router.post('/users/:userId/send-password-reset', async (req, res) => {
+  try {
+    const adminUserId = req.sessionUser?.uid;
+    const { userId } = req.params;
+
+    if (!adminUserId) {
+      return sendUnauthorized(res);
+    }
+
+    if (!isValidId(userId)) {
+      return sendBadRequest(res, 'Invalid user ID');
+    }
+
+    const rateLimit = await checkAdminRateLimit('sendPasswordReset', userId);
+    if (!rateLimit.allowed) {
+      res.setHeader('Retry-After', rateLimit.retryAfter.toString());
+      return res.status(429).json({
+        success: false,
+        error: 'Too many password reset requests for this user',
+        retryAfter: rateLimit.retryAfter,
+      });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, email: true, name: true },
+    });
+
+    if (!user) {
+      return sendBadRequest(res, 'User not found');
+    }
+
+    const rawToken = await createPasswordResetToken(user.id);
+    await sendPasswordResetEmail(user, rawToken, 'admin_password_reset');
+
+    console.log(`[Admin] Password reset emailed to ${user.email} by ${adminUserId}`);
+
+    res.json({ success: true });
+  } catch (error) {
+    logError('Admin send password reset', error);
+    return sendInternalError(res, 'Failed to send password reset email');
   }
 });
 

--- a/apps/api/src/routes/waitlist.ts
+++ b/apps/api/src/routes/waitlist.ts
@@ -7,7 +7,7 @@ import { checkAuthRateLimit } from '../lib/rate-limit';
 import { logger } from '../lib/logger';
 import { config } from '../config/env';
 import { validatePassword, hashPassword } from '../auth/password.utils';
-import { setSessionCookie } from '../auth/session';
+import { issueWebSession } from '../auth/session-issuer';
 import { setCsrfCookie } from '../auth/csrf';
 import { createNewUser, verifyEmailAvailable } from '../services/signup.service';
 
@@ -83,7 +83,7 @@ router.post('/waitlist', express.json(), async (req: Request, res) => {
       const passwordHash = await hashPassword(password);
       const { user } = await createNewUser({ email: verifiedEmail, name: trimmedName, passwordHash, ref });
 
-      setSessionCookie(res, { uid: user.id, email: user.email, authAt: Date.now() });
+      await issueWebSession(res, { id: user.id, email: user.email });
       const csrfToken = setCsrfCookie(res);
 
       return res.status(201).json({ ok: true, waitlist: false, csrfToken });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -5,6 +5,7 @@ import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import pinoHttp from 'pino-http';
 import { ApolloServer } from '@apollo/server';
+import { sentryApolloPlugin } from './lib/sentry-apollo-plugin';
 import { expressMiddleware, type ExpressContextFunctionArgument } from '@as-integrations/express4';
 import { typeDefs } from './graphql/schema';
 import { resolvers } from './graphql/resolvers';
@@ -212,8 +213,24 @@ const startServer = async () => {
   // Skips: GET/HEAD/OPTIONS, Bearer token auth (mobile), unauthenticated requests
   app.use(verifyCsrf);
 
+  // Sentry smoke-test endpoint. Only active when ENABLE_SENTRY_TEST=true in
+  // the environment. Used to verify source maps + release tags after a deploy:
+  //   curl https://<api>/debug-sentry
+  // Unset the env var once you've confirmed the Sentry event looks right.
+  if (process.env.ENABLE_SENTRY_TEST === 'true') {
+    app.get('/debug-sentry', () => {
+      throw new Error(`Sentry smoke test — ${new Date().toISOString()}`);
+    });
+  }
+
   // ---- GraphQL ----
-  const server = new ApolloServer<GraphQLContext>({ typeDefs, resolvers });
+  const server = new ApolloServer<GraphQLContext>({
+    typeDefs,
+    resolvers,
+    // Turn resolver-thrown errors into first-class Sentry events with the
+    // operation name + variables + query, instead of generic Express noise.
+    plugins: [sentryApolloPlugin()],
+  });
   await server.start();
 
   // Explicitly handle GET /graphql (helps debugging and some tooling)

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -13,6 +13,10 @@ import { getRedisConnection, checkRedisHealth } from './lib/redis';
 import { startEmailScheduler, stopEmailScheduler } from './services/email-scheduler.service';
 import { startImportSessionChecker, stopImportSessionChecker } from './services/import-session-checker.service';
 import { startOAuthCleanup, stopOAuthCleanup } from './services/oauth-cleanup.service';
+import {
+  startPasswordResetCleanup,
+  stopPasswordResetCleanup,
+} from './services/password-reset-cleanup.service';
 import { rootLogger, logger } from './lib/logger';
 import { validateEncryptionKey } from './lib/crypto';
 import {
@@ -313,6 +317,9 @@ const startServer = async () => {
   // Start OAuth attempt cleanup (deletes expired records hourly)
   startOAuthCleanup();
 
+  // Start password reset token cleanup (deletes tokens expired >7d ago, daily)
+  startPasswordResetCleanup();
+
   app.listen(PORT, HOST, () => {
     logger.info({ port: PORT }, 'LoamLogger backend running (GraphQL at /graphql)');
   });
@@ -321,6 +328,7 @@ const startServer = async () => {
     await stopEmailScheduler();
     await stopImportSessionChecker();
     stopOAuthCleanup();
+    stopPasswordResetCleanup();
     await stopWorkers();
     await Sentry.flush(2000).catch(() => {});
     await server.stop();

--- a/apps/api/src/services/oauth-cleanup.service.ts
+++ b/apps/api/src/services/oauth-cleanup.service.ts
@@ -29,6 +29,9 @@ export function startOAuthCleanup(): void {
   }
 
   log.info('Starting OAuth attempt cleanup (hourly)');
+  // Run once immediately so a fresh deploy doesn't wait a full interval
+  // before pruning the table.
+  void runCleanup();
   cleanupInterval = setInterval(runCleanup, CLEANUP_INTERVAL_MS);
 }
 

--- a/apps/api/src/services/password-notification.service.ts
+++ b/apps/api/src/services/password-notification.service.ts
@@ -1,9 +1,11 @@
 import { sendReactEmailWithAudit } from './email.service';
-import PasswordAddedEmail, {
+import {
+  buildPasswordAddedEmailElement,
   getPasswordAddedEmailSubject,
   PASSWORD_ADDED_TEMPLATE_VERSION,
 } from '../templates/emails/password-added';
-import PasswordChangedEmail, {
+import {
+  buildPasswordChangedEmailElement,
   getPasswordChangedEmailSubject,
   PASSWORD_CHANGED_TEMPLATE_VERSION,
 } from '../templates/emails/password-changed';
@@ -26,12 +28,10 @@ export async function sendPasswordAddedNotification(user: PasswordNotificationUs
     await sendReactEmailWithAudit({
       to: user.email,
       subject: getPasswordAddedEmailSubject(),
-      reactElement: (
-        <PasswordAddedEmail
-          recipientFirstName={firstName}
-          email={user.email}
-        />
-      ),
+      reactElement: buildPasswordAddedEmailElement({
+        recipientFirstName: firstName,
+        email: user.email,
+      }),
       userId: user.id,
       emailType: 'password_added',
       triggerSource: 'user_action',
@@ -57,12 +57,10 @@ export async function sendPasswordChangedNotification(user: PasswordNotification
     await sendReactEmailWithAudit({
       to: user.email,
       subject: getPasswordChangedEmailSubject(),
-      reactElement: (
-        <PasswordChangedEmail
-          recipientFirstName={firstName}
-          email={user.email}
-        />
-      ),
+      reactElement: buildPasswordChangedEmailElement({
+        recipientFirstName: firstName,
+        email: user.email,
+      }),
       userId: user.id,
       emailType: 'password_changed',
       triggerSource: 'user_action',

--- a/apps/api/src/services/password-reset-cleanup.service.ts
+++ b/apps/api/src/services/password-reset-cleanup.service.ts
@@ -1,0 +1,43 @@
+import { cleanupExpiredPasswordResetTokens } from './password-reset.service';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('password-reset-cleanup');
+
+// Run cleanup once a day
+const CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+// Delete tokens that expired more than 7 days ago — keeps the recent history
+// around for forensic lookup (e.g. "when was the last reset sent?") without
+// letting the table grow unbounded.
+const EXPIRED_OLDER_THAN_HOURS = 7 * 24;
+
+let cleanupInterval: NodeJS.Timeout | null = null;
+
+async function runCleanup(): Promise<void> {
+  try {
+    const deleted = await cleanupExpiredPasswordResetTokens(EXPIRED_OLDER_THAN_HOURS);
+    if (deleted > 0) {
+      log.info({ deleted }, 'Cleaned up expired password reset tokens');
+    }
+  } catch (err) {
+    log.error({ err }, 'Password reset token cleanup failed');
+  }
+}
+
+export function startPasswordResetCleanup(): void {
+  if (cleanupInterval) {
+    log.info('Already running');
+    return;
+  }
+
+  log.info('Starting password reset token cleanup (daily)');
+  cleanupInterval = setInterval(runCleanup, CLEANUP_INTERVAL_MS);
+}
+
+export function stopPasswordResetCleanup(): void {
+  if (cleanupInterval) {
+    clearInterval(cleanupInterval);
+    cleanupInterval = null;
+    log.info('Stopped password reset token cleanup');
+  }
+}

--- a/apps/api/src/services/password-reset-cleanup.service.ts
+++ b/apps/api/src/services/password-reset-cleanup.service.ts
@@ -31,6 +31,9 @@ export function startPasswordResetCleanup(): void {
   }
 
   log.info('Starting password reset token cleanup (daily)');
+  // Run once immediately so a fresh deploy doesn't wait a full interval
+  // before pruning the table.
+  void runCleanup();
   cleanupInterval = setInterval(runCleanup, CLEANUP_INTERVAL_MS);
 }
 

--- a/apps/api/src/services/password-reset.service.test.ts
+++ b/apps/api/src/services/password-reset.service.test.ts
@@ -51,14 +51,19 @@ beforeEach(() => {
 });
 
 describe('buildResetUrl', () => {
-  it('builds a URL at /reset-password with the token in the query string', () => {
+  it('builds a URL at /reset-password with the token and source=email in the query string', () => {
     const url = buildResetUrl('abc123');
-    expect(url).toBe('https://loamlogger.app/reset-password?token=abc123');
+    expect(url).toBe('https://loamlogger.app/reset-password?token=abc123&source=email');
   });
 
   it('URL-encodes token characters that need escaping', () => {
     const url = buildResetUrl('a+b/c=d');
     expect(url).toContain('token=a%2Bb%2Fc%3Dd');
+  });
+
+  it('always includes source=email so the web page knows to attempt the app hand-off', () => {
+    const url = new URL(buildResetUrl('abc123'));
+    expect(url.searchParams.get('source')).toBe('email');
   });
 });
 

--- a/apps/api/src/services/password-reset.service.test.ts
+++ b/apps/api/src/services/password-reset.service.test.ts
@@ -191,17 +191,20 @@ describe('consumePasswordResetToken', () => {
     expect(mockPasswordResetToken.updateMany).not.toHaveBeenCalled();
   });
 
-  it('returns { ok: false, reason: "already_used", userId } when the atomic update loses the race (count=0)', async () => {
-    // Both reads see usedAt: null, but only one updateMany wins.
-    mockPasswordResetToken.findUnique.mockResolvedValue({
+  it('returns { ok: false, reason: "already_used", userId } when the atomic update loses the race to a concurrent consumer', async () => {
+    const record = {
       id: 'tok_1',
       userId: 'user_7',
       tokenHash: 'hash',
       expiresAt: new Date(Date.now() + 60_000),
       usedAt: null,
       createdAt: new Date(),
-    });
-    // This call loses the race — count is 0.
+    };
+    // First call: the initial lookup. Second call: the race-disambiguation
+    // re-read that now shows the row has been consumed by someone else.
+    mockPasswordResetToken.findUnique
+      .mockResolvedValueOnce(record)
+      .mockResolvedValueOnce({ usedAt: new Date(), expiresAt: record.expiresAt });
     mockPasswordResetToken.updateMany.mockResolvedValue({ count: 0 });
 
     const result = await consumePasswordResetToken('raw-token');
@@ -209,18 +212,71 @@ describe('consumePasswordResetToken', () => {
     expect(result).toEqual({ ok: false, reason: 'already_used', userId: 'user_7' });
   });
 
+  it('returns { ok: false, reason: "race_expired", userId } when the atomic update loses the race to expiry (benign)', async () => {
+    // Initial read sees a valid token, but in the sub-ms gap to updateMany
+    // the token expires, so the expiresAt guard excludes it. The follow-up
+    // read confirms it's still unused — so this is expiry, not reuse.
+    const expiredRow = new Date(Date.now() - 1);
+    const record = {
+      id: 'tok_1',
+      userId: 'user_11',
+      tokenHash: 'hash',
+      expiresAt: new Date(Date.now() + 1), // valid at first read
+      usedAt: null,
+      createdAt: new Date(),
+    };
+    mockPasswordResetToken.findUnique
+      .mockResolvedValueOnce(record)
+      .mockResolvedValueOnce({ usedAt: null, expiresAt: expiredRow });
+    mockPasswordResetToken.updateMany.mockResolvedValue({ count: 0 });
+
+    const result = await consumePasswordResetToken('raw-token');
+
+    expect(result).toEqual({ ok: false, reason: 'race_expired', userId: 'user_11' });
+  });
+
+  it('returns race_expired (not already_used) when the follow-up read finds the row missing', async () => {
+    const record = {
+      id: 'tok_1',
+      userId: 'user_12',
+      tokenHash: 'hash',
+      expiresAt: new Date(Date.now() + 60_000),
+      usedAt: null,
+      createdAt: new Date(),
+    };
+    mockPasswordResetToken.findUnique
+      .mockResolvedValueOnce(record)
+      .mockResolvedValueOnce(null); // row vanished
+    mockPasswordResetToken.updateMany.mockResolvedValue({ count: 0 });
+
+    const result = await consumePasswordResetToken('raw-token');
+
+    // Unknown cause — default to the non-alerting branch to avoid false positives.
+    expect(result).toEqual({ ok: false, reason: 'race_expired', userId: 'user_12' });
+  });
+
   it('prevents double-consumption under concurrent calls (only one succeeds)', async () => {
-    // Both concurrent calls see the same unused record
-    mockPasswordResetToken.findUnique.mockResolvedValue({
+    const activeRecord = {
       id: 'tok_1',
       userId: 'user_1',
       tokenHash: 'hash',
       expiresAt: new Date(Date.now() + 60_000),
       usedAt: null,
       createdAt: new Date(),
+    };
+
+    // Both concurrent calls see the same unused record on the initial lookup.
+    // The loser's follow-up disambiguation read sees the row as used (the
+    // winner just consumed it), so the loser resolves to `already_used`.
+    let lookupCount = 0;
+    mockPasswordResetToken.findUnique.mockImplementation(async () => {
+      lookupCount += 1;
+      // First two calls are the concurrent initial lookups — both see unused.
+      if (lookupCount <= 2) return activeRecord;
+      // The loser's follow-up read sees the winner's write.
+      return { usedAt: new Date(), expiresAt: activeRecord.expiresAt };
     });
 
-    // Simulate a DB race: the first updateMany returns count=1, the second returns count=0.
     let winnerAcknowledged = false;
     mockPasswordResetToken.updateMany.mockImplementation(async () => {
       if (!winnerAcknowledged) {

--- a/apps/api/src/services/password-reset.service.test.ts
+++ b/apps/api/src/services/password-reset.service.test.ts
@@ -1,0 +1,282 @@
+// Mock dependencies BEFORE importing the service
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    passwordResetToken: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      updateMany: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}));
+
+jest.mock('./email.service', () => ({
+  sendReactEmailWithAudit: jest.fn().mockResolvedValue({ messageId: 'mid_1', status: 'sent' }),
+}));
+
+jest.mock('../lib/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock('../config/env', () => ({
+  FRONTEND_URL: 'https://loamlogger.app',
+}));
+
+import { prisma } from '../lib/prisma';
+import { sendReactEmailWithAudit } from './email.service';
+import {
+  createPasswordResetToken,
+  consumePasswordResetToken,
+  sendPasswordResetEmail,
+  buildResetUrl,
+  PASSWORD_RESET_TTL_MINUTES,
+} from './password-reset.service';
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockSendReactEmailWithAudit = sendReactEmailWithAudit as jest.Mock;
+
+// Type-helper to re-expose mock methods on nested Prisma fields with correct typing.
+const mockPasswordResetToken = mockPrisma.passwordResetToken as unknown as {
+  findUnique: jest.Mock;
+  create: jest.Mock;
+  updateMany: jest.Mock;
+};
+const mockTransaction = mockPrisma.$transaction as unknown as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('buildResetUrl', () => {
+  it('builds a URL at /reset-password with the token in the query string', () => {
+    const url = buildResetUrl('abc123');
+    expect(url).toBe('https://loamlogger.app/reset-password?token=abc123');
+  });
+
+  it('URL-encodes token characters that need escaping', () => {
+    const url = buildResetUrl('a+b/c=d');
+    expect(url).toContain('token=a%2Bb%2Fc%3Dd');
+  });
+});
+
+describe('createPasswordResetToken', () => {
+  it('invalidates prior unused tokens and persists a new one in a single transaction', async () => {
+    // Capture what the service passes to $transaction
+    mockTransaction.mockResolvedValue([{ count: 0 }, { id: 'tok_1' }]);
+
+    const rawToken = await createPasswordResetToken('user_1');
+
+    expect(typeof rawToken).toBe('string');
+    expect(rawToken.length).toBeGreaterThan(20);
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+
+    // Extract the two prisma ops that were queued inside the transaction
+    const ops = mockTransaction.mock.calls[0][0] as unknown[];
+    expect(ops).toHaveLength(2);
+  });
+
+  it('generates a fresh raw token on each call (cryptographic randomness)', async () => {
+    mockTransaction.mockResolvedValue([{ count: 0 }, { id: 'tok' }]);
+
+    const tokens = await Promise.all([
+      createPasswordResetToken('user_1'),
+      createPasswordResetToken('user_1'),
+      createPasswordResetToken('user_1'),
+    ]);
+
+    expect(new Set(tokens).size).toBe(3);
+  });
+
+  it('stores only a SHA-256 hash (never the raw token) in the DB payload', async () => {
+    // Spy on the actual ops by capturing them through the transaction's second arg.
+    const createSpy = mockPasswordResetToken.create;
+    const updateManySpy = mockPasswordResetToken.updateMany;
+    createSpy.mockReturnValue({ __op: 'create' });
+    updateManySpy.mockReturnValue({ __op: 'updateMany' });
+    mockTransaction.mockResolvedValue([{ count: 0 }, { id: 'tok' }]);
+
+    const rawToken = await createPasswordResetToken('user_1');
+
+    const createCall = createSpy.mock.calls[0][0];
+    expect(createCall.data.userId).toBe('user_1');
+    expect(createCall.data.tokenHash).toBeDefined();
+    // The hash must not equal the raw token
+    expect(createCall.data.tokenHash).not.toBe(rawToken);
+    // SHA-256 hex string is 64 chars
+    expect(createCall.data.tokenHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('sets expiresAt to now + TTL', async () => {
+    const createSpy = mockPasswordResetToken.create;
+    createSpy.mockReturnValue({ __op: 'create' });
+    mockPasswordResetToken.updateMany.mockReturnValue({ __op: 'updateMany' });
+    mockTransaction.mockResolvedValue([{ count: 0 }, { id: 'tok' }]);
+
+    const before = Date.now();
+    await createPasswordResetToken('user_1');
+    const after = Date.now();
+
+    const createCall = createSpy.mock.calls[0][0];
+    const expiresAt = (createCall.data.expiresAt as Date).getTime();
+    const ttlMs = PASSWORD_RESET_TTL_MINUTES * 60 * 1000;
+    expect(expiresAt).toBeGreaterThanOrEqual(before + ttlMs - 1000);
+    expect(expiresAt).toBeLessThanOrEqual(after + ttlMs + 1000);
+  });
+});
+
+describe('consumePasswordResetToken', () => {
+  it('returns { ok: true, userId } on first successful consumption', async () => {
+    mockPasswordResetToken.findUnique.mockResolvedValue({
+      id: 'tok_1',
+      userId: 'user_1',
+      tokenHash: 'hash',
+      expiresAt: new Date(Date.now() + 60_000),
+      usedAt: null,
+      createdAt: new Date(),
+    });
+    mockPasswordResetToken.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await consumePasswordResetToken('raw-token');
+
+    expect(result).toEqual({ ok: true, userId: 'user_1' });
+    expect(mockPasswordResetToken.updateMany).toHaveBeenCalledWith({
+      where: { id: 'tok_1', usedAt: null },
+      data: { usedAt: expect.any(Date) },
+    });
+  });
+
+  it('returns { ok: false, reason: "not_found" } when the token does not exist', async () => {
+    mockPasswordResetToken.findUnique.mockResolvedValue(null);
+
+    const result = await consumePasswordResetToken('raw-token');
+
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+    expect(mockPasswordResetToken.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('returns { ok: false, reason: "already_used", userId } when the token was previously consumed', async () => {
+    mockPasswordResetToken.findUnique.mockResolvedValue({
+      id: 'tok_1',
+      userId: 'user_42',
+      tokenHash: 'hash',
+      expiresAt: new Date(Date.now() + 60_000),
+      usedAt: new Date(Date.now() - 10_000),
+      createdAt: new Date(),
+    });
+
+    const result = await consumePasswordResetToken('raw-token');
+
+    expect(result).toEqual({ ok: false, reason: 'already_used', userId: 'user_42' });
+    expect(mockPasswordResetToken.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('returns { ok: false, reason: "expired" } when the token is past its expiry', async () => {
+    mockPasswordResetToken.findUnique.mockResolvedValue({
+      id: 'tok_1',
+      userId: 'user_1',
+      tokenHash: 'hash',
+      expiresAt: new Date(Date.now() - 1),
+      usedAt: null,
+      createdAt: new Date(),
+    });
+
+    const result = await consumePasswordResetToken('raw-token');
+
+    expect(result).toEqual({ ok: false, reason: 'expired' });
+    expect(mockPasswordResetToken.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('returns { ok: false, reason: "already_used", userId } when the atomic update loses the race (count=0)', async () => {
+    // Both reads see usedAt: null, but only one updateMany wins.
+    mockPasswordResetToken.findUnique.mockResolvedValue({
+      id: 'tok_1',
+      userId: 'user_7',
+      tokenHash: 'hash',
+      expiresAt: new Date(Date.now() + 60_000),
+      usedAt: null,
+      createdAt: new Date(),
+    });
+    // This call loses the race — count is 0.
+    mockPasswordResetToken.updateMany.mockResolvedValue({ count: 0 });
+
+    const result = await consumePasswordResetToken('raw-token');
+
+    expect(result).toEqual({ ok: false, reason: 'already_used', userId: 'user_7' });
+  });
+
+  it('prevents double-consumption under concurrent calls (only one succeeds)', async () => {
+    // Both concurrent calls see the same unused record
+    mockPasswordResetToken.findUnique.mockResolvedValue({
+      id: 'tok_1',
+      userId: 'user_1',
+      tokenHash: 'hash',
+      expiresAt: new Date(Date.now() + 60_000),
+      usedAt: null,
+      createdAt: new Date(),
+    });
+
+    // Simulate a DB race: the first updateMany returns count=1, the second returns count=0.
+    let winnerAcknowledged = false;
+    mockPasswordResetToken.updateMany.mockImplementation(async () => {
+      if (!winnerAcknowledged) {
+        winnerAcknowledged = true;
+        return { count: 1 };
+      }
+      return { count: 0 };
+    });
+
+    const [a, b] = await Promise.all([
+      consumePasswordResetToken('raw-token'),
+      consumePasswordResetToken('raw-token'),
+    ]);
+
+    const outcomes = [a, b];
+    const successes = outcomes.filter((r) => r.ok);
+    const failures = outcomes.filter((r) => !r.ok);
+
+    expect(successes).toHaveLength(1);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({ ok: false, reason: 'already_used', userId: 'user_1' });
+  });
+
+  it('hashes the raw token before lookup (does not query by raw token)', async () => {
+    mockPasswordResetToken.findUnique.mockResolvedValue(null);
+
+    await consumePasswordResetToken('raw-token-xyz');
+
+    const call = mockPasswordResetToken.findUnique.mock.calls[0][0];
+    expect(call.where.tokenHash).not.toBe('raw-token-xyz');
+    expect(call.where.tokenHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('sendPasswordResetEmail', () => {
+  it('emails the user with the reset URL via sendReactEmailWithAudit (bypassing unsubscribe)', async () => {
+    await sendPasswordResetEmail(
+      { id: 'user_1', email: 'rider@example.com', name: 'Alex Example' },
+      'raw-token',
+      'admin_password_reset',
+    );
+
+    expect(mockSendReactEmailWithAudit).toHaveBeenCalledTimes(1);
+    const arg = mockSendReactEmailWithAudit.mock.calls[0][0];
+    expect(arg.to).toBe('rider@example.com');
+    expect(arg.userId).toBe('user_1');
+    expect(arg.emailType).toBe('password_reset');
+    expect(arg.triggerSource).toBe('admin_password_reset');
+    expect(arg.bypassUnsubscribe).toBe(true);
+    expect(arg.subject).toMatch(/reset/i);
+    // Make sure the template version is propagated
+    expect(arg.templateVersion).toBeDefined();
+  });
+
+  it('forwards the user_action trigger source for self-service resets', async () => {
+    await sendPasswordResetEmail(
+      { id: 'user_1', email: 'a@b.com' },
+      'tok',
+      'user_action',
+    );
+
+    expect(mockSendReactEmailWithAudit.mock.calls[0][0].triggerSource).toBe('user_action');
+  });
+});

--- a/apps/api/src/services/password-reset.service.test.ts
+++ b/apps/api/src/services/password-reset.service.test.ts
@@ -5,6 +5,7 @@ jest.mock('../lib/prisma', () => ({
       findUnique: jest.fn(),
       create: jest.fn(),
       updateMany: jest.fn(),
+      deleteMany: jest.fn(),
     },
     $transaction: jest.fn(),
   },
@@ -29,6 +30,7 @@ import {
   consumePasswordResetToken,
   sendPasswordResetEmail,
   buildResetUrl,
+  cleanupExpiredPasswordResetTokens,
   PASSWORD_RESET_TTL_MINUTES,
 } from './password-reset.service';
 
@@ -40,6 +42,7 @@ const mockPasswordResetToken = mockPrisma.passwordResetToken as unknown as {
   findUnique: jest.Mock;
   create: jest.Mock;
   updateMany: jest.Mock;
+  deleteMany: jest.Mock;
 };
 const mockTransaction = mockPrisma.$transaction as unknown as jest.Mock;
 
@@ -139,8 +142,10 @@ describe('consumePasswordResetToken', () => {
     const result = await consumePasswordResetToken('raw-token');
 
     expect(result).toEqual({ ok: true, userId: 'user_1' });
+    // Atomic update must re-check both usedAt AND expiresAt to prevent a
+    // token expiring between the findUnique and the write from slipping through.
     expect(mockPasswordResetToken.updateMany).toHaveBeenCalledWith({
-      where: { id: 'tok_1', usedAt: null },
+      where: { id: 'tok_1', usedAt: null, expiresAt: { gt: expect.any(Date) } },
       data: { usedAt: expect.any(Date) },
     });
   });
@@ -278,5 +283,47 @@ describe('sendPasswordResetEmail', () => {
     );
 
     expect(mockSendReactEmailWithAudit.mock.calls[0][0].triggerSource).toBe('user_action');
+  });
+});
+
+describe('cleanupExpiredPasswordResetTokens', () => {
+  it('deletes tokens whose expiresAt is older than the cutoff (default: 7 days)', async () => {
+    mockPasswordResetToken.deleteMany.mockResolvedValue({ count: 42 });
+
+    const before = Date.now();
+    const deleted = await cleanupExpiredPasswordResetTokens();
+    const after = Date.now();
+
+    expect(deleted).toBe(42);
+    expect(mockPasswordResetToken.deleteMany).toHaveBeenCalledTimes(1);
+
+    const call = mockPasswordResetToken.deleteMany.mock.calls[0][0];
+    const cutoff = (call.where.expiresAt.lt as Date).getTime();
+    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+    // cutoff should be roughly `now - 7 days`
+    expect(cutoff).toBeGreaterThanOrEqual(before - sevenDaysMs - 1000);
+    expect(cutoff).toBeLessThanOrEqual(after - sevenDaysMs + 1000);
+  });
+
+  it('honors a custom olderThanHours argument', async () => {
+    mockPasswordResetToken.deleteMany.mockResolvedValue({ count: 0 });
+
+    const before = Date.now();
+    await cleanupExpiredPasswordResetTokens(1); // 1 hour ago
+    const after = Date.now();
+
+    const call = mockPasswordResetToken.deleteMany.mock.calls[0][0];
+    const cutoff = (call.where.expiresAt.lt as Date).getTime();
+    const oneHourMs = 60 * 60 * 1000;
+    expect(cutoff).toBeGreaterThanOrEqual(before - oneHourMs - 1000);
+    expect(cutoff).toBeLessThanOrEqual(after - oneHourMs + 1000);
+  });
+
+  it('returns 0 when there is nothing to clean up', async () => {
+    mockPasswordResetToken.deleteMany.mockResolvedValue({ count: 0 });
+
+    const deleted = await cleanupExpiredPasswordResetTokens();
+
+    expect(deleted).toBe(0);
   });
 });

--- a/apps/api/src/services/password-reset.service.ts
+++ b/apps/api/src/services/password-reset.service.ts
@@ -2,7 +2,8 @@ import crypto from 'crypto';
 import { prisma } from '../lib/prisma';
 import { logger } from '../lib/logger';
 import { sendReactEmailWithAudit } from './email.service';
-import PasswordResetEmail, {
+import {
+  buildPasswordResetEmailElement,
   getPasswordResetEmailSubject,
   PASSWORD_RESET_TEMPLATE_VERSION,
 } from '../templates/emails/password-reset';
@@ -71,14 +72,12 @@ export async function sendPasswordResetEmail(
   await sendReactEmailWithAudit({
     to: user.email,
     subject: getPasswordResetEmailSubject(),
-    reactElement: (
-      <PasswordResetEmail
-        recipientFirstName={firstName}
-        email={user.email}
-        resetUrl={resetUrl}
-        expiresInMinutes={PASSWORD_RESET_TTL_MINUTES}
-      />
-    ),
+    reactElement: buildPasswordResetEmailElement({
+      recipientFirstName: firstName,
+      email: user.email,
+      resetUrl,
+      expiresInMinutes: PASSWORD_RESET_TTL_MINUTES,
+    }),
     userId: user.id,
     emailType: 'password_reset',
     triggerSource,

--- a/apps/api/src/services/password-reset.service.ts
+++ b/apps/api/src/services/password-reset.service.ts
@@ -50,10 +50,17 @@ export async function createPasswordResetToken(userId: string): Promise<string> 
  * Build the reset URL that lands on the web app's reset-password page.
  * The web page handles redirecting to the mobile deep link for app users
  * (iOS/Android universal link interception also handled via expo scheme).
+ *
+ * The `source=email` query param signals to the web page that the visitor
+ * arrived by tapping an email link, so the mobile deep-link hand-off fires
+ * only in that context. Direct visits (typed URL, bookmark, re-nav) skip it
+ * to avoid triggering spurious "Open in app?" prompts or error dialogs on
+ * mobile browsers when the app isn't installed.
  */
 export function buildResetUrl(rawToken: string): string {
   const url = new URL('/reset-password', FRONTEND_URL);
   url.searchParams.set('token', rawToken);
+  url.searchParams.set('source', 'email');
   return url.toString();
 }
 

--- a/apps/api/src/services/password-reset.service.tsx
+++ b/apps/api/src/services/password-reset.service.tsx
@@ -91,11 +91,15 @@ export async function sendPasswordResetEmail(
 
 export type ConsumeResult =
   | { ok: true; userId: string }
-  | { ok: false; reason: 'not_found' | 'expired' | 'already_used' };
+  | { ok: false; reason: 'not_found' | 'expired' }
+  | { ok: false; reason: 'already_used'; userId: string };
 
 /**
  * Verify a raw token and mark it used. Returns the associated userId on success.
  * Safe against token reuse — the same token cannot be consumed twice.
+ *
+ * `already_used` results include the userId so callers can log which user's
+ * reset link may have leaked, without exposing that distinction to the client.
  */
 export async function consumePasswordResetToken(rawToken: string): Promise<ConsumeResult> {
   const tokenHash = hashToken(rawToken);
@@ -107,7 +111,7 @@ export async function consumePasswordResetToken(rawToken: string): Promise<Consu
     return { ok: false, reason: 'not_found' };
   }
   if (record.usedAt) {
-    return { ok: false, reason: 'already_used' };
+    return { ok: false, reason: 'already_used', userId: record.userId };
   }
   if (record.expiresAt.getTime() < Date.now()) {
     return { ok: false, reason: 'expired' };
@@ -119,7 +123,8 @@ export async function consumePasswordResetToken(rawToken: string): Promise<Consu
   });
 
   if (updated.count === 0) {
-    return { ok: false, reason: 'already_used' };
+    // Race: someone else consumed this token between our findUnique and updateMany.
+    return { ok: false, reason: 'already_used', userId: record.userId };
   }
 
   return { ok: true, userId: record.userId };

--- a/apps/api/src/services/password-reset.service.tsx
+++ b/apps/api/src/services/password-reset.service.tsx
@@ -1,0 +1,126 @@
+import crypto from 'crypto';
+import { prisma } from '../lib/prisma';
+import { logger } from '../lib/logger';
+import { sendReactEmailWithAudit } from './email.service';
+import PasswordResetEmail, {
+  getPasswordResetEmailSubject,
+  PASSWORD_RESET_TEMPLATE_VERSION,
+} from '../templates/emails/password-reset';
+import { FRONTEND_URL } from '../config/env';
+import type { TriggerSource } from '@prisma/client';
+
+export const PASSWORD_RESET_TTL_MINUTES = 60;
+const TOKEN_BYTES = 32;
+
+export type PasswordResetUser = {
+  id: string;
+  email: string;
+  name?: string | null;
+};
+
+function hashToken(rawToken: string): string {
+  return crypto.createHash('sha256').update(rawToken).digest('hex');
+}
+
+/**
+ * Generate a new password reset token for a user.
+ * Invalidates any existing unused tokens for the same user.
+ * Returns the raw token — store only the hash, never persist the raw token.
+ */
+export async function createPasswordResetToken(userId: string): Promise<string> {
+  const rawToken = crypto.randomBytes(TOKEN_BYTES).toString('base64url');
+  const tokenHash = hashToken(rawToken);
+  const expiresAt = new Date(Date.now() + PASSWORD_RESET_TTL_MINUTES * 60 * 1000);
+
+  await prisma.$transaction([
+    prisma.passwordResetToken.updateMany({
+      where: { userId, usedAt: null },
+      data: { usedAt: new Date() },
+    }),
+    prisma.passwordResetToken.create({
+      data: { userId, tokenHash, expiresAt },
+    }),
+  ]);
+
+  return rawToken;
+}
+
+/**
+ * Build the reset URL that lands on the web app's reset-password page.
+ * The web page handles redirecting to the mobile deep link for app users
+ * (iOS/Android universal link interception also handled via expo scheme).
+ */
+export function buildResetUrl(rawToken: string): string {
+  const url = new URL('/reset-password', FRONTEND_URL);
+  url.searchParams.set('token', rawToken);
+  return url.toString();
+}
+
+/**
+ * Send a password reset email to a user.
+ * Bypasses the emailUnsubscribed flag (security notification).
+ */
+export async function sendPasswordResetEmail(
+  user: PasswordResetUser,
+  rawToken: string,
+  triggerSource: TriggerSource,
+): Promise<void> {
+  const firstName = user.name?.split(' ')[0];
+  const resetUrl = buildResetUrl(rawToken);
+
+  await sendReactEmailWithAudit({
+    to: user.email,
+    subject: getPasswordResetEmailSubject(),
+    reactElement: (
+      <PasswordResetEmail
+        recipientFirstName={firstName}
+        email={user.email}
+        resetUrl={resetUrl}
+        expiresInMinutes={PASSWORD_RESET_TTL_MINUTES}
+      />
+    ),
+    userId: user.id,
+    emailType: 'password_reset',
+    triggerSource,
+    templateVersion: PASSWORD_RESET_TEMPLATE_VERSION,
+    bypassUnsubscribe: true,
+  });
+
+  logger.info({ userId: user.id }, 'Password reset email sent');
+}
+
+export type ConsumeResult =
+  | { ok: true; userId: string }
+  | { ok: false; reason: 'not_found' | 'expired' | 'already_used' };
+
+/**
+ * Verify a raw token and mark it used. Returns the associated userId on success.
+ * Safe against token reuse — the same token cannot be consumed twice.
+ */
+export async function consumePasswordResetToken(rawToken: string): Promise<ConsumeResult> {
+  const tokenHash = hashToken(rawToken);
+  const record = await prisma.passwordResetToken.findUnique({
+    where: { tokenHash },
+  });
+
+  if (!record) {
+    return { ok: false, reason: 'not_found' };
+  }
+  if (record.usedAt) {
+    return { ok: false, reason: 'already_used' };
+  }
+  if (record.expiresAt.getTime() < Date.now()) {
+    return { ok: false, reason: 'expired' };
+  }
+
+  const updated = await prisma.passwordResetToken.updateMany({
+    where: { id: record.id, usedAt: null },
+    data: { usedAt: new Date() },
+  });
+
+  if (updated.count === 0) {
+    return { ok: false, reason: 'already_used' };
+  }
+
+  return { ok: true, userId: record.userId };
+}

--- a/apps/api/src/services/password-reset.service.tsx
+++ b/apps/api/src/services/password-reset.service.tsx
@@ -92,7 +92,12 @@ export async function sendPasswordResetEmail(
 export type ConsumeResult =
   | { ok: true; userId: string }
   | { ok: false; reason: 'not_found' | 'expired' }
-  | { ok: false; reason: 'already_used'; userId: string };
+  | { ok: false; reason: 'already_used'; userId: string }
+  // Atomic update lost the race (count=0 after passing the initial checks).
+  // The cause is either a concurrent consumer or sub-ms expiry — a follow-up
+  // read disambiguates. Surfaced separately so the caller doesn't log the
+  // benign expiry case as a security event.
+  | { ok: false; reason: 'race_expired'; userId: string };
 
 /**
  * Verify a raw token and mark it used. Returns the associated userId on success.
@@ -125,10 +130,19 @@ export async function consumePasswordResetToken(rawToken: string): Promise<Consu
   });
 
   if (updated.count === 0) {
-    // Race: either another request consumed it, or it expired in the sub-ms
-    // gap between our read and write. Treat both as already_used for the
-    // caller — we already logged the userId so the signal isn't lost.
-    return { ok: false, reason: 'already_used', userId: record.userId };
+    // Atomic update lost the race. Re-read to tell "concurrent consumer
+    // (security signal)" apart from "just expired between our read and
+    // write (benign, no alert)".
+    const refreshed = await prisma.passwordResetToken.findUnique({
+      where: { id: record.id },
+      select: { usedAt: true, expiresAt: true },
+    });
+    if (refreshed?.usedAt) {
+      return { ok: false, reason: 'already_used', userId: record.userId };
+    }
+    // Either the row vanished (unlikely) or it's past expiry now — treat as
+    // a benign expiry race. No security alert warranted.
+    return { ok: false, reason: 'race_expired', userId: record.userId };
   }
 
   return { ok: true, userId: record.userId };

--- a/apps/api/src/services/password-reset.service.tsx
+++ b/apps/api/src/services/password-reset.service.tsx
@@ -118,14 +118,32 @@ export async function consumePasswordResetToken(rawToken: string): Promise<Consu
   }
 
   const updated = await prisma.passwordResetToken.updateMany({
-    where: { id: record.id, usedAt: null },
+    // Re-check both unused and not-yet-expired atomically so a token expiring
+    // between the findUnique above and this write can't slip through.
+    where: { id: record.id, usedAt: null, expiresAt: { gt: new Date() } },
     data: { usedAt: new Date() },
   });
 
   if (updated.count === 0) {
-    // Race: someone else consumed this token between our findUnique and updateMany.
+    // Race: either another request consumed it, or it expired in the sub-ms
+    // gap between our read and write. Treat both as already_used for the
+    // caller — we already logged the userId so the signal isn't lost.
     return { ok: false, reason: 'already_used', userId: record.userId };
   }
 
   return { ok: true, userId: record.userId };
+}
+
+/**
+ * Delete password reset tokens whose `expiresAt` was more than `olderThanHours`
+ * hours ago. Invalidated-but-never-used and expired tokens accumulate
+ * indefinitely otherwise; a scheduled job calls this to keep the table bounded.
+ * Returns the number of deleted rows.
+ */
+export async function cleanupExpiredPasswordResetTokens(olderThanHours = 7 * 24): Promise<number> {
+  const cutoff = new Date(Date.now() - olderThanHours * 60 * 60 * 1000);
+  const result = await prisma.passwordResetToken.deleteMany({
+    where: { expiresAt: { lt: cutoff } },
+  });
+  return result.count;
 }

--- a/apps/api/src/templates/emails/password-added.tsx
+++ b/apps/api/src/templates/emails/password-added.tsx
@@ -26,3 +26,11 @@ export default function PasswordAddedEmail(props: PasswordSecurityEmailProps) {
 export function getPasswordAddedEmailSubject(): string {
   return "Password added to your Loam Logger account";
 }
+
+/**
+ * Build the React element for the password-added email.
+ * Keeping the JSX in the template module lets consumer service files stay .ts.
+ */
+export function buildPasswordAddedEmailElement(props: PasswordSecurityEmailProps) {
+  return <PasswordAddedEmail {...props} />;
+}

--- a/apps/api/src/templates/emails/password-changed.tsx
+++ b/apps/api/src/templates/emails/password-changed.tsx
@@ -26,3 +26,11 @@ export default function PasswordChangedEmail(props: PasswordSecurityEmailProps) 
 export function getPasswordChangedEmailSubject(): string {
   return "Your Loam Logger password was changed";
 }
+
+/**
+ * Build the React element for the password-changed email.
+ * Keeping the JSX in the template module lets consumer service files stay .ts.
+ */
+export function buildPasswordChangedEmailElement(props: PasswordSecurityEmailProps) {
+  return <PasswordChangedEmail {...props} />;
+}

--- a/apps/api/src/templates/emails/password-reset.tsx
+++ b/apps/api/src/templates/emails/password-reset.tsx
@@ -142,3 +142,11 @@ export default function PasswordResetEmail({
 export function getPasswordResetEmailSubject(): string {
   return "Reset your Loam Logger password";
 }
+
+/**
+ * Build the React element for the password reset email.
+ * Keeping the JSX in the template module lets the service file stay .ts.
+ */
+export function buildPasswordResetEmailElement(props: PasswordResetEmailProps) {
+  return <PasswordResetEmail {...props} />;
+}

--- a/apps/api/src/templates/emails/password-reset.tsx
+++ b/apps/api/src/templates/emails/password-reset.tsx
@@ -1,0 +1,144 @@
+import * as React from "react";
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+  Hr,
+} from "@react-email/components";
+import { sanitizeUserInput } from "../../lib/html";
+import { TOKENS, darkModeStyles, baseStyles } from "./shared-styles";
+
+export const PASSWORD_RESET_TEMPLATE_VERSION = "1.0.0";
+
+export type PasswordResetEmailProps = {
+  recipientFirstName?: string;
+  email?: string;
+  resetUrl: string;
+  expiresInMinutes?: number;
+  supportEmail?: string;
+};
+
+export default function PasswordResetEmail({
+  recipientFirstName,
+  email = "rider@example.com",
+  resetUrl,
+  expiresInMinutes = 60,
+  supportEmail = "ryan.lecours@loamlogger.app",
+}: PasswordResetEmailProps) {
+  const safeName = sanitizeUserInput(recipientFirstName);
+  const safeEmail = sanitizeUserInput(email, 254);
+  const greeting = safeName ? `Hi ${safeName},` : "Hi there,";
+
+  return (
+    <Html>
+      <Head>
+        <meta name="color-scheme" content="light dark" />
+        <meta name="supported-color-schemes" content="light dark" />
+        <style dangerouslySetInnerHTML={{ __html: darkModeStyles }} />
+      </Head>
+
+      <Preview>Reset your Loam Logger password</Preview>
+
+      <Body className="ll-body" style={baseStyles.body}>
+        <Container className="ll-container" style={baseStyles.container}>
+          <Section style={{ padding: "8px 6px 14px 6px" }}>
+            <Text className="ll-brand" style={baseStyles.brand}>
+              LoamLogger
+            </Text>
+          </Section>
+
+          <Section className="ll-card" style={baseStyles.card}>
+            <Heading className="ll-h1" style={baseStyles.h1}>
+              Reset your password
+            </Heading>
+
+            <Text className="ll-p" style={baseStyles.p}>
+              {greeting}
+            </Text>
+
+            <Text className="ll-p" style={baseStyles.p}>
+              We received a request to reset the password for your Loam Logger account ({safeEmail}).
+              Click the button below to choose a new password.
+            </Text>
+
+            <Section style={{ textAlign: "center", margin: "20px 0" }}>
+              <Button
+                className="ll-button"
+                href={resetUrl}
+                style={{
+                  backgroundColor: TOKENS.ctaBg,
+                  color: TOKENS.ctaText,
+                  padding: "12px 24px",
+                  borderRadius: 10,
+                  fontSize: 15,
+                  fontWeight: 700,
+                  textDecoration: "none",
+                  display: "inline-block",
+                }}
+              >
+                Reset password
+              </Button>
+            </Section>
+
+            <Text className="ll-p" style={baseStyles.p}>
+              This link will expire in {expiresInMinutes} minutes. If the button doesn&apos;t work,
+              paste this URL into your browser:
+            </Text>
+
+            <Text
+              className="ll-p"
+              style={{ ...baseStyles.p, wordBreak: "break-all", fontSize: 12 }}
+            >
+              <Link href={resetUrl} style={{ color: TOKENS.text }}>
+                {resetUrl}
+              </Link>
+            </Text>
+
+            <Hr className="ll-hr" style={baseStyles.hr} />
+
+            <Section className="ll-warning" style={baseStyles.warning}>
+              <Text className="ll-warning-text" style={baseStyles.warningText}>
+                <strong>If you didn&apos;t request this</strong>, you can safely ignore this email —
+                your password won&apos;t change. If you&apos;re concerned about your account, contact us at{" "}
+                <Link href={`mailto:${supportEmail}`} style={baseStyles.warningLink}>
+                  {supportEmail}
+                </Link>
+                .
+              </Text>
+            </Section>
+
+            <Text
+              className="ll-signature"
+              style={{
+                ...baseStyles.p,
+                marginTop: 14,
+                marginBottom: 0,
+                color: TOKENS.text,
+                fontWeight: 800,
+              }}
+            >
+              – The Loam Logger Team
+            </Text>
+          </Section>
+
+          <Section style={baseStyles.footer}>
+            <Text className="ll-footer" style={{ ...baseStyles.footerText, marginBottom: 0 }}>
+              Loam Logger • This is a security notification and cannot be unsubscribed.
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+export function getPasswordResetEmailSubject(): string {
+  return "Reset your Loam Logger password";
+}

--- a/apps/api/vite.config.ts
+++ b/apps/api/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 import path from "path";
 
 export default defineConfig({
@@ -8,10 +9,31 @@ export default defineConfig({
       "@loam/shared": path.resolve(__dirname, "../../libs/shared/src/index.ts"),
     },
   },
+  plugins: [
+    sentryVitePlugin({
+      org: "loam-labs-llc",
+      project: "node",
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      // No-op locally without the token, same as the web config.
+      disable: !process.env.SENTRY_AUTH_TOKEN,
+      release: process.env.SENTRY_RELEASE
+        ? { name: process.env.SENTRY_RELEASE }
+        : undefined,
+      // Bound scope to the server bundle + its sourcemap.
+      sourcemaps: {
+        assets: ["../../dist/apps/api/**/*.cjs", "../../dist/apps/api/**/*.map"],
+      },
+    }),
+  ],
   build: {
     ssr: "src/server.ts",
     outDir: "../../dist/apps/api",
     target: "node18",
+    // Emit source maps so Sentry can symbolicate production stack traces.
+    // 'hidden' means no //# sourceMappingURL comment in the built server.cjs —
+    // maps still land in dist/ and get uploaded to Sentry but aren't served
+    // publicly.
+    sourcemap: "hidden",
     rollupOptions: {
       external: [
         // keep native/binary deps and prisma external

--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "57Z6GUJL4D.com.loamlabs.loamlogger",
+        "paths": ["/reset-password", "/reset-password/*"]
+      }
+    ]
+  }
+}

--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -1,10 +1,18 @@
 {
   "applinks": {
-    "apps": [],
     "details": [
       {
-        "appID": "57Z6GUJL4D.com.loamlabs.loamlogger",
-        "paths": ["/reset-password", "/reset-password/*"]
+        "appIDs": ["57Z6GUJL4D.com.loamlabs.loamlogger"],
+        "components": [
+          {
+            "/": "/reset-password",
+            "comment": "Opens the reset-password screen in the mobile app"
+          },
+          {
+            "/": "/reset-password/*",
+            "comment": "Opens the reset-password screen in the mobile app"
+          }
+        ]
       }
     ]
   }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,6 +16,7 @@ import BetaTesterWaitlist from './pages/BetaTesterWaitlist';
 import ClosedBeta from './pages/ClosedBeta';
 import AlreadyOnWaitlist from './pages/AlreadyOnWaitlist';
 import ChangePassword from './pages/ChangePassword';
+import ResetPassword from './pages/ResetPassword';
 
 import AuthGate from './components/AuthGate';
 import AppShell from './components/layout/AppShell';
@@ -81,6 +82,7 @@ function AppRoutes() {
           <Route path="/closed-beta" element={<Page><ClosedBeta /></Page>} />
           <Route path="/already-on-waitlist" element={<Page><AlreadyOnWaitlist /></Page>} />
           <Route path="/change-password" element={<Page><ChangePassword /></Page>} />
+          <Route path="/reset-password" element={<Page><ResetPassword /></Page>} />
           <Route path="/auth/complete" element={<AuthComplete />} />
 
           {/* Onboarding */}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -17,6 +17,7 @@ import ClosedBeta from './pages/ClosedBeta';
 import AlreadyOnWaitlist from './pages/AlreadyOnWaitlist';
 import ChangePassword from './pages/ChangePassword';
 import ResetPassword from './pages/ResetPassword';
+import ForgotPassword from './pages/ForgotPassword';
 
 import AuthGate from './components/AuthGate';
 import AppShell from './components/layout/AppShell';
@@ -83,6 +84,7 @@ function AppRoutes() {
           <Route path="/already-on-waitlist" element={<Page><AlreadyOnWaitlist /></Page>} />
           <Route path="/change-password" element={<Page><ChangePassword /></Page>} />
           <Route path="/reset-password" element={<Page><ResetPassword /></Page>} />
+          <Route path="/forgot-password" element={<Page><ForgotPassword /></Page>} />
           <Route path="/auth/complete" element={<AuthComplete />} />
 
           {/* Onboarding */}

--- a/apps/web/src/components/AuthGate.tsx
+++ b/apps/web/src/components/AuthGate.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 import { useQuery } from '@apollo/client'
 import { ME_QUERY } from '../graphql/me'
+import { useSentryUser } from '../hooks/useSentryUser'
 
 export default function AuthGate({ children }: { children: ReactNode }) {
   const location = useLocation()
@@ -9,6 +10,10 @@ export default function AuthGate({ children }: { children: ReactNode }) {
     fetchPolicy: 'cache-and-network',
     nextFetchPolicy: 'cache-first',
   })
+
+  // Tag browser-side Sentry events with the authenticated user's id so alerts
+  // can surface who was affected. Clears on logout.
+  useSentryUser()
 
   if (loading && !data?.me) return <div className="p-6">Loading…</div>
   if (!data?.me) {

--- a/apps/web/src/hooks/useSentryUser.ts
+++ b/apps/web/src/hooks/useSentryUser.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+import * as Sentry from '@sentry/react';
+import { useCurrentUser } from './useCurrentUser';
+
+/**
+ * Keep Sentry's user scope in sync with the currently authenticated user.
+ *
+ * - When a logged-in user is loaded, tag Sentry events with their id so
+ *   browser-side errors can be correlated to "who was affected".
+ * - When the user logs out (ME_QUERY resolves to null), clear the scope.
+ *
+ * Intentionally only tags `id`. Email / name are PII we don't need in Sentry
+ * to triage issues; the id is enough to cross-reference logs and DB.
+ *
+ * Mount this in components that wrap authenticated routes (e.g. AuthGate).
+ */
+export function useSentryUser(): void {
+  const { user } = useCurrentUser();
+  const lastAppliedIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const id = user?.id ?? null;
+    if (id === lastAppliedIdRef.current) return;
+    lastAppliedIdRef.current = id;
+    if (id) {
+      Sentry.setUser({ id });
+    } else {
+      Sentry.setUser(null);
+    }
+  }, [user?.id]);
+}

--- a/apps/web/src/instrument.ts
+++ b/apps/web/src/instrument.ts
@@ -6,9 +6,13 @@ import {
   createRoutesFromChildren,
   matchRoutes,
 } from "react-router-dom";
+import { scrubKnownSecrets } from "./lib/sentry-scrub";
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
+  // Tag every event with the deploy SHA so Sentry can group errors by release
+  // and bind uploaded source maps to the right build.
+  release: import.meta.env.VITE_SENTRY_RELEASE || 'unknown',
   environment: import.meta.env.MODE,
   enabled: import.meta.env.PROD,
 
@@ -33,4 +37,22 @@ Sentry.init({
   // Session Replay
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
+
+  // Filter classic browser noise that isn't actionable.
+  ignoreErrors: [
+    // ResizeObserver loop warnings — harmless, fires on any dashboard with
+    // charts responding to window resize.
+    "ResizeObserver loop limit exceeded",
+    "ResizeObserver loop completed with undelivered notifications",
+    // Thrown non-Error values that Sentry normalizes into this cryptic message.
+    "Non-Error promise rejection captured",
+    // Browser extensions / ad blockers firing inside the page.
+    /extension:\/\//,
+  ],
+
+  // Strip secret-looking keys (password, token, cookie, etc.) from every
+  // event before it leaves the browser.
+  beforeSend(event) {
+    return scrubKnownSecrets(event);
+  },
 });

--- a/apps/web/src/lib/apolloClient.ts
+++ b/apps/web/src/lib/apolloClient.ts
@@ -1,6 +1,7 @@
-import { ApolloClient, InMemoryCache, HttpLink, from } from '@apollo/client';
+import { ApolloClient, ApolloLink, InMemoryCache, HttpLink, from } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 import { onError } from '@apollo/client/link/error';
+import * as Sentry from '@sentry/react';
 import { getCsrfToken } from './csrf';
 
 const graphqlUrl = import.meta.env.VITE_API_URL
@@ -12,6 +13,27 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
     for (const e of graphQLErrors) console.warn('[GraphQL error]', e.message);
   }
   if (networkError) console.warn('[Network error]', networkError);
+});
+
+// Record a Sentry breadcrumb per GraphQL operation with its name and duration.
+// Gives error events context like "before this crash, user ran RidesQuery then
+// DeleteRideMutation". Variables are intentionally excluded — they may contain
+// sensitive input (e.g. newPassword for reset flows).
+const sentryBreadcrumbLink = new ApolloLink((operation, forward) => {
+  const started = performance.now();
+  return forward(operation).map((result) => {
+    Sentry.addBreadcrumb({
+      category: 'graphql',
+      type: 'http',
+      level: result.errors?.length ? 'warning' : 'info',
+      message: operation.operationName || 'anonymous',
+      data: {
+        durationMs: Math.round(performance.now() - started),
+        hasErrors: Boolean(result.errors?.length),
+      },
+    });
+    return result;
+  });
 });
 
 const authLink = setContext((_, { headers }) => {
@@ -30,7 +52,7 @@ const httpLink = new HttpLink({
 });
 
 const client = new ApolloClient({
-  link: from([errorLink, authLink, httpLink]),
+  link: from([errorLink, sentryBreadcrumbLink, authLink, httpLink]),
   // Disable canonizeResults to avoid frozen-object and object-identity issues in React strict mode
   cache: new InMemoryCache({ canonizeResults: false }),
 });

--- a/apps/web/src/lib/sentry-scrub.ts
+++ b/apps/web/src/lib/sentry-scrub.ts
@@ -1,0 +1,73 @@
+/**
+ * Strip secret-looking keys from Sentry events before they leave the browser.
+ *
+ * Session Replay masks DOM input, but a GraphQL error whose variables include
+ * `{ password: ... }` or a thrown error whose breadcrumb carries a reset token
+ * would still land in Sentry unredacted. This walks the event in place.
+ *
+ * Kept independent of the API-side copy ([apps/api/src/lib/sentry-scrub.ts])
+ * so the browser bundle stays free of Node-only deps. Pattern must stay in
+ * sync with the server version.
+ */
+
+const SENSITIVE_KEY_PATTERN = /password|token|secret|cookie|authorization|bearer|apiKey|api_key|resetToken|sessionToken/i;
+
+const FILTERED = '[Filtered]';
+const MAX_DEPTH = 8;
+
+type Scrubable = Record<string, unknown> | unknown[] | null | undefined;
+
+function scrubInPlace(value: Scrubable, depth: number, seen: WeakSet<object>): void {
+  if (value === null || value === undefined) return;
+  if (typeof value !== 'object') return;
+  if (depth > MAX_DEPTH) return;
+  if (seen.has(value)) return;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (item && typeof item === 'object') {
+        scrubInPlace(item as Scrubable, depth + 1, seen);
+      }
+    }
+    return;
+  }
+
+  const obj = value as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      obj[key] = FILTERED;
+      continue;
+    }
+    const child = obj[key];
+    if (child && typeof child === 'object') {
+      scrubInPlace(child as Scrubable, depth + 1, seen);
+    }
+  }
+}
+
+export type ScrubbableSentryEvent = {
+  request?: {
+    data?: unknown;
+    headers?: Record<string, unknown>;
+    cookies?: unknown;
+    query_string?: unknown;
+  };
+  contexts?: Record<string, unknown>;
+  extra?: Record<string, unknown>;
+  breadcrumbs?: Array<{ data?: unknown; message?: string }>;
+  tags?: Record<string, unknown>;
+};
+
+export function scrubKnownSecrets<T extends ScrubbableSentryEvent>(event: T): T {
+  const seen = new WeakSet<object>();
+  if (event.request) scrubInPlace(event.request as Scrubable, 0, seen);
+  if (event.contexts) scrubInPlace(event.contexts as Scrubable, 0, seen);
+  if (event.extra) scrubInPlace(event.extra as Scrubable, 0, seen);
+  if (event.breadcrumbs) {
+    for (const bc of event.breadcrumbs) {
+      if (bc.data) scrubInPlace(bc.data as Scrubable, 0, seen);
+    }
+  }
+  return event;
+}

--- a/apps/web/src/pages/Admin.tsx
+++ b/apps/web/src/pages/Admin.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Navigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { formatDistanceToNow } from 'date-fns';
 import { useCurrentUser } from '../hooks/useCurrentUser';
 import { getAuthHeaders } from '@/lib/csrf';
 
@@ -22,6 +24,7 @@ interface UserEntry {
   activatedAt: string | null;
   emailUnsubscribed: boolean;
   isFoundingRider: boolean;
+  lastPasswordResetEmailAt: string | null;
 }
 
 interface AdminStats {
@@ -593,7 +596,15 @@ export default function Admin() {
   };
 
   const handleSendPasswordReset = async (userId: string, email: string) => {
-    if (!confirm(`Email a password reset link to ${email}?`)) {
+    // Guard against accidental double-sends: if a reset was emailed recently,
+    // show the admin when it was sent before they confirm a new one.
+    const user = users.find((u) => u.id === userId);
+    const lastSent = user?.lastPasswordResetEmailAt;
+    const prompt = lastSent
+      ? `A reset link was already sent to ${email} ${formatDistanceToNow(new Date(lastSent))} ago. Send another?`
+      : `Email a password reset link to ${email}?`;
+
+    if (!confirm(prompt)) {
       return;
     }
 
@@ -613,10 +624,17 @@ export default function Admin() {
         throw new Error(data.error || 'Failed to send password reset email');
       }
 
-      alert(`Password reset link sent to ${email}.`);
+      // Update the local timestamp so the admin sees the new "sent just now"
+      // value without a full refetch.
+      const now = new Date().toISOString();
+      setUsers((prev) =>
+        prev.map((u) => (u.id === userId ? { ...u, lastPasswordResetEmailAt: now } : u))
+      );
+
+      toast.success(`Password reset link sent to ${email}.`);
     } catch (err) {
       console.error('Send password reset failed:', err);
-      alert(err instanceof Error ? err.message : 'Failed to send password reset email');
+      toast.error(err instanceof Error ? err.message : 'Failed to send password reset email');
     } finally {
       setResettingPassword(null);
     }
@@ -1895,7 +1913,11 @@ export default function Admin() {
                         onClick={() => handleSendPasswordReset(u.id, u.email)}
                         disabled={resettingPassword === u.id || deleting === u.id || demoting === u.id}
                         className="btn-sm rounded-xl px-3 py-1.5 text-xs font-medium text-white bg-primary hover:bg-primary/80 transition disabled:opacity-50 disabled:cursor-not-allowed"
-                        title="Email a password reset link"
+                        title={
+                          u.lastPasswordResetEmailAt
+                            ? `Last reset sent ${formatDistanceToNow(new Date(u.lastPasswordResetEmailAt))} ago`
+                            : 'Email a password reset link'
+                        }
                       >
                         {resettingPassword === u.id ? 'Sending...' : 'Reset Pwd'}
                       </button>

--- a/apps/web/src/pages/Admin.tsx
+++ b/apps/web/src/pages/Admin.tsx
@@ -115,6 +115,7 @@ export default function Admin() {
   const [activating, setActivating] = useState<string | null>(null);
   const [deleting, setDeleting] = useState<string | null>(null);
   const [demoting, setDemoting] = useState<string | null>(null);
+  const [resettingPassword, setResettingPassword] = useState<string | null>(null);
   const [showAddUserForm, setShowAddUserForm] = useState(false);
   const [addingUser, setAddingUser] = useState(false);
   const [addUserForm, setAddUserForm] = useState<AddUserForm>({
@@ -588,6 +589,36 @@ export default function Admin() {
       alert(err instanceof Error ? err.message : 'Failed to delete user');
     } finally {
       setDeleting(null);
+    }
+  };
+
+  const handleSendPasswordReset = async (userId: string, email: string) => {
+    if (!confirm(`Email a password reset link to ${email}?`)) {
+      return;
+    }
+
+    try {
+      setResettingPassword(userId);
+      const res = await fetch(
+        `${import.meta.env.VITE_API_URL}/api/admin/users/${userId}/send-password-reset`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: getAuthHeaders(),
+        }
+      );
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Failed to send password reset email');
+      }
+
+      alert(`Password reset link sent to ${email}.`);
+    } catch (err) {
+      console.error('Send password reset failed:', err);
+      alert(err instanceof Error ? err.message : 'Failed to send password reset email');
+    } finally {
+      setResettingPassword(null);
     }
   };
 
@@ -1859,6 +1890,14 @@ export default function Admin() {
                         title={u.emailUnsubscribed ? 'User has unsubscribed' : 'Send email'}
                       >
                         Email
+                      </button>
+                      <button
+                        onClick={() => handleSendPasswordReset(u.id, u.email)}
+                        disabled={resettingPassword === u.id || deleting === u.id || demoting === u.id}
+                        className="btn-sm rounded-xl px-3 py-1.5 text-xs font-medium text-white bg-primary hover:bg-primary/80 transition disabled:opacity-50 disabled:cursor-not-allowed"
+                        title="Email a password reset link"
+                      >
+                        {resettingPassword === u.id ? 'Sending...' : 'Reset Pwd'}
                       </button>
                       <button
                         onClick={() => handleDemoteUser(u.id, u.email)}

--- a/apps/web/src/pages/ForgotPassword.tsx
+++ b/apps/web/src/pages/ForgotPassword.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { motion } from 'motion/react';
+import { Button } from '@/components/ui';
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setError(null);
+
+    if (!email.trim()) {
+      setError('Please enter your email.');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      await fetch(`${import.meta.env.VITE_API_URL}/auth/forgot-password`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email.trim() }),
+      });
+      // The server always returns 200 to avoid leaking which emails are registered.
+      // Show the same confirmation regardless.
+      setSubmitted(true);
+    } catch (err) {
+      console.error('[ForgotPassword] Network error', err);
+      setError('A network error occurred. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-dark">
+      <div
+        className="absolute inset-0 z-0 hidden md:block"
+        style={{
+          backgroundImage: 'url(/mtbLandingPhoto.jpg)',
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          backgroundAttachment: 'fixed',
+        }}
+      >
+        <div className="absolute inset-0 bg-gradient-to-b from-black/75 via-black/60 to-black/75" />
+      </div>
+
+      <div
+        className="absolute inset-0 z-0 md:hidden"
+        style={{
+          backgroundImage: 'url(/mtbLandingPhotoMobile.jpg)',
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+        }}
+      >
+        <div className="absolute inset-0 bg-gradient-to-b from-black/75 via-black/60 to-black/75" />
+      </div>
+
+      <motion.div
+        className="relative z-10 container px-6 max-w-md w-full"
+        initial={{ opacity: 0, y: 30 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8 }}
+      >
+        <div
+          className="w-full rounded-2xl p-8 space-y-6"
+          style={{
+            backgroundColor: 'var(--glass)',
+            border: '1px solid var(--slate)',
+            backdropFilter: 'blur(12px)',
+          }}
+        >
+          <div className="text-center space-y-1">
+            <p className="text-xs uppercase tracking-[0.4em]" style={{ color: 'var(--sage)' }}>
+              Loam Logger
+            </p>
+            <h1 className="text-2xl font-semibold" style={{ color: 'var(--cream)' }}>
+              {submitted ? 'Check Your Email' : 'Forgot Password'}
+            </h1>
+            <p className="text-sm" style={{ color: 'var(--concrete)' }}>
+              {submitted
+                ? `If an account exists for that email, we've sent a reset link. It expires in 1 hour.`
+                : 'Enter your email and we\u2019ll send you a link to reset your password.'}
+            </p>
+          </div>
+
+          {submitted ? (
+            <Link
+              to="/login"
+              className="block w-full text-center btn-primary rounded-full px-4 py-3 text-base font-semibold"
+            >
+              Back to Sign In
+            </Link>
+          ) : (
+            <form
+              className="space-y-4 p-4 rounded-xl"
+              style={{ backgroundColor: 'rgba(54, 60, 57, 0.3)' }}
+              onSubmit={handleSubmit}
+            >
+              {error && (
+                <div className="alert alert-danger">
+                  <p>{error}</p>
+                </div>
+              )}
+
+              <label className="block text-xs uppercase tracking-[0.3em]" style={{ color: 'var(--concrete)' }}>
+                Email
+                <input
+                  type="email"
+                  autoComplete="email"
+                  className="mt-1 w-full input-soft"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@example.com"
+                  disabled={isLoading}
+                  required
+                />
+              </label>
+
+              {isLoading && (
+                <div className="flex justify-center">
+                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+                </div>
+              )}
+
+              <Button
+                type="submit"
+                variant="primary"
+                className="w-full justify-center text-base"
+                disabled={isLoading}
+              >
+                {isLoading ? 'Sending...' : 'Send Reset Link'}
+              </Button>
+
+              <div className="text-center text-sm" style={{ color: 'var(--concrete)' }}>
+                <Link to="/login" className="hover:underline">
+                  Back to Sign In
+                </Link>
+              </div>
+            </form>
+          )}
+        </div>
+      </motion.div>
+    </section>
+  );
+}

--- a/apps/web/src/pages/ForgotPassword.tsx
+++ b/apps/web/src/pages/ForgotPassword.tsx
@@ -21,13 +21,22 @@ export default function ForgotPassword() {
     setIsLoading(true);
 
     try {
-      await fetch(`${import.meta.env.VITE_API_URL}/auth/forgot-password`, {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/auth/forgot-password`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: email.trim() }),
       });
-      // The server always returns 200 to avoid leaking which emails are registered.
-      // Show the same confirmation regardless.
+
+      // Surface rate-limit specifically so the user knows to retry later.
+      // Other non-200 codes still fall through to the generic "Check Your Email"
+      // screen to preserve enumeration resistance.
+      if (res.status === 429) {
+        const data = await res.json().catch(() => ({}));
+        const retryAfter = typeof data.retryAfter === 'number' ? data.retryAfter : 60;
+        setError(`Too many attempts. Please try again in ${retryAfter} seconds.`);
+        return;
+      }
+
       setSubmitted(true);
     } catch (err) {
       console.error('[ForgotPassword] Network error', err);

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -322,18 +322,31 @@ export default function Login() {
             />
           </label>
           {mode === 'login' && (
-            <label className="block text-xs uppercase tracking-[0.3em]" style={{ color: 'var(--concrete)' }}>
-              Password
-              <input
-                type="password"
-                className="mt-1 w-full input-soft"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="********"
-                disabled={isLoading}
-                required
-              />
-            </label>
+            <>
+              <label className="block text-xs uppercase tracking-[0.3em]" style={{ color: 'var(--concrete)' }}>
+                Password
+                <input
+                  type="password"
+                  className="mt-1 w-full input-soft"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="********"
+                  disabled={isLoading}
+                  required
+                />
+              </label>
+              <div className="text-right text-sm">
+                <button
+                  type="button"
+                  onClick={() => navigate('/forgot-password')}
+                  disabled={isLoading}
+                  className="hover:underline"
+                  style={{ color: 'var(--sage)' }}
+                >
+                  Forgot password?
+                </button>
+              </div>
+            </>
           )}
           {mode === 'signup' && waitlistEnabled && (
             <div className="text-sm p-3 rounded-lg" style={{ backgroundColor: 'rgba(134, 169, 139, 0.15)', color: 'var(--sage)' }}>

--- a/apps/web/src/pages/ResetPassword.tsx
+++ b/apps/web/src/pages/ResetPassword.tsx
@@ -30,13 +30,39 @@ export default function ResetPassword() {
   // screen) skip it — otherwise mobile browsers can show "Open in app?"
   // prompts or error dialogs even when the user is intentionally using the
   // web flow.
+  //
+  // Uses a hidden iframe rather than `window.location.href` so a failed scheme
+  // (app not installed) doesn't navigate the main frame to a broken URL — the
+  // user stays on the web form, which is already rendered. If the app DOES
+  // launch, the tab is backgrounded; `visibilitychange` tells us to clean up.
   useEffect(() => {
     if (!token) return;
     if (searchParams.get('source') !== 'email') return;
     const ua = navigator.userAgent;
     const isMobile = /iPhone|iPad|iPod|Android/i.test(ua);
     if (!isMobile) return;
-    window.location.href = `loamlogger://reset-password?token=${encodeURIComponent(token)}`;
+
+    const deepLink = `loamlogger://reset-password?token=${encodeURIComponent(token)}`;
+    const iframe = document.createElement('iframe');
+    iframe.style.display = 'none';
+    iframe.src = deepLink;
+    document.body.appendChild(iframe);
+
+    // If the app opens, the page goes into the background. Clean up silently.
+    // If 1.5s passes with the page still visible, the app didn't open — also
+    // clean up (the web form is already behind the form UI and fully usable).
+    const cleanup = () => {
+      iframe.remove();
+      document.removeEventListener('visibilitychange', onVisibility);
+      clearTimeout(timer);
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden') cleanup();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    const timer = setTimeout(cleanup, 1500);
+
+    return cleanup;
   }, [token, searchParams]);
 
   async function handleSubmit(event: React.FormEvent) {

--- a/apps/web/src/pages/ResetPassword.tsx
+++ b/apps/web/src/pages/ResetPassword.tsx
@@ -19,18 +19,25 @@ export default function ResetPassword() {
   // the user an actionable difference.
   const [expired, setExpired] = useState(!token);
 
-  // If the user is on a phone and has the app installed, try to hand off to it.
-  // On iOS with universal links configured, the OS intercepts the https:// link
-  // before we even load — this fallback only fires when that didn't happen
-  // (app not installed, old build without entitlement, in-app browser, etc.).
-  // If the scheme isn't registered the navigation silently fails and the web form stays visible.
+  // If the user is on a phone and arrived from an email link, try to hand off
+  // to the app. On iOS with universal links configured, the OS intercepts the
+  // https:// link before we even load — this fallback only fires when that
+  // didn't happen (app not installed, old build without entitlement, in-app
+  // browser, etc.).
+  //
+  // Gated on `?source=email` so only users arriving from the email attempt the
+  // hand-off. Direct visits (typed URL, bookmark, redirect from the expired
+  // screen) skip it — otherwise mobile browsers can show "Open in app?"
+  // prompts or error dialogs even when the user is intentionally using the
+  // web flow.
   useEffect(() => {
     if (!token) return;
+    if (searchParams.get('source') !== 'email') return;
     const ua = navigator.userAgent;
     const isMobile = /iPhone|iPad|iPod|Android/i.test(ua);
     if (!isMobile) return;
     window.location.href = `loamlogger://reset-password?token=${encodeURIComponent(token)}`;
-  }, [token]);
+  }, [token, searchParams]);
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault();

--- a/apps/web/src/pages/ResetPassword.tsx
+++ b/apps/web/src/pages/ResetPassword.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { motion } from 'motion/react';
+import { Button } from '@/components/ui';
+import { validatePassword, PASSWORD_RULES } from '@loam/shared';
+
+export default function ResetPassword() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
+
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  // If the user is on a phone and has the app installed, try to hand off to it.
+  // On iOS with universal links configured, the OS intercepts the https:// link
+  // before we even load — this fallback only fires when that didn't happen
+  // (app not installed, old build without entitlement, in-app browser, etc.).
+  // If the scheme isn't registered the navigation silently fails and the web form stays visible.
+  useEffect(() => {
+    if (!token) return;
+    const ua = navigator.userAgent;
+    const isMobile = /iPhone|iPad|iPod|Android/i.test(ua);
+    if (!isMobile) return;
+    window.location.href = `loamlogger://reset-password?token=${encodeURIComponent(token)}`;
+  }, [token]);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setError(null);
+
+    if (!token) {
+      setError('This reset link is missing its token. Please request a new one.');
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError('New passwords do not match.');
+      return;
+    }
+
+    const validation = validatePassword(newPassword);
+    if (!validation.isValid) {
+      setError(validation.error || 'Password does not meet requirements.');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/auth/reset-password`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, newPassword }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || 'Failed to reset password.');
+        return;
+      }
+
+      setSuccess(true);
+    } catch (err) {
+      console.error('[ResetPassword] Network error', err);
+      setError('A network error occurred. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-dark">
+      <div
+        className="absolute inset-0 z-0 hidden md:block"
+        style={{
+          backgroundImage: 'url(/mtbLandingPhoto.jpg)',
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          backgroundAttachment: 'fixed',
+        }}
+      >
+        <div className="absolute inset-0 bg-gradient-to-b from-black/75 via-black/60 to-black/75" />
+      </div>
+
+      <div
+        className="absolute inset-0 z-0 md:hidden"
+        style={{
+          backgroundImage: 'url(/mtbLandingPhotoMobile.jpg)',
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+        }}
+      >
+        <div className="absolute inset-0 bg-gradient-to-b from-black/75 via-black/60 to-black/75" />
+      </div>
+
+      <motion.div
+        className="relative z-10 container px-6 max-w-md w-full"
+        initial={{ opacity: 0, y: 30 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8 }}
+      >
+        <div
+          className="w-full rounded-2xl p-8 space-y-6"
+          style={{
+            backgroundColor: 'var(--glass)',
+            border: '1px solid var(--slate)',
+            backdropFilter: 'blur(12px)',
+          }}
+        >
+          <div className="text-center space-y-1">
+            <p className="text-xs uppercase tracking-[0.4em]" style={{ color: 'var(--sage)' }}>
+              Loam Logger
+            </p>
+            <h1 className="text-2xl font-semibold" style={{ color: 'var(--cream)' }}>
+              Reset Password
+            </h1>
+            <p className="text-sm" style={{ color: 'var(--concrete)' }}>
+              {success
+                ? 'Your password has been updated. You can now sign in.'
+                : 'Choose a new password for your account.'}
+            </p>
+          </div>
+
+          {success ? (
+            <Button
+              type="button"
+              variant="primary"
+              className="w-full justify-center text-base"
+              onClick={() => navigate('/login', { replace: true })}
+            >
+              Go to Sign In
+            </Button>
+          ) : (
+            <form
+              className="space-y-4 p-4 rounded-xl"
+              style={{ backgroundColor: 'rgba(54, 60, 57, 0.3)' }}
+              onSubmit={handleSubmit}
+            >
+              {error && (
+                <div className="alert alert-danger">
+                  <p>{error}</p>
+                </div>
+              )}
+
+              <label className="block text-xs uppercase tracking-[0.3em]" style={{ color: 'var(--concrete)' }}>
+                New Password
+                <input
+                  type="password"
+                  autoComplete="new-password"
+                  className="mt-1 w-full input-soft"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  placeholder="At least 8 characters"
+                  disabled={isLoading}
+                  required
+                />
+              </label>
+
+              <label className="block text-xs uppercase tracking-[0.3em]" style={{ color: 'var(--concrete)' }}>
+                Confirm New Password
+                <input
+                  type="password"
+                  autoComplete="new-password"
+                  className="mt-1 w-full input-soft"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  placeholder="Confirm your new password"
+                  disabled={isLoading}
+                  required
+                />
+              </label>
+
+              <div className="text-xs" style={{ color: 'var(--concrete)' }}>
+                <p className="font-medium mb-1">Password requirements:</p>
+                <ul className="list-disc list-inside space-y-0.5">
+                  {PASSWORD_RULES.map((rule) => (
+                    <li key={rule.key}>{rule.label}</li>
+                  ))}
+                </ul>
+              </div>
+
+              {isLoading && (
+                <div className="flex justify-center">
+                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+                </div>
+              )}
+
+              <Button
+                type="submit"
+                variant="primary"
+                className="w-full justify-center text-base"
+                disabled={isLoading}
+              >
+                {isLoading ? 'Updating...' : 'Reset Password'}
+              </Button>
+            </form>
+          )}
+        </div>
+      </motion.div>
+    </section>
+  );
+}

--- a/apps/web/src/pages/ResetPassword.tsx
+++ b/apps/web/src/pages/ResetPassword.tsx
@@ -14,7 +14,10 @@ export default function ResetPassword() {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [success, setSuccess] = useState(false);
-  const [expired, setExpired] = useState(false);
+  // Missing-token and expired-token land on the same UX: the link can't be
+  // completed, so offer a fresh reset. Distinguishing the two wouldn't give
+  // the user an actionable difference.
+  const [expired, setExpired] = useState(!token);
 
   // If the user is on a phone and has the app installed, try to hand off to it.
   // On iOS with universal links configured, the OS intercepts the https:// link
@@ -33,10 +36,7 @@ export default function ResetPassword() {
     event.preventDefault();
     setError(null);
 
-    if (!token) {
-      setError('This reset link is missing its token. Please request a new one.');
-      return;
-    }
+    if (!token) return; // Defensive: the form shouldn't render when token is missing.
 
     if (newPassword !== confirmPassword) {
       setError('New passwords do not match.');

--- a/apps/web/src/pages/ResetPassword.tsx
+++ b/apps/web/src/pages/ResetPassword.tsx
@@ -14,6 +14,7 @@ export default function ResetPassword() {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [success, setSuccess] = useState(false);
+  const [expired, setExpired] = useState(false);
 
   // If the user is on a phone and has the app installed, try to hand off to it.
   // On iOS with universal links configured, the OS intercepts the https:// link
@@ -59,6 +60,10 @@ export default function ResetPassword() {
 
       if (!res.ok) {
         const data = await res.json();
+        if (data.code === 'TOKEN_EXPIRED') {
+          setExpired(true);
+          return;
+        }
         setError(data.error || 'Failed to reset password.');
         return;
       }
@@ -116,16 +121,37 @@ export default function ResetPassword() {
               Loam Logger
             </p>
             <h1 className="text-2xl font-semibold" style={{ color: 'var(--cream)' }}>
-              Reset Password
+              {expired ? 'Link Expired' : 'Reset Password'}
             </h1>
             <p className="text-sm" style={{ color: 'var(--concrete)' }}>
-              {success
-                ? 'Your password has been updated. You can now sign in.'
-                : 'Choose a new password for your account.'}
+              {expired
+                ? 'This reset link has expired. Request a new one to continue.'
+                : success
+                  ? 'Your password has been updated. You can now sign in.'
+                  : 'Choose a new password for your account.'}
             </p>
           </div>
 
-          {success ? (
+          {expired ? (
+            <div className="space-y-3">
+              <Button
+                type="button"
+                variant="primary"
+                className="w-full justify-center text-base"
+                onClick={() => navigate('/forgot-password', { replace: true })}
+              >
+                Request a New Link
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full justify-center text-base"
+                onClick={() => navigate('/login', { replace: true })}
+              >
+                Back to Sign In
+              </Button>
+            </div>
+          ) : success ? (
             <Button
               type="button"
               variant="primary"

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
       project: "javascript-react",
       authToken: process.env.SENTRY_AUTH_TOKEN,
       disable: !process.env.SENTRY_AUTH_TOKEN,
+      // Same release tag the runtime uses so uploaded source maps bind to the
+      // right build in Sentry. Set in CI from the short git SHA.
+      release: process.env.SENTRY_RELEASE
+        ? { name: process.env.SENTRY_RELEASE }
+        : undefined,
     }),
   ],
   cacheDir: path.resolve(__dirname, '../../.cache/vite/web'),

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,13 @@
   "outputDirectory": "dist/apps/web",
   "installCommand": "npm ci",
   "framework": "vite",
+  "headers": [
+    {
+      "source": "/.well-known/apple-app-site-association",
+      "headers": [{ "key": "Content-Type", "value": "application/json" }]
+    }
+  ],
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    { "source": "/((?!\\.well-known/).*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
# Password Reset: Admin Tool, Self-Service, and Security Hardening

Combines two commits ([5224bcf](../../commit/5224bcf) and [da46e31](../../commit/da46e31)) that together ship the full password-reset story: admin-triggered resets, user-facing forgot-password flow, iOS Universal Links for in-app reset, session invalidation on credential changes, and audit logging for suspicious activity.

## Summary

- **Admin-triggered resets** — new "Reset Pwd" button next to each user in the admin portal emails a secure, time-limited reset link. Tooltip shows when the last reset was sent to that user; confirmation prompt guards against accidental double-sends.
- **Self-service forgot-password** — new `/forgot-password` flow on web and mobile, linked from the login pages. Enumeration-safe (always returns 200) and rate-limited per IP.
- **Session invalidation** — introduced `sessionTokenVersion` on the User model. Bumped on password reset, change, and admin demote. Tokens issued before the bump are rejected at the middleware, so an attacker with a stale session gets kicked out everywhere.
- **iOS Universal Links** — tapping a reset link in iOS Mail opens the app directly at `/reset-password` instead of bouncing through the browser.
- **Audit logging** — suspicious replays of already-consumed reset tokens are logged with `userId` + `clientIp` at `warn` level, without leaking the distinction to the client.

## Architecture notes

### Reset flow

1. Admin clicks "Reset Pwd" (or user submits `/forgot-password`) → `POST /api/admin/users/:userId/send-password-reset` or `POST /auth/forgot-password`.
2. `createPasswordResetToken` in `apps/api/src/services/password-reset.service.tsx` generates a 32-byte random token, stores only its SHA-256 hash in the new `PasswordResetToken` table, sets `expiresAt = now + 1h`, and invalidates any prior unused tokens for the same user.
3. Email is sent via the existing Resend-backed `sendReactEmailWithAudit` helper with `bypassUnsubscribe: true` (security email). New `password-reset.tsx` template matches the existing `password-security-base` styling.
4. User taps the link, lands on `/reset-password?token=...` (web or iOS app via Universal Link).
5. `POST /auth/reset-password` calls `consumePasswordResetToken`, which uses an atomic `updateMany({ where: { id, usedAt: null } })` to prevent double-consumption under concurrent requests. Password is hashed with bcrypt (12 rounds), `sessionTokenVersion` bumped.

### Session invalidation

Added `sessionTokenVersion Int @default(0)` to `User`. The `v` claim is baked into every JWT (web session cookie and mobile access/refresh tokens) at issuance via a new `session-issuer.ts` helper. On every authenticated request, `attachUser` middleware verifies the token and compares its `v` against the current DB value — one extra `SELECT sessionTokenVersion` per request. Mismatch → token rejected.

Bumped on:
- `POST /auth/reset-password` — kicks everyone out (intended attacker removal).
- `POST /auth/change-password` — re-issues cookie so the current device stays logged in; other devices are kicked out.
- `POST /auth/mobile/password/change` — returns a fresh `{ accessToken, refreshToken }` pair for the same reason.
- `POST /api/admin/users/:userId/demote` — logs the demoted user out everywhere.

Skipped on `/password/add` (OAuth users adding a password isn't a credential replacement).

### Enumeration resistance

- `/auth/forgot-password` always returns 200 regardless of whether the email matches a user. Invalid emails and DB errors both no-op with the same response.
- `/auth/reset-password` returns distinct codes (`TOKEN_EXPIRED` vs `TOKEN_INVALID`) so the client can show a dedicated "link expired" screen — but `not_found` and `already_used` collapse into the same `TOKEN_INVALID` code to avoid leaking whether a token ever existed.
- Already-used tokens are still logged server-side with the `userId` so you can spot leaked emails.

### iOS Universal Links

- Added `apps/web/public/.well-known/apple-app-site-association` (no extension) with `appID: "57Z6GUJL4D.com.loamlabs.loamlogger"` scoped to `/reset-password` paths.
- Updated `vercel.json` to (a) add explicit `application/json` Content-Type for the AASA file and (b) exclude `.well-known/` paths from the SPA catch-all rewrite (otherwise iOS got the SPA HTML back).
- Companion mobile change: `ios.associatedDomains: ["applinks:loamlogger.app"]` in `app.json`. Requires a native iOS rebuild to take effect.
- Web `ResetPassword.tsx` falls back to firing `loamlogger://` on mount for mobile UAs — covers the case where the app isn't installed, isn't updated, or the link was opened in a context that skips universal links.

### Rate limiting

New entries in `apps/api/src/lib/rate-limit.ts`:
- `sendPasswordReset`: 30s per target user (admin endpoint — prevents double-click spam).
- `reset-password`: 10 req/min per IP (prevents token-guessing).
- `forgot-password`: 5 req/min per IP (prevents email-blast abuse).

## Files changed

### Backend (`apps/api`)
- `prisma/schema.prisma` — new `PasswordResetToken` model, `sessionTokenVersion` field on `User`, new `password_reset` `EmailType`, new `admin_password_reset` `TriggerSource`.
- `src/services/password-reset.service.tsx` *(new)* — token lifecycle: create, send, consume.
- `src/templates/emails/password-reset.tsx` *(new)* — React Email template with CTA button.
- `src/auth/session-issuer.ts` *(new)* — centralized token issuance stamping the current `sessionTokenVersion`.
- `src/auth/session.ts` — `attachUser` now validates `v` against DB on every request (async with try/catch fail-closed behavior).
- `src/auth/token.ts` — `TokenPayload` gains optional `v` field.
- `src/auth/email.route.ts` — new `/auth/forgot-password` and `/auth/reset-password` endpoints; `change-password` bumps version and re-issues cookie.
- `src/auth/mobile.route.ts` — all token issuance migrated to `issueMobileTokens`; refresh endpoint validates `v`; mobile `change-password` bumps and returns new token pair.
- `src/auth/google.route.ts`, `src/routes/waitlist.ts` — migrated to `issueWebSession`.
- `src/routes/admin.ts` — new `POST /api/admin/users/:userId/send-password-reset`; demote bumps `sessionTokenVersion`; `GET /api/admin/users` now returns `lastPasswordResetEmailAt` per user.
- `src/lib/rate-limit.ts` — new limits listed above.

### Web (`apps/web`)
- `src/pages/ResetPassword.tsx` *(new)* — form + expired-token screen with "Request a New Link" CTA + mobile-deep-link fallback.
- `src/pages/ForgotPassword.tsx` *(new)* — email-input screen.
- `src/pages/Admin.tsx` — new "Reset Pwd" button, toast-based feedback, "last reset sent X ago" tooltip, double-send confirmation guard.
- `src/pages/Login.tsx` — "Forgot password?" link below the password field.
- `src/App.tsx` — registered `/reset-password` and `/forgot-password` routes.
- `public/.well-known/apple-app-site-association` *(new)* — iOS Universal Links association.
- `vercel.json` — Content-Type header + excluded `.well-known/` from SPA rewrite.

### Mobile (`loam-logger-mobile`, separate repo — companion changes)
- `app/reset-password.tsx` — reset form + expired-token screen.
- `app/(auth)/forgot-password.tsx` — email-input screen.
- `app/(auth)/login.tsx` — "Forgot password?" link.
- `app.json` — `ios.associatedDomains: ["applinks:loamlogger.app"]`.

## Database migration

New migration adds `PasswordResetToken` table and `sessionTokenVersion` column on `User`. No backfill needed — the column defaults to 0 and existing sessions carry `v: undefined`, which compares equal to 0 via the middleware's `payload.v ?? 0` fallback.

```bash
npx prisma migrate deploy
```

## Test plan

- [ ] **Admin reset** — click "Reset Pwd" in admin portal. Toast appears. Check Resend dashboard for the email. Tooltip now shows "Last reset sent just now".
- [ ] **Double-send guard** — click "Reset Pwd" again on the same user within 30s. Expect 429 from the rate limiter. After 30s, clicking shows the "already sent X ago — send another?" confirmation.
- [ ] **Reset completion (web)** — click the email link on desktop. Form accepts new password. User can log in with it. Any pre-existing sessions on other devices are logged out.
- [ ] **Reset completion (iOS)** — on a device with the newly-built app installed, long-press the reset link in Mail. Expect "Open in Loam Logger" option. Normal tap opens the app directly at `/reset-password`.
- [ ] **Expired-token UX** — manually expire a token (`UPDATE password_reset_tokens SET "expiresAt" = NOW() - INTERVAL '1 hour'` then submit). Expect dedicated "Link Expired" screen with "Request a New Link" button.
- [ ] **Token reuse logging** — complete a reset, then replay the same URL. Client sees generic "invalid or expired" error. Server log contains a `warn`-level line: `[EmailAuth] Password reset token reuse attempted` with `userId` and `clientIp`.
- [ ] **Forgot-password flow** — from web login, click "Forgot password?", submit a valid email. Receive email. Click link → lands on `/reset-password`. Complete flow.
- [ ] **Enumeration resistance** — submit `/auth/forgot-password` with a non-existent email. Client sees 200 + "Check Your Email" copy. Server produces no `EmailSend` row.
- [ ] **Change-password continuity** — while logged in on web, change password. Stay logged in on that tab. Existing mobile session logs out on next request (it had stale `v`).
- [ ] **AASA reachability** — after deploy: `curl -iL https://loamlogger.app/.well-known/apple-app-site-association`. Expect 200, `content-type: application/json`, JSON body. Must **not** return the SPA HTML.
- [ ] **Apple validator** — `https://app-site-association.cdn-apple.com/a/v1/loamlogger.app` returns the same JSON.
- [ ] **SPA rewrite intact** — `/dashboard`, `/login`, `/gear` all still load correctly.

## Follow-ups (deferred, tracked in `TODO.md` - not checked in to source control)

- **Android App Links** — mirror the iOS setup. Blocked on the Play Store signing SHA256 fingerprint.
