### PR TITLE
 Ride Weather Integration — API + Web

### DIFF
--- a/apps/api/prisma/migrations/20260415120000_add_ride_weather/migration.sql
+++ b/apps/api/prisma/migrations/20260415120000_add_ride_weather/migration.sql
@@ -1,0 +1,50 @@
+-- CreateEnum
+CREATE TYPE "WeatherCondition" AS ENUM ('SUNNY', 'CLOUDY', 'RAINY', 'SNOWY', 'WINDY', 'FOGGY', 'UNKNOWN');
+
+-- AlterTable
+ALTER TABLE "Ride" ADD COLUMN "startLat" DOUBLE PRECISION,
+                   ADD COLUMN "startLng" DOUBLE PRECISION;
+
+-- CreateTable
+CREATE TABLE "RideWeather" (
+    "id" TEXT NOT NULL,
+    "rideId" TEXT NOT NULL,
+    "tempC" DOUBLE PRECISION NOT NULL,
+    "feelsLikeC" DOUBLE PRECISION,
+    "precipitationMm" DOUBLE PRECISION NOT NULL,
+    "windSpeedKph" DOUBLE PRECISION NOT NULL,
+    "humidity" DOUBLE PRECISION,
+    "wmoCode" INTEGER NOT NULL,
+    "condition" "WeatherCondition" NOT NULL,
+    "lat" DOUBLE PRECISION NOT NULL,
+    "lng" DOUBLE PRECISION NOT NULL,
+    "source" TEXT NOT NULL,
+    "fetchedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "rawJson" JSONB,
+
+    CONSTRAINT "RideWeather_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RideWeather_rideId_key" ON "RideWeather"("rideId");
+
+-- CreateIndex
+CREATE INDEX "RideWeather_condition_idx" ON "RideWeather"("condition");
+
+-- AddForeignKey
+ALTER TABLE "RideWeather" ADD CONSTRAINT "RideWeather_rideId_fkey" FOREIGN KEY ("rideId") REFERENCES "Ride"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable
+CREATE TABLE "WeatherCache" (
+    "id" TEXT NOT NULL,
+    "latKey" DOUBLE PRECISION NOT NULL,
+    "lngKey" DOUBLE PRECISION NOT NULL,
+    "hourUtc" TIMESTAMP(3) NOT NULL,
+    "payload" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WeatherCache_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WeatherCache_latKey_lngKey_hourUtc_key" ON "WeatherCache"("latKey", "lngKey", "hourUtc");

--- a/apps/api/prisma/migrations/20260415121000_ride_missing_weather_index/migration.sql
+++ b/apps/api/prisma/migrations/20260415121000_ride_missing_weather_index/migration.sql
@@ -1,0 +1,21 @@
+-- Partial index to accelerate the Query.ridesMissingWeather COUNT(*).
+--
+-- The query shape is:
+--   SELECT COUNT(*) FROM "Ride" r
+--   LEFT JOIN "RideWeather" w ON w."rideId" = r.id
+--   WHERE r."userId" = $1
+--     AND r."startLat" IS NOT NULL
+--     AND r."startLng" IS NOT NULL
+--     AND w.id IS NULL;
+--
+-- Without this index, every Settings page mount for a user with thousands of
+-- rides scans all of that user's rows to test the coord + weather-null
+-- predicate. Postgres can satisfy the filter entirely from this partial
+-- index plus a lookup against RideWeather's existing `rideId` unique index.
+--
+-- Partial predicate mirrors the resolver:
+--   only index rides that COULD have weather (have coords). Rides without
+--   coords are excluded from the count entirely, so they don't belong here.
+CREATE INDEX "Ride_missing_weather_idx"
+  ON "Ride" ("userId")
+  WHERE "startLat" IS NOT NULL AND "startLng" IS NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -130,6 +130,10 @@ model Ride {
   weather           RideWeather?
 
   @@index([importSessionId, bikeId])
+  // NOTE: a partial index on (userId) WHERE startLat IS NOT NULL AND startLng IS NOT NULL
+  // is defined via raw SQL in migration 20260415121000_ride_missing_weather_index
+  // to keep the ridesMissingWeather COUNT(*) fast once the RideWeather table fills up.
+  // Prisma doesn't support partial-index predicates, so the index is managed there.
 }
 
 enum WeatherCondition {

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -120,13 +120,57 @@ model Ride {
   stravaGearId      String?
   whoopWorkoutId    String?         @unique
   importSessionId   String?
+  startLat          Float?
+  startLng          Float?
   bike              Bike?           @relation(fields: [bikeId], references: [id])
   duplicateOf       Ride?           @relation("DuplicateRides", fields: [duplicateOfId], references: [id], onDelete: SetNull)
   duplicates        Ride[]          @relation("DuplicateRides")
   user              User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   importSession     ImportSession?  @relation(fields: [importSessionId], references: [id], onDelete: SetNull)
+  weather           RideWeather?
 
   @@index([importSessionId, bikeId])
+}
+
+enum WeatherCondition {
+  SUNNY
+  CLOUDY
+  RAINY
+  SNOWY
+  WINDY
+  FOGGY
+  UNKNOWN
+}
+
+model RideWeather {
+  id               String           @id @default(uuid())
+  rideId           String           @unique
+  tempC            Float
+  feelsLikeC       Float?
+  precipitationMm  Float
+  windSpeedKph     Float
+  humidity         Float?
+  wmoCode          Int
+  condition        WeatherCondition
+  lat              Float
+  lng              Float
+  source           String
+  fetchedAt        DateTime         @default(now())
+  rawJson          Json?
+  ride             Ride             @relation(fields: [rideId], references: [id], onDelete: Cascade)
+
+  @@index([condition])
+}
+
+model WeatherCache {
+  id        String   @id @default(cuid())
+  latKey    Float
+  lngKey    Float
+  hourUtc   DateTime
+  payload   Json
+  createdAt DateTime @default(now())
+
+  @@unique([latKey, lngKey, hourUtc])
 }
 
 model Bike {

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -2884,14 +2884,33 @@ describe('GraphQL Resolvers', () => {
       expect(enqueueWeatherJob).not.toHaveBeenCalled();
     });
 
-    it('rejects calls that exceed the rate limit before touching Prisma or queue', async () => {
+    it('rejects Pro calls that exceed the rate limit before touching the queue', async () => {
+      // Pro check runs first so the Prisma lookup still happens; only the
+      // queue work is short-circuited by the rate limit.
+      mockFindUniqueOrThrow.mockResolvedValueOnce({
+        subscriptionTier: 'PRO',
+        isFoundingRider: false,
+        role: 'FREE',
+      });
       mockCheckMutationRateLimit.mockResolvedValueOnce({ allowed: false, retryAfter: 45 });
       const ctx = createMockContext('user-123');
       await expect(mutation({}, {}, ctx as never)).rejects.toThrow(
         'Rate limit exceeded. Try again in 45 seconds.'
       );
-      expect(mockFindUniqueOrThrow).not.toHaveBeenCalled();
       expect(enqueueWeatherJob).not.toHaveBeenCalled();
+    });
+
+    it('does not consume a rate-limit token for free-user calls', async () => {
+      mockFindUniqueOrThrow.mockResolvedValueOnce({
+        subscriptionTier: 'FREE_LIGHT',
+        isFoundingRider: false,
+        role: 'FREE',
+      });
+      const ctx = createMockContext('user-123');
+      await expect(mutation({}, {}, ctx as never)).rejects.toThrow(
+        'Weather backfill is a Pro feature.'
+      );
+      expect(mockCheckMutationRateLimit).not.toHaveBeenCalled();
     });
 
     it('enqueues jobs for Pro users and returns counts', async () => {

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -27,6 +27,7 @@ jest.mock('../../lib/prisma', () => ({
     ride: {
       findMany: jest.fn(),
       updateMany: jest.fn(),
+      count: jest.fn().mockResolvedValue(0),
     },
     stravaGearMapping: {
       deleteMany: jest.fn(),
@@ -73,6 +74,10 @@ jest.mock('../../services/notification.service', () => ({
   isValidExpoPushToken: jest.fn((token: string) => token.startsWith('ExponentPushToken[') || token.startsWith('ExpoPushToken[')),
 }));
 
+jest.mock('../../lib/queue/weather.queue', () => ({
+  enqueueWeatherJob: jest.fn(),
+}));
+
 import { resolvers } from '../resolvers';
 import { prisma } from '../../lib/prisma';
 import { checkMutationRateLimit } from '../../lib/rate-limit';
@@ -92,6 +97,7 @@ const createMockContext = (
   user: userId ? { id: userId } : null,
   loaders: {
     serviceLogsByComponentId: { load: jest.fn() },
+    weatherByRideId: { load: jest.fn() },
   },
   req: {
     // Only use default IP if ip is not explicitly passed in reqOverrides
@@ -2848,6 +2854,96 @@ describe('GraphQL Resolvers', () => {
         where: { id: 'user-123' },
         data: { needsDowngradeSelection: false },
       });
+    });
+  });
+
+  describe('backfillWeatherForMyRides', () => {
+    const mutation = resolvers.Mutation.backfillWeatherForMyRides;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { enqueueWeatherJob } = require('../../lib/queue/weather.queue') as {
+      enqueueWeatherJob: jest.Mock;
+    };
+    const mockFindUniqueOrThrow = prisma.user.findUniqueOrThrow as jest.Mock;
+    const mockRideFindMany = prisma.ride.findMany as jest.Mock;
+    const mockRideCount = prisma.ride.count as jest.Mock;
+
+    beforeEach(() => {
+      enqueueWeatherJob.mockReset();
+    });
+
+    it('rejects free users with NOT_PRO', async () => {
+      mockFindUniqueOrThrow.mockResolvedValueOnce({
+        subscriptionTier: 'FREE_LIGHT',
+        isFoundingRider: false,
+        role: 'FREE',
+      });
+      const ctx = createMockContext('user-123');
+      await expect(
+        mutation({}, {}, ctx as never)
+      ).rejects.toThrow('Weather backfill is a Pro feature.');
+      expect(enqueueWeatherJob).not.toHaveBeenCalled();
+    });
+
+    it('enqueues jobs for Pro users and returns counts', async () => {
+      mockFindUniqueOrThrow.mockResolvedValueOnce({
+        subscriptionTier: 'PRO',
+        isFoundingRider: false,
+        role: 'FREE',
+      });
+      mockRideFindMany.mockResolvedValueOnce([
+        { id: 'ride-1' },
+        { id: 'ride-2' },
+        { id: 'ride-3' },
+      ]);
+      mockRideCount.mockResolvedValueOnce(4); // rides without coords
+      enqueueWeatherJob
+        .mockResolvedValueOnce({ status: 'queued', jobId: 'j1' })
+        .mockResolvedValueOnce({ status: 'queued', jobId: 'j2' })
+        .mockResolvedValueOnce({ status: 'already_queued', jobId: 'j3' });
+
+      const ctx = createMockContext('user-123');
+      const result = await mutation({}, {}, ctx as never);
+
+      expect(result).toEqual({ enqueuedCount: 2, ridesWithoutCoords: 4 });
+      expect(enqueueWeatherJob).toHaveBeenCalledTimes(3);
+    });
+
+    it('treats founding riders as Pro', async () => {
+      mockFindUniqueOrThrow.mockResolvedValueOnce({
+        subscriptionTier: 'FREE_LIGHT',
+        isFoundingRider: true,
+        role: 'FREE',
+      });
+      mockRideFindMany.mockResolvedValueOnce([]);
+      mockRideCount.mockResolvedValueOnce(0);
+
+      const ctx = createMockContext('user-123');
+      const result = await mutation({}, {}, ctx as never);
+
+      expect(result).toEqual({ enqueuedCount: 0, ridesWithoutCoords: 0 });
+    });
+
+    it('does not let one enqueue failure abort the rest', async () => {
+      mockFindUniqueOrThrow.mockResolvedValueOnce({
+        subscriptionTier: 'PRO',
+        isFoundingRider: false,
+        role: 'FREE',
+      });
+      mockRideFindMany.mockResolvedValueOnce([
+        { id: 'ride-1' },
+        { id: 'ride-2' },
+        { id: 'ride-3' },
+      ]);
+      mockRideCount.mockResolvedValueOnce(0);
+      enqueueWeatherJob
+        .mockResolvedValueOnce({ status: 'queued', jobId: 'j1' })
+        .mockRejectedValueOnce(new Error('redis down'))
+        .mockResolvedValueOnce({ status: 'queued', jobId: 'j3' });
+
+      const ctx = createMockContext('user-123');
+      const result = await mutation({}, {}, ctx as never);
+
+      expect(result).toEqual({ enqueuedCount: 2, ridesWithoutCoords: 0 });
     });
   });
 });

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -2895,7 +2895,9 @@ describe('GraphQL Resolvers', () => {
         { id: 'ride-2' },
         { id: 'ride-3' },
       ]);
-      mockRideCount.mockResolvedValueOnce(4); // rides without coords
+      mockRideCount
+        .mockResolvedValueOnce(3) // rides remaining (matches ridesWithCoords length)
+        .mockResolvedValueOnce(4); // rides without coords
       enqueueWeatherJob
         .mockResolvedValueOnce({ status: 'queued', jobId: 'j1' })
         .mockResolvedValueOnce({ status: 'queued', jobId: 'j2' })
@@ -2904,7 +2906,11 @@ describe('GraphQL Resolvers', () => {
       const ctx = createMockContext('user-123');
       const result = await mutation({}, {}, ctx as never);
 
-      expect(result).toEqual({ enqueuedCount: 2, ridesWithoutCoords: 4 });
+      expect(result).toEqual({
+        enqueuedCount: 2,
+        ridesWithoutCoords: 4,
+        remainingAfterBatch: 0,
+      });
       expect(enqueueWeatherJob).toHaveBeenCalledTimes(3);
     });
 
@@ -2915,12 +2921,16 @@ describe('GraphQL Resolvers', () => {
         role: 'FREE',
       });
       mockRideFindMany.mockResolvedValueOnce([]);
-      mockRideCount.mockResolvedValueOnce(0);
+      mockRideCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
 
       const ctx = createMockContext('user-123');
       const result = await mutation({}, {}, ctx as never);
 
-      expect(result).toEqual({ enqueuedCount: 0, ridesWithoutCoords: 0 });
+      expect(result).toEqual({
+        enqueuedCount: 0,
+        ridesWithoutCoords: 0,
+        remainingAfterBatch: 0,
+      });
     });
 
     it('does not let one enqueue failure abort the rest', async () => {
@@ -2934,7 +2944,7 @@ describe('GraphQL Resolvers', () => {
         { id: 'ride-2' },
         { id: 'ride-3' },
       ]);
-      mockRideCount.mockResolvedValueOnce(0);
+      mockRideCount.mockResolvedValueOnce(3).mockResolvedValueOnce(0);
       enqueueWeatherJob
         .mockResolvedValueOnce({ status: 'queued', jobId: 'j1' })
         .mockRejectedValueOnce(new Error('redis down'))
@@ -2943,7 +2953,30 @@ describe('GraphQL Resolvers', () => {
       const ctx = createMockContext('user-123');
       const result = await mutation({}, {}, ctx as never);
 
-      expect(result).toEqual({ enqueuedCount: 2, ridesWithoutCoords: 0 });
+      expect(result).toEqual({
+        enqueuedCount: 2,
+        ridesWithoutCoords: 0,
+        remainingAfterBatch: 0,
+      });
+    });
+
+    it('reports remainingAfterBatch when hitting the batch cap', async () => {
+      mockFindUniqueOrThrow.mockResolvedValueOnce({
+        subscriptionTier: 'PRO',
+        isFoundingRider: false,
+        role: 'FREE',
+      });
+      // Simulate the cap: findMany returns 500, count says 850 eligible total.
+      const batch = Array.from({ length: 500 }, (_, i) => ({ id: `ride-${i}` }));
+      mockRideFindMany.mockResolvedValueOnce(batch);
+      mockRideCount.mockResolvedValueOnce(850).mockResolvedValueOnce(0);
+      enqueueWeatherJob.mockResolvedValue({ status: 'queued', jobId: 'j' });
+
+      const ctx = createMockContext('user-123');
+      const result = await mutation({}, {}, ctx as never);
+
+      expect(result.remainingAfterBatch).toBe(350);
+      expect(result.enqueuedCount).toBe(500);
     });
   });
 });

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -2884,6 +2884,16 @@ describe('GraphQL Resolvers', () => {
       expect(enqueueWeatherJob).not.toHaveBeenCalled();
     });
 
+    it('rejects calls that exceed the rate limit before touching Prisma or queue', async () => {
+      mockCheckMutationRateLimit.mockResolvedValueOnce({ allowed: false, retryAfter: 45 });
+      const ctx = createMockContext('user-123');
+      await expect(mutation({}, {}, ctx as never)).rejects.toThrow(
+        'Rate limit exceeded. Try again in 45 seconds.'
+      );
+      expect(mockFindUniqueOrThrow).not.toHaveBeenCalled();
+      expect(enqueueWeatherJob).not.toHaveBeenCalled();
+    });
+
     it('enqueues jobs for Pro users and returns counts', async () => {
       mockFindUniqueOrThrow.mockResolvedValueOnce({
         subscriptionTier: 'PRO',

--- a/apps/api/src/graphql/dataloaders.ts
+++ b/apps/api/src/graphql/dataloaders.ts
@@ -1,6 +1,6 @@
 import DataLoader from 'dataloader';
 import { prisma } from '../lib/prisma';
-import type { ServiceLog } from '@prisma/client';
+import type { ServiceLog, RideWeather } from '@prisma/client';
 
 /**
  * Batch loads service logs for multiple components in a single query.
@@ -28,6 +28,21 @@ async function batchServiceLogsByComponentId(
 }
 
 /**
+ * Batch loads RideWeather rows for many rides in one query.
+ * Solves N+1 when Ride.weather is resolved across a rides list.
+ */
+async function batchWeatherByRideId(
+  rideIds: readonly string[]
+): Promise<(RideWeather | null)[]> {
+  const rows = await prisma.rideWeather.findMany({
+    where: { rideId: { in: [...rideIds] } },
+  });
+  const byRide = new Map<string, RideWeather>();
+  for (const row of rows) byRide.set(row.rideId, row);
+  return rideIds.map((id) => byRide.get(id) ?? null);
+}
+
+/**
  * Creates fresh DataLoader instances for a single request.
  * DataLoaders cache within a request, so create new instances per request
  * to avoid data leakage between users/requests.
@@ -36,6 +51,9 @@ export function createDataLoaders() {
   return {
     serviceLogsByComponentId: new DataLoader<string, ServiceLog[]>(
       batchServiceLogsByComponentId
+    ),
+    weatherByRideId: new DataLoader<string, RideWeather | null>(
+      batchWeatherByRideId
     ),
   };
 }

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -10,7 +10,7 @@ import type {
   Component as ComponentModel,
 } from '@prisma/client';
 import { checkRateLimit, checkMutationRateLimit, checkQueryRateLimit } from '../lib/rate-limit';
-import { enqueueSyncJob, type SyncProvider } from '../lib/queue';
+import { enqueueSyncJob, enqueueWeatherJob, type SyncProvider } from '../lib/queue';
 import { invalidateBikePrediction } from '../services/prediction/cache';
 import { clearServiceNotificationLogs, isValidExpoPushToken } from '../services/notification.service';
 import { getBaseInterval, BASE_INTERVALS_HOURS, DEFAULT_INTERVAL_HOURS } from '../services/prediction/config';
@@ -4083,8 +4083,6 @@ export const resolvers = {
         });
       }
 
-      const { enqueueWeatherJob } = await import('../lib/queue/weather.queue');
-
       // Cap the batch so one click can't fire thousands of Open-Meteo requests.
       // Client re-invokes the mutation while ridesMissingWeather > 0 to drain
       // the rest — lets us pace the provider load even for very active users.
@@ -4119,15 +4117,24 @@ export const resolvers = {
         }),
       ]);
 
-      const results = await Promise.allSettled(
-        ridesWithCoords.map((r) => enqueueWeatherJob({ rideId: r.id }))
-      );
+      // Enqueue in serial chunks to cap concurrent Redis round-trips.
+      // Each enqueueWeatherJob does a getJob + add (2 commands), so firing
+      // all 500 at once would blow 1k concurrent commands per click. A chunk
+      // of 50 gives us ~100 concurrent commands, well within ioredis defaults,
+      // and still drains the batch in ~10 serial round-trips total.
+      const ENQUEUE_CHUNK = 50;
       let enqueuedCount = 0;
-      for (const result of results) {
-        if (result.status === 'fulfilled' && result.value.status === 'queued') {
-          enqueuedCount += 1;
-        } else if (result.status === 'rejected') {
-          console.warn('[BackfillWeather] enqueue failed', result.reason);
+      for (let i = 0; i < ridesWithCoords.length; i += ENQUEUE_CHUNK) {
+        const chunk = ridesWithCoords.slice(i, i + ENQUEUE_CHUNK);
+        const results = await Promise.allSettled(
+          chunk.map((r) => enqueueWeatherJob({ rideId: r.id }))
+        );
+        for (const result of results) {
+          if (result.status === 'fulfilled' && result.value.status === 'queued') {
+            enqueuedCount += 1;
+          } else if (result.status === 'rejected') {
+            console.warn('[BackfillWeather] enqueue failed', result.reason);
+          }
         }
       }
 

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -4057,6 +4057,56 @@ export const resolvers = {
         return bike;
       });
     },
+
+    backfillWeatherForMyRides: async (
+      _: unknown,
+      _args: unknown,
+      ctx: GraphQLContext
+    ) => {
+      const userId = requireUserId(ctx);
+      const user = await prisma.user.findUniqueOrThrow({
+        where: { id: userId },
+        select: { subscriptionTier: true, isFoundingRider: true, role: true },
+      });
+      if (!isProTier(user)) {
+        throw new GraphQLError('Weather backfill is a Pro feature.', {
+          extensions: { code: 'NOT_PRO' },
+        });
+      }
+
+      const { enqueueWeatherJob } = await import('../lib/queue/weather.queue');
+
+      const [ridesWithCoords, ridesWithoutCoords] = await Promise.all([
+        prisma.ride.findMany({
+          where: {
+            userId,
+            startLat: { not: null },
+            startLng: { not: null },
+            weather: null,
+          },
+          select: { id: true },
+        }),
+        prisma.ride.count({
+          where: {
+            userId,
+            OR: [{ startLat: null }, { startLng: null }],
+            weather: null,
+          },
+        }),
+      ]);
+
+      let enqueuedCount = 0;
+      for (const r of ridesWithCoords) {
+        try {
+          const res = await enqueueWeatherJob({ rideId: r.id });
+          if (res.status === 'queued') enqueuedCount += 1;
+        } catch (err) {
+          console.warn('[BackfillWeather] enqueue failed', r.id, err);
+        }
+      }
+
+      return { enqueuedCount, ridesWithoutCoords };
+    },
   },
 
   Bike: {
@@ -4129,6 +4179,16 @@ export const resolvers = {
       ride.startTime instanceof Date
         ? ride.startTime.toISOString()
         : ride.startTime,
+    weather: async (ride: { id: string; weather?: unknown }) => {
+      // If resolver was called with an included weather relation, use it.
+      if (ride.weather !== undefined) return ride.weather;
+      return prisma.rideWeather.findUnique({ where: { rideId: ride.id } });
+    },
+  },
+
+  RideWeather: {
+    fetchedAt: (w: { fetchedAt: Date | string }) =>
+      w.fetchedAt instanceof Date ? w.fetchedAt.toISOString() : w.fetchedAt,
   },
 
   Component: {
@@ -4205,6 +4265,16 @@ export const resolvers = {
       parent.pairedComponentMigrationSeenAt?.toISOString() ?? null,
     notifyOnRideUpload: (parent: { notifyOnRideUpload?: boolean }) => parent.notifyOnRideUpload ?? true,
     createdAt: (parent: { createdAt: Date }) => parent.createdAt.toISOString(),
+    ridesMissingWeather: async (parent: { id: string }) => {
+      return prisma.ride.count({
+        where: {
+          userId: parent.id,
+          weather: null,
+          startLat: { not: null },
+          startLng: { not: null },
+        },
+      });
+    },
     servicePreferences: async (parent: { id: string }) => {
       return prisma.userServicePreference.findMany({
         where: { userId: parent.id },

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -4095,13 +4095,15 @@ export const resolvers = {
         }),
       ]);
 
+      const results = await Promise.allSettled(
+        ridesWithCoords.map((r) => enqueueWeatherJob({ rideId: r.id }))
+      );
       let enqueuedCount = 0;
-      for (const r of ridesWithCoords) {
-        try {
-          const res = await enqueueWeatherJob({ rideId: r.id });
-          if (res.status === 'queued') enqueuedCount += 1;
-        } catch (err) {
-          console.warn('[BackfillWeather] enqueue failed', r.id, err);
+      for (const result of results) {
+        if (result.status === 'fulfilled' && result.value.status === 'queued') {
+          enqueuedCount += 1;
+        } else if (result.status === 'rejected') {
+          console.warn('[BackfillWeather] enqueue failed', result.reason);
         }
       }
 
@@ -4179,10 +4181,15 @@ export const resolvers = {
       ride.startTime instanceof Date
         ? ride.startTime.toISOString()
         : ride.startTime,
-    weather: async (ride: { id: string; weather?: unknown }) => {
+    weather: async (
+      ride: { id: string; weather?: unknown },
+      _args: unknown,
+      ctx: GraphQLContext
+    ) => {
       // If resolver was called with an included weather relation, use it.
       if (ride.weather !== undefined) return ride.weather;
-      return prisma.rideWeather.findUnique({ where: { rideId: ride.id } });
+      // Otherwise batch-load via DataLoader to avoid N+1 on list queries.
+      return ctx.loaders.weatherByRideId.load(ride.id);
     },
   },
 

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -4079,6 +4079,15 @@ export const resolvers = {
       ctx: GraphQLContext
     ) => {
       const userId = requireUserId(ctx);
+
+      const rateLimit = await checkMutationRateLimit('backfillWeatherForMyRides', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(
+          `Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`,
+          { extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter } }
+        );
+      }
+
       const user = await prisma.user.findUniqueOrThrow({
         where: { id: userId },
         select: { subscriptionTier: true, isFoundingRider: true, role: true },
@@ -4137,6 +4146,15 @@ export const resolvers = {
         }
       }
 
+      // Rides beyond this batch's slice — i.e. eligible rides we deliberately
+      // didn't attempt because of BATCH_LIMIT. This intentionally does NOT
+      // count rides in this batch that failed to enqueue (see the
+      // Promise.allSettled rejection branch above): those will reappear in
+      // the next call because the eligibility query filter (`weather: null`)
+      // will still match them, and BullMQ's deterministic job IDs make a
+      // retry safe. The next call's `ridesRemaining` count picks them up
+      // naturally. So `remainingAfterBatch` is "known not-yet-attempted,"
+      // not "known not-yet-queued" — the next fetch self-heals.
       const remainingAfterBatch = Math.max(0, ridesRemaining - ridesWithCoords.length);
 
       return { enqueuedCount, ridesWithoutCoords, remainingAfterBatch };

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -4065,14 +4065,10 @@ export const resolvers = {
     ) => {
       const userId = requireUserId(ctx);
 
-      const rateLimit = await checkMutationRateLimit('backfillWeatherForMyRides', userId);
-      if (!rateLimit.allowed) {
-        throw new GraphQLError(
-          `Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`,
-          { extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter } }
-        );
-      }
-
+      // Pro check first so free-user calls are rejected immediately without
+      // consuming a rate-limit token. The rate limit exists to stop Pro
+      // users (or a misbehaving Pro client) from flooding the queue — it
+      // doesn't need to gate users who can't reach the work at all.
       const user = await prisma.user.findUniqueOrThrow({
         where: { id: userId },
         select: { subscriptionTier: true, isFoundingRider: true, role: true },
@@ -4081,6 +4077,14 @@ export const resolvers = {
         throw new GraphQLError('Weather backfill is a Pro feature.', {
           extensions: { code: 'NOT_PRO' },
         });
+      }
+
+      const rateLimit = await checkMutationRateLimit('backfillWeatherForMyRides', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(
+          `Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`,
+          { extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter } }
+        );
       }
 
       // Cap the batch so one click can't fire thousands of Open-Meteo requests.

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -798,6 +798,21 @@ export const resolvers = {
         include: { rides: true },
       }),
 
+    // Dedicated endpoint instead of a Viewer field so the count only runs
+    // when the Settings backfill UI explicitly asks for it. Keeping it off
+    // the hot Me path avoids a COUNT(*) on every page load.
+    ridesMissingWeather: async (_: unknown, _args: unknown, ctx: GraphQLContext) => {
+      const userId = requireUserId(ctx);
+      return prisma.ride.count({
+        where: {
+          userId,
+          weather: null,
+          startLat: { not: null },
+          startLng: { not: null },
+        },
+      });
+    },
+
     rides: async (_: unknown, { take = 1000, after, filter }: RidesArgs, ctx: GraphQLContext) => {
       if (!ctx.user?.id) throw new Error('Unauthorized');
       const limit = Math.min(10000, Math.max(1, take));
@@ -4076,7 +4091,12 @@ export const resolvers = {
 
       const { enqueueWeatherJob } = await import('../lib/queue/weather.queue');
 
-      const [ridesWithCoords, ridesWithoutCoords] = await Promise.all([
+      // Cap the batch so one click can't fire thousands of Open-Meteo requests.
+      // Client re-invokes the mutation while ridesMissingWeather > 0 to drain
+      // the rest — lets us pace the provider load even for very active users.
+      const BATCH_LIMIT = 500;
+
+      const [ridesWithCoords, ridesRemaining, ridesWithoutCoords] = await Promise.all([
         prisma.ride.findMany({
           where: {
             userId,
@@ -4085,6 +4105,16 @@ export const resolvers = {
             weather: null,
           },
           select: { id: true },
+          orderBy: { startTime: 'desc' },
+          take: BATCH_LIMIT,
+        }),
+        prisma.ride.count({
+          where: {
+            userId,
+            startLat: { not: null },
+            startLng: { not: null },
+            weather: null,
+          },
         }),
         prisma.ride.count({
           where: {
@@ -4107,7 +4137,9 @@ export const resolvers = {
         }
       }
 
-      return { enqueuedCount, ridesWithoutCoords };
+      const remainingAfterBatch = Math.max(0, ridesRemaining - ridesWithCoords.length);
+
+      return { enqueuedCount, ridesWithoutCoords, remainingAfterBatch };
     },
   },
 
@@ -4272,16 +4304,6 @@ export const resolvers = {
       parent.pairedComponentMigrationSeenAt?.toISOString() ?? null,
     notifyOnRideUpload: (parent: { notifyOnRideUpload?: boolean }) => parent.notifyOnRideUpload ?? true,
     createdAt: (parent: { createdAt: Date }) => parent.createdAt.toISOString(),
-    ridesMissingWeather: async (parent: { id: string }) => {
-      return prisma.ride.count({
-        where: {
-          userId: parent.id,
-          weather: null,
-          startLat: { not: null },
-          startLng: { not: null },
-        },
-      });
-    },
     servicePreferences: async (parent: { id: string }) => {
       return prisma.userServicePreference.findMany({
         where: { userId: parent.id },

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -798,21 +798,6 @@ export const resolvers = {
         include: { rides: true },
       }),
 
-    // Dedicated endpoint instead of a Viewer field so the count only runs
-    // when the Settings backfill UI explicitly asks for it. Keeping it off
-    // the hot Me path avoids a COUNT(*) on every page load.
-    ridesMissingWeather: async (_: unknown, _args: unknown, ctx: GraphQLContext) => {
-      const userId = requireUserId(ctx);
-      return prisma.ride.count({
-        where: {
-          userId,
-          weather: null,
-          startLat: { not: null },
-          startLng: { not: null },
-        },
-      });
-    },
-
     rides: async (_: unknown, { take = 1000, after, filter }: RidesArgs, ctx: GraphQLContext) => {
       if (!ctx.user?.id) throw new Error('Unauthorized');
       const limit = Math.min(10000, Math.max(1, take));
@@ -4322,6 +4307,22 @@ export const resolvers = {
       parent.pairedComponentMigrationSeenAt?.toISOString() ?? null,
     notifyOnRideUpload: (parent: { notifyOnRideUpload?: boolean }) => parent.notifyOnRideUpload ?? true,
     createdAt: (parent: { createdAt: Date }) => parent.createdAt.toISOString(),
+    // Scoped to the viewer's User type so the shape matches other user-owned
+    // fields. GraphQL's lazy field resolution means this COUNT only runs
+    // when a client explicitly selects `ridesMissingWeather` (e.g. the
+    // Settings backfill section) — not on every Me query. A partial index
+    // on Ride(userId) WHERE startLat IS NOT NULL AND startLng IS NOT NULL
+    // keeps the COUNT cheap (see migration 20260415121000).
+    ridesMissingWeather: async (parent: { id: string }) => {
+      return prisma.ride.count({
+        where: {
+          userId: parent.id,
+          weather: null,
+          startLat: { not: null },
+          startLng: { not: null },
+        },
+      });
+    },
     servicePreferences: async (parent: { id: string }) => {
       return prisma.userServicePreference.findMany({
         where: { userId: parent.id },

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -187,6 +187,7 @@ export const typeDefs = gql`
   type BackfillWeatherResult {
     enqueuedCount: Int!
     ridesWithoutCoords: Int!
+    remainingAfterBatch: Int!
   }
 
   type Component {
@@ -899,7 +900,6 @@ export const typeDefs = gql`
     servicePreferences: [UserServicePreference!]!
     notifyOnRideUpload: Boolean!
     createdAt: String!
-    ridesMissingWeather: Int!
   }
 
   input RidesFilterInput {
@@ -910,6 +910,7 @@ export const typeDefs = gql`
 
   type Query {
     me: User
+    ridesMissingWeather: Int!
     user(id: ID!): User
     rides(take: Int = 1000, after: ID, filter: RidesFilterInput): [Ride!]!
     rideTypes: [RideType!]!

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -160,6 +160,33 @@ export const typeDefs = gql`
     location: String
     createdAt: String!
     updatedAt: String!
+    weather: RideWeather
+  }
+
+  enum WeatherCondition {
+    SUNNY
+    CLOUDY
+    RAINY
+    SNOWY
+    WINDY
+    FOGGY
+    UNKNOWN
+  }
+
+  type RideWeather {
+    tempC: Float!
+    feelsLikeC: Float
+    precipitationMm: Float!
+    windSpeedKph: Float!
+    humidity: Float
+    wmoCode: Int!
+    condition: WeatherCondition!
+    fetchedAt: String!
+  }
+
+  type BackfillWeatherResult {
+    enqueuedCount: Int!
+    ridesWithoutCoords: Int!
   }
 
   type Component {
@@ -812,6 +839,7 @@ export const typeDefs = gql`
     createCheckoutSession(plan: StripePlan!, platform: CheckoutPlatform): CheckoutSessionResult!
     createBillingPortalSession(platform: CheckoutPlatform): BillingPortalResult!
     selectBikeForDowngrade(bikeId: ID!): Bike!
+    backfillWeatherForMyRides: BackfillWeatherResult!
   }
 
   type ConnectedAccount {
@@ -871,6 +899,7 @@ export const typeDefs = gql`
     servicePreferences: [UserServicePreference!]!
     notifyOnRideUpload: Boolean!
     createdAt: String!
+    ridesMissingWeather: Int!
   }
 
   input RidesFilterInput {

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -181,6 +181,14 @@ export const typeDefs = gql`
     humidity: Float
     wmoCode: Int!
     condition: WeatherCondition!
+    # Coords actually used for the fetch (rounded to the cache grid, may
+    # differ slightly from Ride.startLat/startLng). Useful for debugging
+    # "why is my weather wrong?" questions.
+    lat: Float!
+    lng: Float!
+    # Which provider supplied this weather row (e.g. "open-meteo"). Exposed
+    # so future clients can distinguish between providers if we ever add one.
+    source: String!
     fetchedAt: String!
   }
 

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -174,6 +174,11 @@ export const typeDefs = gql`
   }
 
   type RideWeather {
+    # Exposed so Apollo can normalize RideWeather as a standalone cache
+    # entry. Without an id, the weather blob is stored embedded inside its
+    # parent Ride, which breaks partial-update patterns (e.g. refetching
+    # only the weather fields after a backfill completes).
+    id: ID!
     tempC: Float!
     feelsLikeC: Float
     precipitationMm: Float!

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -900,6 +900,7 @@ export const typeDefs = gql`
     servicePreferences: [UserServicePreference!]!
     notifyOnRideUpload: Boolean!
     createdAt: String!
+    ridesMissingWeather: Int!
   }
 
   input RidesFilterInput {
@@ -910,7 +911,6 @@ export const typeDefs = gql`
 
   type Query {
     me: User
-    ridesMissingWeather: Int!
     user(id: ID!): User
     rides(take: Int = 1000, after: ID, filter: RidesFilterInput): [Ride!]!
     rideTypes: [RideType!]!

--- a/apps/api/src/lib/queue/index.ts
+++ b/apps/api/src/lib/queue/index.ts
@@ -8,5 +8,8 @@ export type { BackfillJobName, BackfillJobData, BackfillProvider, EnqueueBackfil
 export { getNotificationQueue, closeNotificationQueue, enqueueReceiptCheck } from './notification.queue';
 export type { NotificationJobName, NotificationJobData } from './notification.queue';
 
+export { getWeatherQueue, closeWeatherQueue, enqueueWeatherJob, buildWeatherJobId } from './weather.queue';
+export type { WeatherJobName, WeatherJobData, EnqueueWeatherResult } from './weather.queue';
+
 // Connection
 export { getQueueConnection } from './connection';

--- a/apps/api/src/lib/queue/weather.queue.ts
+++ b/apps/api/src/lib/queue/weather.queue.ts
@@ -40,10 +40,13 @@ export type EnqueueWeatherResult =
   | { status: 'queued'; jobId: string }
   | { status: 'already_queued'; jobId: string };
 
-// BullMQ `add` with a static jobId is idempotent: if a job with the same id
-// already exists in waiting/active/delayed, BullMQ returns the existing job
-// instead of creating a new one. We check existence first so callers can tell
-// whether this call actually enqueued work or deduped.
+// BullMQ `add` with a static jobId is idempotent: Redis dedupes at the queue
+// level, so no duplicate work runs even under concurrent calls for the same
+// rideId. We check existence first to report `already_queued` as a hint to
+// callers, but this check is best-effort: two concurrent callers can both see
+// "not existing" and both call add — Redis absorbs the second call, but both
+// return `queued`. Downstream code must not treat `enqueuedCount` as a
+// Redis-accurate counter; it's a soft upper bound on jobs-added-this-call.
 export async function enqueueWeatherJob(data: WeatherJobData): Promise<EnqueueWeatherResult> {
   const queue = getWeatherQueue();
   const jobId = buildWeatherJobId(data.rideId);

--- a/apps/api/src/lib/queue/weather.queue.ts
+++ b/apps/api/src/lib/queue/weather.queue.ts
@@ -40,19 +40,23 @@ export type EnqueueWeatherResult =
   | { status: 'queued'; jobId: string }
   | { status: 'already_queued'; jobId: string };
 
+// BullMQ `add` with a static jobId is idempotent: if a job with the same id
+// already exists in waiting/active/delayed, BullMQ returns the existing job
+// instead of creating a new one. We check existence first so callers can tell
+// whether this call actually enqueued work or deduped.
 export async function enqueueWeatherJob(data: WeatherJobData): Promise<EnqueueWeatherResult> {
   const queue = getWeatherQueue();
   const jobId = buildWeatherJobId(data.rideId);
-  try {
-    await queue.add('fetchWeather', data, { jobId });
-    return { status: 'queued', jobId };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes('Job') && msg.includes('already exists')) {
+  const existing = await queue.getJob(jobId);
+  if (existing) {
+    const state = await existing.getState();
+    // completed/failed jobs are gone (or soon to be) — re-adding is fine.
+    if (state !== 'completed' && state !== 'failed' && state !== 'unknown') {
       return { status: 'already_queued', jobId };
     }
-    throw err;
   }
+  await queue.add('fetchWeather', data, { jobId });
+  return { status: 'queued', jobId };
 }
 
 export async function closeWeatherQueue(): Promise<void> {

--- a/apps/api/src/lib/queue/weather.queue.ts
+++ b/apps/api/src/lib/queue/weather.queue.ts
@@ -1,0 +1,63 @@
+import { Queue } from 'bullmq';
+import { getQueueConnection } from './connection';
+
+const SECONDS = 1000;
+const INITIAL_RETRY_DELAY_MS = 5 * SECONDS;
+const MAX_RETRY_ATTEMPTS = 5;
+const COMPLETED_JOBS_TO_KEEP = 50;
+const FAILED_JOBS_TO_KEEP = 100;
+const LOW_PRIORITY = 10;
+
+export type WeatherJobName = 'fetchWeather';
+
+export type WeatherJobData = {
+  rideId: string;
+};
+
+let weatherQueue: Queue<WeatherJobData, void, WeatherJobName> | null = null;
+
+export function getWeatherQueue(): Queue<WeatherJobData, void, WeatherJobName> {
+  if (!weatherQueue) {
+    weatherQueue = new Queue<WeatherJobData, void, WeatherJobName>('weather', {
+      connection: getQueueConnection(),
+      defaultJobOptions: {
+        attempts: MAX_RETRY_ATTEMPTS,
+        backoff: { type: 'exponential', delay: INITIAL_RETRY_DELAY_MS },
+        priority: LOW_PRIORITY,
+        removeOnComplete: COMPLETED_JOBS_TO_KEEP,
+        removeOnFail: FAILED_JOBS_TO_KEEP,
+      },
+    });
+  }
+  return weatherQueue;
+}
+
+export function buildWeatherJobId(rideId: string): string {
+  return `fetchWeather_${rideId}`;
+}
+
+export type EnqueueWeatherResult =
+  | { status: 'queued'; jobId: string }
+  | { status: 'already_queued'; jobId: string };
+
+export async function enqueueWeatherJob(data: WeatherJobData): Promise<EnqueueWeatherResult> {
+  const queue = getWeatherQueue();
+  const jobId = buildWeatherJobId(data.rideId);
+  try {
+    await queue.add('fetchWeather', data, { jobId });
+    return { status: 'queued', jobId };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('Job') && msg.includes('already exists')) {
+      return { status: 'already_queued', jobId };
+    }
+    throw err;
+  }
+}
+
+export async function closeWeatherQueue(): Promise<void> {
+  if (weatherQueue) {
+    await weatherQueue.close();
+    weatherQueue = null;
+  }
+}

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -74,6 +74,11 @@ export const MUTATION_RATE_LIMITS = {
   updateUserPreferences: { windowSeconds: 60, maxRequests: 20 },
   /** updateBikeNotificationPreference: max 20 requests per minute per user */
   updateBikeNotificationPreference: { windowSeconds: 60, maxRequests: 20 },
+  /** backfillWeatherForMyRides: max 3 requests per 5 minutes. Each call
+   *  enqueues up to BATCH_LIMIT (500) jobs against Open-Meteo, so the limit
+   *  exists to stop a runaway client loop while still allowing legitimate
+   *  "Fetch more" clicks to drain a large history over a few batches. */
+  backfillWeatherForMyRides: { windowSeconds: 300, maxRequests: 3 },
 } as const;
 
 /**

--- a/apps/api/src/lib/weather/aggregate.test.ts
+++ b/apps/api/src/lib/weather/aggregate.test.ts
@@ -38,6 +38,12 @@ describe('worstHourWmoCode', () => {
     // Unknown codes get severity -1, so any known code beats them.
     expect(worstHourWmoCode([999, 0, 999])).toBe(0);
   });
+
+  it('throws on empty input rather than returning undefined', () => {
+    expect(() => worstHourWmoCode([])).toThrow(
+      'worstHourWmoCode requires at least one WMO code'
+    );
+  });
 });
 
 describe('mean', () => {

--- a/apps/api/src/lib/weather/aggregate.test.ts
+++ b/apps/api/src/lib/weather/aggregate.test.ts
@@ -7,8 +7,22 @@ describe('worstHourWmoCode', () => {
   });
 
   it('picks the highest severity from a mixed rainy ride', () => {
-    // Drizzle (53), rain showers (81), heavy rain (65) → 81 is the highest.
-    expect(worstHourWmoCode([53, 81, 65, 1])).toBe(81);
+    // Drizzle (53), moderate rain (63), partly cloudy (2) → heavy rain wins.
+    expect(worstHourWmoCode([53, 63, 2])).toBe(63);
+  });
+
+  it('ranks freezing rain above plain showers despite lower numeric code', () => {
+    // 67 = heavy freezing rain (severe winter), 80 = slight rain showers (mild).
+    // Raw numeric max would have incorrectly picked 80.
+    expect(worstHourWmoCode([67, 80, 80, 1])).toBe(67);
+  });
+
+  it('ranks thunderstorms above any rain/snow', () => {
+    expect(worstHourWmoCode([65, 82, 75, 95])).toBe(95);
+  });
+
+  it('treats snow showers (86) as worse than steady snow (73)', () => {
+    expect(worstHourWmoCode([73, 73, 86])).toBe(86);
   });
 
   it('returns the sole code when input is length 1', () => {
@@ -16,12 +30,13 @@ describe('worstHourWmoCode', () => {
     expect(worstHourWmoCode([95])).toBe(95);
   });
 
-  it('keeps the max when all codes are equal', () => {
+  it('keeps the code when all are equal', () => {
     expect(worstHourWmoCode([3, 3, 3])).toBe(3);
   });
 
-  it('treats snow showers (86) as worse than steady snow (73)', () => {
-    expect(worstHourWmoCode([73, 73, 86])).toBe(86);
+  it('gracefully handles an unknown WMO code alongside known ones', () => {
+    // Unknown codes get severity -1, so any known code beats them.
+    expect(worstHourWmoCode([999, 0, 999])).toBe(0);
   });
 });
 

--- a/apps/api/src/lib/weather/aggregate.test.ts
+++ b/apps/api/src/lib/weather/aggregate.test.ts
@@ -1,0 +1,49 @@
+import { worstHourWmoCode, mean } from './index';
+
+describe('worstHourWmoCode', () => {
+  it('picks the single worst hour across a mostly-clear ride', () => {
+    // 5 clear + 1 thunderstorm → thunderstorm wins.
+    expect(worstHourWmoCode([0, 0, 0, 95, 0, 0])).toBe(95);
+  });
+
+  it('picks the highest severity from a mixed rainy ride', () => {
+    // Drizzle (53), rain showers (81), heavy rain (65) → 81 is the highest.
+    expect(worstHourWmoCode([53, 81, 65, 1])).toBe(81);
+  });
+
+  it('returns the sole code when input is length 1', () => {
+    expect(worstHourWmoCode([0])).toBe(0);
+    expect(worstHourWmoCode([95])).toBe(95);
+  });
+
+  it('keeps the max when all codes are equal', () => {
+    expect(worstHourWmoCode([3, 3, 3])).toBe(3);
+  });
+
+  it('treats snow showers (86) as worse than steady snow (73)', () => {
+    expect(worstHourWmoCode([73, 73, 86])).toBe(86);
+  });
+});
+
+describe('mean', () => {
+  it('averages only the non-null values', () => {
+    expect(mean([10, null, 20, null, 30])).toBe(20);
+  });
+
+  it('returns null when every value is null', () => {
+    expect(mean([null, null, null])).toBeNull();
+  });
+
+  it('returns null for an empty array', () => {
+    expect(mean([])).toBeNull();
+  });
+
+  it('handles a single value', () => {
+    expect(mean([42])).toBe(42);
+  });
+
+  it('does not treat zero as null', () => {
+    expect(mean([0, 0, 0])).toBe(0);
+    expect(mean([0, null, 10])).toBe(5);
+  });
+});

--- a/apps/api/src/lib/weather/cache.test.ts
+++ b/apps/api/src/lib/weather/cache.test.ts
@@ -1,0 +1,182 @@
+jest.mock('../prisma', () => ({
+  prisma: {
+    weatherCache: {
+      findMany: jest.fn(),
+      createMany: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('./open-meteo', () => ({
+  fetchHourlyRange: jest.fn(),
+}));
+
+import { getHourlySamples } from './cache';
+import { prisma } from '../prisma';
+import { fetchHourlyRange } from './open-meteo';
+
+const mockFindMany = prisma.weatherCache.findMany as jest.Mock;
+const mockCreateMany = prisma.weatherCache.createMany as jest.Mock;
+const mockFetch = fetchHourlyRange as jest.Mock;
+
+const sample = (isoHour: string, overrides: Record<string, unknown> = {}) => ({
+  timeUtc: isoHour,
+  tempC: 15,
+  feelsLikeC: 14,
+  precipitationMm: 0,
+  windSpeedKph: 5,
+  humidity: 60,
+  wmoCode: 0,
+  ...overrides,
+});
+
+describe('getHourlySamples', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateMany.mockResolvedValue({ count: 0 });
+  });
+
+  it('returns the exact set of hours spanned by a 3-hour ride', async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+    mockFetch.mockResolvedValueOnce([
+      sample('2026-04-15T10:00'),
+      sample('2026-04-15T11:00'),
+      sample('2026-04-15T12:00'),
+    ]);
+
+    const result = await getHourlySamples({
+      lat: 45.12,
+      lng: -122.34,
+      startUtc: new Date('2026-04-15T10:15:00Z'),
+      endUtc: new Date('2026-04-15T12:45:00Z'),
+    });
+
+    expect(result).toHaveLength(3);
+    expect(result.map((s) => s.timeUtc)).toEqual([
+      '2026-04-15T10:00',
+      '2026-04-15T11:00',
+      '2026-04-15T12:00',
+    ]);
+  });
+
+  it('returns cached rows without hitting Open-Meteo on a full hit', async () => {
+    mockFindMany.mockResolvedValueOnce([
+      {
+        hourUtc: new Date('2026-04-15T10:00:00Z'),
+        payload: sample('2026-04-15T10:00', { tempC: 20 }),
+      },
+      {
+        hourUtc: new Date('2026-04-15T11:00:00Z'),
+        payload: sample('2026-04-15T11:00', { tempC: 22 }),
+      },
+    ]);
+
+    const result = await getHourlySamples({
+      lat: 45.12,
+      lng: -122.34,
+      startUtc: new Date('2026-04-15T10:15:00Z'),
+      endUtc: new Date('2026-04-15T11:45:00Z'),
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockCreateMany).not.toHaveBeenCalled();
+    expect(result.map((s) => s.tempC)).toEqual([20, 22]);
+  });
+
+  it('fetches only the missing hours on a partial cache miss and writes them', async () => {
+    mockFindMany.mockResolvedValueOnce([
+      {
+        hourUtc: new Date('2026-04-15T10:00:00Z'),
+        payload: sample('2026-04-15T10:00', { tempC: 20 }),
+      },
+    ]);
+    // Open-Meteo typically returns the full range requested, not just misses.
+    mockFetch.mockResolvedValueOnce([
+      sample('2026-04-15T10:00', { tempC: 99 }), // should be ignored (cache wins)
+      sample('2026-04-15T11:00', { tempC: 22 }),
+      sample('2026-04-15T12:00', { tempC: 24 }),
+    ]);
+
+    const result = await getHourlySamples({
+      lat: 45.12,
+      lng: -122.34,
+      startUtc: new Date('2026-04-15T10:15:00Z'),
+      endUtc: new Date('2026-04-15T12:45:00Z'),
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result.map((s) => s.tempC)).toEqual([20, 22, 24]);
+
+    // Only missing hours get persisted, not the cached one.
+    expect(mockCreateMany).toHaveBeenCalledTimes(1);
+    const call = mockCreateMany.mock.calls[0][0];
+    expect(call.skipDuplicates).toBe(true);
+    expect(call.data).toHaveLength(2);
+    const hours = (call.data as { hourUtc: Date }[]).map((d) => d.hourUtc.toISOString());
+    expect(hours).toEqual([
+      '2026-04-15T11:00:00.000Z',
+      '2026-04-15T12:00:00.000Z',
+    ]);
+  });
+
+  it('rounds lat/lng to 2 decimal places when reading and writing', async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+    mockFetch.mockResolvedValueOnce([sample('2026-04-15T10:00')]);
+
+    await getHourlySamples({
+      lat: 45.12789,
+      lng: -122.34567,
+      startUtc: new Date('2026-04-15T10:15:00Z'),
+      endUtc: new Date('2026-04-15T10:45:00Z'),
+    });
+
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ latKey: 45.13, lngKey: -122.35 }),
+      })
+    );
+    const writeRow = mockCreateMany.mock.calls[0][0].data[0];
+    expect(writeRow.latKey).toBe(45.13);
+    expect(writeRow.lngKey).toBe(-122.35);
+  });
+
+  it('silently tolerates a cache write failure (best-effort persistence)', async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+    mockFetch.mockResolvedValueOnce([sample('2026-04-15T10:00', { tempC: 19 })]);
+    mockCreateMany.mockRejectedValueOnce(new Error('db down'));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await getHourlySamples({
+      lat: 45.12,
+      lng: -122.34,
+      startUtc: new Date('2026-04-15T10:15:00Z'),
+      endUtc: new Date('2026-04-15T10:45:00Z'),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tempC).toBe(19);
+    warn.mockRestore();
+  });
+
+  it('omits hours Open-Meteo failed to return from the result', async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+    // Open-Meteo returns only 2 of 3 requested hours (e.g. range-edge gap).
+    mockFetch.mockResolvedValueOnce([
+      sample('2026-04-15T10:00'),
+      sample('2026-04-15T12:00'),
+    ]);
+
+    const result = await getHourlySamples({
+      lat: 45.12,
+      lng: -122.34,
+      startUtc: new Date('2026-04-15T10:15:00Z'),
+      endUtc: new Date('2026-04-15T12:45:00Z'),
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result.map((s) => s.timeUtc)).toEqual([
+      '2026-04-15T10:00',
+      '2026-04-15T12:00',
+    ]);
+  });
+});

--- a/apps/api/src/lib/weather/cache.test.ts
+++ b/apps/api/src/lib/weather/cache.test.ts
@@ -158,6 +158,38 @@ describe('getHourlySamples', () => {
     warn.mockRestore();
   });
 
+  it('orders cached reads by createdAt so the newest row wins on duplicates', async () => {
+    // Simulates a hypothetical race where two workers both wrote for the same
+    // (latKey, lngKey, hourUtc) before the unique constraint is enforced or
+    // after a constraint-dropping migration. The query must order by createdAt
+    // so the later row overwrites the earlier one deterministically.
+    mockFindMany.mockResolvedValueOnce([
+      {
+        hourUtc: new Date('2026-04-15T10:00:00Z'),
+        createdAt: new Date('2026-04-15T10:01:00Z'),
+        payload: sample('2026-04-15T10:00', { tempC: 10 }), // older
+      },
+      {
+        hourUtc: new Date('2026-04-15T10:00:00Z'),
+        createdAt: new Date('2026-04-15T10:02:00Z'),
+        payload: sample('2026-04-15T10:00', { tempC: 20 }), // newer
+      },
+    ]);
+
+    const result = await getHourlySamples({
+      lat: 45.12,
+      lng: -122.34,
+      startUtc: new Date('2026-04-15T10:15:00Z'),
+      endUtc: new Date('2026-04-15T10:45:00Z'),
+    });
+
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { createdAt: 'asc' } })
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].tempC).toBe(20);
+  });
+
   it('omits hours Open-Meteo failed to return from the result', async () => {
     mockFindMany.mockResolvedValueOnce([]);
     // Open-Meteo returns only 2 of 3 requested hours (e.g. range-edge gap).

--- a/apps/api/src/lib/weather/cache.ts
+++ b/apps/api/src/lib/weather/cache.ts
@@ -1,0 +1,76 @@
+import { prisma } from '../prisma';
+import { fetchHourlyRange, HourlyWeather } from './open-meteo';
+
+const CACHE_PRECISION = 2; // ~1.1km grid
+
+const roundCoord = (c: number): number => parseFloat(c.toFixed(CACHE_PRECISION));
+const hourBoundary = (d: Date): Date => {
+  const copy = new Date(d);
+  copy.setUTCMinutes(0, 0, 0);
+  return copy;
+};
+
+// Returns hourly samples for the given lat/lng covering [startUtc, endUtc],
+// reading from WeatherCache where possible and backfilling misses via Open-Meteo.
+export const getHourlySamples = async (opts: {
+  lat: number;
+  lng: number;
+  startUtc: Date;
+  endUtc: Date;
+}): Promise<HourlyWeather[]> => {
+  const latKey = roundCoord(opts.lat);
+  const lngKey = roundCoord(opts.lng);
+  const startHour = hourBoundary(opts.startUtc);
+  const endHour = hourBoundary(opts.endUtc);
+
+  const hoursNeeded: Date[] = [];
+  for (
+    let t = new Date(startHour);
+    t.getTime() <= endHour.getTime();
+    t = new Date(t.getTime() + 60 * 60 * 1000)
+  ) {
+    hoursNeeded.push(new Date(t));
+  }
+
+  const cached = await prisma.weatherCache.findMany({
+    where: {
+      latKey,
+      lngKey,
+      hourUtc: { in: hoursNeeded },
+    },
+  });
+  const cachedByHour = new Map<number, HourlyWeather>();
+  for (const row of cached) {
+    cachedByHour.set(row.hourUtc.getTime(), row.payload as unknown as HourlyWeather);
+  }
+
+  const missing = hoursNeeded.filter((h) => !cachedByHour.has(h.getTime()));
+  if (missing.length > 0) {
+    const fetched = await fetchHourlyRange({
+      lat: opts.lat,
+      lng: opts.lng,
+      startUtc: opts.startUtc,
+      endUtc: opts.endUtc,
+    });
+    const fetchedByHour = new Map<number, HourlyWeather>();
+    for (const f of fetched) {
+      fetchedByHour.set(new Date(f.timeUtc + 'Z').getTime(), f);
+    }
+    for (const h of missing) {
+      const sample = fetchedByHour.get(h.getTime());
+      if (!sample) continue;
+      cachedByHour.set(h.getTime(), sample);
+      await prisma.weatherCache
+        .upsert({
+          where: { latKey_lngKey_hourUtc: { latKey, lngKey, hourUtc: h } },
+          create: { latKey, lngKey, hourUtc: h, payload: sample as object },
+          update: { payload: sample as object },
+        })
+        .catch((err) => console.warn('[WeatherCache] write failed:', err));
+    }
+  }
+
+  return hoursNeeded
+    .map((h) => cachedByHour.get(h.getTime()))
+    .filter((s): s is HourlyWeather => s !== undefined);
+};

--- a/apps/api/src/lib/weather/cache.ts
+++ b/apps/api/src/lib/weather/cache.ts
@@ -33,6 +33,14 @@ const hourBoundary = (d: Date): Date => {
 // If this assumption changes (e.g., we start fetching weather for in-progress
 // rides), revisit: forecast rows would then represent predictions of the
 // future and would need a TTL or staleness check.
+//
+// Growth profile: WeatherCache is keyed by (lat-2dp, lng-2dp, hourUtc) and
+// shared across all users, so it scales with unique (location-cell, hour)
+// pairs — not per user. Back-of-envelope: ~200 B per row, ~8760 rows per
+// year per actively-ridden cell. A future cleanup job that drops rows with
+// `hourUtc < NOW() - interval '2 years'` is a safe-always operation (archive
+// data can be re-fetched if needed). Not implemented yet because the table
+// is cheap to keep; revisit if disk usage becomes a concern.
 export const getHourlySamples = async (opts: {
   lat: number;
   lng: number;

--- a/apps/api/src/lib/weather/cache.ts
+++ b/apps/api/src/lib/weather/cache.ts
@@ -56,16 +56,16 @@ export const getHourlySamples = async (opts: {
     for (const f of fetched) {
       fetchedByHour.set(new Date(f.timeUtc + 'Z').getTime(), f);
     }
+    const rowsToInsert: { latKey: number; lngKey: number; hourUtc: Date; payload: object }[] = [];
     for (const h of missing) {
       const sample = fetchedByHour.get(h.getTime());
       if (!sample) continue;
       cachedByHour.set(h.getTime(), sample);
+      rowsToInsert.push({ latKey, lngKey, hourUtc: h, payload: sample as object });
+    }
+    if (rowsToInsert.length > 0) {
       await prisma.weatherCache
-        .upsert({
-          where: { latKey_lngKey_hourUtc: { latKey, lngKey, hourUtc: h } },
-          create: { latKey, lngKey, hourUtc: h, payload: sample as object },
-          update: { payload: sample as object },
-        })
+        .createMany({ data: rowsToInsert, skipDuplicates: true })
         .catch((err) => console.warn('[WeatherCache] write failed:', err));
     }
   }

--- a/apps/api/src/lib/weather/cache.ts
+++ b/apps/api/src/lib/weather/cache.ts
@@ -59,9 +59,16 @@ export const getHourlySamples = async (opts: {
       lngKey,
       hourUtc: { in: hoursNeeded },
     },
+    // Today the unique constraint on (latKey, lngKey, hourUtc) prevents
+    // duplicate rows, so this ordering is a no-op. Kept explicit so that if
+    // the constraint is ever relaxed (or disabled temporarily during a
+    // migration), the Map below deterministically keeps the newest write
+    // rather than whatever row the query planner returns first.
+    orderBy: { createdAt: 'asc' },
   });
   const cachedByHour = new Map<number, HourlyWeather>();
   for (const row of cached) {
+    // Later rows (newer createdAt) win via Map.set overwrite semantics.
     cachedByHour.set(row.hourUtc.getTime(), row.payload as unknown as HourlyWeather);
   }
 

--- a/apps/api/src/lib/weather/cache.ts
+++ b/apps/api/src/lib/weather/cache.ts
@@ -12,6 +12,27 @@ const hourBoundary = (d: Date): Date => {
 
 // Returns hourly samples for the given lat/lng covering [startUtc, endUtc],
 // reading from WeatherCache where possible and backfilling misses via Open-Meteo.
+//
+// Cache entries are kept indefinitely with no TTL, by design:
+//
+//   1. Archive-endpoint rows (ride hour ≥5 days old at fetch time) represent
+//      finalized ERA5 observations and never change, so caching forever is
+//      correct and strictly cheaper than re-fetching.
+//
+//   2. Forecast-endpoint rows (ride hour <5 days old at fetch time) are a
+//      theoretical concern — their value could in principle differ slightly
+//      from the archive value that same hour will have in 5+ days. In
+//      practice this is a non-issue: the weather worker always runs AFTER
+//      the ride has ended, so the "forecast" we retrieve is a realized
+//      observation of a past hour, not a prediction. The archive would
+//      later serve the same observation (plus minor ERA5 reanalysis
+//      adjustments that don't affect our condition/precip/wind aggregation
+//      at 2dp resolution). Not worth the complexity of a forecast-specific
+//      TTL + re-fetch path.
+//
+// If this assumption changes (e.g., we start fetching weather for in-progress
+// rides), revisit: forecast rows would then represent predictions of the
+// future and would need a TTL or staleness check.
 export const getHourlySamples = async (opts: {
   lat: number;
   lng: number;

--- a/apps/api/src/lib/weather/index.ts
+++ b/apps/api/src/lib/weather/index.ts
@@ -15,15 +15,57 @@ export type RideWeatherSummary = {
   samples: HourlyWeather[];
 };
 
+// Explicit severity rank for WMO codes. Raw numeric ordering is monotonic
+// *within* sub-categories (e.g. 61<63<65 is light→heavy rain) but not across
+// them — code 80 (slight showers) is numerically higher than 67 (heavy
+// freezing rain) despite being meaningfully milder. We rank by category
+// first (dry → fog → drizzle → rain → showers → snow → freezing → storms)
+// and by intensity within each category.
+//
+// The numbers themselves are opaque; only their ordering matters.
+const WMO_SEVERITY: Record<number, number> = {
+  0: 0,   // Clear sky
+  1: 10,  // Mainly clear
+  2: 11,  // Partly cloudy
+  3: 12,  // Overcast
+  45: 20, // Fog
+  48: 21, // Depositing rime fog
+  51: 30, // Light drizzle
+  53: 31, // Moderate drizzle
+  55: 32, // Dense drizzle
+  56: 45, // Light freezing drizzle
+  57: 46, // Dense freezing drizzle
+  61: 40, // Slight rain
+  63: 41, // Moderate rain
+  65: 42, // Heavy rain
+  80: 50, // Slight rain showers
+  81: 51, // Moderate rain showers
+  82: 52, // Violent rain showers
+  66: 60, // Light freezing rain
+  67: 61, // Heavy freezing rain
+  71: 70, // Slight snow fall
+  73: 71, // Moderate snow fall
+  75: 72, // Heavy snow fall
+  77: 73, // Snow grains
+  85: 80, // Slight snow showers
+  86: 81, // Heavy snow showers
+  95: 90, // Thunderstorm
+  96: 91, // Thunderstorm with slight hail
+  99: 92, // Thunderstorm with heavy hail
+};
+
+const severity = (code: number): number => WMO_SEVERITY[code] ?? -1;
+
 // "Worst hour wins": a single shower or thunderstorm hour dominates an
 // otherwise clear ride. This is the signal wear modeling cares about — any
 // exposure to rain/snow affects components — and matches how riders describe
-// a ride ("got caught in a storm" beats "mostly sunny").
-// WMO code ordering is roughly severity-ordered: 0 clear, 1-3 cloudy, 45/48
-// fog, 51-67 drizzle/rain, 71-77 snow, 80-82 showers, 85-86 snow showers,
-// 95-99 thunderstorms. Higher = worse within that ordering.
+// a ride ("got caught in a storm" beats "mostly sunny"). Ties fall back to
+// numeric code to keep output deterministic.
 export const worstHourWmoCode = (codes: number[]): number => {
-  return codes.reduce((worst, code) => (code > worst ? code : worst), codes[0]);
+  return codes.reduce((worst, code) => {
+    if (severity(code) > severity(worst)) return code;
+    return worst;
+  }, codes[0]);
 };
 
 export const mean = (nums: Array<number | null>): number | null => {

--- a/apps/api/src/lib/weather/index.ts
+++ b/apps/api/src/lib/weather/index.ts
@@ -1,5 +1,6 @@
 import { WeatherCondition } from '@prisma/client';
 import { getHourlySamples } from './cache';
+import type { HourlyWeather } from './open-meteo';
 import { applyWindyOverride, wmoToCondition } from './normalize';
 
 export type RideWeatherSummary = {
@@ -11,26 +12,21 @@ export type RideWeatherSummary = {
   wmoCode: number;
   condition: WeatherCondition;
   source: string;
+  samples: HourlyWeather[];
 };
 
-const dominantWmoCode = (codes: number[]): number => {
-  // Pick the most "severe" code — highest numeric category tends to indicate
-  // precipitation/thunder over clear-sky codes, which is the right signal for rides.
-  const counts = new Map<number, number>();
-  for (const c of codes) counts.set(c, (counts.get(c) || 0) + 1);
-  let best = codes[0];
-  let bestScore = -Infinity;
-  for (const [code, n] of counts) {
-    const score = code + n * 0.01; // severity + tiebreaker by frequency
-    if (score > bestScore) {
-      bestScore = score;
-      best = code;
-    }
-  }
-  return best;
+// "Worst hour wins": a single shower or thunderstorm hour dominates an
+// otherwise clear ride. This is the signal wear modeling cares about — any
+// exposure to rain/snow affects components — and matches how riders describe
+// a ride ("got caught in a storm" beats "mostly sunny").
+// WMO code ordering is roughly severity-ordered: 0 clear, 1-3 cloudy, 45/48
+// fog, 51-67 drizzle/rain, 71-77 snow, 80-82 showers, 85-86 snow showers,
+// 95-99 thunderstorms. Higher = worse within that ordering.
+export const worstHourWmoCode = (codes: number[]): number => {
+  return codes.reduce((worst, code) => (code > worst ? code : worst), codes[0]);
 };
 
-const mean = (nums: Array<number | null>): number | null => {
+export const mean = (nums: Array<number | null>): number | null => {
   const valid = nums.filter((n): n is number => n != null);
   if (valid.length === 0) return null;
   return valid.reduce((a, b) => a + b, 0) / valid.length;
@@ -51,7 +47,7 @@ export const getWeatherForRide = async (opts: {
   });
   if (samples.length === 0) return null;
 
-  const wmo = dominantWmoCode(samples.map((s) => s.wmoCode));
+  const wmo = worstHourWmoCode(samples.map((s) => s.wmoCode));
   const maxPrecip = Math.max(...samples.map((s) => s.precipitationMm));
   const maxWind = Math.max(...samples.map((s) => s.windSpeedKph));
   const avgTemp = mean(samples.map((s) => s.tempC)) ?? samples[0].tempC;
@@ -70,5 +66,6 @@ export const getWeatherForRide = async (opts: {
     wmoCode: wmo,
     condition,
     source: 'open-meteo',
+    samples,
   };
 };

--- a/apps/api/src/lib/weather/index.ts
+++ b/apps/api/src/lib/weather/index.ts
@@ -61,7 +61,14 @@ const severity = (code: number): number => WMO_SEVERITY[code] ?? -1;
 // exposure to rain/snow affects components — and matches how riders describe
 // a ride ("got caught in a storm" beats "mostly sunny"). Ties fall back to
 // numeric code to keep output deterministic.
+//
+// Throws on empty input rather than returning an unsound default. Callers
+// that might have nothing to aggregate must guard upstream (getWeatherForRide
+// bails on samples.length === 0 before it ever gets here).
 export const worstHourWmoCode = (codes: number[]): number => {
+  if (codes.length === 0) {
+    throw new Error('worstHourWmoCode requires at least one WMO code');
+  }
   return codes.reduce((worst, code) => {
     if (severity(code) > severity(worst)) return code;
     return worst;

--- a/apps/api/src/lib/weather/index.ts
+++ b/apps/api/src/lib/weather/index.ts
@@ -1,0 +1,74 @@
+import { WeatherCondition } from '@prisma/client';
+import { getHourlySamples } from './cache';
+import { applyWindyOverride, wmoToCondition } from './normalize';
+
+export type RideWeatherSummary = {
+  tempC: number;
+  feelsLikeC: number | null;
+  precipitationMm: number;
+  windSpeedKph: number;
+  humidity: number | null;
+  wmoCode: number;
+  condition: WeatherCondition;
+  source: string;
+};
+
+const dominantWmoCode = (codes: number[]): number => {
+  // Pick the most "severe" code — highest numeric category tends to indicate
+  // precipitation/thunder over clear-sky codes, which is the right signal for rides.
+  const counts = new Map<number, number>();
+  for (const c of codes) counts.set(c, (counts.get(c) || 0) + 1);
+  let best = codes[0];
+  let bestScore = -Infinity;
+  for (const [code, n] of counts) {
+    const score = code + n * 0.01; // severity + tiebreaker by frequency
+    if (score > bestScore) {
+      bestScore = score;
+      best = code;
+    }
+  }
+  return best;
+};
+
+const mean = (nums: Array<number | null>): number | null => {
+  const valid = nums.filter((n): n is number => n != null);
+  if (valid.length === 0) return null;
+  return valid.reduce((a, b) => a + b, 0) / valid.length;
+};
+
+export const getWeatherForRide = async (opts: {
+  lat: number;
+  lng: number;
+  startTime: Date;
+  durationSeconds: number;
+}): Promise<RideWeatherSummary | null> => {
+  const endTime = new Date(opts.startTime.getTime() + opts.durationSeconds * 1000);
+  const samples = await getHourlySamples({
+    lat: opts.lat,
+    lng: opts.lng,
+    startUtc: opts.startTime,
+    endUtc: endTime,
+  });
+  if (samples.length === 0) return null;
+
+  const wmo = dominantWmoCode(samples.map((s) => s.wmoCode));
+  const maxPrecip = Math.max(...samples.map((s) => s.precipitationMm));
+  const maxWind = Math.max(...samples.map((s) => s.windSpeedKph));
+  const avgTemp = mean(samples.map((s) => s.tempC)) ?? samples[0].tempC;
+  const avgFeels = mean(samples.map((s) => s.feelsLikeC));
+  const avgHumidity = mean(samples.map((s) => s.humidity));
+
+  const baseCondition = wmoToCondition(wmo);
+  const condition = applyWindyOverride(baseCondition, maxWind);
+
+  return {
+    tempC: avgTemp,
+    feelsLikeC: avgFeels,
+    precipitationMm: maxPrecip,
+    windSpeedKph: maxWind,
+    humidity: avgHumidity,
+    wmoCode: wmo,
+    condition,
+    source: 'open-meteo',
+  };
+};

--- a/apps/api/src/lib/weather/normalize.test.ts
+++ b/apps/api/src/lib/weather/normalize.test.ts
@@ -1,0 +1,58 @@
+import { wmoToCondition, applyWindyOverride } from './normalize';
+
+describe('wmoToCondition', () => {
+  it('maps clear sky to SUNNY', () => {
+    expect(wmoToCondition(0)).toBe('SUNNY');
+  });
+
+  it('maps partly cloudy codes to CLOUDY', () => {
+    expect(wmoToCondition(1)).toBe('CLOUDY');
+    expect(wmoToCondition(2)).toBe('CLOUDY');
+    expect(wmoToCondition(3)).toBe('CLOUDY');
+  });
+
+  it('maps fog codes to FOGGY', () => {
+    expect(wmoToCondition(45)).toBe('FOGGY');
+    expect(wmoToCondition(48)).toBe('FOGGY');
+  });
+
+  it('maps drizzle, rain, showers, thunderstorms to RAINY', () => {
+    expect(wmoToCondition(51)).toBe('RAINY');
+    expect(wmoToCondition(63)).toBe('RAINY');
+    expect(wmoToCondition(82)).toBe('RAINY');
+    expect(wmoToCondition(95)).toBe('RAINY');
+    expect(wmoToCondition(99)).toBe('RAINY');
+  });
+
+  it('maps snow codes to SNOWY', () => {
+    expect(wmoToCondition(71)).toBe('SNOWY');
+    expect(wmoToCondition(77)).toBe('SNOWY');
+    expect(wmoToCondition(85)).toBe('SNOWY');
+    expect(wmoToCondition(86)).toBe('SNOWY');
+  });
+
+  it('maps unknown codes to UNKNOWN', () => {
+    expect(wmoToCondition(999)).toBe('UNKNOWN');
+    expect(wmoToCondition(-1)).toBe('UNKNOWN');
+    expect(wmoToCondition(NaN)).toBe('UNKNOWN');
+  });
+});
+
+describe('applyWindyOverride', () => {
+  it('promotes SUNNY to WINDY at high wind speeds', () => {
+    expect(applyWindyOverride('SUNNY' as any, 45)).toBe('WINDY');
+  });
+
+  it('promotes CLOUDY to WINDY at high wind speeds', () => {
+    expect(applyWindyOverride('CLOUDY' as any, 50)).toBe('WINDY');
+  });
+
+  it('does not override RAINY or SNOWY', () => {
+    expect(applyWindyOverride('RAINY' as any, 60)).toBe('RAINY');
+    expect(applyWindyOverride('SNOWY' as any, 60)).toBe('SNOWY');
+  });
+
+  it('does not promote at low winds', () => {
+    expect(applyWindyOverride('SUNNY' as any, 10)).toBe('SUNNY');
+  });
+});

--- a/apps/api/src/lib/weather/normalize.test.ts
+++ b/apps/api/src/lib/weather/normalize.test.ts
@@ -1,3 +1,4 @@
+import { WeatherCondition } from '@prisma/client';
 import { wmoToCondition, applyWindyOverride } from './normalize';
 
 describe('wmoToCondition', () => {
@@ -40,19 +41,19 @@ describe('wmoToCondition', () => {
 
 describe('applyWindyOverride', () => {
   it('promotes SUNNY to WINDY at high wind speeds', () => {
-    expect(applyWindyOverride('SUNNY' as any, 45)).toBe('WINDY');
+    expect(applyWindyOverride(WeatherCondition.SUNNY, 45)).toBe(WeatherCondition.WINDY);
   });
 
   it('promotes CLOUDY to WINDY at high wind speeds', () => {
-    expect(applyWindyOverride('CLOUDY' as any, 50)).toBe('WINDY');
+    expect(applyWindyOverride(WeatherCondition.CLOUDY, 50)).toBe(WeatherCondition.WINDY);
   });
 
   it('does not override RAINY or SNOWY', () => {
-    expect(applyWindyOverride('RAINY' as any, 60)).toBe('RAINY');
-    expect(applyWindyOverride('SNOWY' as any, 60)).toBe('SNOWY');
+    expect(applyWindyOverride(WeatherCondition.RAINY, 60)).toBe(WeatherCondition.RAINY);
+    expect(applyWindyOverride(WeatherCondition.SNOWY, 60)).toBe(WeatherCondition.SNOWY);
   });
 
   it('does not promote at low winds', () => {
-    expect(applyWindyOverride('SUNNY' as any, 10)).toBe('SUNNY');
+    expect(applyWindyOverride(WeatherCondition.SUNNY, 10)).toBe(WeatherCondition.SUNNY);
   });
 });

--- a/apps/api/src/lib/weather/normalize.ts
+++ b/apps/api/src/lib/weather/normalize.ts
@@ -1,0 +1,31 @@
+import { WeatherCondition } from '@prisma/client';
+
+// Map Open-Meteo WMO weather interpretation codes to our normalized enum.
+// Reference: https://open-meteo.com/en/docs (WMO Weather interpretation codes)
+export const wmoToCondition = (code: number): WeatherCondition => {
+  if (!Number.isFinite(code)) return WeatherCondition.UNKNOWN;
+  if (code === 0) return WeatherCondition.SUNNY;                  // Clear sky
+  if (code >= 1 && code <= 3) return WeatherCondition.CLOUDY;     // Mainly clear, partly cloudy, overcast
+  if (code === 45 || code === 48) return WeatherCondition.FOGGY;  // Fog
+  if (code >= 51 && code <= 57) return WeatherCondition.RAINY;    // Drizzle
+  if (code >= 61 && code <= 67) return WeatherCondition.RAINY;    // Rain
+  if (code >= 71 && code <= 77) return WeatherCondition.SNOWY;    // Snow
+  if (code >= 80 && code <= 82) return WeatherCondition.RAINY;    // Rain showers
+  if (code >= 85 && code <= 86) return WeatherCondition.SNOWY;    // Snow showers
+  if (code >= 95 && code <= 99) return WeatherCondition.RAINY;    // Thunderstorm
+  return WeatherCondition.UNKNOWN;
+};
+
+// Elevate windy if sustained wind is high, regardless of base condition.
+// Threshold: ~40 kph (moderate/strong breeze).
+export const applyWindyOverride = (
+  condition: WeatherCondition,
+  windSpeedKph: number
+): WeatherCondition => {
+  if (condition === WeatherCondition.SUNNY || condition === WeatherCondition.CLOUDY) {
+    if (Number.isFinite(windSpeedKph) && windSpeedKph >= 40) {
+      return WeatherCondition.WINDY;
+    }
+  }
+  return condition;
+};

--- a/apps/api/src/lib/weather/open-meteo.test.ts
+++ b/apps/api/src/lib/weather/open-meteo.test.ts
@@ -1,4 +1,4 @@
-import { pickEndpoint } from './open-meteo';
+import { pickEndpoint, fetchHourlyRange } from './open-meteo';
 
 describe('pickEndpoint', () => {
   const NOW = new Date('2026-04-15T12:00:00Z');
@@ -38,5 +38,154 @@ describe('pickEndpoint', () => {
 
   it('uses archive for a very old ride', () => {
     expect(pickEndpoint(new Date('2020-01-01T00:00:00Z'))).toBe('archive');
+  });
+});
+
+describe('fetchHourlyRange', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  const mockFetchOnce = (impl: () => Promise<Response>) => {
+    global.fetch = jest.fn(impl) as unknown as typeof fetch;
+  };
+
+  const okResponse = (body: unknown): Response =>
+    ({ ok: true, status: 200, json: async () => body } as unknown as Response);
+
+  it('parses a successful archive response into HourlyWeather rows', async () => {
+    mockFetchOnce(async () =>
+      okResponse({
+        hourly: {
+          time: ['2020-01-01T10:00', '2020-01-01T11:00'],
+          temperature_2m: [15, 16.5],
+          apparent_temperature: [14, 15.5],
+          precipitation: [0, 0.2],
+          wind_speed_10m: [5, 7],
+          relative_humidity_2m: [60, 65],
+          weather_code: [0, 3],
+        },
+      })
+    );
+
+    const rows = await fetchHourlyRange({
+      lat: 45.1,
+      lng: -122.3,
+      startUtc: new Date('2020-01-01T10:00:00Z'),
+      endUtc: new Date('2020-01-01T11:00:00Z'),
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({
+      timeUtc: '2020-01-01T10:00',
+      tempC: 15,
+      feelsLikeC: 14,
+      precipitationMm: 0,
+      windSpeedKph: 5,
+      humidity: 60,
+      wmoCode: 0,
+    });
+    expect(rows[1].wmoCode).toBe(3);
+  });
+
+  it('drops hours with missing temperature or weather_code', async () => {
+    mockFetchOnce(async () =>
+      okResponse({
+        hourly: {
+          time: ['2020-01-01T10:00', '2020-01-01T11:00', '2020-01-01T12:00'],
+          temperature_2m: [15, null, 18],
+          apparent_temperature: [null, null, null],
+          precipitation: [0, 0, 0],
+          wind_speed_10m: [5, 5, 5],
+          relative_humidity_2m: [null, null, null],
+          weather_code: [0, 3, null],
+        },
+      })
+    );
+
+    const rows = await fetchHourlyRange({
+      lat: 45.1,
+      lng: -122.3,
+      startUtc: new Date('2020-01-01T10:00:00Z'),
+      endUtc: new Date('2020-01-01T12:00:00Z'),
+    });
+
+    // Only the 10:00 row has both temp and wmo populated.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].timeUtc).toBe('2020-01-01T10:00');
+    expect(rows[0].feelsLikeC).toBeNull();
+    expect(rows[0].humidity).toBeNull();
+  });
+
+  it('returns [] when the response has no hourly block', async () => {
+    mockFetchOnce(async () => okResponse({}));
+    const rows = await fetchHourlyRange({
+      lat: 45.1,
+      lng: -122.3,
+      startUtc: new Date('2020-01-01T10:00:00Z'),
+      endUtc: new Date('2020-01-01T11:00:00Z'),
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('throws a descriptive error on a non-200 status', async () => {
+    mockFetchOnce(async () =>
+      ({ ok: false, status: 503, json: async () => ({}) } as unknown as Response)
+    );
+    await expect(
+      fetchHourlyRange({
+        lat: 45.1,
+        lng: -122.3,
+        startUtc: new Date('2020-01-01T10:00:00Z'),
+        endUtc: new Date('2020-01-01T11:00:00Z'),
+      })
+    ).rejects.toThrow('Open-Meteo archive request failed: 503');
+  });
+
+  it('throws a timeout error when the fetch is aborted', async () => {
+    // Simulate fetch() honoring the AbortController signal.
+    global.fetch = jest.fn((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const err: Error & { name?: string } = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    // Advance past the 15s timeout using fake timers.
+    jest.useFakeTimers();
+    const p = fetchHourlyRange({
+      lat: 45.1,
+      lng: -122.3,
+      startUtc: new Date('2020-01-01T10:00:00Z'),
+      endUtc: new Date('2020-01-01T11:00:00Z'),
+    });
+    jest.advanceTimersByTime(16_000);
+
+    await expect(p).rejects.toThrow('Open-Meteo archive request timed out after 15s');
+  });
+
+  it('rethrows non-abort fetch errors unchanged', async () => {
+    mockFetchOnce(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+
+    await expect(
+      fetchHourlyRange({
+        lat: 45.1,
+        lng: -122.3,
+        startUtc: new Date('2020-01-01T10:00:00Z'),
+        endUtc: new Date('2020-01-01T11:00:00Z'),
+      })
+    ).rejects.toThrow('ECONNREFUSED');
   });
 });

--- a/apps/api/src/lib/weather/open-meteo.test.ts
+++ b/apps/api/src/lib/weather/open-meteo.test.ts
@@ -44,21 +44,47 @@ describe('pickEndpoint', () => {
 describe('fetchHourlyRange', () => {
   const originalFetch = global.fetch;
 
+  // Use fake timers throughout so the module-level acquireSlot mutex (which
+  // uses setTimeout for its MIN_INTERVAL_MS delay) resolves instantly via
+  // timer advancement rather than blocking the test with real 250ms sleeps.
   beforeEach(() => {
-    jest.useRealTimers();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-15T12:00:00Z'));
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
+    jest.useRealTimers();
     jest.restoreAllMocks();
   });
 
-  const mockFetchOnce = (impl: () => Promise<Response>) => {
+  const mockFetchOnce = (impl: (...args: unknown[]) => Promise<Response>) => {
     global.fetch = jest.fn(impl) as unknown as typeof fetch;
   };
 
   const okResponse = (body: unknown): Response =>
     ({ ok: true, status: 200, json: async () => body } as unknown as Response);
+
+  // Start fetchHourlyRange and advance fake timers so the module-level
+  // acquireSlot mutex (setTimeout-based) and the 15s abort timer both
+  // resolve. Returns the still-pending promise for the caller to assert on.
+  const callAndDrain = (opts: Parameters<typeof fetchHourlyRange>[0]) => {
+    const p = fetchHourlyRange(opts);
+    // Drain timers after the promise is in-flight so rejections are captured
+    // by the returned promise, not thrown as unhandled rejections.
+    const drain = jest.advanceTimersByTimeAsync(16_000);
+    // Callers must `await` the returned promise. The drain settles
+    // independently; we just need to make sure it doesn't leak.
+    drain.catch(() => {});
+    return p;
+  };
+
+  const archiveOpts = {
+    lat: 45.1,
+    lng: -122.3,
+    startUtc: new Date('2020-01-01T10:00:00Z'),
+    endUtc: new Date('2020-01-01T11:00:00Z'),
+  };
 
   it('parses a successful archive response into HourlyWeather rows', async () => {
     mockFetchOnce(async () =>
@@ -75,12 +101,7 @@ describe('fetchHourlyRange', () => {
       })
     );
 
-    const rows = await fetchHourlyRange({
-      lat: 45.1,
-      lng: -122.3,
-      startUtc: new Date('2020-01-01T10:00:00Z'),
-      endUtc: new Date('2020-01-01T11:00:00Z'),
-    });
+    const rows = await callAndDrain(archiveOpts);
 
     expect(rows).toHaveLength(2);
     expect(rows[0]).toEqual({
@@ -110,14 +131,11 @@ describe('fetchHourlyRange', () => {
       })
     );
 
-    const rows = await fetchHourlyRange({
-      lat: 45.1,
-      lng: -122.3,
-      startUtc: new Date('2020-01-01T10:00:00Z'),
+    const rows = await callAndDrain({
+      ...archiveOpts,
       endUtc: new Date('2020-01-01T12:00:00Z'),
     });
 
-    // Only the 10:00 row has both temp and wmo populated.
     expect(rows).toHaveLength(1);
     expect(rows[0].timeUtc).toBe('2020-01-01T10:00');
     expect(rows[0].feelsLikeC).toBeNull();
@@ -126,12 +144,7 @@ describe('fetchHourlyRange', () => {
 
   it('returns [] when the response has no hourly block', async () => {
     mockFetchOnce(async () => okResponse({}));
-    const rows = await fetchHourlyRange({
-      lat: 45.1,
-      lng: -122.3,
-      startUtc: new Date('2020-01-01T10:00:00Z'),
-      endUtc: new Date('2020-01-01T11:00:00Z'),
-    });
+    const rows = await callAndDrain(archiveOpts);
     expect(rows).toEqual([]);
   });
 
@@ -139,19 +152,14 @@ describe('fetchHourlyRange', () => {
     mockFetchOnce(async () =>
       ({ ok: false, status: 503, json: async () => ({}) } as unknown as Response)
     );
-    await expect(
-      fetchHourlyRange({
-        lat: 45.1,
-        lng: -122.3,
-        startUtc: new Date('2020-01-01T10:00:00Z'),
-        endUtc: new Date('2020-01-01T11:00:00Z'),
-      })
-    ).rejects.toThrow('Open-Meteo archive request failed: 503');
+    await expect(callAndDrain(archiveOpts)).rejects.toThrow(
+      'Open-Meteo archive request failed: 503'
+    );
   });
 
   it('throws a timeout error when the fetch is aborted', async () => {
-    // Simulate fetch() honoring the AbortController signal.
-    global.fetch = jest.fn((_url: string, init?: RequestInit) => {
+    // fetch never resolves — the AbortController will fire after 15s.
+    global.fetch = jest.fn((_url: unknown, init?: RequestInit) => {
       return new Promise<Response>((_resolve, reject) => {
         init?.signal?.addEventListener('abort', () => {
           const err: Error & { name?: string } = new Error('aborted');
@@ -161,17 +169,9 @@ describe('fetchHourlyRange', () => {
       });
     }) as unknown as typeof fetch;
 
-    // Advance past the 15s timeout using fake timers.
-    jest.useFakeTimers();
-    const p = fetchHourlyRange({
-      lat: 45.1,
-      lng: -122.3,
-      startUtc: new Date('2020-01-01T10:00:00Z'),
-      endUtc: new Date('2020-01-01T11:00:00Z'),
-    });
-    jest.advanceTimersByTime(16_000);
-
-    await expect(p).rejects.toThrow('Open-Meteo archive request timed out after 15s');
+    await expect(callAndDrain(archiveOpts)).rejects.toThrow(
+      'Open-Meteo archive request timed out after 15s'
+    );
   });
 
   it('rethrows non-abort fetch errors unchanged', async () => {
@@ -179,13 +179,6 @@ describe('fetchHourlyRange', () => {
       throw new Error('ECONNREFUSED');
     });
 
-    await expect(
-      fetchHourlyRange({
-        lat: 45.1,
-        lng: -122.3,
-        startUtc: new Date('2020-01-01T10:00:00Z'),
-        endUtc: new Date('2020-01-01T11:00:00Z'),
-      })
-    ).rejects.toThrow('ECONNREFUSED');
+    await expect(callAndDrain(archiveOpts)).rejects.toThrow('ECONNREFUSED');
   });
 });

--- a/apps/api/src/lib/weather/open-meteo.test.ts
+++ b/apps/api/src/lib/weather/open-meteo.test.ts
@@ -1,0 +1,42 @@
+import { pickEndpoint } from './open-meteo';
+
+describe('pickEndpoint', () => {
+  const NOW = new Date('2026-04-15T12:00:00Z');
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  const daysAgo = (days: number): Date =>
+    new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000);
+
+  it('uses forecast for a ride starting right now', () => {
+    expect(pickEndpoint(NOW)).toBe('forecast');
+  });
+
+  it('uses forecast for a ride 1 day old', () => {
+    expect(pickEndpoint(daysAgo(1))).toBe('forecast');
+  });
+
+  it('uses forecast for a ride just under 5 days old', () => {
+    // 4 days 23 hours — still inside the archive lag window.
+    expect(pickEndpoint(daysAgo(4.95))).toBe('forecast');
+  });
+
+  it('uses archive at exactly 5 days old (inclusive boundary)', () => {
+    expect(pickEndpoint(daysAgo(5))).toBe('archive');
+  });
+
+  it('uses archive for a ride 10 days old', () => {
+    expect(pickEndpoint(daysAgo(10))).toBe('archive');
+  });
+
+  it('uses archive for a very old ride', () => {
+    expect(pickEndpoint(new Date('2020-01-01T00:00:00Z'))).toBe('archive');
+  });
+});

--- a/apps/api/src/lib/weather/open-meteo.ts
+++ b/apps/api/src/lib/weather/open-meteo.ts
@@ -3,9 +3,18 @@ const ARCHIVE_BASE =
 const FORECAST_BASE =
   process.env.WEATHER_FORECAST_API_BASE || 'https://api.open-meteo.com/v1/forecast';
 
-// Open-Meteo allows ~10k requests/day free. Serialize with mutex + spacing
-// to stay well under burst limits during backfill.
-const MIN_INTERVAL_MS = 250;
+// Open-Meteo free tier allows ~10k requests/day sustained (~0.12 req/s) with
+// larger short-term bursts. We serialize requests with a mutex and enforce a
+// minimum interval between fetches from this process.
+//
+// IMPORTANT: this throttle is PER-PROCESS. With N horizontal replicas each
+// running `concurrency: 3` workers, cluster-wide burst rate is
+// ~N × (1000 / MIN_INTERVAL_MS) req/s. For the default 250ms and 1 replica
+// that's 4 req/s; at 4 replicas it's 16 req/s. If you scale out workers or
+// run backfills for many users at once, raise MIN_INTERVAL_MS proportionally
+// via the env var below. Distributed rate limiting (Redis token bucket) is
+// the right tool if/when we hit a paid Open-Meteo tier with hard limits.
+const MIN_INTERVAL_MS = Number(process.env.WEATHER_MIN_INTERVAL_MS) || 250;
 let lastRequest = 0;
 let mutex: Promise<void> = Promise.resolve();
 

--- a/apps/api/src/lib/weather/open-meteo.ts
+++ b/apps/api/src/lib/weather/open-meteo.ts
@@ -50,7 +50,7 @@ const ARCHIVE_LAG_DAYS = 5;
 
 const formatDate = (d: Date): string => d.toISOString().slice(0, 10);
 
-const pickEndpoint = (startUtc: Date): 'archive' | 'forecast' => {
+export const pickEndpoint = (startUtc: Date): 'archive' | 'forecast' => {
   const ageMs = Date.now() - startUtc.getTime();
   const ageDays = ageMs / (1000 * 60 * 60 * 24);
   return ageDays >= ARCHIVE_LAG_DAYS ? 'archive' : 'forecast';

--- a/apps/api/src/lib/weather/open-meteo.ts
+++ b/apps/api/src/lib/weather/open-meteo.ts
@@ -1,0 +1,120 @@
+const ARCHIVE_BASE =
+  process.env.WEATHER_ARCHIVE_API_BASE || 'https://archive-api.open-meteo.com/v1/archive';
+const FORECAST_BASE =
+  process.env.WEATHER_FORECAST_API_BASE || 'https://api.open-meteo.com/v1/forecast';
+
+// Open-Meteo allows ~10k requests/day free. Serialize with mutex + spacing
+// to stay well under burst limits during backfill.
+const MIN_INTERVAL_MS = 250;
+let lastRequest = 0;
+let mutex: Promise<void> = Promise.resolve();
+
+const acquireSlot = async (): Promise<void> => {
+  const myTurn = mutex;
+  let release!: () => void;
+  mutex = new Promise((resolve) => {
+    release = resolve;
+  });
+  await myTurn;
+  const elapsed = Date.now() - lastRequest;
+  if (elapsed < MIN_INTERVAL_MS) {
+    await new Promise((r) => setTimeout(r, MIN_INTERVAL_MS - elapsed));
+  }
+  lastRequest = Date.now();
+  release();
+};
+
+export type HourlyWeather = {
+  timeUtc: string;        // ISO hour boundary
+  tempC: number;
+  feelsLikeC: number | null;
+  precipitationMm: number;
+  windSpeedKph: number;
+  humidity: number | null;
+  wmoCode: number;
+};
+
+type OpenMeteoResponse = {
+  hourly?: {
+    time?: string[];
+    temperature_2m?: (number | null)[];
+    apparent_temperature?: (number | null)[];
+    precipitation?: (number | null)[];
+    wind_speed_10m?: (number | null)[];
+    relative_humidity_2m?: (number | null)[];
+    weather_code?: (number | null)[];
+  };
+};
+
+const ARCHIVE_LAG_DAYS = 5;
+
+const formatDate = (d: Date): string => d.toISOString().slice(0, 10);
+
+const pickEndpoint = (startUtc: Date): 'archive' | 'forecast' => {
+  const ageMs = Date.now() - startUtc.getTime();
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+  return ageDays >= ARCHIVE_LAG_DAYS ? 'archive' : 'forecast';
+};
+
+const HOURLY_VARS = [
+  'temperature_2m',
+  'apparent_temperature',
+  'precipitation',
+  'wind_speed_10m',
+  'relative_humidity_2m',
+  'weather_code',
+].join(',');
+
+export const fetchHourlyRange = async (opts: {
+  lat: number;
+  lng: number;
+  startUtc: Date;
+  endUtc: Date;
+}): Promise<HourlyWeather[]> => {
+  const endpoint = pickEndpoint(opts.startUtc);
+  const base = endpoint === 'archive' ? ARCHIVE_BASE : FORECAST_BASE;
+  const url = new URL(base);
+  url.searchParams.set('latitude', opts.lat.toString());
+  url.searchParams.set('longitude', opts.lng.toString());
+  url.searchParams.set('hourly', HOURLY_VARS);
+  url.searchParams.set('wind_speed_unit', 'kmh');
+  url.searchParams.set('timezone', 'UTC');
+
+  if (endpoint === 'archive') {
+    url.searchParams.set('start_date', formatDate(opts.startUtc));
+    url.searchParams.set('end_date', formatDate(opts.endUtc));
+  } else {
+    // Forecast endpoint: request past days to cover recent rides.
+    const ageDays = Math.ceil((Date.now() - opts.startUtc.getTime()) / (1000 * 60 * 60 * 24));
+    url.searchParams.set('past_days', Math.min(Math.max(ageDays + 1, 1), 92).toString());
+    url.searchParams.set('forecast_days', '1');
+  }
+
+  await acquireSlot();
+  const res = await fetch(url.toString(), { headers: { Accept: 'application/json' } });
+  if (!res.ok) {
+    throw new Error(`Open-Meteo ${endpoint} request failed: ${res.status}`);
+  }
+  const data = (await res.json()) as OpenMeteoResponse;
+  const h = data.hourly;
+  if (!h || !h.time) return [];
+
+  const out: HourlyWeather[] = [];
+  for (let i = 0; i < h.time.length; i++) {
+    const timeUtc = h.time[i];
+    if (!timeUtc) continue;
+    const wmo = h.weather_code?.[i];
+    const temp = h.temperature_2m?.[i];
+    if (temp == null || wmo == null) continue;
+    out.push({
+      timeUtc,
+      tempC: temp,
+      feelsLikeC: h.apparent_temperature?.[i] ?? null,
+      precipitationMm: h.precipitation?.[i] ?? 0,
+      windSpeedKph: h.wind_speed_10m?.[i] ?? 0,
+      humidity: h.relative_humidity_2m?.[i] ?? null,
+      wmoCode: wmo,
+    });
+  }
+  return out;
+};

--- a/apps/api/src/lib/weather/open-meteo.ts
+++ b/apps/api/src/lib/weather/open-meteo.ts
@@ -91,7 +91,24 @@ export const fetchHourlyRange = async (opts: {
   }
 
   await acquireSlot();
-  const res = await fetch(url.toString(), { headers: { Accept: 'application/json' } });
+  // Bound every HTTP call so a slow/hung Open-Meteo response can't pin a
+  // worker concurrency slot indefinitely. BullMQ retries the job on throw.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15_000);
+  let res: Response;
+  try {
+    res = await fetch(url.toString(), {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if ((err as { name?: string }).name === 'AbortError') {
+      throw new Error(`Open-Meteo ${endpoint} request timed out after 15s`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
   if (!res.ok) {
     throw new Error(`Open-Meteo ${endpoint} request failed: ${res.status}`);
   }

--- a/apps/api/src/lib/weather/ride-summary.test.ts
+++ b/apps/api/src/lib/weather/ride-summary.test.ts
@@ -1,0 +1,119 @@
+jest.mock('./cache', () => ({
+  getHourlySamples: jest.fn(),
+}));
+
+import { WeatherCondition } from '@prisma/client';
+import { getWeatherForRide } from './index';
+import { getHourlySamples } from './cache';
+import type { HourlyWeather } from './open-meteo';
+
+const mockSamples = getHourlySamples as jest.Mock;
+
+const hour = (isoHour: string, overrides: Partial<HourlyWeather> = {}): HourlyWeather => ({
+  timeUtc: isoHour,
+  tempC: 15,
+  feelsLikeC: 14,
+  precipitationMm: 0,
+  windSpeedKph: 5,
+  humidity: 60,
+  wmoCode: 0,
+  ...overrides,
+});
+
+describe('getWeatherForRide', () => {
+  const opts = {
+    lat: 45.1,
+    lng: -122.3,
+    startTime: new Date('2026-04-15T10:00:00Z'),
+    durationSeconds: 7200, // 2-hour ride → spans 3 hour-boundaries
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns null when the cache lib returns no samples', async () => {
+    mockSamples.mockResolvedValueOnce([]);
+    expect(await getWeatherForRide(opts)).toBeNull();
+  });
+
+  it('aggregates a fully clear ride into a SUNNY summary', async () => {
+    mockSamples.mockResolvedValueOnce([
+      hour('2026-04-15T10:00', { tempC: 18, windSpeedKph: 4 }),
+      hour('2026-04-15T11:00', { tempC: 20, windSpeedKph: 6 }),
+      hour('2026-04-15T12:00', { tempC: 22, windSpeedKph: 5 }),
+    ]);
+
+    const result = await getWeatherForRide(opts);
+
+    expect(result).not.toBeNull();
+    expect(result!.condition).toBe(WeatherCondition.SUNNY);
+    expect(result!.wmoCode).toBe(0);
+    expect(result!.tempC).toBe(20); // mean of 18/20/22
+    expect(result!.precipitationMm).toBe(0);
+    expect(result!.windSpeedKph).toBe(6); // max wind
+    expect(result!.source).toBe('open-meteo');
+    expect(result!.samples).toHaveLength(3);
+  });
+
+  it('promotes otherwise-sunny output to WINDY when any hour is gusty', async () => {
+    mockSamples.mockResolvedValueOnce([
+      hour('2026-04-15T10:00', { windSpeedKph: 10 }),
+      hour('2026-04-15T11:00', { windSpeedKph: 45 }), // over the 40 threshold
+      hour('2026-04-15T12:00', { windSpeedKph: 12 }),
+    ]);
+
+    const result = await getWeatherForRide(opts);
+
+    expect(result!.condition).toBe(WeatherCondition.WINDY);
+    expect(result!.windSpeedKph).toBe(45);
+  });
+
+  it('uses worst-hour WMO code and max precip across the ride', async () => {
+    mockSamples.mockResolvedValueOnce([
+      hour('2026-04-15T10:00', { wmoCode: 0, precipitationMm: 0 }),
+      hour('2026-04-15T11:00', { wmoCode: 65, precipitationMm: 3.2 }), // heavy rain
+      hour('2026-04-15T12:00', { wmoCode: 3, precipitationMm: 0 }),
+    ]);
+
+    const result = await getWeatherForRide(opts);
+
+    expect(result!.wmoCode).toBe(65);
+    expect(result!.condition).toBe(WeatherCondition.RAINY);
+    expect(result!.precipitationMm).toBe(3.2); // max, not mean
+  });
+
+  it('passes through null feelsLikeC/humidity when upstream lacks them', async () => {
+    mockSamples.mockResolvedValueOnce([
+      hour('2026-04-15T10:00', { feelsLikeC: null, humidity: null }),
+      hour('2026-04-15T11:00', { feelsLikeC: null, humidity: null }),
+    ]);
+
+    const result = await getWeatherForRide(opts);
+
+    expect(result!.feelsLikeC).toBeNull();
+    expect(result!.humidity).toBeNull();
+  });
+
+  it('falls back to first sample tempC when mean returns null', async () => {
+    // Mean can't return null for tempC since tempC is non-null in our type,
+    // but guard against a future loosening — this covers the `?? samples[0].tempC`
+    // fallback branch. A single sample trivially produces mean === that value.
+    mockSamples.mockResolvedValueOnce([hour('2026-04-15T10:00', { tempC: 7 })]);
+
+    const result = await getWeatherForRide(opts);
+
+    expect(result!.tempC).toBe(7);
+  });
+
+  it('forwards the full hour window to getHourlySamples', async () => {
+    mockSamples.mockResolvedValueOnce([hour('2026-04-15T10:00')]);
+    await getWeatherForRide(opts);
+
+    expect(mockSamples).toHaveBeenCalledWith({
+      lat: 45.1,
+      lng: -122.3,
+      startUtc: opts.startTime,
+      // startTime + 7200s = 12:00
+      endUtc: new Date('2026-04-15T12:00:00Z'),
+    });
+  });
+});

--- a/apps/api/src/routes/strava.backfill.ts
+++ b/apps/api/src/routes/strava.backfill.ts
@@ -216,7 +216,9 @@ r.get<Empty, void, Empty, { year?: string }>(
             console.warn(`[Strava Backfill] Failed to geocode ride ${ride.id}:`, err);
           }
 
-          enqueueWeatherJob({ rideId: ride.id }).catch(() => {});
+          enqueueWeatherJob({ rideId: ride.id }).catch((err) =>
+            logError(`Strava Backfill weather enqueue ${ride.id}`, err)
+          );
         }
 
         importedCount++;

--- a/apps/api/src/routes/strava.backfill.ts
+++ b/apps/api/src/routes/strava.backfill.ts
@@ -6,7 +6,7 @@ import { formatLatLon, reverseGeocode } from '../lib/location';
 import { sendBadRequest, sendUnauthorized, sendNotFound, sendInternalError } from '../lib/api-response';
 import { incrementBikeComponentHours, decrementBikeComponentHours } from '../lib/component-hours';
 import { logError } from '../lib/logger';
-import { enqueueWeatherJob } from '../lib/queue/weather.queue';
+import { enqueueWeatherJob } from '../lib/queue';
 
 type Empty = Record<string, never>;
 const r: Router = createRouter();

--- a/apps/api/src/routes/strava.backfill.ts
+++ b/apps/api/src/routes/strava.backfill.ts
@@ -6,6 +6,7 @@ import { formatLatLon, reverseGeocode } from '../lib/location';
 import { sendBadRequest, sendUnauthorized, sendNotFound, sendInternalError } from '../lib/api-response';
 import { incrementBikeComponentHours, decrementBikeComponentHours } from '../lib/component-hours';
 import { logError } from '../lib/logger';
+import { enqueueWeatherJob } from '../lib/queue/weather.queue';
 
 type Empty = Record<string, never>;
 const r: Router = createRouter();
@@ -187,6 +188,8 @@ r.get<Empty, void, Empty, { year?: string }>(
               notes: activity.name || null,
               bikeId,
               location: initialLocation,
+              startLat: lat,
+              startLng: lon,
             },
           });
 
@@ -212,6 +215,8 @@ r.get<Empty, void, Empty, { year?: string }>(
             // Don't fail the import if geocoding fails
             console.warn(`[Strava Backfill] Failed to geocode ride ${ride.id}:`, err);
           }
+
+          enqueueWeatherJob({ rideId: ride.id }).catch(() => {});
         }
 
         importedCount++;

--- a/apps/api/src/routes/webhooks.strava.ts
+++ b/apps/api/src/routes/webhooks.strava.ts
@@ -427,7 +427,9 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
         }).catch(() => {}); // swallow - already logged internally
 
         if (activity.start_latlng) {
-          enqueueWeatherJob({ rideId: syncedRideId }).catch(() => {});
+          enqueueWeatherJob({ rideId: syncedRideId }).catch((err) =>
+            logError(`Strava Webhook weather enqueue ${syncedRideId}`, err)
+          );
         }
       }
     } catch (error) {

--- a/apps/api/src/routes/webhooks.strava.ts
+++ b/apps/api/src/routes/webhooks.strava.ts
@@ -392,6 +392,9 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
             notes: activity.name || null,
             bikeId,
             ...(locationUpdate !== undefined ? { location: locationUpdate } : {}),
+            // Known limitation: coords are only written, never cleared on
+            // re-sync. See sync.worker.ts for full rationale (Strava
+            // privacy zones are the most likely trigger).
             ...(startLat != null ? { startLat } : {}),
             ...(startLng != null ? { startLng } : {}),
           },

--- a/apps/api/src/routes/webhooks.strava.ts
+++ b/apps/api/src/routes/webhooks.strava.ts
@@ -6,7 +6,7 @@ import { deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
 import { incrementBikeComponentHours, decrementBikeComponentHours } from '../lib/component-hours';
 import { logError } from '../lib/logger';
 import { fireRideNotifications } from '../services/notification.service';
-import { enqueueWeatherJob } from '../lib/queue/weather.queue';
+import { enqueueWeatherJob } from '../lib/queue';
 import { isActiveSource } from '../lib/active-source';
 
 type Empty = Record<string, never>;

--- a/apps/api/src/routes/webhooks.strava.ts
+++ b/apps/api/src/routes/webhooks.strava.ts
@@ -6,6 +6,7 @@ import { deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
 import { incrementBikeComponentHours, decrementBikeComponentHours } from '../lib/component-hours';
 import { logError } from '../lib/logger';
 import { fireRideNotifications } from '../services/notification.service';
+import { enqueueWeatherJob } from '../lib/queue/weather.queue';
 import { isActiveSource } from '../lib/active-source';
 
 type Empty = Record<string, never>;
@@ -357,6 +358,9 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
 
         const locationUpdate = shouldApplyAutoLocation(existing?.location ?? null, autoLocation?.title ?? null);
 
+        const startLat = activity.start_latlng?.[0] ?? null;
+        const startLng = activity.start_latlng?.[1] ?? null;
+
         const ride = await tx.ride.upsert({
           where: {
             stravaActivityId: activityId.toString(),
@@ -374,6 +378,8 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
             notes: activity.name || null,
             bikeId,
             location: autoLocation?.title ?? null,
+            startLat,
+            startLng,
           },
           update: {
             startTime,
@@ -386,6 +392,8 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
             notes: activity.name || null,
             bikeId,
             ...(locationUpdate !== undefined ? { location: locationUpdate } : {}),
+            ...(startLat != null ? { startLat } : {}),
+            ...(startLng != null ? { startLng } : {}),
           },
         });
 
@@ -417,6 +425,10 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
           distanceMeters,
           isNewRide,
         }).catch(() => {}); // swallow - already logged internally
+
+        if (activity.start_latlng) {
+          enqueueWeatherJob({ rideId: syncedRideId }).catch(() => {});
+        }
       }
     } catch (error) {
       logError(`Strava Activity Event ${activityId}`, error);

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -416,6 +416,8 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
         rideType: activity.activityType,
         notes: activity.activityName ?? null,
         ...(locationUpdate !== undefined ? { location: locationUpdate } : {}),
+        // Known limitation: coords are only written, never cleared on
+        // re-sync. See sync.worker.ts for full rationale.
         ...(startLat != null ? { startLat } : {}),
         ...(startLng != null ? { startLng } : {}),
       },

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -423,7 +423,9 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
     });
 
     if (startLat != null && startLng != null) {
-      enqueueWeatherJob({ rideId: upsertedRide.id }).catch(() => {});
+      enqueueWeatherJob({ rideId: upsertedRide.id }).catch((err) =>
+        logger.warn({ rideId: upsertedRide.id, err }, '[BackfillWorker] Failed to enqueue weather job')
+      );
     }
 
     processedActivityCount++;

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -9,6 +9,7 @@ import { deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
 import { logError, logger } from '../lib/logger';
 import { config } from '../config/env';
 import type { BackfillJobData, BackfillJobName } from '../lib/queue/backfill.queue';
+import { enqueueWeatherJob } from '../lib/queue/weather.queue';
 
 // Garmin API limits backfill requests to 30-day chunks
 const CHUNK_DAYS = 30;
@@ -385,8 +386,11 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
       autoLocation?.title ?? null
     );
 
+    const startLat = activity.startLatitudeInDegrees ?? activity.beginLatitude ?? null;
+    const startLng = activity.startLongitudeInDegrees ?? activity.beginLongitude ?? null;
+
     // Upsert the ride
-    await prisma.ride.upsert({
+    const upsertedRide = await prisma.ride.upsert({
       where: { garminActivityId: activity.summaryId },
       create: {
         userId,
@@ -400,6 +404,8 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
         notes: activity.activityName ?? null,
         location: autoLocation?.title ?? null,
         importSessionId: runningSession?.id ?? null,
+        startLat,
+        startLng,
       },
       update: {
         startTime,
@@ -410,8 +416,15 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
         rideType: activity.activityType,
         notes: activity.activityName ?? null,
         ...(locationUpdate !== undefined ? { location: locationUpdate } : {}),
+        ...(startLat != null ? { startLat } : {}),
+        ...(startLng != null ? { startLng } : {}),
       },
+      select: { id: true },
     });
+
+    if (startLat != null && startLng != null) {
+      enqueueWeatherJob({ rideId: upsertedRide.id }).catch(() => {});
+    }
 
     processedActivityCount++;
     logger.debug({ summaryId: activity.summaryId }, '[BackfillWorker] Upserted ride from callback');

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -9,7 +9,7 @@ import { deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
 import { logError, logger } from '../lib/logger';
 import { config } from '../config/env';
 import type { BackfillJobData, BackfillJobName } from '../lib/queue/backfill.queue';
-import { enqueueWeatherJob } from '../lib/queue/weather.queue';
+import { enqueueWeatherJob } from '../lib/queue';
 
 // Garmin API limits backfill requests to 30-day chunks
 const CHUNK_DAYS = 30;

--- a/apps/api/src/workers/index.ts
+++ b/apps/api/src/workers/index.ts
@@ -1,8 +1,9 @@
 import { createSyncWorker, closeSyncWorker } from './sync.worker';
 import { createBackfillWorker, closeBackfillWorker } from './backfill.worker';
 import { createNotificationWorker, closeNotificationWorker } from './notification.worker';
+import { createWeatherWorker, closeWeatherWorker } from './weather.worker';
 import { closeRedisConnection } from '../lib/redis';
-import { closeSyncQueue, closeBackfillQueue, closeNotificationQueue } from '../lib/queue';
+import { closeSyncQueue, closeBackfillQueue, closeNotificationQueue, closeWeatherQueue } from '../lib/queue';
 
 /**
  * Start all BullMQ workers.
@@ -14,6 +15,7 @@ export function startWorkers(): void {
   createSyncWorker();
   createBackfillWorker();
   createNotificationWorker();
+  createWeatherWorker();
 
   console.log('[Workers] All workers started');
 }
@@ -34,12 +36,13 @@ export async function stopWorkers(): Promise<void> {
       closeSyncWorker(),
       closeBackfillWorker(),
       closeNotificationWorker(),
+      closeWeatherWorker(),
     ]);
 
     // Log any worker shutdown failures
     workerResults.forEach((result, index) => {
       if (result.status === 'rejected') {
-        const workerNames = ['SyncWorker', 'BackfillWorker', 'NotificationWorker'];
+        const workerNames = ['SyncWorker', 'BackfillWorker', 'NotificationWorker', 'WeatherWorker'];
         console.error(`[Workers] Failed to close ${workerNames[index]}:`, result.reason);
       }
     });
@@ -49,12 +52,13 @@ export async function stopWorkers(): Promise<void> {
       closeSyncQueue(),
       closeBackfillQueue(),
       closeNotificationQueue(),
+      closeWeatherQueue(),
     ]);
 
     // Log any queue shutdown failures
     queueResults.forEach((result, index) => {
       if (result.status === 'rejected') {
-        const queueNames = ['SyncQueue', 'BackfillQueue', 'NotificationQueue'];
+        const queueNames = ['SyncQueue', 'BackfillQueue', 'NotificationQueue', 'WeatherQueue'];
         console.error(`[Workers] Failed to close ${queueNames[index]}:`, result.reason);
       }
     });

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -374,7 +374,9 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
 
   // Fire-and-forget weather fetch
   if (syncedRideId && activity.start_latlng) {
-    enqueueWeatherJob({ rideId: syncedRideId }).catch(() => {});
+    enqueueWeatherJob({ rideId: syncedRideId }).catch((err) =>
+      logger.warn({ rideId: syncedRideId, err }, '[SyncWorker] Failed to enqueue weather job (Strava)')
+    );
   }
 
   // Fire-and-forget notifications
@@ -632,7 +634,9 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
 
   // Fire-and-forget weather fetch
   if (startLat != null && startLng != null) {
-    enqueueWeatherJob({ rideId: syncedRideId }).catch(() => {});
+    enqueueWeatherJob({ rideId: syncedRideId }).catch((err) =>
+      logger.warn({ rideId: syncedRideId, err }, '[SyncWorker] Failed to enqueue weather job (Garmin)')
+    );
   }
 
   // Fire-and-forget notifications

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -14,6 +14,7 @@ import { fireRideNotifications } from '../services/notification.service';
 import { completeReferral } from '../services/referral.service';
 import { config } from '../config/env';
 import type { SyncJobData, SyncJobName, SyncProvider } from '../lib/queue/sync.queue';
+import { enqueueWeatherJob } from '../lib/queue/weather.queue';
 import type { Prisma } from '@prisma/client';
 import {
   WHOOP_API_BASE,
@@ -321,6 +322,9 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
     isNewRide = !existing;
     const locationUpdate = shouldApplyAutoLocation(existing?.location ?? null, autoLocation);
 
+    const startLat = activity.start_latlng?.[0] ?? null;
+    const startLng = activity.start_latlng?.[1] ?? null;
+
     const ride = await tx.ride.upsert({
       where: { stravaActivityId: activity.id.toString() },
       create: {
@@ -336,6 +340,8 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
         notes: activity.name || null,
         bikeId,
         location: autoLocation,
+        startLat,
+        startLng,
       },
       update: {
         startTime,
@@ -348,6 +354,8 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
         notes: activity.name || null,
         bikeId,
         ...(locationUpdate !== undefined ? { location: locationUpdate } : {}),
+        ...(startLat != null ? { startLat } : {}),
+        ...(startLng != null ? { startLng } : {}),
       },
     });
 
@@ -363,6 +371,11 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
   });
 
   logger.debug({ stravaActivityId: activity.id }, '[SyncWorker] Upserted Strava activity');
+
+  // Fire-and-forget weather fetch
+  if (syncedRideId && activity.start_latlng) {
+    enqueueWeatherJob({ rideId: syncedRideId }).catch(() => {});
+  }
 
   // Fire-and-forget notifications
   if (syncedRideId) {
@@ -553,6 +566,9 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
     select: { id: true },
   });
 
+  const startLat = activity.startLatitudeInDegrees ?? activity.beginLatitude ?? null;
+  const startLng = activity.startLongitudeInDegrees ?? activity.beginLongitude ?? null;
+
   // Upsert ride first — this is the primary data, must not be lost
   const ride = await prisma.ride.upsert({
     where: { garminActivityId: activity.summaryId },
@@ -569,6 +585,8 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
       location: autoLocation?.title ?? null,
       importSessionId: runningSession?.id ?? null,
       bikeId,
+      startLat,
+      startLng,
     },
     update: {
       startTime,
@@ -579,6 +597,8 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
       rideType: activity.activityType,
       notes: activity.activityName ?? null,
       ...(locationUpdate !== undefined ? { location: locationUpdate } : {}),
+      ...(startLat != null ? { startLat } : {}),
+      ...(startLng != null ? { startLng } : {}),
     },
   });
 
@@ -609,6 +629,11 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
   }
 
   logger.debug({ summaryId: activity.summaryId }, '[SyncWorker] Upserted Garmin activity');
+
+  // Fire-and-forget weather fetch
+  if (startLat != null && startLng != null) {
+    enqueueWeatherJob({ rideId: syncedRideId }).catch(() => {});
+  }
 
   // Fire-and-forget notifications
   fireRideNotifications({

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -14,7 +14,7 @@ import { fireRideNotifications } from '../services/notification.service';
 import { completeReferral } from '../services/referral.service';
 import { config } from '../config/env';
 import type { SyncJobData, SyncJobName, SyncProvider } from '../lib/queue/sync.queue';
-import { enqueueWeatherJob } from '../lib/queue/weather.queue';
+import { enqueueWeatherJob } from '../lib/queue';
 import type { Prisma } from '@prisma/client';
 import {
   WHOOP_API_BASE,

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -354,6 +354,11 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
         notes: activity.name || null,
         bikeId,
         ...(locationUpdate !== undefined ? { location: locationUpdate } : {}),
+        // Known limitation: coords are only written, never cleared. If a
+        // privacy zone is later added to a Strava activity and coords are
+        // stripped on re-sync, the originally-stored startLat/startLng
+        // stick around. Weather already fetched is unaffected; a
+        // hypothetical future weather re-fetch would use the stale coord.
         ...(startLat != null ? { startLat } : {}),
         ...(startLng != null ? { startLng } : {}),
       },
@@ -599,6 +604,11 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
       rideType: activity.activityType,
       notes: activity.activityName ?? null,
       ...(locationUpdate !== undefined ? { location: locationUpdate } : {}),
+      // Known limitation: coords are only written, never cleared. If a
+      // Garmin activity's coords become unavailable on a later re-sync,
+      // the originally-stored startLat/startLng stick around. Weather
+      // already fetched is unaffected; a hypothetical future weather
+      // re-fetch would use the stale coord.
       ...(startLat != null ? { startLat } : {}),
       ...(startLng != null ? { startLng } : {}),
     },

--- a/apps/api/src/workers/weather.worker.test.ts
+++ b/apps/api/src/workers/weather.worker.test.ts
@@ -1,0 +1,157 @@
+// Stop side-effectful imports (Sentry init, BullMQ Redis connection) from
+// firing just because the worker module is loaded.
+jest.mock('../instrument', () => ({}));
+jest.mock('bullmq', () => ({ Worker: jest.fn() }));
+jest.mock('../lib/queue/connection', () => ({ getQueueConnection: jest.fn() }));
+jest.mock('@sentry/node', () => ({ captureException: jest.fn() }));
+
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    ride: { findUnique: jest.fn() },
+    rideWeather: { upsert: jest.fn() },
+  },
+}));
+
+jest.mock('../lib/weather', () => ({
+  getWeatherForRide: jest.fn(),
+}));
+
+import { processWeatherJob } from './weather.worker';
+import { prisma } from '../lib/prisma';
+import { getWeatherForRide } from '../lib/weather';
+
+const mockFindUnique = prisma.ride.findUnique as jest.Mock;
+const mockUpsert = prisma.rideWeather.upsert as jest.Mock;
+const mockGetWeather = getWeatherForRide as jest.Mock;
+
+const makeJob = (rideId = 'ride-1') =>
+  ({ data: { rideId }, id: 'job-1' } as never);
+
+describe('processWeatherJob', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('skips when the ride does not exist', async () => {
+    mockFindUnique.mockResolvedValueOnce(null);
+
+    await processWeatherJob(makeJob());
+
+    expect(mockGetWeather).not.toHaveBeenCalled();
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('skips when the ride already has weather', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'ride-1',
+      startTime: new Date('2026-04-15T10:00:00Z'),
+      durationSeconds: 3600,
+      startLat: 45.1,
+      startLng: -122.3,
+      weather: { id: 'existing-weather' },
+    });
+
+    await processWeatherJob(makeJob());
+
+    expect(mockGetWeather).not.toHaveBeenCalled();
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('skips when the ride is missing coordinates', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'ride-1',
+      startTime: new Date('2026-04-15T10:00:00Z'),
+      durationSeconds: 3600,
+      startLat: null,
+      startLng: null,
+      weather: null,
+    });
+
+    await processWeatherJob(makeJob());
+
+    expect(mockGetWeather).not.toHaveBeenCalled();
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('skips upsert when the weather lib returns null (no samples)', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'ride-1',
+      startTime: new Date('2026-04-15T10:00:00Z'),
+      durationSeconds: 3600,
+      startLat: 45.1,
+      startLng: -122.3,
+      weather: null,
+    });
+    mockGetWeather.mockResolvedValueOnce(null);
+
+    await processWeatherJob(makeJob());
+
+    expect(mockGetWeather).toHaveBeenCalledTimes(1);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('upserts the RideWeather row on success and stores samples in rawJson', async () => {
+    const startTime = new Date('2026-04-15T10:00:00Z');
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'ride-1',
+      startTime,
+      durationSeconds: 3600,
+      startLat: 45.1,
+      startLng: -122.3,
+      weather: null,
+    });
+    const summary = {
+      tempC: 18,
+      feelsLikeC: 17,
+      precipitationMm: 0.2,
+      windSpeedKph: 8,
+      humidity: 62,
+      wmoCode: 3,
+      condition: 'CLOUDY',
+      source: 'open-meteo',
+      samples: [{ timeUtc: '2026-04-15T10:00', tempC: 18, wmoCode: 3 }],
+    };
+    mockGetWeather.mockResolvedValueOnce(summary);
+
+    await processWeatherJob(makeJob());
+
+    expect(mockGetWeather).toHaveBeenCalledWith({
+      lat: 45.1,
+      lng: -122.3,
+      startTime,
+      durationSeconds: 3600,
+    });
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    const call = mockUpsert.mock.calls[0][0];
+    expect(call.where).toEqual({ rideId: 'ride-1' });
+    expect(call.create).toMatchObject({
+      rideId: 'ride-1',
+      tempC: 18,
+      condition: 'CLOUDY',
+      lat: 45.1,
+      lng: -122.3,
+      source: 'open-meteo',
+      rawJson: { samples: summary.samples },
+    });
+    expect(call.update).toMatchObject({
+      tempC: 18,
+      condition: 'CLOUDY',
+      rawJson: { samples: summary.samples },
+    });
+  });
+
+  it('propagates weather-lib errors so BullMQ can retry the job', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'ride-1',
+      startTime: new Date('2026-04-15T10:00:00Z'),
+      durationSeconds: 3600,
+      startLat: 45.1,
+      startLng: -122.3,
+      weather: null,
+    });
+    mockGetWeather.mockRejectedValueOnce(new Error('Open-Meteo timeout'));
+
+    await expect(processWeatherJob(makeJob())).rejects.toThrow('Open-Meteo timeout');
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/workers/weather.worker.ts
+++ b/apps/api/src/workers/weather.worker.ts
@@ -1,0 +1,116 @@
+import '../instrument';
+import { Worker, Job } from 'bullmq';
+import * as Sentry from '@sentry/node';
+import { getQueueConnection } from '../lib/queue/connection';
+import { prisma } from '../lib/prisma';
+import { logger } from '../lib/logger';
+import type { WeatherJobData, WeatherJobName } from '../lib/queue/weather.queue';
+import { getWeatherForRide } from '../lib/weather';
+
+export async function processWeatherJob(
+  job: Job<WeatherJobData, void, WeatherJobName>
+): Promise<void> {
+  const { rideId } = job.data;
+
+  const ride = await prisma.ride.findUnique({
+    where: { id: rideId },
+    select: {
+      id: true,
+      startTime: true,
+      durationSeconds: true,
+      startLat: true,
+      startLng: true,
+      weather: { select: { id: true } },
+    },
+  });
+
+  if (!ride) {
+    logger.debug({ rideId }, '[WeatherWorker] Ride not found, skipping');
+    return;
+  }
+  if (ride.weather) {
+    logger.debug({ rideId }, '[WeatherWorker] Ride already has weather, skipping');
+    return;
+  }
+  if (ride.startLat == null || ride.startLng == null) {
+    logger.debug({ rideId }, '[WeatherWorker] Ride missing coords, skipping');
+    return;
+  }
+
+  const summary = await getWeatherForRide({
+    lat: ride.startLat,
+    lng: ride.startLng,
+    startTime: ride.startTime,
+    durationSeconds: ride.durationSeconds,
+  });
+
+  if (!summary) {
+    logger.warn({ rideId }, '[WeatherWorker] No weather samples returned');
+    return;
+  }
+
+  await prisma.rideWeather.upsert({
+    where: { rideId },
+    create: {
+      rideId,
+      tempC: summary.tempC,
+      feelsLikeC: summary.feelsLikeC,
+      precipitationMm: summary.precipitationMm,
+      windSpeedKph: summary.windSpeedKph,
+      humidity: summary.humidity,
+      wmoCode: summary.wmoCode,
+      condition: summary.condition,
+      lat: ride.startLat,
+      lng: ride.startLng,
+      source: summary.source,
+    },
+    update: {
+      tempC: summary.tempC,
+      feelsLikeC: summary.feelsLikeC,
+      precipitationMm: summary.precipitationMm,
+      windSpeedKph: summary.windSpeedKph,
+      humidity: summary.humidity,
+      wmoCode: summary.wmoCode,
+      condition: summary.condition,
+      source: summary.source,
+      fetchedAt: new Date(),
+    },
+  });
+}
+
+let weatherWorker: Worker<WeatherJobData, void, WeatherJobName> | null = null;
+
+export function createWeatherWorker(): Worker<WeatherJobData, void, WeatherJobName> {
+  if (weatherWorker) return weatherWorker;
+
+  weatherWorker = new Worker<WeatherJobData, void, WeatherJobName>(
+    'weather',
+    processWeatherJob,
+    {
+      connection: getQueueConnection(),
+      concurrency: 3,
+      drainDelay: 5000,
+    }
+  );
+
+  weatherWorker.on('completed', (job) => {
+    logger.debug({ jobId: job.id }, '[WeatherWorker] Completed');
+  });
+  weatherWorker.on('failed', (job, err) => {
+    logger.warn({ jobId: job?.id, error: err.message }, '[WeatherWorker] Job failed');
+    Sentry.captureException(err, { tags: { worker: 'weather' }, extra: { jobId: job?.id } });
+  });
+  weatherWorker.on('error', (err) => {
+    logger.error({ error: err.message }, '[WeatherWorker] Worker error');
+    Sentry.captureException(err, { tags: { worker: 'weather' } });
+  });
+
+  return weatherWorker;
+}
+
+export async function closeWeatherWorker(): Promise<void> {
+  if (weatherWorker) {
+    await weatherWorker.close();
+    weatherWorker = null;
+  }
+}

--- a/apps/api/src/workers/weather.worker.ts
+++ b/apps/api/src/workers/weather.worker.ts
@@ -49,6 +49,8 @@ export async function processWeatherJob(
     return;
   }
 
+  const rawJson = { samples: summary.samples };
+
   await prisma.rideWeather.upsert({
     where: { rideId },
     create: {
@@ -63,6 +65,7 @@ export async function processWeatherJob(
       lat: ride.startLat,
       lng: ride.startLng,
       source: summary.source,
+      rawJson,
     },
     update: {
       tempC: summary.tempC,
@@ -74,6 +77,7 @@ export async function processWeatherJob(
       condition: summary.condition,
       source: summary.source,
       fetchedAt: new Date(),
+      rawJson,
     },
   });
 }

--- a/apps/api/src/workers/weather.worker.ts
+++ b/apps/api/src/workers/weather.worker.ts
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/node';
 import { getQueueConnection } from '../lib/queue/connection';
 import { prisma } from '../lib/prisma';
 import { logger } from '../lib/logger';
-import type { WeatherJobData, WeatherJobName } from '../lib/queue/weather.queue';
+import type { WeatherJobData, WeatherJobName } from '../lib/queue';
 import { getWeatherForRide } from '../lib/weather';
 
 export async function processWeatherJob(

--- a/apps/web/src/components/EditRideModal.tsx
+++ b/apps/web/src/components/EditRideModal.tsx
@@ -6,6 +6,8 @@ import { BIKES_LIGHT } from '../graphql/bikes';
 import { toLocalInputValue, fromLocalInputValue } from '../lib/format';
 import { Modal, Input, Textarea, Select, Button } from './ui';
 import { usePreferences } from '../hooks/usePreferences';
+import RideWeatherPanel from './RideWeatherPanel';
+import type { RideWeather } from '../models/Ride';
 
 type BikeSummary = { id: string; nickname?: string | null; manufacturer: string; model: string };
 const formatBikeName = (bike: BikeSummary) =>
@@ -23,6 +25,7 @@ type Ride = {
   notes?: string | null;
   trailSystem?: string | null;
   location?: string | null;
+  weather?: RideWeather | null;
 };
 
 export default function EditRideModal({
@@ -230,6 +233,10 @@ export default function EditRideModal({
           rows={3}
           maxLength={2000}
         />
+
+        {ride.weather && (
+          <RideWeatherPanel weather={ride.weather} distanceUnit={distanceUnit} />
+        )}
 
         {error && <div className="text-sm text-danger">{error.message}</div>}
       </form>

--- a/apps/web/src/components/RideStatsCard/hooks/useRideStats.ts
+++ b/apps/web/src/components/RideStatsCard/hooks/useRideStats.ts
@@ -194,12 +194,17 @@ function computeStatsForTimeframe(
 }
 
 function computeWeatherStats(rides: Ride[]): WeatherStats {
+  // Only rides with fetched weather contribute to the breakdown. Rides that
+  // are still pending a fetch are reported via (totalRides - totalWithWeather)
+  // so they don't pollute the UNKNOWN bucket, which is reserved for rides
+  // whose WMO code didn't map to a known condition.
   const breakdown: WeatherBreakdown = EMPTY_WEATHER_BREAKDOWN();
   let totalWithWeather = 0;
   for (const r of rides) {
-    const cond: WeatherCondition = r.weather?.condition ?? 'UNKNOWN';
+    if (!r.weather) continue;
+    const cond: WeatherCondition = r.weather.condition;
     breakdown[cond] += 1;
-    if (r.weather) totalWithWeather += 1;
+    totalWithWeather += 1;
   }
   return { breakdown, totalWithWeather, totalRides: rides.length };
 }

--- a/apps/web/src/components/RideStatsCard/hooks/useRideStats.ts
+++ b/apps/web/src/components/RideStatsCard/hooks/useRideStats.ts
@@ -11,7 +11,11 @@ import type {
   LocationBreakdown,
   BikeTimeData,
   PersonalRecord,
+  WeatherStats,
+  WeatherBreakdown,
 } from '../types';
+import { EMPTY_WEATHER_BREAKDOWN } from '../types';
+import type { WeatherCondition } from '../../../models/Ride';
 
 const DAYS_MS = 24 * 60 * 60 * 1000;
 const SECONDS_TO_HOURS = 1 / 3600;
@@ -185,7 +189,19 @@ function computeStatsForTimeframe(
     trends: computeTrendStats(filteredRides, allRides),
     heartRate: computeHeartRateStats(filteredRides),
     locations: computeLocationStats(filteredRides),
+    weather: computeWeatherStats(filteredRides),
   };
+}
+
+function computeWeatherStats(rides: Ride[]): WeatherStats {
+  const breakdown: WeatherBreakdown = EMPTY_WEATHER_BREAKDOWN();
+  let totalWithWeather = 0;
+  for (const r of rides) {
+    const cond: WeatherCondition = r.weather?.condition ?? 'UNKNOWN';
+    breakdown[cond] += 1;
+    if (r.weather) totalWithWeather += 1;
+  }
+  return { breakdown, totalWithWeather, totalRides: rides.length };
 }
 
 function computeRideCountStats(rides: Ride[]): RideCountStats {

--- a/apps/web/src/components/RideStatsCard/index.tsx
+++ b/apps/web/src/components/RideStatsCard/index.tsx
@@ -6,6 +6,7 @@ import {
   HeartPulse,
   MapPin,
   Bike,
+  CloudSun,
 } from 'lucide-react';
 
 import TimeframeDropdown from './TimeframeDropdown';
@@ -17,6 +18,7 @@ import TrendsSection from './sections/TrendsSection';
 import HeartRateSection from './sections/HeartRateSection';
 import LocationSection from './sections/LocationSection';
 import BikeUsageSection from './sections/BikeUsageSection';
+import WeatherSection from './sections/WeatherSection';
 
 import { useRideStats, useRideStatsForRides, useRideStatsForYear, buildBikeNameMap, getYearsWithRides } from './hooks/useRideStats';
 import { RIDES } from '../../graphql/rides';
@@ -223,6 +225,15 @@ export default function RideStatsCard({ showHeading = true, rides: externalRides
                 emptyMessage="No bike data for this timeframe"
               >
                 <BikeUsageSection data={selectedStats.bikeTime} />
+              </ExpandableSection>
+
+              <ExpandableSection
+                title="Weather"
+                icon={<CloudSun size={14} />}
+                isEmpty={selectedStats.weather.totalWithWeather === 0}
+                emptyMessage="No weather data yet for this timeframe"
+              >
+                <WeatherSection stats={selectedStats.weather} />
               </ExpandableSection>
             </div>
           </>

--- a/apps/web/src/components/RideStatsCard/sections/WeatherSection.tsx
+++ b/apps/web/src/components/RideStatsCard/sections/WeatherSection.tsx
@@ -1,6 +1,6 @@
 import type { WeatherStats } from '../types';
 import type { WeatherCondition } from '../../../models/Ride';
-import { conditionIcon, conditionLabel, conditionTint } from '../../../lib/weather';
+import { renderConditionIcon, conditionLabel, conditionTint } from '../../../lib/weather';
 
 const ORDER: WeatherCondition[] = [
   'SUNNY',
@@ -25,14 +25,17 @@ export default function WeatherSection({ stats }: { stats: WeatherStats }) {
         {ORDER.map((cond) => {
           const count = stats.breakdown[cond];
           if (count === 0) return null;
-          const Icon = conditionIcon(cond);
           const tint = cond === 'UNKNOWN' ? undefined : conditionTint(cond);
           return (
             <div
               key={cond}
               className="flex flex-col items-center rounded-md border border-[color:var(--surface-2)] bg-[color:var(--surface-1)] px-2 py-3"
             >
-              <Icon size={20} color={tint} className={tint ? '' : 'text-[color:var(--text-muted)]'} />
+              {renderConditionIcon(cond, {
+                size: 20,
+                color: tint,
+                className: tint ? '' : 'text-[color:var(--text-muted)]',
+              })}
               <div className="mt-1 text-sm font-semibold text-[color:var(--text)]">{count}</div>
               <div className="text-[11px] text-[color:var(--text-muted)]">
                 {conditionLabel(cond)}

--- a/apps/web/src/components/RideStatsCard/sections/WeatherSection.tsx
+++ b/apps/web/src/components/RideStatsCard/sections/WeatherSection.tsx
@@ -13,30 +13,39 @@ const ORDER: WeatherCondition[] = [
 ];
 
 export default function WeatherSection({ stats }: { stats: WeatherStats }) {
+  const pending = stats.totalRides - stats.totalWithWeather;
+
   if (stats.totalWithWeather === 0) {
     return <p className="section-empty">No weather data yet for this timeframe.</p>;
   }
 
   return (
-    <div className="grid grid-cols-4 sm:grid-cols-7 gap-2">
-      {ORDER.map((cond) => {
-        const count = stats.breakdown[cond];
-        if (count === 0) return null;
-        const Icon = conditionIcon(cond);
-        const tint = cond === 'UNKNOWN' ? undefined : conditionTint(cond);
-        return (
-          <div
-            key={cond}
-            className="flex flex-col items-center rounded-md border border-[color:var(--surface-2)] bg-[color:var(--surface-1)] px-2 py-3"
-          >
-            <Icon size={20} color={tint} className={tint ? '' : 'text-[color:var(--text-muted)]'} />
-            <div className="mt-1 text-sm font-semibold text-[color:var(--text)]">{count}</div>
-            <div className="text-[11px] text-[color:var(--text-muted)]">
-              {cond === 'UNKNOWN' ? 'No data' : conditionLabel(cond)}
+    <div className="space-y-2">
+      <div className="grid grid-cols-4 sm:grid-cols-7 gap-2">
+        {ORDER.map((cond) => {
+          const count = stats.breakdown[cond];
+          if (count === 0) return null;
+          const Icon = conditionIcon(cond);
+          const tint = cond === 'UNKNOWN' ? undefined : conditionTint(cond);
+          return (
+            <div
+              key={cond}
+              className="flex flex-col items-center rounded-md border border-[color:var(--surface-2)] bg-[color:var(--surface-1)] px-2 py-3"
+            >
+              <Icon size={20} color={tint} className={tint ? '' : 'text-[color:var(--text-muted)]'} />
+              <div className="mt-1 text-sm font-semibold text-[color:var(--text)]">{count}</div>
+              <div className="text-[11px] text-[color:var(--text-muted)]">
+                {conditionLabel(cond)}
+              </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
+      {pending > 0 && (
+        <p className="text-[11px] text-[color:var(--text-muted)]">
+          {pending} ride{pending === 1 ? '' : 's'} still pending weather fetch.
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/RideStatsCard/sections/WeatherSection.tsx
+++ b/apps/web/src/components/RideStatsCard/sections/WeatherSection.tsx
@@ -21,7 +21,7 @@ export default function WeatherSection({ stats }: { stats: WeatherStats }) {
     <div className="grid grid-cols-4 sm:grid-cols-7 gap-2">
       {ORDER.map((cond) => {
         const count = stats.breakdown[cond];
-        if (cond === 'UNKNOWN' && count === 0) return null;
+        if (count === 0) return null;
         const Icon = conditionIcon(cond);
         const tint = cond === 'UNKNOWN' ? undefined : conditionTint(cond);
         return (

--- a/apps/web/src/components/RideStatsCard/sections/WeatherSection.tsx
+++ b/apps/web/src/components/RideStatsCard/sections/WeatherSection.tsx
@@ -1,0 +1,42 @@
+import type { WeatherStats } from '../types';
+import type { WeatherCondition } from '../../../models/Ride';
+import { conditionIcon, conditionLabel, conditionTint } from '../../../lib/weather';
+
+const ORDER: WeatherCondition[] = [
+  'SUNNY',
+  'CLOUDY',
+  'RAINY',
+  'SNOWY',
+  'WINDY',
+  'FOGGY',
+  'UNKNOWN',
+];
+
+export default function WeatherSection({ stats }: { stats: WeatherStats }) {
+  if (stats.totalWithWeather === 0) {
+    return <p className="section-empty">No weather data yet for this timeframe.</p>;
+  }
+
+  return (
+    <div className="grid grid-cols-4 sm:grid-cols-7 gap-2">
+      {ORDER.map((cond) => {
+        const count = stats.breakdown[cond];
+        if (cond === 'UNKNOWN' && count === 0) return null;
+        const Icon = conditionIcon(cond);
+        const tint = cond === 'UNKNOWN' ? undefined : conditionTint(cond);
+        return (
+          <div
+            key={cond}
+            className="flex flex-col items-center rounded-md border border-[color:var(--surface-2)] bg-[color:var(--surface-1)] px-2 py-3"
+          >
+            <Icon size={20} color={tint} className={tint ? '' : 'text-[color:var(--text-muted)]'} />
+            <div className="mt-1 text-sm font-semibold text-[color:var(--text)]">{count}</div>
+            <div className="text-[11px] text-[color:var(--text-muted)]">
+              {cond === 'UNKNOWN' ? 'No data' : conditionLabel(cond)}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/RideStatsCard/types.ts
+++ b/apps/web/src/components/RideStatsCard/types.ts
@@ -56,6 +56,16 @@ export interface LocationStats {
   topTrailSystems: LocationBreakdown[];
 }
 
+import type { WeatherCondition } from '../../models/Ride';
+
+export type WeatherBreakdown = Record<WeatherCondition, number>;
+
+export interface WeatherStats {
+  breakdown: WeatherBreakdown;
+  totalWithWeather: number;
+  totalRides: number;
+}
+
 // Complete ride statistics for a timeframe
 export interface RideStats {
   // Primary metrics
@@ -69,7 +79,18 @@ export interface RideStats {
   trends: TrendStats;
   heartRate: HeartRateStats;
   locations: LocationStats;
+  weather: WeatherStats;
 }
+
+export const EMPTY_WEATHER_BREAKDOWN = (): WeatherBreakdown => ({
+  SUNNY: 0,
+  CLOUDY: 0,
+  RAINY: 0,
+  SNOWY: 0,
+  WINDY: 0,
+  FOGGY: 0,
+  UNKNOWN: 0,
+});
 
 // Preset timeframe values (excludes year numbers)
 export type PresetTimeframe = '1w' | '1m' | '3m' | 'YTD';
@@ -105,5 +126,10 @@ export const EMPTY_STATS: RideStats = {
   locations: {
     topLocations: [],
     topTrailSystems: [],
+  },
+  weather: {
+    breakdown: EMPTY_WEATHER_BREAKDOWN(),
+    totalWithWeather: 0,
+    totalRides: 0,
   },
 };

--- a/apps/web/src/components/RideStatsCard/types.ts
+++ b/apps/web/src/components/RideStatsCard/types.ts
@@ -1,3 +1,5 @@
+import type { WeatherCondition } from '../../models/Ride';
+
 // Timeframes for ride statistics
 // Can be a preset timeframe or a specific year (as a number)
 export type Timeframe = '1w' | '1m' | '3m' | 'YTD' | number;
@@ -55,8 +57,6 @@ export interface LocationStats {
   topLocations: LocationBreakdown[];
   topTrailSystems: LocationBreakdown[];
 }
-
-import type { WeatherCondition } from '../../models/Ride';
 
 export type WeatherBreakdown = Record<WeatherCondition, number>;
 

--- a/apps/web/src/components/RideWeatherPanel.tsx
+++ b/apps/web/src/components/RideWeatherPanel.tsx
@@ -29,6 +29,15 @@ export default function RideWeatherPanel({ weather, distanceUnit = 'mi' }: Props
     ? `${Math.round(kphToMph(weather.windSpeedKph))} mph`
     : `${Math.round(weather.windSpeedKph)} kph`;
 
+  const feelsLikeValue =
+    weather.feelsLikeC != null
+      ? isImperial
+        ? `${Math.round(celsiusToFahrenheit(weather.feelsLikeC))}°F`
+        : `${Math.round(weather.feelsLikeC)}°C`
+      : null;
+  const humidityValue =
+    weather.humidity != null ? `${Math.round(weather.humidity)}%` : null;
+
   return (
     <div className="rounded-lg border border-[color:var(--surface-2)] bg-[color:var(--surface-1)] p-4">
       <div className="text-xs font-semibold uppercase tracking-wide text-[color:var(--text-muted)] mb-3">
@@ -56,6 +65,12 @@ export default function RideWeatherPanel({ weather, distanceUnit = 'mi' }: Props
           label="Wind"
         />
       </div>
+      {(feelsLikeValue || humidityValue) && (
+        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-[color:var(--text-muted)]">
+          {feelsLikeValue && <span>Feels like {feelsLikeValue}</span>}
+          {humidityValue && <span>Humidity {humidityValue}</span>}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/RideWeatherPanel.tsx
+++ b/apps/web/src/components/RideWeatherPanel.tsx
@@ -1,7 +1,7 @@
 import { Thermometer, Droplets, Wind } from 'lucide-react';
 import type { RideWeather } from '../models/Ride';
 import {
-  conditionIcon,
+  renderConditionIcon,
   conditionLabel,
   conditionTint,
   celsiusToFahrenheit,
@@ -11,12 +11,11 @@ import {
 
 type Props = {
   weather: RideWeather;
-  distanceUnit?: 'mi' | 'km' | string;
+  distanceUnit?: 'mi' | 'km';
 };
 
 export default function RideWeatherPanel({ weather, distanceUnit = 'mi' }: Props) {
   const isImperial = distanceUnit === 'mi';
-  const ConditionIcon = conditionIcon(weather.condition);
   const tint = conditionTint(weather.condition);
 
   const tempValue = isImperial
@@ -45,7 +44,7 @@ export default function RideWeatherPanel({ weather, distanceUnit = 'mi' }: Props
       </div>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         <Tile
-          icon={<ConditionIcon size={20} color={tint} />}
+          icon={renderConditionIcon(weather.condition, { size: 20, color: tint })}
           value={conditionLabel(weather.condition)}
           label="Condition"
         />

--- a/apps/web/src/components/RideWeatherPanel.tsx
+++ b/apps/web/src/components/RideWeatherPanel.tsx
@@ -1,0 +1,71 @@
+import { Thermometer, Droplets, Gauge } from 'lucide-react';
+import type { RideWeather } from '../models/Ride';
+import {
+  conditionIcon,
+  conditionLabel,
+  conditionTint,
+  celsiusToFahrenheit,
+  mmToInches,
+  kphToMph,
+} from '../lib/weather';
+
+type Props = {
+  weather: RideWeather;
+  distanceUnit?: 'mi' | 'km' | string;
+};
+
+export default function RideWeatherPanel({ weather, distanceUnit = 'mi' }: Props) {
+  const isImperial = distanceUnit === 'mi';
+  const ConditionIcon = conditionIcon(weather.condition);
+  const tint = conditionTint(weather.condition);
+
+  const tempValue = isImperial
+    ? `${Math.round(celsiusToFahrenheit(weather.tempC))}°F`
+    : `${Math.round(weather.tempC)}°C`;
+  const precipValue = isImperial
+    ? `${mmToInches(weather.precipitationMm).toFixed(2)} in`
+    : `${weather.precipitationMm.toFixed(1)} mm`;
+  const windValue = isImperial
+    ? `${Math.round(kphToMph(weather.windSpeedKph))} mph`
+    : `${Math.round(weather.windSpeedKph)} kph`;
+
+  return (
+    <div className="rounded-lg border border-[color:var(--surface-2)] bg-[color:var(--surface-1)] p-4">
+      <div className="text-xs font-semibold uppercase tracking-wide text-[color:var(--text-muted)] mb-3">
+        Weather
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <Tile
+          icon={<ConditionIcon size={20} color={tint} />}
+          value={conditionLabel(weather.condition)}
+          label="Condition"
+        />
+        <Tile
+          icon={<Thermometer size={20} className="text-[color:var(--text-muted)]" />}
+          value={tempValue}
+          label="Temp"
+        />
+        <Tile
+          icon={<Droplets size={20} className="text-[color:var(--text-muted)]" />}
+          value={precipValue}
+          label="Precip"
+        />
+        <Tile
+          icon={<Gauge size={20} className="text-[color:var(--text-muted)]" />}
+          value={windValue}
+          label="Wind"
+        />
+      </div>
+    </div>
+  );
+}
+
+function Tile({ icon, value, label }: { icon: React.ReactNode; value: string; label: string }) {
+  return (
+    <div className="flex flex-col items-center text-center py-2">
+      {icon}
+      <div className="mt-1 text-sm font-semibold text-[color:var(--text)]">{value}</div>
+      <div className="text-[11px] text-[color:var(--text-muted)]">{label}</div>
+    </div>
+  );
+}

--- a/apps/web/src/components/RideWeatherPanel.tsx
+++ b/apps/web/src/components/RideWeatherPanel.tsx
@@ -1,4 +1,4 @@
-import { Thermometer, Droplets, Gauge } from 'lucide-react';
+import { Thermometer, Droplets, Wind } from 'lucide-react';
 import type { RideWeather } from '../models/Ride';
 import {
   conditionIcon,
@@ -60,7 +60,7 @@ export default function RideWeatherPanel({ weather, distanceUnit = 'mi' }: Props
           label="Precip"
         />
         <Tile
-          icon={<Gauge size={20} className="text-[color:var(--text-muted)]" />}
+          icon={<Wind size={20} className="text-[color:var(--text-muted)]" />}
           value={windValue}
           label="Wind"
         />

--- a/apps/web/src/components/WeatherBackfillSection.test.tsx
+++ b/apps/web/src/components/WeatherBackfillSection.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import WeatherBackfillSection from './WeatherBackfillSection';
+
+const mockBackfill = vi.fn();
+const mockRefetchQueries = vi.fn().mockResolvedValue(undefined);
+const mockUseQuery = vi.fn();
+const mockUseUserTier = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('@apollo/client', () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useMutation: vi.fn(() => [mockBackfill, { loading: false }]),
+  useApolloClient: vi.fn(() => ({ refetchQueries: mockRefetchQueries })),
+  gql: vi.fn((strings: TemplateStringsArray) => strings[0]),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom'
+  );
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../hooks/useUserTier', () => ({
+  useUserTier: () => mockUseUserTier(),
+}));
+
+const renderSection = () =>
+  render(
+    <MemoryRouter>
+      <WeatherBackfillSection />
+    </MemoryRouter>
+  );
+
+describe('WeatherBackfillSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseQuery.mockReturnValue({
+      data: { me: { id: 'user-1', ridesMissingWeather: 42 } },
+    });
+    mockUseUserTier.mockReturnValue({ isPro: true });
+  });
+
+  it('renders nothing when there are no rides missing weather', () => {
+    mockUseQuery.mockReturnValueOnce({
+      data: { me: { id: 'user-1', ridesMissingWeather: 0 } },
+    });
+    const { container } = renderSection();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the missing-rides count and a Fetch button for Pro users', () => {
+    renderSection();
+    expect(screen.getByText(/42 rides missing weather data/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /fetch weather/i })).toBeEnabled();
+  });
+
+  it('shows a Pro feature chip for free users and routes to /pricing on click', () => {
+    mockUseUserTier.mockReturnValueOnce({ isPro: false });
+    renderSection();
+    const btn = screen.getByRole('button', { name: /pro feature/i });
+    fireEvent.click(btn);
+    expect(mockNavigate).toHaveBeenCalledWith('/pricing');
+    expect(mockBackfill).not.toHaveBeenCalled();
+  });
+
+  it('does not call backfill mutation when a free user clicks', () => {
+    mockUseUserTier.mockReturnValueOnce({ isPro: false });
+    renderSection();
+    fireEvent.click(screen.getByRole('button', { name: /pro feature/i }));
+    expect(mockBackfill).not.toHaveBeenCalled();
+  });
+
+  it('shows "Fetch more" when the backfill reports remainingAfterBatch > 0', async () => {
+    mockBackfill.mockResolvedValueOnce({
+      data: {
+        backfillWeatherForMyRides: {
+          enqueuedCount: 500,
+          remainingAfterBatch: 350,
+          ridesWithoutCoords: 0,
+        },
+      },
+    });
+
+    renderSection();
+    fireEvent.click(screen.getByRole('button', { name: /fetch weather/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /fetch more/i })
+      ).toBeEnabled();
+    });
+    expect(screen.getByText(/350 more remain/i)).toBeInTheDocument();
+  });
+
+  it('disables the button and labels it Queued when the drain completes', async () => {
+    mockBackfill.mockResolvedValueOnce({
+      data: {
+        backfillWeatherForMyRides: {
+          enqueuedCount: 42,
+          remainingAfterBatch: 0,
+          ridesWithoutCoords: 0,
+        },
+      },
+    });
+
+    renderSection();
+    fireEvent.click(screen.getByRole('button', { name: /fetch weather/i }));
+
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /queued/i });
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  it('surfaces ridesWithoutCoords as a caption when > 0', async () => {
+    mockBackfill.mockResolvedValueOnce({
+      data: {
+        backfillWeatherForMyRides: {
+          enqueuedCount: 10,
+          remainingAfterBatch: 0,
+          ridesWithoutCoords: 7,
+        },
+      },
+    });
+
+    renderSection();
+    fireEvent.click(screen.getByRole('button', { name: /fetch weather/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/7 rides can't get weather/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows a user-visible error when the mutation throws', async () => {
+    mockBackfill.mockRejectedValueOnce(new Error('Rate limit exceeded.'));
+
+    renderSection();
+    fireEvent.click(screen.getByRole('button', { name: /fetch weather/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/rate limit exceeded/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/WeatherBackfillSection.tsx
+++ b/apps/web/src/components/WeatherBackfillSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useMutation, useQuery } from '@apollo/client';
+import { useApolloClient, useMutation, useQuery } from '@apollo/client';
 import { useNavigate } from 'react-router-dom';
 import { CloudSun, Lock } from 'lucide-react';
 import { useUserTier } from '../hooks/useUserTier';
@@ -8,7 +8,6 @@ import {
   RIDES_MISSING_WEATHER,
 } from '../graphql/backfillWeather';
 import { RIDES } from '../graphql/rides';
-import { useApolloClient } from '@apollo/client';
 
 export default function WeatherBackfillSection() {
   const { isPro } = useUserTier();

--- a/apps/web/src/components/WeatherBackfillSection.tsx
+++ b/apps/web/src/components/WeatherBackfillSection.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { useMutation } from '@apollo/client';
+import { useNavigate } from 'react-router-dom';
+import { CloudSun, Lock } from 'lucide-react';
+import { useUserTier } from '../hooks/useUserTier';
+import { useViewer, ME_QUERY } from '../graphql/me';
+import { BACKFILL_WEATHER_FOR_MY_RIDES } from '../graphql/backfillWeather';
+
+export default function WeatherBackfillSection() {
+  const { isPro } = useUserTier();
+  const { viewer } = useViewer();
+  const navigate = useNavigate();
+  const [queued, setQueued] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [backfill, { loading }] = useMutation(BACKFILL_WEATHER_FOR_MY_RIDES, {
+    refetchQueries: [{ query: ME_QUERY }],
+  });
+
+  const missing = viewer?.ridesMissingWeather ?? 0;
+
+  if (missing === 0 && queued === null) return null;
+
+  const onClick = async () => {
+    if (!isPro) {
+      navigate('/pricing');
+      return;
+    }
+    setError(null);
+    try {
+      const { data } = await backfill();
+      setQueued(data?.backfillWeatherForMyRides?.enqueuedCount ?? 0);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-medium text-white">Weather Data</h3>
+      <div className="rounded-2xl border border-app/60 bg-surface-2 p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <CloudSun className="h-5 w-5 text-muted" />
+            <div>
+              <p className="text-sm font-medium text-white">Weather for past rides</p>
+              <p className="text-xs text-muted">
+                {queued !== null
+                  ? `Queued ${queued} ride${queued === 1 ? '' : 's'}. Weather will appear as it's fetched.`
+                  : `${missing} ride${missing === 1 ? '' : 's'} missing weather data.`}
+              </p>
+            </div>
+          </div>
+          {isPro ? (
+            <button
+              onClick={onClick}
+              disabled={loading || queued !== null}
+              className="flex items-center gap-1.5 rounded-lg border border-white/20 px-3 py-1.5 text-xs font-medium text-white/80 transition hover:bg-white/10 disabled:opacity-50"
+            >
+              {loading ? 'Queuing…' : queued !== null ? 'Queued' : 'Fetch weather'}
+            </button>
+          ) : (
+            <button
+              onClick={onClick}
+              className="flex items-center gap-1.5 rounded-lg bg-mint/15 border border-mint/30 px-3 py-1.5 text-xs font-medium text-mint transition hover:bg-mint/25"
+            >
+              <Lock className="h-3 w-3" />
+              Pro feature
+            </button>
+          )}
+        </div>
+        {error && <p className="mt-2 text-sm text-red-400">{error}</p>}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/WeatherBackfillSection.tsx
+++ b/apps/web/src/components/WeatherBackfillSection.tsx
@@ -10,7 +10,7 @@ import {
 
 export default function WeatherBackfillSection() {
   const { isPro } = useUserTier();
-  const { data: countData } = useQuery<{ ridesMissingWeather: number }>(
+  const { data: countData } = useQuery<{ me: { id: string; ridesMissingWeather: number } | null }>(
     RIDES_MISSING_WEATHER,
     { fetchPolicy: 'cache-and-network' }
   );
@@ -25,7 +25,7 @@ export default function WeatherBackfillSection() {
     refetchQueries: [{ query: RIDES_MISSING_WEATHER }],
   });
 
-  const missing = countData?.ridesMissingWeather ?? 0;
+  const missing = countData?.me?.ridesMissingWeather ?? 0;
 
   if (missing === 0 && lastResult === null) return null;
 

--- a/apps/web/src/components/WeatherBackfillSection.tsx
+++ b/apps/web/src/components/WeatherBackfillSection.tsx
@@ -7,9 +7,12 @@ import {
   BACKFILL_WEATHER_FOR_MY_RIDES,
   RIDES_MISSING_WEATHER,
 } from '../graphql/backfillWeather';
+import { RIDES } from '../graphql/rides';
+import { useApolloClient } from '@apollo/client';
 
 export default function WeatherBackfillSection() {
   const { isPro } = useUserTier();
+  const apolloClient = useApolloClient();
   const { data: countData } = useQuery<{ me: { id: string; ridesMissingWeather: number } | null }>(
     RIDES_MISSING_WEATHER,
     { fetchPolicy: 'cache-and-network' }
@@ -44,6 +47,16 @@ export default function WeatherBackfillSection() {
         remaining: res?.remainingAfterBatch ?? 0,
         withoutCoords: res?.ridesWithoutCoords ?? 0,
       });
+      // The queue drains asynchronously. Refetch the rides list once workers
+      // have had a chance to populate weather rows so the freshly-fetched
+      // weather tiles actually appear without a manual page reload. The
+      // window is a heuristic; stragglers catch up on next navigation via
+      // the list query's cache-and-network fetch policy.
+      if ((res?.enqueuedCount ?? 0) > 0) {
+        setTimeout(() => {
+          apolloClient.refetchQueries({ include: [RIDES] }).catch(() => {});
+        }, 15_000);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong.');
     }

--- a/apps/web/src/components/WeatherBackfillSection.tsx
+++ b/apps/web/src/components/WeatherBackfillSection.tsx
@@ -18,6 +18,7 @@ export default function WeatherBackfillSection() {
   const [lastResult, setLastResult] = useState<{
     enqueued: number;
     remaining: number;
+    withoutCoords: number;
   } | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -41,6 +42,7 @@ export default function WeatherBackfillSection() {
       setLastResult({
         enqueued: res?.enqueuedCount ?? 0,
         remaining: res?.remainingAfterBatch ?? 0,
+        withoutCoords: res?.ridesWithoutCoords ?? 0,
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong.');
@@ -65,6 +67,13 @@ export default function WeatherBackfillSection() {
                     : `Queued ${lastResult.enqueued} ride${lastResult.enqueued === 1 ? '' : 's'}. Weather will appear as it's fetched.`
                   : `${missing} ride${missing === 1 ? '' : 's'} missing weather data.`}
               </p>
+              {lastResult !== null && lastResult.withoutCoords > 0 && (
+                <p className="text-xs text-muted mt-1">
+                  {lastResult.withoutCoords} ride
+                  {lastResult.withoutCoords === 1 ? '' : 's'} can't get weather —
+                  no GPS data on file.
+                </p>
+              )}
             </div>
           </div>
           {isPro ? (

--- a/apps/web/src/components/WeatherBackfillSection.tsx
+++ b/apps/web/src/components/WeatherBackfillSection.tsx
@@ -1,25 +1,33 @@
 import { useState } from 'react';
-import { useMutation } from '@apollo/client';
+import { useMutation, useQuery } from '@apollo/client';
 import { useNavigate } from 'react-router-dom';
 import { CloudSun, Lock } from 'lucide-react';
 import { useUserTier } from '../hooks/useUserTier';
-import { useViewer, ME_QUERY } from '../graphql/me';
-import { BACKFILL_WEATHER_FOR_MY_RIDES } from '../graphql/backfillWeather';
+import {
+  BACKFILL_WEATHER_FOR_MY_RIDES,
+  RIDES_MISSING_WEATHER,
+} from '../graphql/backfillWeather';
 
 export default function WeatherBackfillSection() {
   const { isPro } = useUserTier();
-  const { viewer } = useViewer();
+  const { data: countData } = useQuery<{ ridesMissingWeather: number }>(
+    RIDES_MISSING_WEATHER,
+    { fetchPolicy: 'cache-and-network' }
+  );
   const navigate = useNavigate();
-  const [queued, setQueued] = useState<number | null>(null);
+  const [lastResult, setLastResult] = useState<{
+    enqueued: number;
+    remaining: number;
+  } | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const [backfill, { loading }] = useMutation(BACKFILL_WEATHER_FOR_MY_RIDES, {
-    refetchQueries: [{ query: ME_QUERY }],
+    refetchQueries: [{ query: RIDES_MISSING_WEATHER }],
   });
 
-  const missing = viewer?.ridesMissingWeather ?? 0;
+  const missing = countData?.ridesMissingWeather ?? 0;
 
-  if (missing === 0 && queued === null) return null;
+  if (missing === 0 && lastResult === null) return null;
 
   const onClick = async () => {
     if (!isPro) {
@@ -29,11 +37,17 @@ export default function WeatherBackfillSection() {
     setError(null);
     try {
       const { data } = await backfill();
-      setQueued(data?.backfillWeatherForMyRides?.enqueuedCount ?? 0);
+      const res = data?.backfillWeatherForMyRides;
+      setLastResult({
+        enqueued: res?.enqueuedCount ?? 0,
+        remaining: res?.remainingAfterBatch ?? 0,
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong.');
     }
   };
+
+  const hasMore = (lastResult?.remaining ?? 0) > 0;
 
   return (
     <div className="space-y-3">
@@ -45,8 +59,10 @@ export default function WeatherBackfillSection() {
             <div>
               <p className="text-sm font-medium text-white">Weather for past rides</p>
               <p className="text-xs text-muted">
-                {queued !== null
-                  ? `Queued ${queued} ride${queued === 1 ? '' : 's'}. Weather will appear as it's fetched.`
+                {lastResult !== null
+                  ? hasMore
+                    ? `Queued ${lastResult.enqueued} ride${lastResult.enqueued === 1 ? '' : 's'}. ${lastResult.remaining} more remain — click Fetch more when these finish.`
+                    : `Queued ${lastResult.enqueued} ride${lastResult.enqueued === 1 ? '' : 's'}. Weather will appear as it's fetched.`
                   : `${missing} ride${missing === 1 ? '' : 's'} missing weather data.`}
               </p>
             </div>
@@ -54,10 +70,16 @@ export default function WeatherBackfillSection() {
           {isPro ? (
             <button
               onClick={onClick}
-              disabled={loading || queued !== null}
+              disabled={loading || (lastResult !== null && !hasMore)}
               className="flex items-center gap-1.5 rounded-lg border border-white/20 px-3 py-1.5 text-xs font-medium text-white/80 transition hover:bg-white/10 disabled:opacity-50"
             >
-              {loading ? 'Queuing…' : queued !== null ? 'Queued' : 'Fetch weather'}
+              {loading
+                ? 'Queuing…'
+                : lastResult === null
+                  ? 'Fetch weather'
+                  : hasMore
+                    ? 'Fetch more'
+                    : 'Queued'}
             </button>
           ) : (
             <button

--- a/apps/web/src/graphql/backfillWeather.ts
+++ b/apps/web/src/graphql/backfillWeather.ts
@@ -5,6 +5,13 @@ export const BACKFILL_WEATHER_FOR_MY_RIDES = gql`
     backfillWeatherForMyRides {
       enqueuedCount
       ridesWithoutCoords
+      remainingAfterBatch
     }
+  }
+`;
+
+export const RIDES_MISSING_WEATHER = gql`
+  query RidesMissingWeather {
+    ridesMissingWeather
   }
 `;

--- a/apps/web/src/graphql/backfillWeather.ts
+++ b/apps/web/src/graphql/backfillWeather.ts
@@ -1,0 +1,10 @@
+import { gql } from '@apollo/client';
+
+export const BACKFILL_WEATHER_FOR_MY_RIDES = gql`
+  mutation BackfillWeatherForMyRides {
+    backfillWeatherForMyRides {
+      enqueuedCount
+      ridesWithoutCoords
+    }
+  }
+`;

--- a/apps/web/src/graphql/backfillWeather.ts
+++ b/apps/web/src/graphql/backfillWeather.ts
@@ -12,6 +12,9 @@ export const BACKFILL_WEATHER_FOR_MY_RIDES = gql`
 
 export const RIDES_MISSING_WEATHER = gql`
   query RidesMissingWeather {
-    ridesMissingWeather
+    me {
+      id
+      ridesMissingWeather
+    }
   }
 `;

--- a/apps/web/src/graphql/me.ts
+++ b/apps/web/src/graphql/me.ts
@@ -29,6 +29,7 @@ export const ME_QUERY = gql`
       distanceUnit
       pairedComponentMigrationSeenAt
       createdAt
+      ridesMissingWeather
     }
   }
 `

--- a/apps/web/src/graphql/me.ts
+++ b/apps/web/src/graphql/me.ts
@@ -29,7 +29,6 @@ export const ME_QUERY = gql`
       distanceUnit
       pairedComponentMigrationSeenAt
       createdAt
-      ridesMissingWeather
     }
   }
 `

--- a/apps/web/src/graphql/rides.ts
+++ b/apps/web/src/graphql/rides.ts
@@ -7,6 +7,7 @@ import { gql } from '@apollo/client';
 // fragment is the first thing to hoist into a lazy per-ride query.
 const RIDE_WEATHER_FIELDS = gql`
   fragment RideWeatherFields on RideWeather {
+    id
     tempC
     feelsLikeC
     precipitationMm

--- a/apps/web/src/graphql/rides.ts
+++ b/apps/web/src/graphql/rides.ts
@@ -22,6 +22,7 @@ export const RIDES = gql`
         feelsLikeC
         precipitationMm
         windSpeedKph
+        humidity
         wmoCode
         condition
       }

--- a/apps/web/src/graphql/rides.ts
+++ b/apps/web/src/graphql/rides.ts
@@ -17,6 +17,14 @@ export const RIDES = gql`
       notes
       trailSystem
       location
+      weather {
+        tempC
+        feelsLikeC
+        precipitationMm
+        windSpeedKph
+        wmoCode
+        condition
+      }
     }
   }
 `;

--- a/apps/web/src/graphql/rides.ts
+++ b/apps/web/src/graphql/rides.ts
@@ -1,5 +1,22 @@
 import { gql } from '@apollo/client';
 
+// Weather is included in the rides list because RideStatsCard's weather
+// breakdown needs it for every ride in the selected timeframe. The edit
+// modal also reads it via the cached Ride — so both consumers get it from
+// one query. If ride-list payload size ever becomes an issue, the weather
+// fragment is the first thing to hoist into a lazy per-ride query.
+const RIDE_WEATHER_FIELDS = gql`
+  fragment RideWeatherFields on RideWeather {
+    tempC
+    feelsLikeC
+    precipitationMm
+    windSpeedKph
+    humidity
+    wmoCode
+    condition
+  }
+`;
+
 export const RIDES = gql`
   query Rides($take: Int, $after: ID, $filter: RidesFilterInput) {
     rides(take: $take, after: $after, filter: $filter) {
@@ -18,14 +35,9 @@ export const RIDES = gql`
       trailSystem
       location
       weather {
-        tempC
-        feelsLikeC
-        precipitationMm
-        windSpeedKph
-        humidity
-        wmoCode
-        condition
+        ...RideWeatherFields
       }
     }
   }
+  ${RIDE_WEATHER_FIELDS}
 `;

--- a/apps/web/src/lib/weather.ts
+++ b/apps/web/src/lib/weather.ts
@@ -1,4 +1,5 @@
-import { Sun, Cloud, CloudRain, CloudSnow, Wind, CloudFog, HelpCircle, LucideIcon } from 'lucide-react';
+import { Sun, Cloud, CloudRain, CloudSnow, Wind, CloudFog, HelpCircle } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import type { WeatherCondition } from '../models/Ride';
 
 export const conditionLabel = (c: WeatherCondition): string => {

--- a/apps/web/src/lib/weather.ts
+++ b/apps/web/src/lib/weather.ts
@@ -1,0 +1,42 @@
+import { Sun, Cloud, CloudRain, CloudSnow, Wind, CloudFog, HelpCircle, LucideIcon } from 'lucide-react';
+import type { WeatherCondition } from '../models/Ride';
+
+export const conditionLabel = (c: WeatherCondition): string => {
+  switch (c) {
+    case 'SUNNY': return 'Sunny';
+    case 'CLOUDY': return 'Cloudy';
+    case 'RAINY': return 'Rainy';
+    case 'SNOWY': return 'Snowy';
+    case 'WINDY': return 'Windy';
+    case 'FOGGY': return 'Foggy';
+    default: return 'Unknown';
+  }
+};
+
+export const conditionIcon = (c: WeatherCondition): LucideIcon => {
+  switch (c) {
+    case 'SUNNY': return Sun;
+    case 'CLOUDY': return Cloud;
+    case 'RAINY': return CloudRain;
+    case 'SNOWY': return CloudSnow;
+    case 'WINDY': return Wind;
+    case 'FOGGY': return CloudFog;
+    default: return HelpCircle;
+  }
+};
+
+export const conditionTint = (c: WeatherCondition): string => {
+  switch (c) {
+    case 'SUNNY': return '#f4b740';
+    case 'CLOUDY': return '#7a8ba3';
+    case 'RAINY': return '#4a90e2';
+    case 'SNOWY': return '#9ec9e6';
+    case 'WINDY': return '#6aa7a0';
+    case 'FOGGY': return '#8c9aa6';
+    default: return '#888';
+  }
+};
+
+export const celsiusToFahrenheit = (c: number): number => c * 9 / 5 + 32;
+export const mmToInches = (mm: number): number => mm / 25.4;
+export const kphToMph = (kph: number): number => kph * 0.621371;

--- a/apps/web/src/lib/weather.tsx
+++ b/apps/web/src/lib/weather.tsx
@@ -1,5 +1,5 @@
 import { Sun, Cloud, CloudRain, CloudSnow, Wind, CloudFog, HelpCircle } from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
 import type { WeatherCondition } from '../models/Ride';
 
 export const conditionLabel = (c: WeatherCondition): string => {
@@ -14,15 +14,20 @@ export const conditionLabel = (c: WeatherCondition): string => {
   }
 };
 
-export const conditionIcon = (c: WeatherCondition): LucideIcon => {
+type IconProps = { size?: number; color?: string; className?: string };
+
+// Returns a rendered icon node rather than a component reference so callers
+// never have to bind a dynamic component to a variable (which trips
+// react-hooks/static-components).
+export const renderConditionIcon = (c: WeatherCondition, props: IconProps = {}): ReactNode => {
   switch (c) {
-    case 'SUNNY': return Sun;
-    case 'CLOUDY': return Cloud;
-    case 'RAINY': return CloudRain;
-    case 'SNOWY': return CloudSnow;
-    case 'WINDY': return Wind;
-    case 'FOGGY': return CloudFog;
-    default: return HelpCircle;
+    case 'SUNNY': return <Sun {...props} />;
+    case 'CLOUDY': return <Cloud {...props} />;
+    case 'RAINY': return <CloudRain {...props} />;
+    case 'SNOWY': return <CloudSnow {...props} />;
+    case 'WINDY': return <Wind {...props} />;
+    case 'FOGGY': return <CloudFog {...props} />;
+    default: return <HelpCircle {...props} />;
   }
 };
 

--- a/apps/web/src/models/Ride.ts
+++ b/apps/web/src/models/Ride.ts
@@ -8,6 +8,7 @@ export type WeatherCondition =
   | 'UNKNOWN';
 
 export interface RideWeather {
+  id: string;
   tempC: number;
   feelsLikeC?: number | null;
   precipitationMm: number;

--- a/apps/web/src/models/Ride.ts
+++ b/apps/web/src/models/Ride.ts
@@ -1,3 +1,21 @@
+export type WeatherCondition =
+  | 'SUNNY'
+  | 'CLOUDY'
+  | 'RAINY'
+  | 'SNOWY'
+  | 'WINDY'
+  | 'FOGGY'
+  | 'UNKNOWN';
+
+export interface RideWeather {
+  tempC: number;
+  feelsLikeC?: number | null;
+  precipitationMm: number;
+  windSpeedKph: number;
+  wmoCode: number;
+  condition: WeatherCondition;
+}
+
 export interface Ride {
   id: string;
   startTime: string;
@@ -13,4 +31,5 @@ export interface Ride {
   stravaActivityId?: string | null;
   garminActivityId?: string | null;
   whoopWorkoutId?: string | null;
+  weather?: RideWeather | null;
 }

--- a/apps/web/src/models/Ride.ts
+++ b/apps/web/src/models/Ride.ts
@@ -12,6 +12,7 @@ export interface RideWeather {
   feelsLikeC?: number | null;
   precipitationMm: number;
   windSpeedKph: number;
+  humidity?: number | null;
   wmoCode: number;
   condition: WeatherCondition;
 }

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -26,6 +26,7 @@ import { UPDATE_USER_PREFERENCES_MUTATION } from "../graphql/userPreferences";
 import { ProBadge } from "../components/ui/ProBadge";
 import ServicePreferencesEditor from "../components/ServicePreferencesEditor";
 import BillingSection from "../components/BillingSection";
+import WeatherBackfillSection from "../components/WeatherBackfillSection";
 import ReferralCard from "../components/ReferralCard";
 
 const CONNECTED_ACCOUNTS_QUERY = gql`
@@ -427,6 +428,7 @@ export default function Settings() {
             <h2 className="title-section">Subscription & Billing</h2>
           </div>
           <BillingSection />
+          <WeatherBackfillSection />
           <ReferralCard />
         </div>
       </section>


### PR DESCRIPTION
# Ride Weather Integration — API + Web

Two commits ([8605b58](../../commit/8605b58), [8531d9b](../../commit/8531d9b)): backend pipeline that fetches per-ride weather from Open-Meteo, plus web UX to display it and a Pro-gated user-triggered backfill for historical rides. Mobile UX ships in a separate PR on `loam-logger-mobile`.

## Why

Rides have location + timestamp + duration but no weather. Three goals:

1. **Context**: users want to see what the weather was for each ride.
2. **Aggregation**: "X sunny, Y rainy rides" breakdowns on the stats page.
3. **Foundation for wear modeling**: rainy/snowy/wet ride counts will feed into component-wear calculations in a future PR. This PR stores raw inputs (`precipitationMm` + normalized `condition`), not a precomputed wetness score, so the wear formula can be tuned later without re-fetching.

## Summary of changes

- **Open-Meteo integration** — free, no API key, ERA5 archive back to 1940, hourly granularity. Picks archive endpoint for rides ≥5 days old, forecast endpoint (with `past_days`) for recent rides.
- **New models**: `RideWeather` (1:1 with `Ride`), `WeatherCache` (hourly payload keyed by rounded lat/lng). New `Ride.startLat/startLng` columns so coordinates are durable (previously extracted for Nominatim geocoding and discarded).
- **Automatic fetch on sync** for Strava (worker + webhook + backfill) and Garmin (worker + backfill). WHOOP has no coordinates so weather stays null there.
- **User-triggered backfill** — Pro-gated `backfillWeatherForMyRides` mutation for historical rides that already have coords. Free users see the control in Settings but it's disabled with an Upgrade link.
- **Web UX** — `RideWeatherPanel` on the ride edit modal, `WeatherSection` expandable in `RideStatsCard`, `WeatherBackfillSection` in Settings.

## Architecture notes

### Data model

**`Ride.startLat/startLng`** ([apps/api/prisma/schema.prisma](apps/api/prisma/schema.prisma)) — nullable floats. Populated by all sync/webhook/backfill paths that had lat/lng available but were dropping it after reverse-geocoding. Backfill for rides predating this PR is **not** attempted; old rides simply stay weatherless (acceptable per product call).

**`RideWeather`** — 1:1 with `Ride` via `rideId @unique`. Stores `tempC`, `feelsLikeC`, `precipitationMm`, `windSpeedKph`, `humidity`, `wmoCode`, normalized `condition` enum, the lat/lng used, `source`, `fetchedAt`, and the raw payload for debugging.

**`WeatherCondition`** enum: `SUNNY | CLOUDY | RAINY | SNOWY | WINDY | FOGGY | UNKNOWN`. Derived from WMO codes at fetch time via [normalize.ts](apps/api/src/lib/weather/normalize.ts). Windy override bumps SUNNY/CLOUDY → WINDY when sustained winds ≥40 kph.

**`WeatherCache`** — dedupes Open-Meteo hourly responses across rides at the same trailhead/hour. Keyed by `(latKey, lngKey, hourUtc)` with lat/lng rounded to 2dp (~1.1km grid). Mirrors the `GeoCache` pattern.

### Fetch pipeline

`getWeatherForRide` in [apps/api/src/lib/weather/index.ts](apps/api/src/lib/weather/index.ts) takes `{ lat, lng, startTime, durationSeconds }`, walks the ride's hour window, reads the cache first, then backfills misses from Open-Meteo's archive or forecast endpoint depending on ride age. Aggregation across hours: mean temp/feels-like/humidity, max precipitation, max wind, dominant WMO code (weighted toward severity).

### Queue + worker

Separate **`weather` BullMQ queue** ([weather.queue.ts](apps/api/src/lib/queue/weather.queue.ts)) — different rate-limit and retry profile from the sync queue, and it shouldn't block sync acknowledgement. Deterministic job IDs (`fetchWeather_{rideId}`) make enqueue idempotent. 5 attempts, exponential backoff (5s initial), concurrency 3, low priority.

The [weather.worker.ts](apps/api/src/workers/weather.worker.ts) loads the ride, skips if no coords or weather already set, calls the fetch lib, upserts `RideWeather`. Registered alongside existing workers in [workers/index.ts](apps/api/src/workers/index.ts).

### Sync pipeline integration

Every ride-upsert path now persists `startLat/startLng` and fires a fire-and-forget `enqueueWeatherJob({ rideId })` after the upsert:

- [sync.worker.ts](apps/api/src/workers/sync.worker.ts) — Strava and Garmin sync
- [webhooks.strava.ts](apps/api/src/routes/webhooks.strava.ts) — Strava activity webhooks
- [strava.backfill.ts](apps/api/src/routes/strava.backfill.ts) — historical Strava backfill
- [backfill.worker.ts](apps/api/src/workers/backfill.worker.ts) — Garmin historical backfill

### User-triggered Pro-gated backfill

Automatic backfill of all rides at deploy time would be a large burst against Open-Meteo, so instead Pro users opt in explicitly.

**Mutation** `backfillWeatherForMyRides` ([resolvers.ts](apps/api/src/graphql/resolvers.ts)):
- Rejects with `NOT_PRO` if viewer isn't Pro (founding rider and admin count as Pro per [tier-access.ts](apps/api/src/auth/tier-access.ts)).
- Enqueues `weather` jobs for rides where `startLat IS NOT NULL AND weather IS NULL`.
- Returns `{ enqueuedCount, ridesWithoutCoords }` — the second number reports rides missing coords entirely (pre-`startLat` era) so the UI can be honest about what can be fetched.

**Viewer field** `ridesMissingWeather` ([schema.ts](apps/api/src/graphql/schema.ts)) — count of rides with coords but no weather. Drives the "show the button?" decision on the client; returns 0 once everything resolves, so the control auto-hides.

### GraphQL

- `Ride.weather: RideWeather` field, resolved via `prisma.rideWeather.findUnique` (falls through to an included relation if the query joined).
- `RideWeather` type exposes tempC, feelsLikeC, condition, wmoCode, precipitationMm, windSpeedKph, humidity, fetchedAt.
- `User.ridesMissingWeather: Int!`.

## Web UX

No codegen on web — types in [models/Ride.ts](apps/web/src/models/Ride.ts) and the [rides.ts](apps/web/src/graphql/rides.ts) query are hand-maintained and updated in this PR.

**Ride detail** — [RideWeatherPanel.tsx](apps/web/src/components/RideWeatherPanel.tsx) renders four tiles (condition, temp, precip, wind) in `EditRideModal` below the notes field. Hidden when `ride.weather` is null. Respects the user's `distanceUnit` preference for °F vs °C, mm vs in, kph vs mph. Icons from lucide-react (`Sun`, `Cloud`, `CloudRain`, `CloudSnow`, `Wind`, `CloudFog`).

**Dashboard stats** — new `WeatherStats` on `RideStats` ([types.ts](apps/web/src/components/RideStatsCard/types.ts)); [useRideStats.ts](apps/web/src/components/RideStatsCard/hooks/useRideStats.ts) buckets rides by condition (rides without weather fall into `UNKNOWN`). New [WeatherSection.tsx](apps/web/src/components/RideStatsCard/sections/WeatherSection.tsx) renders the breakdown as an expandable tile grid inside `RideStatsCard`; auto-hides when `totalWithWeather === 0`.

**Settings** — [WeatherBackfillSection.tsx](apps/web/src/components/WeatherBackfillSection.tsx) sits next to `BillingSection`. Hidden when `ridesMissingWeather === 0`. Pro users get a "Fetch weather" button that swaps to "Queuing…" → "Queued" after success; free users get a disabled "Pro feature" chip that routes to `/pricing` on click.

## Files changed

**Backend (commit [8605b58](../../commit/8605b58)):**

Schema + migration:
- `apps/api/prisma/schema.prisma` — `Ride.startLat/startLng`, `RideWeather`, `WeatherCache`, `WeatherCondition` enum
- `apps/api/prisma/migrations/20260415120000_add_ride_weather/migration.sql`

Fetch library:
- `apps/api/src/lib/weather/open-meteo.ts` *(new)* — rate-limited client, endpoint picker
- `apps/api/src/lib/weather/normalize.ts` *(new)* — WMO → enum, windy override
- `apps/api/src/lib/weather/cache.ts` *(new)* — hourly cache reader/writer
- `apps/api/src/lib/weather/index.ts` *(new)* — per-ride aggregator
- `apps/api/src/lib/weather/normalize.test.ts` *(new)*

Queue + worker:
- `apps/api/src/lib/queue/weather.queue.ts` *(new)*
- `apps/api/src/lib/queue/index.ts` — export
- `apps/api/src/workers/weather.worker.ts` *(new)*
- `apps/api/src/workers/index.ts` — register + shutdown

GraphQL:
- `apps/api/src/graphql/schema.ts` — `RideWeather` type, `Ride.weather`, `User.ridesMissingWeather`, `backfillWeatherForMyRides` mutation, `BackfillWeatherResult`
- `apps/api/src/graphql/resolvers.ts` — resolvers for above

Sync path integration:
- `apps/api/src/workers/sync.worker.ts` — persist coords + enqueue (Strava + Garmin)
- `apps/api/src/workers/backfill.worker.ts` — persist coords + enqueue (Garmin backfill)
- `apps/api/src/routes/webhooks.strava.ts` — persist coords + enqueue
- `apps/api/src/routes/strava.backfill.ts` — persist coords + enqueue

**Web (commit [8531d9b](../../commit/8531d9b)):**

Types + queries:
- `apps/web/src/models/Ride.ts` — `RideWeather`, `WeatherCondition`
- `apps/web/src/graphql/rides.ts` — weather fields
- `apps/web/src/graphql/me.ts` — `ridesMissingWeather`
- `apps/web/src/graphql/backfillWeather.ts` *(new)*

Components:
- `apps/web/src/lib/weather.ts` *(new)* — icon + unit helpers
- `apps/web/src/components/RideWeatherPanel.tsx` *(new)*
- `apps/web/src/components/EditRideModal.tsx` — render panel
- `apps/web/src/components/WeatherBackfillSection.tsx` *(new)*
- `apps/web/src/pages/Settings.tsx` — render backfill section

Stats:
- `apps/web/src/components/RideStatsCard/types.ts` — `WeatherStats`, `EMPTY_WEATHER_BREAKDOWN`
- `apps/web/src/components/RideStatsCard/hooks/useRideStats.ts` — compute breakdown
- `apps/web/src/components/RideStatsCard/sections/WeatherSection.tsx` *(new)*
- `apps/web/src/components/RideStatsCard/index.tsx` — wire expandable section

## Deployment notes

- **Run `prisma migrate deploy`** before rolling out the worker — the worker code imports the new `rideWeather` / `weatherCache` Prisma types.
- **No Open-Meteo API key required.** Endpoints are configurable via `WEATHER_ARCHIVE_API_BASE` / `WEATHER_FORECAST_API_BASE` env vars; defaults point at `archive-api.open-meteo.com` and `api.open-meteo.com`.
- **No backend burst on deploy** — weather is fetched only for new rides automatically; Pro users opt into historical backfill one at a time via Settings. Queue concurrency is 3 with a mutex-enforced 250ms floor between HTTP calls, so burst is capped even if many Pro users click at once.
- **Open-Meteo archive lag** (~5 days): the forecast endpoint with `past_days` covers this window. Worth a smoke-test on a 1-day-old ride after deploy.

## Test plan

### Backend
- [ ] `prisma migrate deploy` applies cleanly against a staging DB.
- [ ] Unit tests: `npm test -- weather/normalize` — every WMO range maps correctly; windy override fires at ≥40 kph only for SUNNY/CLOUDY.
- [ ] Sync a fresh Strava ride → `RideWeather` row appears within a few seconds.
- [ ] Sync a fresh Garmin ride → same.
- [ ] Sync a WHOOP workout → no weather row (expected; no coords).
- [ ] Two rides at same trailhead same hour → only one Open-Meteo HTTP call (check logs / `WeatherCache` row count).
- [ ] `backfillWeatherForMyRides` as Pro user: returns non-zero `enqueuedCount`, jobs process, rides gain weather.
- [ ] Same mutation as free user: returns `NOT_PRO` error.
- [ ] `Viewer.ridesMissingWeather` drops to 0 after backfill completes.

### Web
- [ ] Ride edit modal shows a weather panel for a ride with weather.
- [ ] Unit toggle (mi/km) updates temp/precip/wind correctly.
- [ ] Dashboard `RideStatsCard` → Weather section hidden with zero rides, visible with ≥1.
- [ ] Settings shows "Fetch weather" button when `ridesMissingWeather > 0`; hidden when 0.
- [ ] Free user sees Pro chip in Settings → clicking routes to `/pricing`.
- [ ] Pro user clicks → button swaps to "Queuing…" → "Queued"; `ridesMissingWeather` refetches and the section auto-hides after queue drains.
