### PR TITLE
Strava sync: fill gaps on re-sync + WHOOP GPS disclaimer

### DIFF
--- a/apps/api/src/routes/strava.backfill.ts
+++ b/apps/api/src/routes/strava.backfill.ts
@@ -132,11 +132,6 @@ r.get<Empty, void, Empty, { year?: string }>(
           select: { id: true, startLat: true, startLng: true, location: true },
         });
 
-        const distanceMeters = activity.distance;
-        const elevationGainMeters = activity.total_elevation_gain;
-        const startTime = new Date(activity.start_date);
-
-        const durationHours = Math.max(0, activity.moving_time) / 3600;
         const lat = activity.start_latlng?.[0] ?? null;
         const lon = activity.start_latlng?.[1] ?? null;
         const initialLocation = formatLatLon(lat, lon);
@@ -188,9 +183,15 @@ r.get<Empty, void, Empty, { year?: string }>(
           continue;
         }
 
-        // New ride — full create. Bike lookup happens here (not earlier) so
-        // we don't pay for gear-mapping + user-bikes queries on every
-        // existing-ride iteration during a re-sync.
+        // New ride — full create. Field derivation and bike lookup happen
+        // here (not earlier) so we don't pay for gear-mapping + user-bikes
+        // queries or trivially-derived fields on every existing-ride
+        // iteration during a re-sync.
+        const distanceMeters = activity.distance;
+        const elevationGainMeters = activity.total_elevation_gain;
+        const startTime = new Date(activity.start_date);
+        const durationHours = Math.max(0, activity.moving_time) / 3600;
+
         let bikeId: string | null = null;
         if (activity.gear_id) {
           const mapping = await prisma.stravaGearMapping.findUnique({
@@ -287,12 +288,20 @@ r.get<Empty, void, Empty, { year?: string }>(
 
       // Track backfill request in database
       const yearKey = yearParam || 'ytd';
+      // Semantics note: before the gap-fill rework, `ridesFound` meant
+      // "new rides created this run" (existing rides were silently skipped
+      // and excluded). It now means "rides touched this run" — new + updated.
+      // This is what the history UI on web/mobile wants ("N rides synced"),
+      // and without this change, a re-sync of a user's full history would
+      // show 0 here and look broken. WHOOP still tracks new-only because
+      // there's no gap-fill path on that provider.
+      const touchedCount = newCount + updatedCount;
       try {
         await prisma.backfillRequest.upsert({
           where: { userId_provider_year: { userId, provider: 'strava', year: yearKey } },
           update: {
             status: 'completed',
-            ridesFound: newCount + updatedCount,
+            ridesFound: touchedCount,
             completedAt: new Date(),
             updatedAt: new Date(),
           },
@@ -301,7 +310,7 @@ r.get<Empty, void, Empty, { year?: string }>(
             provider: 'strava',
             year: yearKey,
             status: 'completed',
-            ridesFound: newCount + updatedCount,
+            ridesFound: touchedCount,
             completedAt: new Date(),
           },
         });

--- a/apps/api/src/routes/strava.backfill.ts
+++ b/apps/api/src/routes/strava.backfill.ts
@@ -122,20 +122,15 @@ r.get<Empty, void, Empty, { year?: string }>(
       console.log(`[Strava Backfill] Cycling activities: ${cyclingActivities.length}`);
 
       // Import each cycling activity
-      let importedCount = 0;
-      let skippedCount = 0;
+      let newCount = 0;
+      let updatedCount = 0;
       let geocodedCount = 0;
 
       for (const activity of cyclingActivities) {
-        // Check if activity already exists
         const existing = await prisma.ride.findUnique({
           where: { stravaActivityId: activity.id.toString() },
+          select: { id: true, startLat: true, startLng: true, location: true, bikeId: true, durationSeconds: true },
         });
-
-        if (existing) {
-          skippedCount++;
-          continue;
-        }
 
         // Look up bike mapping if gear_id exists
         let bikeId: string | null = null;
@@ -162,7 +157,6 @@ r.get<Empty, void, Empty, { year?: string }>(
           }
         }
 
-        // Convert activity to Ride format
         const distanceMeters = activity.distance;
         const elevationGainMeters = activity.total_elevation_gain;
         const startTime = new Date(activity.start_date);
@@ -170,9 +164,51 @@ r.get<Empty, void, Empty, { year?: string }>(
         const durationHours = Math.max(0, activity.moving_time) / 3600;
         const lat = activity.start_latlng?.[0] ?? null;
         const lon = activity.start_latlng?.[1] ?? null;
-        // Use lat/lon format initially, geocode in background
         const initialLocation = formatLatLon(lat, lon);
 
+        if (existing) {
+          // Backfill any fields the existing ride is missing (e.g. startLat/startLng
+          // for rides imported before coord persistence was added).
+          const patch: Record<string, unknown> = {};
+          if (existing.startLat == null && lat != null) patch.startLat = lat;
+          if (existing.startLng == null && lon != null) patch.startLng = lon;
+          if (!existing.location && initialLocation) patch.location = initialLocation;
+
+          if (Object.keys(patch).length > 0) {
+            await prisma.ride.update({
+              where: { id: existing.id },
+              data: patch,
+            });
+            updatedCount++;
+          }
+
+          // Geocode if the ride was missing a location and we now have coords
+          if (!existing.location && lat !== null && lon !== null) {
+            try {
+              const locationResult = await reverseGeocode(lat, lon);
+              if (locationResult) {
+                await prisma.ride.update({
+                  where: { id: existing.id },
+                  data: { location: locationResult.title },
+                });
+                geocodedCount++;
+              }
+            } catch (err) {
+              console.warn(`[Strava Sync] Failed to geocode ride ${existing.id}:`, err);
+            }
+          }
+
+          // Enqueue weather if coords now exist but weather doesn't
+          if ((patch.startLat || existing.startLat) && (patch.startLng || existing.startLng)) {
+            enqueueWeatherJob({ rideId: existing.id }).catch((err) =>
+              logError(`Strava Sync weather enqueue ${existing.id}`, err)
+            );
+          }
+
+          continue;
+        }
+
+        // New ride — full create
         const ride = await prisma.$transaction(async (tx) => {
           const createdRide = await tx.ride.create({
             data: {
@@ -200,7 +236,6 @@ r.get<Empty, void, Empty, { year?: string }>(
           return createdRide;
         });
 
-        // Geocode synchronously if we have coordinates
         if (lat !== null && lon !== null) {
           try {
             const locationResult = await reverseGeocode(lat, lon);
@@ -212,19 +247,18 @@ r.get<Empty, void, Empty, { year?: string }>(
               geocodedCount++;
             }
           } catch (err) {
-            // Don't fail the import if geocoding fails
-            console.warn(`[Strava Backfill] Failed to geocode ride ${ride.id}:`, err);
+            console.warn(`[Strava Sync] Failed to geocode ride ${ride.id}:`, err);
           }
 
           enqueueWeatherJob({ rideId: ride.id }).catch((err) =>
-            logError(`Strava Backfill weather enqueue ${ride.id}`, err)
+            logError(`Strava Sync weather enqueue ${ride.id}`, err)
           );
         }
 
-        importedCount++;
+        newCount++;
       }
 
-      console.log(`[Strava Backfill] Imported: ${importedCount}, Skipped (existing): ${skippedCount}`);
+      console.log(`[Strava Sync] New: ${newCount}, Updated: ${updatedCount}, Geocoded: ${geocodedCount}`);
 
       // Detect unmapped gears
       const unmappedGearIds = cyclingActivities
@@ -254,7 +288,7 @@ r.get<Empty, void, Empty, { year?: string }>(
           where: { userId_provider_year: { userId, provider: 'strava', year: yearKey } },
           update: {
             status: 'completed',
-            ridesFound: importedCount,
+            ridesFound: newCount + updatedCount,
             completedAt: new Date(),
             updatedAt: new Date(),
           },
@@ -263,7 +297,7 @@ r.get<Empty, void, Empty, { year?: string }>(
             provider: 'strava',
             year: yearKey,
             status: 'completed',
-            ridesFound: importedCount,
+            ridesFound: newCount + updatedCount,
             completedAt: new Date(),
           },
         });
@@ -274,11 +308,11 @@ r.get<Empty, void, Empty, { year?: string }>(
 
       return res.json({
         success: true,
-        message: `Successfully imported ${importedCount} rides from Strava.`,
+        message: `Synced ${newCount} new and ${updatedCount} updated rides from Strava.`,
         totalActivities: activities.length,
         cyclingActivities: cyclingActivities.length,
-        imported: importedCount,
-        skipped: skippedCount,
+        imported: newCount,
+        updated: updatedCount,
         geocoded: geocodedCount,
         unmappedGears,
       });

--- a/apps/api/src/routes/strava.backfill.ts
+++ b/apps/api/src/routes/strava.backfill.ts
@@ -55,7 +55,7 @@ r.get<Empty, void, Empty, { year?: string }>(
       const afterTimestamp = Math.floor(startDate.getTime() / 1000);
       const beforeTimestamp = Math.floor(endDate.getTime() / 1000);
 
-      console.log(`[Strava Backfill] Fetching ${yearParam || currentYear} activities from ${startDate.toISOString()} to ${endDate.toISOString()}`);
+      console.log(`[Strava Sync] Fetching ${yearParam || currentYear} activities from ${startDate.toISOString()} to ${endDate.toISOString()}`);
 
       // Fetch activities from Strava API
       // https://developers.strava.com/docs/reference/#api-Activities-getLoggedInAthleteActivities
@@ -80,14 +80,14 @@ r.get<Empty, void, Empty, { year?: string }>(
 
         if (!activitiesRes.ok) {
           const text = await activitiesRes.text();
-          console.error(`[Strava Backfill] Failed to fetch activities: ${activitiesRes.status} ${text}`);
+          console.error(`[Strava Sync] Failed to fetch activities: ${activitiesRes.status} ${text}`);
           throw new Error(`Failed to fetch activities: ${activitiesRes.status}`);
         }
 
         const pageActivities = (await activitiesRes.json()) as StravaActivity[];
         activities.push(...pageActivities);
 
-        console.log(`[Strava Backfill] Fetched page ${page}: ${pageActivities.length} activities`);
+        console.log(`[Strava Sync] Fetched page ${page}: ${pageActivities.length} activities`);
 
         if (pageActivities.length < perPage) {
           hasMore = false;
@@ -97,12 +97,12 @@ r.get<Empty, void, Empty, { year?: string }>(
 
         // Safety: Limit to 50 pages (2500 activities max)
         if (page > 50) {
-          console.warn('[Strava Backfill] Reached page limit (50), stopping pagination');
+          console.warn('[Strava Sync] Reached page limit (50), stopping pagination');
           hasMore = false;
         }
       }
 
-      console.log(`[Strava Backfill] Total activities fetched: ${activities.length}`);
+      console.log(`[Strava Sync] Total activities fetched: ${activities.length}`);
 
       // Filter cycling activities
       const CYCLING_SPORT_TYPES = [
@@ -119,7 +119,7 @@ r.get<Empty, void, Empty, { year?: string }>(
         CYCLING_SPORT_TYPES.includes(a.sport_type)
       );
 
-      console.log(`[Strava Backfill] Cycling activities: ${cyclingActivities.length}`);
+      console.log(`[Strava Sync] Cycling activities: ${cyclingActivities.length}`);
 
       // Import each cycling activity
       let newCount = 0;
@@ -129,33 +129,8 @@ r.get<Empty, void, Empty, { year?: string }>(
       for (const activity of cyclingActivities) {
         const existing = await prisma.ride.findUnique({
           where: { stravaActivityId: activity.id.toString() },
-          select: { id: true, startLat: true, startLng: true, location: true, bikeId: true, durationSeconds: true },
+          select: { id: true, startLat: true, startLng: true, location: true },
         });
-
-        // Look up bike mapping if gear_id exists
-        let bikeId: string | null = null;
-        if (activity.gear_id) {
-          const mapping = await prisma.stravaGearMapping.findUnique({
-            where: {
-              userId_stravaGearId: {
-                userId,
-                stravaGearId: activity.gear_id,
-              },
-            },
-          });
-          bikeId = mapping?.bikeId ?? null;
-        }
-
-        // If no bike assigned yet, check if user has exactly one bike (auto-assign)
-        if (!bikeId) {
-          const userBikes = await prisma.bike.findMany({
-            where: { userId },
-            select: { id: true },
-          });
-          if (userBikes.length === 1) {
-            bikeId = userBikes[0].id;
-          }
-        }
 
         const distanceMeters = activity.distance;
         const elevationGainMeters = activity.total_elevation_gain;
@@ -172,7 +147,25 @@ r.get<Empty, void, Empty, { year?: string }>(
           const patch: Record<string, unknown> = {};
           if (existing.startLat == null && lat != null) patch.startLat = lat;
           if (existing.startLng == null && lon != null) patch.startLng = lon;
-          if (!existing.location && initialLocation) patch.location = initialLocation;
+
+          // Resolve location before writing so we don't do two round-trips
+          // for the same field: prefer a geocoded name, fall back to the
+          // coord-formatted string only if geocoding fails or isn't possible.
+          if (!existing.location) {
+            let resolvedLocation: string | null = initialLocation;
+            if (lat !== null && lon !== null) {
+              try {
+                const locationResult = await reverseGeocode(lat, lon);
+                if (locationResult) {
+                  resolvedLocation = locationResult.title;
+                  geocodedCount++;
+                }
+              } catch (err) {
+                console.warn(`[Strava Sync] Failed to geocode ride ${existing.id}:`, err);
+              }
+            }
+            if (resolvedLocation) patch.location = resolvedLocation;
+          }
 
           if (Object.keys(patch).length > 0) {
             await prisma.ride.update({
@@ -182,24 +175,11 @@ r.get<Empty, void, Empty, { year?: string }>(
             updatedCount++;
           }
 
-          // Geocode if the ride was missing a location and we now have coords
-          if (!existing.location && lat !== null && lon !== null) {
-            try {
-              const locationResult = await reverseGeocode(lat, lon);
-              if (locationResult) {
-                await prisma.ride.update({
-                  where: { id: existing.id },
-                  data: { location: locationResult.title },
-                });
-                geocodedCount++;
-              }
-            } catch (err) {
-              console.warn(`[Strava Sync] Failed to geocode ride ${existing.id}:`, err);
-            }
-          }
-
-          // Enqueue weather if coords now exist but weather doesn't
-          if ((patch.startLat || existing.startLat) && (patch.startLng || existing.startLng)) {
+          // Only enqueue weather if coords were JUST added on this sync.
+          // Rides that already had coords either already have weather or have
+          // a job in flight — the weather worker would skip them anyway, but
+          // enqueuing N redundant jobs per re-sync is a needless Redis hit.
+          if (patch.startLat !== undefined && patch.startLng !== undefined) {
             enqueueWeatherJob({ rideId: existing.id }).catch((err) =>
               logError(`Strava Sync weather enqueue ${existing.id}`, err)
             );
@@ -208,7 +188,31 @@ r.get<Empty, void, Empty, { year?: string }>(
           continue;
         }
 
-        // New ride — full create
+        // New ride — full create. Bike lookup happens here (not earlier) so
+        // we don't pay for gear-mapping + user-bikes queries on every
+        // existing-ride iteration during a re-sync.
+        let bikeId: string | null = null;
+        if (activity.gear_id) {
+          const mapping = await prisma.stravaGearMapping.findUnique({
+            where: {
+              userId_stravaGearId: {
+                userId,
+                stravaGearId: activity.gear_id,
+              },
+            },
+          });
+          bikeId = mapping?.bikeId ?? null;
+        }
+        if (!bikeId) {
+          const userBikes = await prisma.bike.findMany({
+            where: { userId },
+            select: { id: true },
+          });
+          if (userBikes.length === 1) {
+            bikeId = userBikes[0].id;
+          }
+        }
+
         const ride = await prisma.$transaction(async (tx) => {
           const createdRide = await tx.ride.create({
             data: {
@@ -279,7 +283,7 @@ r.get<Empty, void, Empty, { year?: string }>(
         }
       }
 
-      console.log(`[Strava Backfill] Unmapped gears: ${unmappedGears.length}`);
+      console.log(`[Strava Sync] Unmapped gears: ${unmappedGears.length}`);
 
       // Track backfill request in database
       const yearKey = yearParam || 'ytd';
@@ -302,7 +306,7 @@ r.get<Empty, void, Empty, { year?: string }>(
           },
         });
       } catch (dbError) {
-        logError('Strava Backfill DB tracking', dbError);
+        logError('Strava Sync DB tracking', dbError);
         // Don't fail the request if tracking fails
       }
 
@@ -313,6 +317,13 @@ r.get<Empty, void, Empty, { year?: string }>(
         cyclingActivities: cyclingActivities.length,
         imported: newCount,
         updated: updatedCount,
+        // Legacy alias for `updated`, kept so older clients that read
+        // `response.skipped` (pre-gap-fill, when existing rides were
+        // silently skipped) still get a number rather than undefined. The
+        // meaning has shifted — it's now the count of existing rides that
+        // were touched — which is actually closer to what users cared
+        // about anyway. New clients should read `updated`.
+        skipped: updatedCount,
         geocoded: geocodedCount,
         unmappedGears,
       });
@@ -328,7 +339,7 @@ r.get<Empty, void, Empty, { year?: string }>(
       } catch {
         // Ignore tracking errors
       }
-      logError('Strava Backfill', error);
+      logError('Strava Sync', error);
       return sendInternalError(res, 'Failed to fetch activities');
     }
   }
@@ -419,7 +430,7 @@ r.get<Empty, void, Empty, Empty>(
         message: `Found ${recentStravaRides.length} recent Strava rides (last 30 days), ${totalStravaRides} total`,
       });
     } catch (error) {
-      logError('Strava Backfill Status', error);
+      logError('Strava Sync Status', error);
       return sendInternalError(res, 'Failed to fetch backfill status');
     }
   }

--- a/apps/web/src/components/StravaImportModal.tsx
+++ b/apps/web/src/components/StravaImportModal.tsx
@@ -46,7 +46,7 @@ export default function StravaImportModal({ open, onClose, onSuccess, onDuplicat
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [importStats, setImportStats] = useState<{
     imported: number;
-    skipped: number;
+    updated: number;
     total: number;
   } | null>(null);
   const [unmappedGears, setUnmappedGears] = useState<UnmappedGear[]>([]);
@@ -172,7 +172,7 @@ export default function StravaImportModal({ open, onClose, onSuccess, onDuplicat
       setSuccessMessage(data.message || `Successfully imported rides from Strava.`);
       setImportStats({
         imported: data.imported || 0,
-        skipped: data.skipped || 0,
+        updated: data.updated || 0,
         total: data.cyclingActivities || 0,
       });
       setStep('complete');
@@ -333,7 +333,7 @@ export default function StravaImportModal({ open, onClose, onSuccess, onDuplicat
                 <div className="text-sm mt-3 opacity-90 space-y-1">
                   <p className="font-medium">Sync completed for {year === 'ytd' ? 'Year to Date' : year}</p>
                   <p>• New: {importStats.imported} rides</p>
-                  <p>• Updated: {importStats.skipped} rides</p>
+                  <p>• Updated: {importStats.updated} rides</p>
                   <p>• Total cycling activities found: {importStats.total}</p>
                   {unmappedGears.length > 0 && (
                     <p className="text-warning">• {unmappedGears.length} unmapped bike(s) - visit Gear page to map</p>

--- a/apps/web/src/components/StravaImportModal.tsx
+++ b/apps/web/src/components/StravaImportModal.tsx
@@ -331,9 +331,9 @@ export default function StravaImportModal({ open, onClose, onSuccess, onDuplicat
               </p>
               {importStats && (
                 <div className="text-sm mt-3 opacity-90 space-y-1">
-                  <p className="font-medium">Import completed for {year === 'ytd' ? 'Year to Date' : year}</p>
-                  <p>• Imported: {importStats.imported} rides</p>
-                  <p>• Skipped (already exist): {importStats.skipped} rides</p>
+                  <p className="font-medium">Sync completed for {year === 'ytd' ? 'Year to Date' : year}</p>
+                  <p>• New: {importStats.imported} rides</p>
+                  <p>• Updated: {importStats.skipped} rides</p>
                   <p>• Total cycling activities found: {importStats.total}</p>
                   {unmappedGears.length > 0 && (
                     <p className="text-warning">• {unmappedGears.length} unmapped bike(s) - visit Gear page to map</p>

--- a/apps/web/src/components/WhoopImportModal.tsx
+++ b/apps/web/src/components/WhoopImportModal.tsx
@@ -270,6 +270,9 @@ export default function WhoopImportModal({ open, onClose, onSuccess, onDuplicate
             <p className="text-xs text-muted mt-1">
               Note: WHOOP does not support gear tracking, so rides will be auto-assigned to your bike if you only have one.
             </p>
+            <p className="text-xs text-muted mt-1">
+              WHOOP doesn't share GPS coordinates for workouts, so location and weather data won't be available for WHOOP rides.
+            </p>
           </div>
 
           {error && (

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -472,7 +472,7 @@ export default function Settings() {
                       onClick={() => setImportModalOpen(true)}
                       className="rounded-xl px-3 py-1.5 text-xs font-medium text-blue-400/80 bg-surface-2/50 border border-blue-400/30 hover:bg-surface-2 hover:text-blue-400 hover:border-blue-400/50 hover:cursor-pointer transition"
                     >
-                      Import Previous Rides
+                      Sync Previous Rides
                     </button>
                     {isAdmin && (
                       <button
@@ -514,7 +514,7 @@ export default function Settings() {
                       onClick={() => setStravaImportModalOpen(true)}
                       className="rounded-xl px-3 py-1.5 text-xs font-medium text-[#FC4C02]/80 bg-surface-2/50 border border-[#FC4C02]/30 hover:bg-surface-2 hover:text-[#FC4C02] hover:border-[#FC4C02]/50 hover:cursor-pointer transition"
                     >
-                      Import Previous Rides
+                      Sync Previous Rides
                     </button>
                     {isAdmin && (
                       <button
@@ -556,7 +556,7 @@ export default function Settings() {
                       onClick={() => setWhoopImportModalOpen(true)}
                       className="rounded-xl px-3 py-1.5 text-xs font-medium text-[#00FF87]/80 bg-surface-2/50 border border-[#00FF87]/30 hover:bg-surface-2 hover:text-[#00FF87] hover:border-[#00FF87]/50 hover:cursor-pointer transition"
                     >
-                      Import Previous Rides
+                      Sync Previous Rides
                     </button>
                     {isAdmin && (
                       <button


### PR DESCRIPTION
# Strava sync: fill gaps on re-sync + WHOOP GPS disclaimer

Two small follow-ups to the weather integration PR ([084c3de](../../commit/084c3de), [44056ea](../../commit/44056ea)). One fixes a flaky unit test, the other reshapes the Strava backfill so it can repair existing rides and sets honest expectations for WHOOP users.

## Why

Two problems surfaced after the weather PR landed:

1. **Flaky Open-Meteo test.** The `fetchHourlyRange` tests used fake timers, but pending timer callbacks (the 15s abort timeout, the mutex spacing delay) leaked across test files. On CI this caused Jest to hang and eventually exit non-zero even though every test passed.

2. **Existing rides couldn't get weather.** The migration added `Ride.startLat`/`startLng`, but all pre-existing rides had `NULL` for those columns. The Pro-gated backfill only considers rides with coords, so the Settings button stayed hidden — users with historical rides had no way to populate coords. The existing "Import Previous Rides" flow would have been the natural fix, except the Strava path skipped any ride whose `stravaActivityId` already existed, so a re-run did nothing. And users connecting WHOOP kept wondering why location/weather never showed up for those rides.

## Summary of changes

**Test fix.** `open-meteo.test.ts` now drains remaining timers in `afterEach` via `await jest.runAllTimersAsync()` before switching back to real timers. Stops pending `setTimeout` callbacks from bleeding into the next test file and prevents the CI-only hang.

**Strava backfill → gap-fill sync.** Reworked [strava.backfill.ts](apps/api/src/routes/strava.backfill.ts) so existing rides get a `PATCH`-style update instead of being skipped: on re-sync it fills any missing `startLat` / `startLng` / `location`, runs reverse-geocoding if the ride lacked a location and now has coords, and enqueues a weather job. New rides still take the full create path. Response now reports `imported` (new) + `updated` (gap-filled) separately. This turns "Import Previous Rides" into a true sync — running it after the weather migration backfills coords for a user's entire Strava history, which in turn makes the weather Backfill button appear in Settings.

**"Import" → "Sync" across the UI.** Renamed the user-facing strings on both clients (web and mobile) to match the new semantics. The `imported` response field is kept for API-compat; only the client-facing copy changed. Stats tiles in the mobile completion sheet now read "New" / "Updated" instead of "Imported" / "Skipped".

**WHOOP GPS disclaimer.** Added a one-liner in both import modals explaining that WHOOP doesn't share GPS coordinates for workouts, so location and weather data won't be available for WHOOP rides. Sits next to the existing "no gear tracking" caveat on web, and below the year selector on mobile (mirroring the existing Garmin 30-day note).

## What's not changing

- **Garmin backfill** already used `upsert` with `startLat`/`startLng` in both create and update branches — gap-filling was already working on that path.
- **WHOOP backfill** left as skip-on-duplicate. WHOOP has no coords to fill in, so upserting would just be busywork.

## Files changed

**Commit [084c3de](../../commit/084c3de) — test fix:**
- `apps/api/src/lib/weather/open-meteo.test.ts` — drain fake timers in `afterEach`.

**Commit [44056ea](../../commit/44056ea) — gap-fill + copy:**
- `apps/api/src/routes/strava.backfill.ts` — duplicate-skip → gap-fill upsert; response shape updated with `updated` count.
- `apps/web/src/components/WhoopImportModal.tsx` — GPS disclaimer.
- `apps/web/src/pages/Settings.tsx` — "Import Previous Rides" → "Sync Previous Rides" (all three providers).

Mobile-side string changes (sheet title, button labels, completion copy) ship separately on `loam-logger-mobile`.

## Deployment notes

- **No DB migration** — pure code changes. The weather-migration columns (`startLat`/`startLng`) are the prerequisite, already shipped.
- **Users unblock themselves** — after this lands, a Pro user with existing Strava rides can click "Sync Previous Rides" → coords backfill → the weather backfill section appears in Settings → clicking it drains the queue and weather tiles populate. No ops-side intervention needed.

## Test plan

- [ ] `nx run api:test` — all 66 suites pass locally and on CI (no "did not exit" warning).
- [ ] Pro user with existing Strava rides clicks "Sync Previous Rides" for YTD → response reports non-zero `updated` count → weather backfill section becomes visible in Settings.
- [ ] Same flow for a user with no existing Strava rides → response reports non-zero `imported`, zero `updated` → behaves as before.
- [ ] WHOOP import modal shows the GPS disclaimer above the import button.
- [ ] Web Settings reads "Sync Previous Rides" for all three providers.
