### PR TITLE
 Component install dates: user-specified, retroactively editable

### DIFF
--- a/apps/api/prisma/migrations/20260417120000_add_bike_acquisition_date/migration.sql
+++ b/apps/api/prisma/migrations/20260417120000_add_bike_acquisition_date/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Bike" ADD COLUMN "acquisitionDate" TIMESTAMP(3);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -208,6 +208,7 @@ model Bike {
   motorTorqueNm      Int?
   thumbnailUrl         String?
   acquisitionCondition AcquisitionCondition?
+  acquisitionDate      DateTime?
   status               BikeStatus          @default(ACTIVE)
   retiredAt            DateTime?
   user                 User                @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -28,6 +28,7 @@ jest.mock('../../lib/prisma', () => ({
       findMany: jest.fn(),
       updateMany: jest.fn(),
       count: jest.fn().mockResolvedValue(0),
+      aggregate: jest.fn(),
     },
     rideWeather: {
       groupBy: jest.fn().mockResolvedValue([]),
@@ -38,6 +39,10 @@ jest.mock('../../lib/prisma', () => ({
     serviceLog: {
       create: jest.fn(),
       findMany: jest.fn().mockResolvedValue([]),
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
     },
     termsAcceptance: {
       findUnique: jest.fn(),
@@ -57,10 +62,13 @@ jest.mock('../../lib/prisma', () => ({
       upsert: jest.fn(),
     },
     bikeComponentInstall: {
+      findUnique: jest.fn(),
       findFirst: jest.fn(),
       findMany: jest.fn().mockResolvedValue([]),
       create: jest.fn(),
       update: jest.fn(),
+      updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      delete: jest.fn(),
     },
     $transaction: jest.fn(),
   },
@@ -1086,6 +1094,10 @@ describe('GraphQL Resolvers', () => {
             serviceLog: {
               create: jest.fn().mockResolvedValue({ id: 'log-1' }),
             },
+            bikeComponentInstall: {
+              updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+              create: jest.fn().mockResolvedValue({ id: 'install-1' }),
+            },
           };
           return fn(mockTx);
         }
@@ -1151,6 +1163,10 @@ describe('GraphQL Resolvers', () => {
             },
             serviceLog: {
               create: jest.fn().mockResolvedValue({ id: 'log-1' }),
+            },
+            bikeComponentInstall: {
+              updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+              create: jest.fn().mockResolvedValue({ id: 'install-1' }),
             },
           };
           return fn(mockTx);
@@ -2782,6 +2798,386 @@ describe('GraphQL Resolvers', () => {
       await mutation(null, { id: 'comp-1' }, ctx);
 
       expect(clearServiceNotificationLogs).toHaveBeenCalledWith('comp-1', 'user-123');
+    });
+  });
+
+  describe('Mutation.updateServiceLog', () => {
+    const mutation = resolvers.Mutation.updateServiceLog;
+    const mockLogFindUnique = mockPrisma.serviceLog.findUnique as jest.Mock;
+    const mockLogFindFirst = mockPrisma.serviceLog.findFirst as jest.Mock;
+    const mockLogUpdate = mockPrisma.serviceLog.update as jest.Mock;
+    const mockComponentFindUnique = mockPrisma.component.findUnique as jest.Mock;
+    const mockComponentUpdate = mockPrisma.component.update as jest.Mock;
+    const mockRideAggregate = mockPrisma.ride.aggregate as jest.Mock;
+    const mockTransaction = mockPrisma.$transaction as jest.Mock;
+
+    // Build a tx client that mirrors the module-level prisma mock so the
+    // resolver's inner transaction calls hit the same jest functions we
+    // assert against.
+    const setTransactionPassthrough = () => {
+      mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
+        const tx = {
+          serviceLog: {
+            findFirst: mockLogFindFirst,
+            update: mockLogUpdate,
+            delete: mockPrisma.serviceLog.delete,
+          },
+          component: {
+            findUnique: mockComponentFindUnique,
+            update: mockComponentUpdate,
+          },
+          ride: { aggregate: mockRideAggregate },
+        };
+        return fn(tx);
+      });
+    };
+
+    beforeEach(() => {
+      mockLogFindUnique.mockReset();
+      mockLogFindFirst.mockReset();
+      mockLogUpdate.mockReset().mockResolvedValue({ id: 'log-1' });
+      mockComponentFindUnique.mockReset();
+      mockComponentUpdate.mockReset().mockResolvedValue({ id: 'comp-1' });
+      mockRideAggregate.mockReset().mockResolvedValue({ _sum: { durationSeconds: 0 } });
+      mockTransaction.mockReset();
+      setTransactionPassthrough();
+    });
+
+    it('rejects when the log component belongs to a different user', async () => {
+      mockLogFindUnique.mockResolvedValueOnce({
+        id: 'log-1',
+        component: { id: 'comp-1', userId: 'other-user', bikeId: 'bike-1' },
+      });
+      const ctx = createMockContext('user-123');
+      await expect(
+        mutation({}, { id: 'log-1', input: { notes: 'hi' } }, ctx as never)
+      ).rejects.toThrow('Service log not found');
+      expect(mockLogUpdate).not.toHaveBeenCalled();
+    });
+
+    it('does not touch component anchor when editing a non-latest log', async () => {
+      mockLogFindUnique.mockResolvedValueOnce({
+        id: 'log-old',
+        component: { id: 'comp-1', userId: 'user-123', bikeId: 'bike-1' },
+      });
+      // Latest is a different log
+      mockLogFindFirst.mockResolvedValueOnce({ id: 'log-newer', performedAt: new Date('2026-04-01') });
+
+      const ctx = createMockContext('user-123');
+      await mutation(
+        {},
+        { id: 'log-old', input: { notes: 'typo fixed' } },
+        ctx as never
+      );
+
+      expect(mockLogUpdate).toHaveBeenCalledWith({
+        where: { id: 'log-old' },
+        data: { notes: 'typo fixed' },
+      });
+      // Non-latest + no date change → recompute helper should NOT run
+      expect(mockComponentUpdate).not.toHaveBeenCalled();
+      expect(mockRideAggregate).not.toHaveBeenCalled();
+    });
+
+    it('recomputes anchor + hoursUsed when editing the latest log date', async () => {
+      mockLogFindUnique.mockResolvedValueOnce({
+        id: 'log-latest',
+        component: { id: 'comp-1', userId: 'user-123', bikeId: 'bike-1' },
+      });
+      // This log IS the latest
+      mockLogFindFirst
+        .mockResolvedValueOnce({ id: 'log-latest', performedAt: new Date('2026-03-01') })
+        // Second call: recompute helper asks for the newest remaining log
+        .mockResolvedValueOnce({ performedAt: new Date('2026-04-15') });
+      mockComponentFindUnique.mockResolvedValueOnce({ id: 'comp-1', bikeId: 'bike-1' });
+      mockRideAggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 7200 } }); // 2 hours
+
+      const ctx = createMockContext('user-123');
+      await mutation(
+        {},
+        { id: 'log-latest', input: { performedAt: '2026-04-15T00:00:00.000Z' } },
+        ctx as never
+      );
+
+      expect(mockRideAggregate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            bikeId: 'bike-1',
+            startTime: { gte: new Date('2026-04-15') },
+          }),
+        })
+      );
+      expect(mockComponentUpdate).toHaveBeenCalledWith({
+        where: { id: 'comp-1' },
+        data: { lastServicedAt: new Date('2026-04-15'), hoursUsed: 2 },
+      });
+    });
+
+    it('invalidates prediction cache before and after the transaction', async () => {
+      mockLogFindUnique.mockResolvedValueOnce({
+        id: 'log-1',
+        component: { id: 'comp-1', userId: 'user-123', bikeId: 'bike-7' },
+      });
+      mockLogFindFirst.mockResolvedValue({ id: 'log-other', performedAt: new Date() });
+      const ctx = createMockContext('user-123');
+
+      await mutation({}, { id: 'log-1', input: { notes: 'x' } }, ctx as never);
+
+      const calls = (invalidateBikePrediction as jest.Mock).mock.calls.filter(
+        (c) => c[1] === 'bike-7'
+      );
+      expect(calls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('Mutation.deleteServiceLog', () => {
+    const mutation = resolvers.Mutation.deleteServiceLog;
+    const mockLogFindUnique = mockPrisma.serviceLog.findUnique as jest.Mock;
+    const mockLogFindFirst = mockPrisma.serviceLog.findFirst as jest.Mock;
+    const mockLogDelete = mockPrisma.serviceLog.delete as jest.Mock;
+    const mockComponentFindUnique = mockPrisma.component.findUnique as jest.Mock;
+    const mockComponentUpdate = mockPrisma.component.update as jest.Mock;
+    const mockRideAggregate = mockPrisma.ride.aggregate as jest.Mock;
+    const mockTransaction = mockPrisma.$transaction as jest.Mock;
+
+    const setTransactionPassthrough = () => {
+      mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
+        const tx = {
+          serviceLog: {
+            findFirst: mockLogFindFirst,
+            update: mockPrisma.serviceLog.update,
+            delete: mockLogDelete,
+          },
+          component: {
+            findUnique: mockComponentFindUnique,
+            update: mockComponentUpdate,
+          },
+          ride: { aggregate: mockRideAggregate },
+        };
+        return fn(tx);
+      });
+    };
+
+    beforeEach(() => {
+      mockLogFindUnique.mockReset();
+      mockLogFindFirst.mockReset();
+      mockLogDelete.mockReset().mockResolvedValue({ id: 'log-1' });
+      mockComponentFindUnique.mockReset();
+      mockComponentUpdate.mockReset().mockResolvedValue({ id: 'comp-1' });
+      mockRideAggregate.mockReset().mockResolvedValue({ _sum: { durationSeconds: 0 } });
+      mockTransaction.mockReset();
+      setTransactionPassthrough();
+    });
+
+    it('rejects when the log is not owned by the viewer', async () => {
+      mockLogFindUnique.mockResolvedValueOnce({
+        id: 'log-1',
+        component: { id: 'comp-1', userId: 'other-user', bikeId: 'bike-1' },
+      });
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        mutation({}, { id: 'log-1' }, ctx as never)
+      ).rejects.toThrow('Service log not found');
+      expect(mockLogDelete).not.toHaveBeenCalled();
+    });
+
+    it('leaves the anchor alone when deleting a non-latest log', async () => {
+      mockLogFindUnique.mockResolvedValueOnce({
+        id: 'log-old',
+        component: { id: 'comp-1', userId: 'user-123', bikeId: 'bike-1' },
+      });
+      mockLogFindFirst.mockResolvedValueOnce({ id: 'log-newer' });
+
+      const ctx = createMockContext('user-123');
+      await mutation({}, { id: 'log-old' }, ctx as never);
+
+      expect(mockLogDelete).toHaveBeenCalledWith({ where: { id: 'log-old' } });
+      expect(mockComponentUpdate).not.toHaveBeenCalled();
+      expect(mockRideAggregate).not.toHaveBeenCalled();
+    });
+
+    it('rolls anchor back to the prior log when deleting the latest', async () => {
+      mockLogFindUnique.mockResolvedValueOnce({
+        id: 'log-latest',
+        component: { id: 'comp-1', userId: 'user-123', bikeId: 'bike-1' },
+      });
+      mockLogFindFirst
+        .mockResolvedValueOnce({ id: 'log-latest' }) // was latest
+        .mockResolvedValueOnce({ performedAt: new Date('2026-01-01') }); // prior log after delete
+      mockComponentFindUnique.mockResolvedValueOnce({ id: 'comp-1', bikeId: 'bike-1' });
+      mockRideAggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 18000 } }); // 5 hours
+
+      const ctx = createMockContext('user-123');
+      await mutation({}, { id: 'log-latest' }, ctx as never);
+
+      expect(mockComponentUpdate).toHaveBeenCalledWith({
+        where: { id: 'comp-1' },
+        data: { lastServicedAt: new Date('2026-01-01'), hoursUsed: 5 },
+      });
+    });
+
+    it('sets anchor to null when the last remaining log is deleted', async () => {
+      mockLogFindUnique.mockResolvedValueOnce({
+        id: 'log-last',
+        component: { id: 'comp-1', userId: 'user-123', bikeId: 'bike-1' },
+      });
+      mockLogFindFirst
+        .mockResolvedValueOnce({ id: 'log-last' })
+        .mockResolvedValueOnce(null); // no remaining logs
+      mockComponentFindUnique.mockResolvedValueOnce({ id: 'comp-1', bikeId: 'bike-1' });
+      mockRideAggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 360000 } }); // 100 hours
+
+      const ctx = createMockContext('user-123');
+      await mutation({}, { id: 'log-last' }, ctx as never);
+
+      expect(mockRideAggregate).toHaveBeenCalledWith({
+        where: { bikeId: 'bike-1' },
+        _sum: { durationSeconds: true },
+      });
+      expect(mockComponentUpdate).toHaveBeenCalledWith({
+        where: { id: 'comp-1' },
+        data: { lastServicedAt: null, hoursUsed: 100 },
+      });
+    });
+
+    it('clears notification dedup so overdue alerts can re-trigger', async () => {
+      mockLogFindUnique.mockResolvedValueOnce({
+        id: 'log-1',
+        component: { id: 'comp-1', userId: 'user-123', bikeId: 'bike-1' },
+      });
+      mockLogFindFirst.mockResolvedValueOnce({ id: 'log-other' });
+      const { clearServiceNotificationLogs } = jest.requireMock<typeof import('../../services/notification.service')>('../../services/notification.service');
+      (clearServiceNotificationLogs as jest.Mock).mockClear();
+
+      const ctx = createMockContext('user-123');
+      await mutation({}, { id: 'log-1' }, ctx as never);
+
+      expect(clearServiceNotificationLogs).toHaveBeenCalledWith('comp-1', 'user-123');
+    });
+  });
+
+  describe('Mutation.updateBikeComponentInstall', () => {
+    const mutation = resolvers.Mutation.updateBikeComponentInstall;
+    const mockFindUnique = mockPrisma.bikeComponentInstall.findUnique as jest.Mock;
+    const mockUpdate = mockPrisma.bikeComponentInstall.update as jest.Mock;
+
+    beforeEach(() => {
+      mockFindUnique.mockReset();
+      mockUpdate.mockReset().mockResolvedValue({ id: 'install-1' });
+    });
+
+    it('rejects when the install belongs to a different user', async () => {
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'install-1',
+        userId: 'other-user',
+        bikeId: 'bike-1',
+      });
+      const ctx = createMockContext('user-123');
+      await expect(
+        mutation({}, { id: 'install-1', input: { installedAt: '2026-01-01T00:00:00Z' } }, ctx as never)
+      ).rejects.toThrow('Install record not found');
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects future install dates', async () => {
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'install-1',
+        userId: 'user-123',
+        bikeId: 'bike-1',
+      });
+      const future = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
+      const ctx = createMockContext('user-123');
+      await expect(
+        mutation({}, { id: 'install-1', input: { installedAt: future } }, ctx as never)
+      ).rejects.toThrow('Install date cannot be in the future');
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('updates installedAt and invalidates prediction cache before and after', async () => {
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'install-1',
+        userId: 'user-123',
+        bikeId: 'bike-7',
+      });
+      const ctx = createMockContext('user-123');
+
+      await mutation(
+        {},
+        { id: 'install-1', input: { installedAt: '2025-06-01T00:00:00Z' } },
+        ctx as never
+      );
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        where: { id: 'install-1' },
+        data: { installedAt: new Date('2025-06-01T00:00:00Z') },
+      });
+      const calls = (invalidateBikePrediction as jest.Mock).mock.calls.filter(
+        (c) => c[1] === 'bike-7'
+      );
+      expect(calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('supports clearing removedAt with null', async () => {
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'install-1',
+        userId: 'user-123',
+        bikeId: 'bike-1',
+      });
+      const ctx = createMockContext('user-123');
+
+      await mutation(
+        {},
+        { id: 'install-1', input: { removedAt: null } },
+        ctx as never
+      );
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        where: { id: 'install-1' },
+        data: { removedAt: null },
+      });
+    });
+  });
+
+  describe('Mutation.deleteBikeComponentInstall', () => {
+    const mutation = resolvers.Mutation.deleteBikeComponentInstall;
+    const mockFindUnique = mockPrisma.bikeComponentInstall.findUnique as jest.Mock;
+    const mockDelete = mockPrisma.bikeComponentInstall.delete as jest.Mock;
+
+    beforeEach(() => {
+      mockFindUnique.mockReset();
+      mockDelete.mockReset().mockResolvedValue({ id: 'install-1' });
+    });
+
+    it('rejects when the install is not owned by the viewer', async () => {
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'install-1',
+        userId: 'other-user',
+        bikeId: 'bike-1',
+      });
+      const ctx = createMockContext('user-123');
+      await expect(
+        mutation({}, { id: 'install-1' }, ctx as never)
+      ).rejects.toThrow('Install record not found');
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it('deletes the row and invalidates prediction cache', async () => {
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'install-1',
+        userId: 'user-123',
+        bikeId: 'bike-9',
+      });
+      const ctx = createMockContext('user-123');
+
+      const result = await mutation({}, { id: 'install-1' }, ctx as never);
+
+      expect(mockDelete).toHaveBeenCalledWith({ where: { id: 'install-1' } });
+      expect(result).toBe(true);
+      const calls = (invalidateBikePrediction as jest.Mock).mock.calls.filter(
+        (c) => c[1] === 'bike-9'
+      );
+      expect(calls.length).toBeGreaterThanOrEqual(2);
     });
   });
 

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -3880,6 +3880,24 @@ describe('GraphQL Resolvers', () => {
       expect(mockRideFindMany).not.toHaveBeenCalled();
     });
 
+    it('enforces the rate limit before any DB work', async () => {
+      // Protects against a polling loop fanning out to three findMany
+      // queries per hit. Rate-limit rejection must short-circuit before
+      // the ownership check and before the data queries — so a rejected
+      // caller can't even confirm whether the bike exists.
+      mockCheckMutationRateLimit.mockResolvedValueOnce({ allowed: false, retryAfter: 42 });
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        resolver({}, { bikeId: 'bike-1' }, ctx as never)
+      ).rejects.toThrow('Rate limit exceeded. Try again in 42 seconds.');
+
+      expect(mockBikeFindFirst).not.toHaveBeenCalled();
+      expect(mockRideFindMany).not.toHaveBeenCalled();
+      expect(mockServiceLogFindMany).not.toHaveBeenCalled();
+      expect(mockInstallFindMany).not.toHaveBeenCalled();
+    });
+
     it('returns merged totals and events within the timeframe', async () => {
       mockBikeFindFirst.mockResolvedValueOnce({ id: 'bike-1', userId: 'user-123' });
       mockRideFindMany.mockResolvedValueOnce([

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -1115,6 +1115,86 @@ describe('GraphQL Resolvers', () => {
       expect(result.newComponents).toHaveLength(1);
     });
 
+    it('closes the old install row and creates a new one stamped with installedAt', async () => {
+      // Pins the replace-component install-row fix: the old component's
+      // open BikeComponentInstall row must be closed (removedAt stamped
+      // with the new install date), AND a fresh install row created for
+      // the replacement with the same date. Without these writes, the
+      // BikeHistory timeline would show the old component as still
+      // installed and the new component with no install event at all.
+      const ctx = createMockContext('user-123');
+      const existingComponent = {
+        id: 'comp-1',
+        type: 'TIRES',
+        location: 'FRONT',
+        brand: 'Maxxis',
+        model: 'Minion DHF',
+        bikeId: 'bike-1',
+        userId: 'user-123',
+        pairGroupId: null,
+      };
+      mockPrisma.component.findFirst.mockResolvedValue(existingComponent as never);
+
+      const userInstalledAt = '2025-11-15T00:00:00.000Z';
+      const installUpdateMany = jest.fn().mockResolvedValue({ count: 1 });
+      const installCreate = jest.fn().mockResolvedValue({ id: 'install-new' });
+      mockPrisma.$transaction.mockImplementation(async (fn) => {
+        if (typeof fn !== 'function') return [];
+        const mockTx = {
+          component: {
+            update: jest
+              .fn()
+              .mockResolvedValueOnce({ ...existingComponent, retiredAt: new Date(userInstalledAt) })
+              .mockResolvedValueOnce({ ...existingComponent, replacedById: 'comp-new' }),
+            create: jest.fn().mockResolvedValue({
+              id: 'comp-new',
+              type: 'TIRES',
+              location: 'FRONT',
+              bikeId: 'bike-1',
+            }),
+            findFirst: jest.fn().mockResolvedValue(null),
+          },
+          serviceLog: { create: jest.fn().mockResolvedValue({ id: 'log-new' }) },
+          bikeComponentInstall: {
+            updateMany: installUpdateMany,
+            create: installCreate,
+          },
+        };
+        return fn(mockTx);
+      });
+
+      await mutation(
+        {},
+        {
+          input: {
+            componentId: 'comp-1',
+            newBrand: 'Maxxis',
+            newModel: 'Assegai',
+            installedAt: userInstalledAt,
+          },
+        },
+        ctx as never
+      );
+
+      // Old install row closed: filtered to this component's open install,
+      // stamped with the user-chosen install date.
+      expect(installUpdateMany).toHaveBeenCalledWith({
+        where: { componentId: 'comp-1', removedAt: null },
+        data: { removedAt: new Date(userInstalledAt) },
+      });
+
+      // New install row opened: same date as the closure, pointing at the
+      // replacement component on the same bike/slot.
+      expect(installCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          userId: 'user-123',
+          bikeId: 'bike-1',
+          componentId: 'comp-new',
+          installedAt: new Date(userInstalledAt),
+        }),
+      });
+    });
+
     it('should replace paired component when alsoReplacePair is true', async () => {
       const ctx = createMockContext('user-123');
       const existingComponent = {
@@ -2878,6 +2958,86 @@ describe('GraphQL Resolvers', () => {
       // Non-latest + no date change → recompute helper should NOT run
       expect(mockComponentUpdate).not.toHaveBeenCalled();
       expect(mockRideAggregate).not.toHaveBeenCalled();
+    });
+
+    it('skips recompute when editing notes/hours on the latest log (no date change)', async () => {
+      // Regression: previously the resolver recomputed on ANY edit to the
+      // latest log. Metadata-only edits don't move the anchor, so we
+      // shouldn't aggregate ride hours or touch Component.
+      mockLogFindUnique.mockResolvedValueOnce({
+        id: 'log-latest',
+        component: { id: 'comp-1', userId: 'user-123', bikeId: 'bike-1' },
+      });
+      mockLogFindFirst.mockResolvedValueOnce({
+        id: 'log-latest',
+        performedAt: new Date('2026-03-01'),
+      });
+
+      const ctx = createMockContext('user-123');
+      await mutation(
+        {},
+        { id: 'log-latest', input: { notes: 'updated notes' } },
+        ctx as never
+      );
+
+      expect(mockLogUpdate).toHaveBeenCalledWith({
+        where: { id: 'log-latest' },
+        data: { notes: 'updated notes' },
+      });
+      expect(mockComponentUpdate).not.toHaveBeenCalled();
+      expect(mockRideAggregate).not.toHaveBeenCalled();
+    });
+
+    it('skips recompute when a non-latest date shift stays behind the previous latest', async () => {
+      // Regression: previously any date change triggered recompute. Moving
+      // an old log forward a few days but still earlier than the latest log
+      // leaves the anchor untouched, so no aggregate query is needed.
+      mockLogFindUnique.mockResolvedValueOnce({
+        id: 'log-old',
+        component: { id: 'comp-1', userId: 'user-123', bikeId: 'bike-1' },
+      });
+      mockLogFindFirst.mockResolvedValueOnce({
+        id: 'log-latest',
+        performedAt: new Date('2026-04-01'),
+      });
+
+      const ctx = createMockContext('user-123');
+      await mutation(
+        {},
+        { id: 'log-old', input: { performedAt: '2026-02-20T00:00:00.000Z' } },
+        ctx as never
+      );
+
+      expect(mockLogUpdate).toHaveBeenCalled();
+      expect(mockComponentUpdate).not.toHaveBeenCalled();
+      expect(mockRideAggregate).not.toHaveBeenCalled();
+    });
+
+    it('recomputes when a non-latest log is moved past the previous latest', async () => {
+      // A previously-non-latest log was moved forward to a date that now
+      // beats the old latest — the anchor moves and the helper must run.
+      mockLogFindUnique.mockResolvedValueOnce({
+        id: 'log-old',
+        component: { id: 'comp-1', userId: 'user-123', bikeId: 'bike-1' },
+      });
+      mockLogFindFirst
+        .mockResolvedValueOnce({ id: 'log-latest', performedAt: new Date('2026-01-01') })
+        // After the update, log-old is now the newest.
+        .mockResolvedValueOnce({ performedAt: new Date('2026-03-10') });
+      mockComponentFindUnique.mockResolvedValueOnce({ id: 'comp-1', bikeId: 'bike-1' });
+      mockRideAggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 3600 } });
+
+      const ctx = createMockContext('user-123');
+      await mutation(
+        {},
+        { id: 'log-old', input: { performedAt: '2026-03-10T00:00:00.000Z' } },
+        ctx as never
+      );
+
+      expect(mockComponentUpdate).toHaveBeenCalledWith({
+        where: { id: 'comp-1' },
+        data: { lastServicedAt: new Date('2026-03-10'), hoursUsed: 1 },
+      });
     });
 
     it('recomputes anchor + hoursUsed when editing the latest log date', async () => {

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -2936,6 +2936,22 @@ describe('GraphQL Resolvers', () => {
       expect(mockLogUpdate).not.toHaveBeenCalled();
     });
 
+    it('rejects hoursAtService above the upper cap', async () => {
+      // Blocks wear-engine-blowing submissions like 1e15. The cap is
+      // 100,000 — way above any realistic lifetime — so a normal user
+      // never trips it, but bogus input fails fast instead of silently
+      // skewing every downstream prediction.
+      mockLogFindUnique.mockResolvedValueOnce({
+        id: 'log-1',
+        component: { id: 'comp-1', userId: 'user-123', bikeId: 'bike-1' },
+      });
+      const ctx = createMockContext('user-123');
+      await expect(
+        mutation({}, { id: 'log-1', input: { hoursAtService: 1e15 } }, ctx as never)
+      ).rejects.toThrow('hoursAtService must be between 0 and 100000');
+      expect(mockLogUpdate).not.toHaveBeenCalled();
+    });
+
     it('does not touch component anchor when editing a non-latest log', async () => {
       mockLogFindUnique.mockResolvedValueOnce({
         id: 'log-old',

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -37,6 +37,7 @@ jest.mock('../../lib/prisma', () => ({
     },
     serviceLog: {
       create: jest.fn(),
+      findMany: jest.fn().mockResolvedValue([]),
     },
     termsAcceptance: {
       findUnique: jest.fn(),
@@ -57,6 +58,7 @@ jest.mock('../../lib/prisma', () => ({
     },
     bikeComponentInstall: {
       findFirst: jest.fn(),
+      findMany: jest.fn().mockResolvedValue([]),
       create: jest.fn(),
       update: jest.fn(),
     },
@@ -3158,6 +3160,178 @@ describe('GraphQL Resolvers', () => {
       const totalWhere = mockRideCount.mock.calls[1][0].where;
       expect(totalWhere.startLat).toBeUndefined();
       expect(totalWhere.startLng).toBeUndefined();
+    });
+  });
+
+  describe('Query.bikeHistory', () => {
+    const resolver = resolvers.Query.bikeHistory;
+    const mockBikeFindFirst = mockPrisma.bike.findFirst as jest.Mock;
+    const mockRideFindMany = mockPrisma.ride.findMany as jest.Mock;
+    const mockServiceLogFindMany = mockPrisma.serviceLog.findMany as jest.Mock;
+    const mockInstallFindMany = mockPrisma.bikeComponentInstall.findMany as jest.Mock;
+    const mockUserFindUniqueOrThrow = mockPrisma.user.findUniqueOrThrow as jest.Mock;
+
+    beforeEach(() => {
+      mockBikeFindFirst.mockReset();
+      mockRideFindMany.mockReset().mockResolvedValue([]);
+      mockServiceLogFindMany.mockReset().mockResolvedValue([]);
+      mockInstallFindMany.mockReset().mockResolvedValue([]);
+      // Default to PRO so existing tests see every event type. Individual tests
+      // can override for tier-gated assertions.
+      mockUserFindUniqueOrThrow.mockReset().mockResolvedValue({
+        subscriptionTier: 'PRO',
+        isFoundingRider: false,
+        role: 'FREE',
+      });
+    });
+
+    it('rejects when the bike is not owned by the viewer', async () => {
+      mockBikeFindFirst.mockResolvedValueOnce(null);
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        resolver({}, { bikeId: 'bike-stolen' }, ctx as never)
+      ).rejects.toThrow('Bike not found');
+
+      expect(mockRideFindMany).not.toHaveBeenCalled();
+    });
+
+    it('returns merged totals and events within the timeframe', async () => {
+      mockBikeFindFirst.mockResolvedValueOnce({ id: 'bike-1', userId: 'user-123' });
+      mockRideFindMany.mockResolvedValueOnce([
+        { id: 'r1', distanceMeters: 10000, durationSeconds: 3600, elevationGainMeters: 300 },
+        { id: 'r2', distanceMeters: 5000, durationSeconds: 1800, elevationGainMeters: 150 },
+      ]);
+      mockServiceLogFindMany.mockResolvedValueOnce([
+        {
+          id: 's1',
+          performedAt: new Date('2026-01-15T00:00:00Z'),
+          notes: 'fork lowers',
+          hoursAtService: 120,
+          component: { id: 'c1' },
+        },
+      ]);
+      mockInstallFindMany.mockResolvedValueOnce([]);
+
+      const ctx = createMockContext('user-123');
+      const result = await resolver(
+        {},
+        { bikeId: 'bike-1', startDate: '2026-01-01T00:00:00Z', endDate: '2026-12-31T23:59:59Z' },
+        ctx as never
+      );
+
+      expect(result.totals).toEqual({
+        rideCount: 2,
+        totalDistanceMeters: 15000,
+        totalDurationSeconds: 5400,
+        totalElevationGainMeters: 450,
+        serviceEventCount: 1,
+        installEventCount: 0,
+      });
+      expect(result.serviceEvents[0].performedAt).toBe('2026-01-15T00:00:00.000Z');
+      expect(result.truncated).toBe(false);
+    });
+
+    it('splits a BikeComponentInstall with removedAt into two events', async () => {
+      mockBikeFindFirst.mockResolvedValueOnce({ id: 'bike-1', userId: 'user-123' });
+      mockInstallFindMany.mockResolvedValueOnce([
+        {
+          id: 'i1',
+          installedAt: new Date('2026-01-10T00:00:00Z'),
+          removedAt: new Date('2026-03-20T00:00:00Z'),
+          component: { id: 'c1' },
+        },
+      ]);
+
+      const ctx = createMockContext('user-123');
+      const result = await resolver({}, { bikeId: 'bike-1' }, ctx as never);
+
+      expect(result.installs).toHaveLength(2);
+      expect(result.installs.map((i: { eventType: string }) => i.eventType).sort()).toEqual([
+        'INSTALLED',
+        'REMOVED',
+      ]);
+      expect(result.installs.find((i: { eventType: string }) => i.eventType === 'INSTALLED').occurredAt)
+        .toBe('2026-01-10T00:00:00.000Z');
+      expect(result.installs.find((i: { eventType: string }) => i.eventType === 'REMOVED').occurredAt)
+        .toBe('2026-03-20T00:00:00.000Z');
+    });
+
+    it('drops install/remove events outside the requested timeframe', async () => {
+      mockBikeFindFirst.mockResolvedValueOnce({ id: 'bike-1', userId: 'user-123' });
+      // Install in 2025, removed in 2026 — with a 2026-only filter, only REMOVED should show.
+      mockInstallFindMany.mockResolvedValueOnce([
+        {
+          id: 'i1',
+          installedAt: new Date('2025-06-01T00:00:00Z'),
+          removedAt: new Date('2026-02-01T00:00:00Z'),
+          component: { id: 'c1' },
+        },
+      ]);
+
+      const ctx = createMockContext('user-123');
+      const result = await resolver(
+        {},
+        { bikeId: 'bike-1', startDate: '2026-01-01T00:00:00Z', endDate: '2026-12-31T23:59:59Z' },
+        ctx as never
+      );
+
+      expect(result.installs).toHaveLength(1);
+      expect(result.installs[0].eventType).toBe('REMOVED');
+    });
+
+    it('restricts service & install events to unlocked component types on Free Light', async () => {
+      mockBikeFindFirst.mockResolvedValueOnce({ id: 'bike-1', userId: 'user-123' });
+      mockUserFindUniqueOrThrow.mockReset().mockResolvedValue({
+        subscriptionTier: 'FREE_LIGHT',
+        isFoundingRider: false,
+        role: 'FREE',
+      });
+
+      const ctx = createMockContext('user-123');
+      await resolver({}, { bikeId: 'bike-1' }, ctx as never);
+
+      // Service query's component filter must restrict to unlocked types.
+      const serviceWhere = mockServiceLogFindMany.mock.calls[0][0].where;
+      expect(serviceWhere.component.bikeId).toBe('bike-1');
+      expect(serviceWhere.component.type.in).toEqual(
+        expect.arrayContaining(['FORK', 'SHOCK', 'BRAKE_PAD', 'PIVOT_BEARINGS'])
+      );
+
+      // Install query must scope the same filter onto its joined component.
+      const installWhere = mockInstallFindMany.mock.calls[0][0].where;
+      expect(installWhere.component.type.in).toEqual(
+        expect.arrayContaining(['FORK', 'SHOCK', 'BRAKE_PAD', 'PIVOT_BEARINGS'])
+      );
+    });
+
+    it('does not apply a component type filter for Pro users', async () => {
+      mockBikeFindFirst.mockResolvedValueOnce({ id: 'bike-1', userId: 'user-123' });
+      // Default PRO mock from beforeEach applies.
+
+      const ctx = createMockContext('user-123');
+      await resolver({}, { bikeId: 'bike-1' }, ctx as never);
+
+      const serviceWhere = mockServiceLogFindMany.mock.calls[0][0].where;
+      expect(serviceWhere.component).toEqual({ bikeId: 'bike-1' });
+      const installWhere = mockInstallFindMany.mock.calls[0][0].where;
+      expect(installWhere.component).toBeUndefined();
+    });
+
+    it('marks truncated=true when the ride cap is hit', async () => {
+      mockBikeFindFirst.mockResolvedValueOnce({ id: 'bike-1', userId: 'user-123' });
+      const lotsOfRides = Array.from({ length: 2000 }, (_, i) => ({
+        id: `r${i}`,
+        distanceMeters: 1000,
+        durationSeconds: 600,
+        elevationGainMeters: 50,
+      }));
+      mockRideFindMany.mockResolvedValueOnce(lotsOfRides);
+
+      const ctx = createMockContext('user-123');
+      const result = await resolver({}, { bikeId: 'bike-1' }, ctx as never);
+
+      expect(result.truncated).toBe(true);
     });
   });
 });

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -110,6 +110,7 @@ const createMockContext = (
   user: userId ? { id: userId } : null,
   loaders: {
     serviceLogsByComponentId: { load: jest.fn() },
+    latestServiceLogByComponentId: { load: jest.fn() },
     weatherByRideId: { load: jest.fn() },
   },
   req: {
@@ -3137,6 +3138,70 @@ describe('GraphQL Resolvers', () => {
         data: { removedAt: null },
       });
     });
+
+    it('rejects a removedAt earlier than the existing installedAt', async () => {
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'install-1',
+        userId: 'user-123',
+        bikeId: 'bike-1',
+        installedAt: new Date('2026-03-01T00:00:00Z'),
+      });
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        mutation(
+          {},
+          { id: 'install-1', input: { removedAt: '2026-02-15T00:00:00Z' } },
+          ctx as never
+        )
+      ).rejects.toThrow('Removal date cannot be before install date');
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects removedAt earlier than a same-mutation installedAt', async () => {
+      // User is updating both fields at once — check the NEW installedAt,
+      // not the persisted value, so we don't block a legitimate correction
+      // that moves both dates together.
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'install-1',
+        userId: 'user-123',
+        bikeId: 'bike-1',
+        installedAt: new Date('2020-01-01T00:00:00Z'),
+      });
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        mutation(
+          {},
+          {
+            id: 'install-1',
+            input: {
+              installedAt: '2026-04-01T00:00:00Z',
+              removedAt: '2026-03-15T00:00:00Z',
+            },
+          },
+          ctx as never
+        )
+      ).rejects.toThrow('Removal date cannot be before install date');
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits empty input without touching Prisma or the cache', async () => {
+      const existing = { id: 'install-1', userId: 'user-123', bikeId: 'bike-1' };
+      mockFindUnique.mockResolvedValueOnce(existing);
+      (invalidateBikePrediction as jest.Mock).mockClear();
+
+      const ctx = createMockContext('user-123');
+      const result = await mutation({}, { id: 'install-1', input: {} }, ctx as never);
+
+      // Empty update is a no-op: no write, no cache invalidation, return the
+      // existing row so clients still get a consistent response shape.
+      expect(result).toBe(existing);
+      expect(mockUpdate).not.toHaveBeenCalled();
+      expect(
+        (invalidateBikePrediction as jest.Mock).mock.calls.filter((c) => c[1] === 'bike-1').length
+      ).toBe(0);
+    });
   });
 
   describe('Mutation.deleteBikeComponentInstall', () => {
@@ -3708,10 +3773,32 @@ describe('GraphQL Resolvers', () => {
       const ctx = createMockContext('user-123');
       await resolver({}, { bikeId: 'bike-1' }, ctx as never);
 
+      // Pro tier: no `type` restriction on the joined Component, but the
+      // defense-in-depth userId filter still applies everywhere.
       const serviceWhere = mockServiceLogFindMany.mock.calls[0][0].where;
-      expect(serviceWhere.component).toEqual({ bikeId: 'bike-1' });
+      expect(serviceWhere.component).toEqual({ bikeId: 'bike-1', userId: 'user-123' });
       const installWhere = mockInstallFindMany.mock.calls[0][0].where;
       expect(installWhere.component).toBeUndefined();
+      expect(installWhere.userId).toBe('user-123');
+    });
+
+    it('applies a defense-in-depth userId filter on every sub-query', async () => {
+      // Ownership check above is the primary guard, but every inner query
+      // redundantly restricts by userId so a future refactor can't silently
+      // leak cross-user data.
+      mockBikeFindFirst.mockResolvedValueOnce({ id: 'bike-1', userId: 'user-123' });
+
+      const ctx = createMockContext('user-123');
+      await resolver({}, { bikeId: 'bike-1' }, ctx as never);
+
+      const rideWhere = mockRideFindMany.mock.calls[0][0].where;
+      expect(rideWhere.userId).toBe('user-123');
+
+      const serviceWhere = mockServiceLogFindMany.mock.calls[0][0].where;
+      expect(serviceWhere.component.userId).toBe('user-123');
+
+      const installWhere = mockInstallFindMany.mock.calls[0][0].where;
+      expect(installWhere.userId).toBe('user-123');
     });
 
     it('marks truncated=true when the ride cap is hit', async () => {

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -3362,6 +3362,53 @@ describe('GraphQL Resolvers', () => {
       expect(mockUpdate).not.toHaveBeenCalled();
     });
 
+    it('rejects a new installedAt later than the existing removedAt', async () => {
+      // Only installedAt is in the payload, but the row already has a
+      // removedAt. Without guarding against the persisted removedAt, the
+      // row ends up inverted (installed 2026-02, removed 2026-01).
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'install-1',
+        userId: 'user-123',
+        bikeId: 'bike-1',
+        installedAt: new Date('2025-06-01T00:00:00Z'),
+        removedAt: new Date('2026-01-01T00:00:00Z'),
+      });
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        mutation(
+          {},
+          { id: 'install-1', input: { installedAt: '2026-02-15T00:00:00Z' } },
+          ctx as never
+        )
+      ).rejects.toThrow('Removal date cannot be before install date');
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('allows updating installedAt on a row with a non-conflicting existing removedAt', async () => {
+      // Complement to the case above — if the new installedAt still sits
+      // before the persisted removedAt, the update should proceed normally.
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'install-1',
+        userId: 'user-123',
+        bikeId: 'bike-1',
+        installedAt: new Date('2025-01-01T00:00:00Z'),
+        removedAt: new Date('2026-03-01T00:00:00Z'),
+      });
+      const ctx = createMockContext('user-123');
+
+      await mutation(
+        {},
+        { id: 'install-1', input: { installedAt: '2025-06-15T00:00:00Z' } },
+        ctx as never
+      );
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        where: { id: 'install-1' },
+        data: { installedAt: new Date('2025-06-15T00:00:00Z') },
+      });
+    });
+
     it('short-circuits empty input without touching Prisma or the cache', async () => {
       const existing = { id: 'install-1', userId: 'user-123', bikeId: 'bike-1' };
       mockFindUnique.mockResolvedValueOnce(existing);

--- a/apps/api/src/graphql/dataloaders.ts
+++ b/apps/api/src/graphql/dataloaders.ts
@@ -39,8 +39,13 @@ async function batchLatestServiceLogByComponentId(
   componentIds: readonly string[]
 ): Promise<(ServiceLog | null)[]> {
   if (componentIds.length === 0) return [];
+  // Explicit column list — keeps the DataLoader cheap as ServiceLog evolves.
+  // Every field below is exposed on the GraphQL ServiceLog type; anything
+  // internal (e.g. updatedAt today, or a future rawJson column) stays out
+  // of the batched fetch path automatically.
   const rows = await prisma.$queryRaw<ServiceLog[]>`
-    SELECT DISTINCT ON ("componentId") *
+    SELECT DISTINCT ON ("componentId")
+      "id", "componentId", "performedAt", "notes", "hoursAtService", "createdAt"
     FROM "ServiceLog"
     WHERE "componentId" = ANY(${[...componentIds]}::text[])
     ORDER BY "componentId", "performedAt" DESC, "createdAt" DESC

--- a/apps/api/src/graphql/dataloaders.ts
+++ b/apps/api/src/graphql/dataloaders.ts
@@ -28,6 +28,29 @@ async function batchServiceLogsByComponentId(
 }
 
 /**
+ * Batch loads only the single most recent ServiceLog per component.
+ *
+ * Used by Component.latestServiceLog so pages that only show "last serviced"
+ * metadata don't pay the full-history payload cost. Uses Postgres DISTINCT
+ * ON for a one-query fan-out — cheaper than N separate findFirst calls and
+ * cheaper than fetching every row and picking the first.
+ */
+async function batchLatestServiceLogByComponentId(
+  componentIds: readonly string[]
+): Promise<(ServiceLog | null)[]> {
+  if (componentIds.length === 0) return [];
+  const rows = await prisma.$queryRaw<ServiceLog[]>`
+    SELECT DISTINCT ON ("componentId") *
+    FROM "ServiceLog"
+    WHERE "componentId" = ANY(${[...componentIds]}::text[])
+    ORDER BY "componentId", "performedAt" DESC, "createdAt" DESC
+  `;
+  const byComponent = new Map<string, ServiceLog>();
+  for (const row of rows) byComponent.set(row.componentId, row);
+  return componentIds.map((id) => byComponent.get(id) ?? null);
+}
+
+/**
  * Batch loads RideWeather rows for many rides in one query.
  * Solves N+1 when Ride.weather is resolved across a rides list.
  */
@@ -51,6 +74,9 @@ export function createDataLoaders() {
   return {
     serviceLogsByComponentId: new DataLoader<string, ServiceLog[]>(
       batchServiceLogsByComponentId
+    ),
+    latestServiceLogByComponentId: new DataLoader<string, ServiceLog | null>(
+      batchLatestServiceLogByComponentId
     ),
     weatherByRideId: new DataLoader<string, RideWeather | null>(
       batchWeatherByRideId

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -276,6 +276,17 @@ const cleanText = (v: unknown, max = MAX_LABEL_LEN) =>
  *
  * Uses ride duration on the component's current bike as the wear proxy,
  * matching how `incrementBikeComponentHours` ticks the counter on ride upload.
+ *
+ * **Missing-component tolerance:** the initial `component.findUnique` can
+ * return null if the component was deleted between the caller's ownership
+ * check and this helper (e.g. racing against an account teardown or a
+ * concurrent cascade). In that case the helper silently no-ops — the row
+ * is gone, there's nothing to anchor. Callers don't need to special-case
+ * this: the outer transaction is already doing the "correct" work (the
+ * edit/delete of the triggering ServiceLog), and a missing component just
+ * means the recompute half has no target. Returning void rather than
+ * throwing keeps the mutation's primary effect from rolling back for a
+ * recompute-stage anomaly.
  */
 async function recomputeComponentAfterServiceChange(
   tx: Prisma.TransactionClient,
@@ -1380,6 +1391,23 @@ export const resolvers = {
           },
           orderBy: { startTime: 'desc' },
           take: RIDE_CAP,
+          // Explicit allow-list: keeps the query cheap at the 2000-row cap
+          // as the Ride model grows. Matches the fields that both the web
+          // and mobile BikeHistory ride fragments consume — if a client
+          // adds a new field here, this projection must grow too. The
+          // Ride.weather field resolver lazy-loads via DataLoader from the
+          // ride id, so we deliberately skip including it.
+          select: {
+            id: true,
+            startTime: true,
+            durationSeconds: true,
+            distanceMeters: true,
+            elevationGainMeters: true,
+            averageHr: true,
+            rideType: true,
+            trailSystem: true,
+            location: true,
+          },
         }),
         prisma.serviceLog.findMany({
           where: {
@@ -1390,6 +1418,16 @@ export const resolvers = {
           orderBy: { performedAt: 'desc' },
           take: SERVICE_CAP,
         }),
+        // Each BikeComponentInstall row carries TWO potential timeline
+        // events (installedAt, and optionally removedAt). The OR filter
+        // selects any row where *either* date touches the range, because
+        // we need rows that contribute *any* visible event. But a selected
+        // row can still hold one in-range and one out-of-range date — e.g.
+        // installed 2020, removed 2026, with the user filtering "past
+        // year" should emit only the REMOVED event, not the old INSTALLED.
+        // The per-event `installedInRange` / `removedInRange` checks below
+        // do that second pass; the Prisma filter alone is intentionally
+        // too permissive.
         prisma.bikeComponentInstall.findMany({
           where: {
             userId,
@@ -1460,6 +1498,16 @@ export const resolvers = {
         totalElevationGainMeters += r.elevationGainMeters;
       }
 
+      // `rides` is returned raw from Prisma; the GraphQL `Ride` type at
+      // schema.ts:144 is the authoritative allow-list — graphql-js only
+      // serializes declared fields, so Prisma-internal columns (startLat,
+      // startLng, importSessionId, etc.) never leave the server. We keep
+      // this shape (rather than explicitly projecting like `serviceEvents`
+      // and `installs`) because the existing `rides` query does the same,
+      // and Date → ISO coercion is already handled by the Ride.startTime
+      // field resolver. `serviceEvents` and `installs` are projected only
+      // because they need genuine reshaping (Date → string, splitting one
+      // install row into INSTALLED/REMOVED pair events).
       return {
         bike,
         rides,
@@ -2449,11 +2497,26 @@ export const resolvers = {
           },
         });
 
-        // Recompute anchor + hoursUsed if this edit could have moved the anchor:
-        //   - was the latest AND date/order changed
-        //   - was NOT the latest but new date makes it the latest
+        // Recompute anchor + hoursUsed only when the edit could have moved
+        // `max(performedAt)` for this component:
+        //   a) This log WAS the latest and its date changed. Either it's
+        //      still latest at a new date, or it moved behind another log
+        //      that's now latest — either way, the anchor shifts.
+        //   b) This log WAS NOT the latest but its new date is later than
+        //      the previous latest, meaning it just became latest.
+        //
+        // Non-latest edits with non-anchor-crossing date shifts (e.g. moving
+        // a mid-history log a few days within its window) and
+        // metadata-only edits (notes/hours on any log) leave the anchor
+        // untouched — skipping the helper saves a ride-aggregate query and
+        // a component.update round-trip.
         const dateChanged = !!newPerformedAt;
-        if (wasLatest || dateChanged) {
+        const becameLatest =
+          !wasLatest &&
+          dateChanged &&
+          !!currentLatest &&
+          newPerformedAt! > currentLatest.performedAt;
+        if ((wasLatest && dateChanged) || becameLatest) {
           await recomputeComponentAfterServiceChange(tx, existing.component.id);
         }
 

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -1271,6 +1271,147 @@ export const resolvers = {
       const userId = requireUserId(ctx);
       return getReferralStats(userId);
     },
+
+    bikeHistory: async (
+      _: unknown,
+      { bikeId, startDate, endDate }: { bikeId: string; startDate?: string | null; endDate?: string | null },
+      ctx: GraphQLContext
+    ) => {
+      const userId = requireUserId(ctx);
+
+      const [bike, tierUser] = await Promise.all([
+        prisma.bike.findFirst({ where: { id: bikeId, userId } }),
+        prisma.user.findUniqueOrThrow({
+          where: { id: userId },
+          select: { subscriptionTier: true, isFoundingRider: true, role: true },
+        }),
+      ]);
+      if (!bike) {
+        throw new GraphQLError('Bike not found', { extensions: { code: 'NOT_FOUND' } });
+      }
+
+      // Tier gate: a Free Light user only sees component events whose type is
+      // unlocked for their tier — mirrors the BikeDetail gating so the PDF they
+      // hand a buyer can't accidentally surface data the app hides elsewhere.
+      const allowedTypes = getAllowedComponentTypes(tierUser);
+      const componentTypeFilter: Prisma.ComponentWhereInput | undefined =
+        allowedTypes === 'ALL' ? undefined : { type: { in: allowedTypes } };
+
+      const gte = startDate ? new Date(startDate) : undefined;
+      const lte = endDate ? new Date(endDate) : undefined;
+      const dateRange = gte || lte ? { ...(gte ? { gte } : {}), ...(lte ? { lte } : {}) } : undefined;
+
+      const RIDE_CAP = 2000;
+      const SERVICE_CAP = 1000;
+      const INSTALL_CAP = 1000;
+
+      const [rides, serviceLogs, installs] = await Promise.all([
+        prisma.ride.findMany({
+          where: {
+            userId,
+            bikeId,
+            ...(dateRange ? { startTime: dateRange } : {}),
+          },
+          orderBy: { startTime: 'desc' },
+          take: RIDE_CAP,
+        }),
+        prisma.serviceLog.findMany({
+          where: {
+            component: { bikeId, ...(componentTypeFilter ?? {}) },
+            ...(dateRange ? { performedAt: dateRange } : {}),
+          },
+          include: { component: true },
+          orderBy: { performedAt: 'desc' },
+          take: SERVICE_CAP,
+        }),
+        prisma.bikeComponentInstall.findMany({
+          where: {
+            bikeId,
+            ...(componentTypeFilter ? { component: componentTypeFilter } : {}),
+            ...(dateRange
+              ? {
+                  OR: [
+                    { installedAt: dateRange },
+                    { removedAt: dateRange },
+                  ],
+                }
+              : {}),
+          },
+          include: { component: true },
+          orderBy: { installedAt: 'desc' },
+          take: INSTALL_CAP,
+        }),
+      ]);
+
+      const serviceEvents = serviceLogs.map((log) => ({
+        id: log.id,
+        performedAt: log.performedAt.toISOString(),
+        notes: log.notes,
+        hoursAtService: log.hoursAtService,
+        component: log.component,
+      }));
+
+      const installEvents: Array<{
+        id: string;
+        eventType: 'INSTALLED' | 'REMOVED';
+        occurredAt: string;
+        component: unknown;
+      }> = [];
+      for (const i of installs) {
+        const installedInRange =
+          !dateRange ||
+          ((!gte || i.installedAt >= gte) && (!lte || i.installedAt <= lte));
+        if (installedInRange) {
+          installEvents.push({
+            id: `${i.id}:installed`,
+            eventType: 'INSTALLED',
+            occurredAt: i.installedAt.toISOString(),
+            component: i.component,
+          });
+        }
+        if (i.removedAt) {
+          const removedInRange =
+            !dateRange ||
+            ((!gte || i.removedAt >= gte) && (!lte || i.removedAt <= lte));
+          if (removedInRange) {
+            installEvents.push({
+              id: `${i.id}:removed`,
+              eventType: 'REMOVED',
+              occurredAt: i.removedAt.toISOString(),
+              component: i.component,
+            });
+          }
+        }
+      }
+
+      let totalDistanceMeters = 0;
+      let totalDurationSeconds = 0;
+      let totalElevationGainMeters = 0;
+      for (const r of rides) {
+        totalDistanceMeters += r.distanceMeters;
+        totalDurationSeconds += r.durationSeconds;
+        totalElevationGainMeters += r.elevationGainMeters;
+      }
+
+      return {
+        bike,
+        rides,
+        serviceEvents,
+        installs: installEvents,
+        totals: {
+          rideCount: rides.length,
+          totalDistanceMeters,
+          totalDurationSeconds,
+          totalElevationGainMeters,
+          serviceEventCount: serviceEvents.length,
+          installEventCount: installEvents.length,
+        },
+        truncated:
+          rides.length >= RIDE_CAP ||
+          serviceLogs.length >= SERVICE_CAP ||
+          installs.length >= INSTALL_CAP,
+      };
+    },
   },
   Mutation: {
     addRide: async (_p: unknown, { input }: { input: AddRideInput }, ctx: GraphQLContext) => {

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -1362,6 +1362,19 @@ export const resolvers = {
     ) => {
       const userId = requireUserId(ctx);
 
+      // Read rate limit: each call fans out to three findMany queries
+      // (rides + serviceLogs + installs, up to ~4k rows combined). Higher
+      // ceiling than mutations because toggle/filter/cache-and-network
+      // churn legitimately hits this in bursts, but capped to stop a
+      // polling loop from hammering the DB.
+      const rateLimit = await checkMutationRateLimit('bikeHistory', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(
+          `Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`,
+          { extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter } }
+        );
+      }
+
       const [bike, tierUser] = await Promise.all([
         prisma.bike.findFirst({ where: { id: bikeId, userId } }),
         prisma.user.findUniqueOrThrow({

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -2652,15 +2652,22 @@ export const resolvers = {
       }
 
       // Chronology guard: a component can't come off a bike before it was
-      // installed. Compare against the effective install anchor (the new
-      // value if we're also updating installedAt in the same mutation,
-      // otherwise the persisted value).
-      if (data.removedAt instanceof Date) {
-        const effectiveInstalledAt =
-          data.installedAt instanceof Date ? data.installedAt : existing.installedAt;
-        if (data.removedAt < effectiveInstalledAt) {
-          throw new Error('Removal date cannot be before install date');
-        }
+      // installed. Compare the POST-UPDATE state of both timestamps — a
+      // user who just moves `installedAt` forward past an already-persisted
+      // `removedAt` would otherwise invert the range silently.
+      //
+      // Explicit `removedAt: null` (clearing) skips the check — no removal
+      // date to violate.
+      const effectiveInstalledAt =
+        data.installedAt instanceof Date ? data.installedAt : existing.installedAt;
+      const effectiveRemovedAt: Date | null =
+        data.removedAt === null
+          ? null
+          : data.removedAt instanceof Date
+          ? data.removedAt
+          : existing.removedAt;
+      if (effectiveRemovedAt && effectiveRemovedAt < effectiveInstalledAt) {
+        throw new Error('Removal date cannot be before install date');
       }
 
       // Nothing to change — skip the Prisma round-trip and the pair of cache

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -254,6 +254,16 @@ const MAX_NOTES_LEN = 2000;
 const MAX_LABEL_LEN = 120;
 
 /**
+ * Upper bound for user-supplied "hours at service" values. 100,000 is ~11
+ * years of continuous use — well beyond any realistic component lifetime
+ * (even a 30-hr/week rider accumulates under 50k over a lifetime). Blocks
+ * bogus submissions like 1e15 that would otherwise silently skew wear
+ * predictions, which compare this value against service-interval caps of
+ * 1000h.
+ */
+const MAX_SERVICE_HOURS = 100_000;
+
+/**
  * Clean user input text.
  * - Trims whitespace
  * - Truncates to max length
@@ -2456,7 +2466,7 @@ export const resolvers = {
         include: { component: { select: { id: true, userId: true, bikeId: true } } },
       });
       if (!existing || existing.component.userId !== userId) {
-        throw new Error('Service log not found');
+        throw new GraphQLError('Service log not found', { extensions: { code: 'NOT_FOUND' } });
       }
 
       // Validate input after auth.
@@ -2470,8 +2480,20 @@ export const resolvers = {
         input.notes === undefined ? undefined : input.notes === null ? null : cleanText(input.notes, MAX_NOTES_LEN);
       let newHoursAtService: number | undefined;
       if (input.hoursAtService !== undefined && input.hoursAtService !== null) {
-        if (!Number.isFinite(input.hoursAtService) || input.hoursAtService < 0) {
-          throw new Error('hoursAtService must be a non-negative number');
+        // Upper cap guards the wear engine. 100,000 hours is ~11 years of
+        // continuous use — well above any realistic component lifetime
+        // (even a 30-hr/week rider tops out near 50k over a lifetime).
+        // The engine compares this value against service-interval caps of
+        // 1000h, so bogus inputs like 1e15 would silently skew every
+        // downstream prediction.
+        if (
+          !Number.isFinite(input.hoursAtService) ||
+          input.hoursAtService < 0 ||
+          input.hoursAtService > MAX_SERVICE_HOURS
+        ) {
+          throw new Error(
+            `hoursAtService must be between 0 and ${MAX_SERVICE_HOURS}`
+          );
         }
         newHoursAtService = input.hoursAtService;
       }
@@ -2547,7 +2569,7 @@ export const resolvers = {
         include: { component: { select: { id: true, userId: true, bikeId: true } } },
       });
       if (!existing || existing.component.userId !== userId) {
-        throw new Error('Service log not found');
+        throw new GraphQLError('Service log not found', { extensions: { code: 'NOT_FOUND' } });
       }
 
       const componentId = existing.component.id;
@@ -2605,7 +2627,7 @@ export const resolvers = {
         where: { id },
       });
       if (!existing || existing.userId !== userId) {
-        throw new Error('Install record not found');
+        throw new GraphQLError('Install record not found', { extensions: { code: 'NOT_FOUND' } });
       }
 
       const now = new Date();
@@ -2644,6 +2666,14 @@ export const resolvers = {
       // Nothing to change — skip the Prisma round-trip and the pair of cache
       // invalidations. Callers get back the current row, matching the
       // semantic "update with no fields is a no-op."
+      //
+      // NOTE: `existing` was fetched with no `include`, so any future
+      // nested field resolver on BikeComponentInstall (e.g. a `bike` or
+      // `component` sub-selection) would see `undefined` here instead of
+      // the hydrated relation. Today the type is all scalars, so that's
+      // fine — if a relation gets added, hoist `existing` to include the
+      // same selections the post-update branch returns, or drop this
+      // short-circuit in favor of a regular `update()` round-trip.
       if (Object.keys(data).length === 0) {
         return existing;
       }
@@ -2678,7 +2708,7 @@ export const resolvers = {
         where: { id },
       });
       if (!existing || existing.userId !== userId) {
-        throw new Error('Install record not found');
+        throw new GraphQLError('Install record not found', { extensions: { code: 'NOT_FOUND' } });
       }
 
       if (existing.bikeId) await invalidateBikePrediction(userId, existing.bikeId);

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -1367,6 +1367,10 @@ export const resolvers = {
       const SERVICE_CAP = 1000;
       const INSTALL_CAP = 1000;
 
+      // Defense-in-depth: even though bike ownership is pre-validated above,
+      // every sub-query redundantly filters by userId (directly where the
+      // column exists, or via the joined Component) so a future refactor
+      // that skips the ownership check above still can't leak cross-user data.
       const [rides, serviceLogs, installs] = await Promise.all([
         prisma.ride.findMany({
           where: {
@@ -1379,7 +1383,7 @@ export const resolvers = {
         }),
         prisma.serviceLog.findMany({
           where: {
-            component: { bikeId, ...(componentTypeFilter ?? {}) },
+            component: { bikeId, userId, ...(componentTypeFilter ?? {}) },
             ...(dateRange ? { performedAt: dateRange } : {}),
           },
           include: { component: true },
@@ -1388,6 +1392,7 @@ export const resolvers = {
         }),
         prisma.bikeComponentInstall.findMany({
           where: {
+            userId,
             bikeId,
             ...(componentTypeFilter ? { component: componentTypeFilter } : {}),
             ...(dateRange
@@ -2561,6 +2566,25 @@ export const resolvers = {
         }
       }
 
+      // Chronology guard: a component can't come off a bike before it was
+      // installed. Compare against the effective install anchor (the new
+      // value if we're also updating installedAt in the same mutation,
+      // otherwise the persisted value).
+      if (data.removedAt instanceof Date) {
+        const effectiveInstalledAt =
+          data.installedAt instanceof Date ? data.installedAt : existing.installedAt;
+        if (data.removedAt < effectiveInstalledAt) {
+          throw new Error('Removal date cannot be before install date');
+        }
+      }
+
+      // Nothing to change — skip the Prisma round-trip and the pair of cache
+      // invalidations. Callers get back the current row, matching the
+      // semantic "update with no fields is a no-op."
+      if (Object.keys(data).length === 0) {
+        return existing;
+      }
+
       if (existing.bikeId) await invalidateBikePrediction(userId, existing.bikeId);
 
       const updated = await prisma.bikeComponentInstall.update({
@@ -3658,6 +3682,23 @@ export const resolvers = {
       }
 
       // Parse optional installedAt for the replacement. Default: today.
+      //
+      // This single Date is used as every timestamp inside the transaction —
+      // the new component's install anchor, the old component's retiredAt,
+      // the closing removedAt on the old install row, and the new install
+      // row's installedAt. Intentional: a replacement is a single event, so
+      // the "old came off" and "new went on" moments must line up.
+      //
+      // One subtle consequence: if the user backdates the replacement (e.g.
+      // "I actually swapped forks 3 months ago"), the old component's
+      // retiredAt also moves back 3 months. Any service logs or wear
+      // progression the user recorded after that date for the old component
+      // will look chronologically off — they'll pre-date the component's own
+      // retirement. This is correct for the common case (you stopped using
+      // the old part when you took it off) and the alternative (keeping
+      // retiredAt = now while backdating everything else) would leave the
+      // component looking active-yet-uninstalled for 3 months. Documenting
+      // here rather than complicating the UI around it.
       const now = new Date();
       let installedAt = now;
       if (input.installedAt) {
@@ -4790,6 +4831,8 @@ export const resolvers = {
       component.location ?? 'NONE',
     serviceLogs: (component: ComponentModel, _args: unknown, ctx: GraphQLContext) =>
       ctx.loaders.serviceLogsByComponentId.load(component.id),
+    latestServiceLog: (component: ComponentModel, _args: unknown, ctx: GraphQLContext) =>
+      ctx.loaders.latestServiceLogByComponentId.load(component.id),
     pairedComponent: async (component: ComponentModel) => {
       if (!component.pairGroupId) return null;
       return prisma.component.findFirst({

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -119,6 +119,7 @@ type ReplaceComponentInputGQL = {
   alsoReplacePair?: boolean | null;
   pairBrand?: string | null;
   pairModel?: string | null;
+  installedAt?: string | null;
 };
 
 type NewComponentInputGQL = {
@@ -135,6 +136,7 @@ type InstallComponentInputGQL = {
   alsoReplacePair?: boolean | null;
   pairNewComponent?: NewComponentInputGQL | null;
   noteText?: string | null;
+  installedAt?: string | null;
 };
 
 type SwapComponentsInputGQL = {
@@ -143,6 +145,7 @@ type SwapComponentsInputGQL = {
   bikeIdB: string;
   slotKeyB: string;
   noteText?: string | null;
+  installedAt?: string | null;
 };
 
 type AddBikeNoteInputGQL = {
@@ -177,6 +180,7 @@ type AddBikeInputGQL = {
   motorTorqueNm?: number | null;
   batteryWh?: number | null;
   acquisitionCondition?: AcquisitionCondition | null;
+  acquisitionDate?: string | null;
   spokesComponents?: SpokesComponentsInputGQL | null;
   fork?: BikeComponentInputGQL | null;
   shock?: BikeComponentInputGQL | null;
@@ -210,6 +214,7 @@ type AddComponentInputGQL = {
   isStock?: boolean | null;
   hoursUsed?: number | null;
   serviceDueAtHours?: number | null;
+  installedAt?: string | null;
 };
 
 type UpdateComponentInputGQL = {
@@ -259,6 +264,53 @@ const MAX_LABEL_LEN = 120;
  */
 const cleanText = (v: unknown, max = MAX_LABEL_LEN) =>
   typeof v === 'string' ? (v.trim().slice(0, max) || null) : null;
+
+/**
+ * Re-anchor a component to whatever its newest remaining ServiceLog is,
+ * and recompute hoursUsed from the ride log.
+ *
+ * Called when an edit or delete might have moved the "most recent service"
+ * anchor for a component. `hoursUsed` represents hours accumulated since
+ * the last anchor, so anchor changes require recomputing it from scratch —
+ * otherwise the counter keeps the old window of rides baked in.
+ *
+ * Uses ride duration on the component's current bike as the wear proxy,
+ * matching how `incrementBikeComponentHours` ticks the counter on ride upload.
+ */
+async function recomputeComponentAfterServiceChange(
+  tx: Prisma.TransactionClient,
+  componentId: string
+): Promise<void> {
+  const component = await tx.component.findUnique({
+    where: { id: componentId },
+    select: { id: true, bikeId: true },
+  });
+  if (!component) return;
+
+  const latestLog = await tx.serviceLog.findFirst({
+    where: { componentId },
+    orderBy: [{ performedAt: 'desc' }, { createdAt: 'desc' }],
+    select: { performedAt: true },
+  });
+  const newAnchor = latestLog?.performedAt ?? null;
+
+  let hoursUsed = 0;
+  if (component.bikeId) {
+    const { _sum } = await tx.ride.aggregate({
+      where: {
+        bikeId: component.bikeId,
+        ...(newAnchor ? { startTime: { gte: newAnchor } } : {}),
+      },
+      _sum: { durationSeconds: true },
+    });
+    hoursUsed = (_sum.durationSeconds ?? 0) / 3600;
+  }
+
+  await tx.component.update({
+    where: { id: componentId },
+    data: { lastServicedAt: newAnchor, hoursUsed },
+  });
+}
 
 const componentLabelMap: Partial<Record<ComponentType, string>> = {
   FORK: 'Fork',
@@ -479,6 +531,13 @@ export async function buildBikeComponents(
     userOverrides?: Partial<Record<BikeComponentKey, BikeComponentInputGQL | null>>;
     pairedComponentConfigs?: PairedComponentConfigInputGQL[] | null;
     acquisitionCondition?: string;
+    /**
+     * When the user said they acquired the bike. Used as the installedAt for
+     * all stock + user-override components, matching how a real-world bike
+     * would have those parts installed on the acquisition day.
+     * Defaults to now when unspecified (keeps pre-acquisitionDate bikes working).
+     */
+    installedAt?: Date;
   }
 ): Promise<void> {
   const { bikeId, userId, bikeSpec, spokesComponents, userOverrides, pairedComponentConfigs } = opts;
@@ -495,7 +554,10 @@ export async function buildBikeComponents(
   const baselineWearPercent = 0;
   const baselineMethod: BaselineMethod = 'DEFAULT';
   const baselineConfidence: BaselineConfidence = 'LOW';  // Until refined by user
-  const baselineSetAt = new Date();
+  // If the user told us when they acquired the bike, use that as the install
+  // anchor. Otherwise today — preserves old behavior for callers that don't
+  // pass the field.
+  const baselineSetAt = opts.installedAt ?? new Date();
 
   // Get applicable components from the catalog
   const applicableComponents = getApplicableComponents(bikeSpec);
@@ -1761,6 +1823,16 @@ export const resolvers = {
       // Acquisition condition for baseline tracking (default to USED for backwards compatibility)
       const acquisitionCondition: AcquisitionCondition = input.acquisitionCondition ?? 'USED';
 
+      // Optional: when the user says they got the bike. Drives the install
+      // date stamped onto every stock component + BikeComponentInstall row.
+      let acquisitionDate: Date | null = null;
+      if (input.acquisitionDate) {
+        const parsed = parseISO(input.acquisitionDate);
+        if (isNaN(parsed.getTime())) throw new Error('Invalid acquisitionDate');
+        if (parsed > new Date()) throw new Error('acquisitionDate cannot be in the future');
+        acquisitionDate = parsed;
+      }
+
       // Derive BikeSpec for dynamic component creation
       const bikeSpec = deriveBikeSpec(
         { travelForkMm, travelShockMm },
@@ -1795,6 +1867,7 @@ export const resolvers = {
             motorTorqueNm,
             batteryWh,
             acquisitionCondition,
+            acquisitionDate,
             userId,
           },
         });
@@ -1813,6 +1886,7 @@ export const resolvers = {
             pivotBearings: input.pivotBearings,
           },
           pairedComponentConfigs: input.pairedComponentConfigs,
+          installedAt: acquisitionDate ?? undefined,
         });
 
         // Create default notification preference for the new bike
@@ -2048,6 +2122,16 @@ export const resolvers = {
         const location = input.location ?? 'NONE';
         const status = bikeId ? 'INSTALLED' : 'INVENTORY';
 
+        // Honor user-provided install date. Default: today. Null when this is
+        // a spare (no bike) — the component doesn't need an install anchor.
+        let installedAt: Date | null = bikeId ? now : null;
+        if (bikeId && input.installedAt) {
+          const parsed = parseISO(input.installedAt);
+          if (isNaN(parsed.getTime())) throw new Error('Invalid installedAt date');
+          if (parsed > now) throw new Error('Install date cannot be in the future');
+          installedAt = parsed;
+        }
+
         const component = await prisma.$transaction(async (tx) => {
           const created = await tx.component.create({
             data: {
@@ -2056,20 +2140,20 @@ export const resolvers = {
               location,
               bikeId: bikeId ?? null,
               userId,
-              installedAt: bikeId ? now : null,
+              installedAt,
               status,
             },
           });
 
           // Create install record if component is being installed on a bike
-          if (bikeId) {
+          if (bikeId && installedAt) {
             await tx.bikeComponentInstall.create({
               data: {
                 userId,
                 bikeId,
                 componentId: created.id,
                 slotKey: getSlotKey(type, location),
-                installedAt: now,
+                installedAt,
               },
             });
 
@@ -2077,7 +2161,7 @@ export const resolvers = {
             await tx.serviceLog.create({
               data: {
                 componentId: created.id,
-                performedAt: now,
+                performedAt: installedAt,
                 hoursAtService: 0,
               },
             });
@@ -2291,6 +2375,232 @@ export const resolvers = {
       clearServiceNotificationLogs(input.componentId, userId).catch((err) => logError('clearServiceNotificationLogs', err));
 
       return serviceLog;
+    },
+
+    updateServiceLog: async (
+      _: unknown,
+      {
+        id,
+        input,
+      }: {
+        id: string;
+        input: { performedAt?: string | null; notes?: string | null; hoursAtService?: number | null };
+      },
+      ctx: GraphQLContext
+    ) => {
+      const userId = requireUserId(ctx);
+
+      const rateLimit = await checkMutationRateLimit('updateServiceLog', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(`Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`, {
+          extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
+        });
+      }
+
+      // SECURITY: fetch log + component owner/bike before touching input.
+      const existing = await prisma.serviceLog.findUnique({
+        where: { id },
+        include: { component: { select: { id: true, userId: true, bikeId: true } } },
+      });
+      if (!existing || existing.component.userId !== userId) {
+        throw new Error('Service log not found');
+      }
+
+      // Validate input after auth.
+      let newPerformedAt: Date | undefined;
+      if (input.performedAt !== undefined && input.performedAt !== null) {
+        newPerformedAt = parseISO(input.performedAt);
+        if (isNaN(newPerformedAt.getTime())) throw new Error('Invalid date format');
+        if (newPerformedAt > new Date()) throw new Error('Service date cannot be in the future');
+      }
+      const newNotes =
+        input.notes === undefined ? undefined : input.notes === null ? null : cleanText(input.notes, MAX_NOTES_LEN);
+      let newHoursAtService: number | undefined;
+      if (input.hoursAtService !== undefined && input.hoursAtService !== null) {
+        if (!Number.isFinite(input.hoursAtService) || input.hoursAtService < 0) {
+          throw new Error('hoursAtService must be a non-negative number');
+        }
+        newHoursAtService = input.hoursAtService;
+      }
+
+      const bikeId = existing.component.bikeId;
+      if (bikeId) await invalidateBikePrediction(userId, bikeId);
+
+      const updated = await prisma.$transaction(async (tx) => {
+        // Is this row currently the most recent for its component?
+        const currentLatest = await tx.serviceLog.findFirst({
+          where: { componentId: existing.component.id },
+          orderBy: [{ performedAt: 'desc' }, { createdAt: 'desc' }],
+          select: { id: true, performedAt: true },
+        });
+        const wasLatest = currentLatest?.id === id;
+
+        const updatedLog = await tx.serviceLog.update({
+          where: { id },
+          data: {
+            ...(newPerformedAt ? { performedAt: newPerformedAt } : {}),
+            ...(newNotes !== undefined ? { notes: newNotes } : {}),
+            ...(newHoursAtService !== undefined ? { hoursAtService: newHoursAtService } : {}),
+          },
+        });
+
+        // Recompute anchor + hoursUsed if this edit could have moved the anchor:
+        //   - was the latest AND date/order changed
+        //   - was NOT the latest but new date makes it the latest
+        const dateChanged = !!newPerformedAt;
+        if (wasLatest || dateChanged) {
+          await recomputeComponentAfterServiceChange(tx, existing.component.id);
+        }
+
+        return updatedLog;
+      });
+
+      if (bikeId) await invalidateBikePrediction(userId, bikeId);
+
+      return updated;
+    },
+
+    deleteServiceLog: async (
+      _: unknown,
+      { id }: { id: string },
+      ctx: GraphQLContext
+    ) => {
+      const userId = requireUserId(ctx);
+
+      const rateLimit = await checkMutationRateLimit('deleteServiceLog', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(`Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`, {
+          extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
+        });
+      }
+
+      const existing = await prisma.serviceLog.findUnique({
+        where: { id },
+        include: { component: { select: { id: true, userId: true, bikeId: true } } },
+      });
+      if (!existing || existing.component.userId !== userId) {
+        throw new Error('Service log not found');
+      }
+
+      const componentId = existing.component.id;
+      const bikeId = existing.component.bikeId;
+
+      if (bikeId) await invalidateBikePrediction(userId, bikeId);
+
+      await prisma.$transaction(async (tx) => {
+        const currentLatest = await tx.serviceLog.findFirst({
+          where: { componentId },
+          orderBy: [{ performedAt: 'desc' }, { createdAt: 'desc' }],
+          select: { id: true },
+        });
+        const wasLatest = currentLatest?.id === id;
+
+        await tx.serviceLog.delete({ where: { id } });
+
+        if (wasLatest) {
+          await recomputeComponentAfterServiceChange(tx, componentId);
+        }
+      });
+
+      if (bikeId) await invalidateBikePrediction(userId, bikeId);
+
+      // Reset notification dedup — if removing the latest service makes the
+      // component "overdue" again, it should be free to re-alert.
+      clearServiceNotificationLogs(componentId, userId).catch((err) =>
+        logError('clearServiceNotificationLogs', err)
+      );
+
+      return true;
+    },
+
+    updateBikeComponentInstall: async (
+      _: unknown,
+      {
+        id,
+        input,
+      }: {
+        id: string;
+        input: { installedAt?: string | null; removedAt?: string | null };
+      },
+      ctx: GraphQLContext
+    ) => {
+      const userId = requireUserId(ctx);
+
+      const rateLimit = await checkMutationRateLimit('updateBikeComponentInstall', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(`Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`, {
+          extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
+        });
+      }
+
+      const existing = await prisma.bikeComponentInstall.findUnique({
+        where: { id },
+      });
+      if (!existing || existing.userId !== userId) {
+        throw new Error('Install record not found');
+      }
+
+      const now = new Date();
+      const data: Prisma.BikeComponentInstallUpdateInput = {};
+
+      if (input.installedAt !== undefined && input.installedAt !== null) {
+        const parsed = parseISO(input.installedAt);
+        if (isNaN(parsed.getTime())) throw new Error('Invalid installedAt date');
+        if (parsed > now) throw new Error('Install date cannot be in the future');
+        data.installedAt = parsed;
+      }
+
+      if (input.removedAt !== undefined) {
+        if (input.removedAt === null) {
+          data.removedAt = null;
+        } else {
+          const parsed = parseISO(input.removedAt);
+          if (isNaN(parsed.getTime())) throw new Error('Invalid removedAt date');
+          if (parsed > now) throw new Error('Remove date cannot be in the future');
+          data.removedAt = parsed;
+        }
+      }
+
+      if (existing.bikeId) await invalidateBikePrediction(userId, existing.bikeId);
+
+      const updated = await prisma.bikeComponentInstall.update({
+        where: { id },
+        data,
+      });
+
+      if (existing.bikeId) await invalidateBikePrediction(userId, existing.bikeId);
+
+      return updated;
+    },
+
+    deleteBikeComponentInstall: async (
+      _: unknown,
+      { id }: { id: string },
+      ctx: GraphQLContext
+    ) => {
+      const userId = requireUserId(ctx);
+
+      const rateLimit = await checkMutationRateLimit('deleteBikeComponentInstall', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(`Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`, {
+          extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
+        });
+      }
+
+      const existing = await prisma.bikeComponentInstall.findUnique({
+        where: { id },
+      });
+      if (!existing || existing.userId !== userId) {
+        throw new Error('Install record not found');
+      }
+
+      if (existing.bikeId) await invalidateBikePrediction(userId, existing.bikeId);
+
+      await prisma.bikeComponentInstall.delete({ where: { id } });
+
+      if (existing.bikeId) await invalidateBikePrediction(userId, existing.bikeId);
+
+      return true;
     },
 
     snoozeComponent: async (
@@ -3347,20 +3657,38 @@ export const resolvers = {
         throw new GraphQLError('Component not found', { extensions: { code: 'NOT_FOUND' } });
       }
 
+      // Parse optional installedAt for the replacement. Default: today.
+      const now = new Date();
+      let installedAt = now;
+      if (input.installedAt) {
+        const parsed = parseISO(input.installedAt);
+        if (isNaN(parsed.getTime())) throw new Error('Invalid installedAt date');
+        if (parsed > now) throw new Error('Install date cannot be in the future');
+        installedAt = parsed;
+      }
+
       const replacedComponents: ComponentModel[] = [];
       const newComponents: ComponentModel[] = [];
 
       await prisma.$transaction(async (tx) => {
-        const now = new Date();
         const newPairGroupId = createId();
 
         // Retire the existing component
         // Set bikeId to null to avoid unique constraint violation when creating replacement
         const retired = await tx.component.update({
           where: { id: componentId },
-          data: { retiredAt: now, bikeId: null },
+          data: { retiredAt: installedAt, bikeId: null },
         });
         replacedComponents.push(retired);
+
+        // Mark any open install record for the retired component as removed.
+        // Without this, BikeHistory shows the component as still installed.
+        if (existingComponent.bikeId) {
+          await tx.bikeComponentInstall.updateMany({
+            where: { componentId, removedAt: null },
+            data: { removedAt: installedAt },
+          });
+        }
 
         // Create the new component
         const newComponent = await tx.component.create({
@@ -3373,21 +3701,35 @@ export const resolvers = {
             model: newModel,
             isStock: false,
             hoursUsed: 0,
-            installedAt: now,
+            installedAt,
             baselineWearPercent: 0,
             baselineMethod: 'DEFAULT',
             baselineConfidence: 'HIGH',
-            baselineSetAt: now,
+            baselineSetAt: installedAt,
             pairGroupId: requiresPairing(existingComponent.type) ? newPairGroupId : null,
           },
         });
         newComponents.push(newComponent);
 
+        // Create install record for the new component (previously skipped —
+        // meant BikeHistory couldn't show replacement installs).
+        if (existingComponent.bikeId) {
+          await tx.bikeComponentInstall.create({
+            data: {
+              userId,
+              bikeId: existingComponent.bikeId,
+              componentId: newComponent.id,
+              slotKey: getSlotKey(existingComponent.type, existingComponent.location ?? 'NONE'),
+              installedAt,
+            },
+          });
+        }
+
         // Create initial service log so predictions start from installation date
         await tx.serviceLog.create({
           data: {
             componentId: newComponent.id,
-            performedAt: now,
+            performedAt: installedAt,
             hoursAtService: 0,
           },
         });
@@ -3414,9 +3756,16 @@ export const resolvers = {
             // Set bikeId to null to avoid unique constraint violation when creating replacement
             const retiredPair = await tx.component.update({
               where: { id: pairedComponent.id },
-              data: { retiredAt: now, bikeId: null },
+              data: { retiredAt: installedAt, bikeId: null },
             });
             replacedComponents.push(retiredPair);
+
+            if (pairedComponent.bikeId) {
+              await tx.bikeComponentInstall.updateMany({
+                where: { componentId: pairedComponent.id, removedAt: null },
+                data: { removedAt: installedAt },
+              });
+            }
 
             // Create the new paired component
             const newPairedComponent = await tx.component.create({
@@ -3429,21 +3778,33 @@ export const resolvers = {
                 model: pairModel || newModel,
                 isStock: false,
                 hoursUsed: 0,
-                installedAt: now,
+                installedAt,
                 baselineWearPercent: 0,
                 baselineMethod: 'DEFAULT',
                 baselineConfidence: 'HIGH',
-                baselineSetAt: now,
+                baselineSetAt: installedAt,
                 pairGroupId: newPairGroupId,
               },
             });
             newComponents.push(newPairedComponent);
 
+            if (pairedComponent.bikeId) {
+              await tx.bikeComponentInstall.create({
+                data: {
+                  userId,
+                  bikeId: pairedComponent.bikeId,
+                  componentId: newPairedComponent.id,
+                  slotKey: getSlotKey(pairedComponent.type, pairedComponent.location ?? 'NONE'),
+                  installedAt,
+                },
+              });
+            }
+
             // Create initial service log for paired component
             await tx.serviceLog.create({
               data: {
                 componentId: newPairedComponent.id,
-                performedAt: now,
+                performedAt: installedAt,
                 hoursAtService: 0,
               },
             });
@@ -3532,8 +3893,20 @@ export const resolvers = {
       let createdNote: { id: string; bikeId: string; userId: string; text: string; noteType: string; createdAt: Date; snapshot: unknown; snapshotBefore: unknown; snapshotAfter: unknown; installEventId: string | null } | null = null;
       const bikesToInvalidate = new Set<string>([bikeId]);
 
-      await prisma.$transaction(async (tx) => {
+      // Honor user-specified install date. Default to today if omitted. All
+      // derived timestamps inside the transaction use this same value so the
+      // install/remove pair appears at a single moment in the history.
+      const resolvedInstalledAt = (() => {
         const now = new Date();
+        if (!input.installedAt) return now;
+        const parsed = parseISO(input.installedAt);
+        if (isNaN(parsed.getTime())) throw new Error('Invalid installedAt date');
+        if (parsed > now) throw new Error('Install date cannot be in the future');
+        return parsed;
+      })();
+
+      await prisma.$transaction(async (tx) => {
+        const now = resolvedInstalledAt;
 
         // Capture snapshot BEFORE the change if noteText is provided
         let snapshotBefore: SetupSnapshot | null = null;
@@ -3859,8 +4232,19 @@ export const resolvers = {
       let createdNoteA: BikeNoteRecord | null = null;
       let createdNoteB: BikeNoteRecord | null = null;
 
-      await prisma.$transaction(async (tx) => {
+      // Honor user-specified swap date. All remove/install timestamps use the
+      // same value so the history pair renders at one moment.
+      const resolvedInstalledAt = (() => {
         const now = new Date();
+        if (!input.installedAt) return now;
+        const parsed = parseISO(input.installedAt);
+        if (isNaN(parsed.getTime())) throw new Error('Invalid installedAt date');
+        if (parsed > now) throw new Error('Install date cannot be in the future');
+        return parsed;
+      })();
+
+      await prisma.$transaction(async (tx) => {
+        const now = resolvedInstalledAt;
 
         // Capture snapshots BEFORE the swap if noteText is provided
         let snapshotBeforeA: SetupSnapshot | null = null;

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -542,8 +542,22 @@ export const typeDefs = gql`
     hoursAtService: Float
   }
 
+  """
+  Patch fields on a BikeComponentInstall row.
+
+  **Null handling is asymmetric**, mirroring the underlying Prisma schema:
+
+  - \`installedAt\`: an ISO date string updates the value. \`null\` or omitted
+    is a no-op. You cannot clear this field — \`installedAt\` is required at
+    the database level.
+  - \`removedAt\`: an ISO date string updates the value. Explicit \`null\`
+    **clears** the field (the component is no longer marked as removed).
+    Omitting the key is a no-op.
+  """
   input UpdateBikeComponentInstallInput {
+    """ISO date string. Pass to update; null or omitted is ignored (cannot be cleared)."""
     installedAt: String
+    """ISO date string to set, or explicit null to clear."""
     removedAt: String
   }
 

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -244,6 +244,10 @@ export const typeDefs = gql`
     baselineSetAt: String
     lastServicedAt: String
     serviceLogs: [ServiceLog!]!
+    # The single most recent ServiceLog — lets clients that only render
+    # "last serviced" metadata avoid pulling a component's entire service
+    # history over the wire.
+    latestServiceLog: ServiceLog
     createdAt: String!
     updatedAt: String!
     # Front/rear pairing support

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -326,6 +326,7 @@ export const typeDefs = gql`
     motorTorqueNm: Int
     batteryWh: Int
     acquisitionCondition: AcquisitionCondition
+    acquisitionDate: String
     status: BikeStatus!
     retiredAt: String
     fork: Component
@@ -452,6 +453,7 @@ export const typeDefs = gql`
     motorTorqueNm: Int
     batteryWh: Int
     acquisitionCondition: AcquisitionCondition
+    acquisitionDate: String
     spokesComponents: SpokesComponentsInput
     fork: BikeComponentInput
     shock: BikeComponentInput
@@ -487,6 +489,7 @@ export const typeDefs = gql`
     motorPowerW: Int
     motorTorqueNm: Int
     batteryWh: Int
+    acquisitionDate: String
     spokesComponents: SpokesComponentsInput
     fork: BikeComponentInput
     shock: BikeComponentInput
@@ -504,6 +507,7 @@ export const typeDefs = gql`
     isStock: Boolean
     hoursUsed: Float
     serviceDueAtHours: Float
+    installedAt: String
   }
 
   input UpdateComponentInput {
@@ -526,6 +530,17 @@ export const typeDefs = gql`
     componentId: ID!
     notes: String
     performedAt: String
+  }
+
+  input UpdateServiceLogInput {
+    performedAt: String
+    notes: String
+    hoursAtService: Float
+  }
+
+  input UpdateBikeComponentInstallInput {
+    installedAt: String
+    removedAt: String
   }
 
   input ComponentBaselineInput {
@@ -704,6 +719,7 @@ export const typeDefs = gql`
     alsoReplacePair: Boolean
     pairBrand: String
     pairModel: String
+    installedAt: String
   }
 
   type ReplaceComponentResult {
@@ -734,6 +750,7 @@ export const typeDefs = gql`
     pairNewComponent: NewComponentInput
     # Optional note text for creating a SWAP note with before/after snapshots
     noteText: String
+    installedAt: String
   }
 
   type InstallComponentResult {
@@ -749,6 +766,7 @@ export const typeDefs = gql`
     slotKeyB: String!
     # Optional note text for creating SWAP notes with before/after snapshots
     noteText: String
+    installedAt: String
   }
 
   type SwapComponentsResult {
@@ -848,6 +866,8 @@ export const typeDefs = gql`
     deleteComponent(id: ID!): DeleteResult!
     logComponentService(id: ID!, performedAt: String): Component!
     logService(input: LogServiceInput!): ServiceLog!
+    updateServiceLog(id: ID!, input: UpdateServiceLogInput!): ServiceLog!
+    deleteServiceLog(id: ID!): Boolean!
     snoozeComponent(id: ID!, hours: Float): Component!
     createStravaGearMapping(input: CreateStravaGearMappingInput!): StravaGearMapping!
     deleteStravaGearMapping(id: ID!): DeleteResult!
@@ -871,6 +891,8 @@ export const typeDefs = gql`
     updateBikeNotificationPreference(input: UpdateBikeNotificationPreferenceInput!): BikeNotificationPreference!
     addBikeNote(input: AddBikeNoteInput!): BikeNote!
     deleteBikeNote(id: ID!): DeleteResult!
+    updateBikeComponentInstall(id: ID!, input: UpdateBikeComponentInstallInput!): BikeComponentInstall!
+    deleteBikeComponentInstall(id: ID!): Boolean!
     createCheckoutSession(plan: StripePlan!, platform: CheckoutPlatform): CheckoutSessionResult!
     createBillingPortalSession(platform: CheckoutPlatform): BillingPortalResult!
     selectBikeForDowngrade(bikeId: ID!): Bike!

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -947,6 +947,44 @@ export const typeDefs = gql`
     bikeId: ID
   }
 
+  enum ComponentInstallEventType {
+    INSTALLED
+    REMOVED
+  }
+
+  type ServiceEvent {
+    id: ID!
+    performedAt: String!
+    notes: String
+    hoursAtService: Float!
+    component: Component!
+  }
+
+  type ComponentInstallEvent {
+    id: ID!
+    eventType: ComponentInstallEventType!
+    occurredAt: String!
+    component: Component!
+  }
+
+  type BikeHistoryTotals {
+    rideCount: Int!
+    totalDistanceMeters: Float!
+    totalDurationSeconds: Int!
+    totalElevationGainMeters: Float!
+    serviceEventCount: Int!
+    installEventCount: Int!
+  }
+
+  type BikeHistoryPayload {
+    bike: Bike!
+    rides: [Ride!]!
+    serviceEvents: [ServiceEvent!]!
+    installs: [ComponentInstallEvent!]!
+    totals: BikeHistoryTotals!
+    truncated: Boolean!
+  }
+
   type Query {
     me: User
     user(id: ID!): User
@@ -962,5 +1000,6 @@ export const typeDefs = gql`
     servicePreferenceDefaults: [ServicePreferenceDefault!]!
     bikeNotes(bikeId: ID!, take: Int = 20, after: ID): BikeNotesPage!
     referralStats: ReferralStats!
+    bikeHistory(bikeId: ID!, startDate: String, endDate: String): BikeHistoryPayload!
   }
 `;

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -32,6 +32,14 @@ export const MUTATION_RATE_LIMITS = {
   logService: { windowSeconds: 60, maxRequests: 20 },
   /** logComponentService (reset hours): max 20 requests per minute per user */
   logComponentService: { windowSeconds: 60, maxRequests: 20 },
+  /** updateServiceLog: max 30 requests per minute per user */
+  updateServiceLog: { windowSeconds: 60, maxRequests: 30 },
+  /** deleteServiceLog: max 30 requests per minute per user */
+  deleteServiceLog: { windowSeconds: 60, maxRequests: 30 },
+  /** updateBikeComponentInstall: max 30 requests per minute per user */
+  updateBikeComponentInstall: { windowSeconds: 60, maxRequests: 30 },
+  /** deleteBikeComponentInstall: max 30 requests per minute per user */
+  deleteBikeComponentInstall: { windowSeconds: 60, maxRequests: 30 },
   /** logBulkComponentService (calibration): max 20 requests per minute per user */
   logBulkComponentService: { windowSeconds: 60, maxRequests: 20 },
   /** updateComponent: max 30 requests per minute per user */

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -40,6 +40,14 @@ export const MUTATION_RATE_LIMITS = {
   updateBikeComponentInstall: { windowSeconds: 60, maxRequests: 30 },
   /** deleteBikeComponentInstall: max 30 requests per minute per user */
   deleteBikeComponentInstall: { windowSeconds: 60, maxRequests: 30 },
+  /**
+   * bikeHistory query: max 60 requests per minute per user. Higher than
+   * mutations because it's a read (filter toggling, timeframe changes,
+   * cache-and-network refetches all hit it), but capped to prevent a
+   * polling loop from saturating the DB — each call fires up to three
+   * findMany queries returning ~4k rows combined.
+   */
+  bikeHistory: { windowSeconds: 60, maxRequests: 60 },
   /** logBulkComponentService (calibration): max 20 requests per minute per user */
   logBulkComponentService: { windowSeconds: 60, maxRequests: 20 },
   /** updateComponent: max 30 requests per minute per user */

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@react-oauth/google": "^0.13.4",
+    "@react-pdf/renderer": "^4.5.1",
     "@sentry/react": "^10.48.0",
     "@vercel/analytics": "^2.0.1",
     "date-fns": "^4.1.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-﻿import type { ReactNode } from 'react';
+﻿import { lazy, Suspense, type ReactNode } from 'react';
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 
@@ -10,7 +10,12 @@ import Rides from './pages/Rides';
 import Settings from './pages/Settings';
 import Gear from './pages/Gear';
 import BikeDetail from './pages/BikeDetail';
-import BikeHistory from './pages/BikeHistory';
+
+// Lazy-loaded: only users who navigate to bike history pay for this chunk
+// (which further pulls @react-pdf/renderer's fontkit/crypto tree when the
+// Export button is clicked). Keeps the main bundle lean for the 99% of
+// sessions that never open it.
+const BikeHistory = lazy(() => import('./pages/BikeHistory'));
 import Admin from './pages/Admin';
 import AuthComplete from './pages/AuthComplete';
 import BetaTesterWaitlist from './pages/BetaTesterWaitlist';
@@ -96,7 +101,16 @@ function AppRoutes() {
           <Route path="/rides" element={<ProtectedRoute><Rides /></ProtectedRoute>} />
           <Route path="/gear" element={<ProtectedRoute><Gear /></ProtectedRoute>} />
           <Route path="/gear/:bikeId" element={<ProtectedRoute><BikeDetail /></ProtectedRoute>} />
-          <Route path="/gear/:bikeId/history" element={<ProtectedRoute><BikeHistory /></ProtectedRoute>} />
+          <Route
+            path="/gear/:bikeId/history"
+            element={
+              <ProtectedRoute>
+                <Suspense fallback={<div className="p-6 text-muted">Loading history…</div>}>
+                  <BikeHistory />
+                </Suspense>
+              </ProtectedRoute>
+            }
+          />
           <Route path="/settings" element={<ProtectedRoute><Settings /></ProtectedRoute>} />
           <Route path="/admin" element={<ProtectedRoute><Admin /></ProtectedRoute>} />
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,6 +10,7 @@ import Rides from './pages/Rides';
 import Settings from './pages/Settings';
 import Gear from './pages/Gear';
 import BikeDetail from './pages/BikeDetail';
+import BikeHistory from './pages/BikeHistory';
 import Admin from './pages/Admin';
 import AuthComplete from './pages/AuthComplete';
 import BetaTesterWaitlist from './pages/BetaTesterWaitlist';
@@ -95,6 +96,7 @@ function AppRoutes() {
           <Route path="/rides" element={<ProtectedRoute><Rides /></ProtectedRoute>} />
           <Route path="/gear" element={<ProtectedRoute><Gear /></ProtectedRoute>} />
           <Route path="/gear/:bikeId" element={<ProtectedRoute><BikeDetail /></ProtectedRoute>} />
+          <Route path="/gear/:bikeId/history" element={<ProtectedRoute><BikeHistory /></ProtectedRoute>} />
           <Route path="/settings" element={<ProtectedRoute><Settings /></ProtectedRoute>} />
           <Route path="/admin" element={<ProtectedRoute><Admin /></ProtectedRoute>} />
 

--- a/apps/web/src/components/BikeForm.tsx
+++ b/apps/web/src/components/BikeForm.tsx
@@ -156,6 +156,9 @@ export function BikeForm({
   const [form, setForm] = useState<BikeFormValues>(initial);
   const [showManualEntry, setShowManualEntry] = useState(false);
   const [spokesDetails, setSpokesDetails] = useState<SpokesBikeDetails | null>(null);
+  const [acquisitionDate, setAcquisitionDate] = useState<string>(
+    initial.acquisitionDate ? initial.acquisitionDate.slice(0, 10) : ''
+  );
   const [acquisitionCondition, setAcquisitionCondition] = useState<AcquisitionCondition | null>(
     initial.acquisitionCondition ?? (mode === 'create' ? 'NEW' : null)
   );
@@ -325,6 +328,7 @@ export function BikeForm({
     const finalForm: BikeFormValues = {
       ...form,
       acquisitionCondition: acquisitionCondition ?? 'NEW',
+      acquisitionDate: acquisitionDate ? new Date(acquisitionDate).toISOString() : null,
       spokesComponents: filterNonNullComponents(spokesComponents),
       // Default component state - backend will create actual components
       components: {
@@ -739,6 +743,8 @@ export function BikeForm({
       <WearStartStep
         selected={acquisitionCondition}
         onSelect={setAcquisitionCondition}
+        acquisitionDate={acquisitionDate}
+        onAcquisitionDateChange={setAcquisitionDate}
         onBack={handleBackToStep2}
         onSubmit={handleCreateSubmit}
         submitting={submitting}

--- a/apps/web/src/components/BikeForm.tsx
+++ b/apps/web/src/components/BikeForm.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/utils/bikeFormHelpers';
 import { WearStartStep } from './WearStartStep';
 import { parseTravelFromDescription, type AcquisitionCondition } from '@loam/shared';
+import { dateInputToIsoNoon } from '@/lib/format';
 
 /**
  * Props for ComponentRow - memoized to prevent re-renders on sibling changes
@@ -328,7 +329,7 @@ export function BikeForm({
     const finalForm: BikeFormValues = {
       ...form,
       acquisitionCondition: acquisitionCondition ?? 'NEW',
-      acquisitionDate: acquisitionDate ? new Date(acquisitionDate).toISOString() : null,
+      acquisitionDate: acquisitionDate ? dateInputToIsoNoon(acquisitionDate) : null,
       spokesComponents: filterNonNullComponents(spokesComponents),
       // Default component state - backend will create actual components
       components: {

--- a/apps/web/src/components/ComponentBaselineCard.test.tsx
+++ b/apps/web/src/components/ComponentBaselineCard.test.tsx
@@ -2,9 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ComponentBaselineCard } from './ComponentBaselineCard';
 import type { ComponentBaseline } from '@loam/shared';
+import { todayDateInput } from '../lib/format';
 
-// Get today's date in YYYY-MM-DD format
-const getTodayDate = () => new Date().toISOString().split('T')[0];
+// Match the component's behavior — local date, not UTC. See todayDateInput.
+const getTodayDate = () => todayDateInput();
 
 describe('ComponentBaselineCard', () => {
   const defaultBaseline: ComponentBaseline = {

--- a/apps/web/src/components/ComponentBaselineCard.tsx
+++ b/apps/web/src/components/ComponentBaselineCard.tsx
@@ -3,6 +3,7 @@ import {
   type ComponentBaseline,
   BASELINE_WEAR_SNAP_POINTS,
 } from '@loam/shared';
+import { todayDateInput } from '../lib/format';
 
 interface ComponentBaselineCardProps {
   componentType: string;
@@ -132,7 +133,7 @@ export function ComponentBaselineCard({
             type="date"
             value={lastServicedAt}
             onChange={(e) => handleDateChange(e.target.value)}
-            max={new Date().toISOString().split('T')[0]}
+            max={todayDateInput()}
             className="w-full px-3 py-2 rounded-lg border border-app bg-surface text-primary focus:border-accent focus:ring-1 focus:ring-accent outline-none"
           />
           <p className="text-xs text-muted">

--- a/apps/web/src/components/RideCard.tsx
+++ b/apps/web/src/components/RideCard.tsx
@@ -9,6 +9,8 @@ import { fmtDateTime, fmtDuration, fmtDistance, fmtElevation } from '../lib/form
 import { usePreferences } from '../hooks/usePreferences';
 import { Select } from './ui';
 import { getRideSource, SOURCE_LABELS } from '../utils/rideSource';
+import WeatherBadge from './WeatherBadge';
+import type { RideWeather } from '../models/Ride';
 
 type Ride = {
   id: string;
@@ -25,6 +27,7 @@ type Ride = {
   notes?: string | null;
   trailSystem?: string | null;
   location?: string | null;
+  weather?: RideWeather | null;
 };
 
 type Bike = {
@@ -111,6 +114,11 @@ export default function RideCard({ ride, bikes = [] }: RideCardProps) {
             <span className="meta-item">{fmtElevation(ride.elevationGainMeters)}</span>
             {typeof ride.averageHr === 'number' && (
               <span className="meta-item">{ride.averageHr} bpm</span>
+            )}
+            {ride.weather && (
+              <span className="meta-item">
+                <WeatherBadge weather={ride.weather} distanceUnit={distanceUnit} />
+              </span>
             )}
           </div>
 

--- a/apps/web/src/components/RideStatsCard/index.tsx
+++ b/apps/web/src/components/RideStatsCard/index.tsx
@@ -239,7 +239,7 @@ export default function RideStatsCard({ showHeading = true, rides: externalRides
       {truncated && (
         <p className="text-xs text-muted italic px-4 pb-2">
           Showing stats based on your most recent {MAX_RIDES_FOR_STATS} rides.
-          Weather totals cover your full history.
+          Weather totals cover the full selected timeframe.
         </p>
       )}
 

--- a/apps/web/src/components/WearStartStep.test.tsx
+++ b/apps/web/src/components/WearStartStep.test.tsx
@@ -7,6 +7,8 @@ describe('WearStartStep', () => {
   const defaultProps = {
     selected: null,
     onSelect: vi.fn(),
+    acquisitionDate: '',
+    onAcquisitionDateChange: vi.fn(),
     onBack: vi.fn(),
     onSubmit: vi.fn(),
     submitting: false,

--- a/apps/web/src/components/WearStartStep.tsx
+++ b/apps/web/src/components/WearStartStep.tsx
@@ -5,6 +5,8 @@ import type { LucideIcon } from 'lucide-react';
 interface WearStartStepProps {
   selected: AcquisitionCondition | null;
   onSelect: (condition: AcquisitionCondition) => void;
+  acquisitionDate: string;
+  onAcquisitionDateChange: (value: string) => void;
   onBack: () => void;
   onSubmit: () => void;
   submitting: boolean;
@@ -40,10 +42,13 @@ const STOCK_OPTIONS: StockOption[] = [
 export function WearStartStep({
   selected,
   onSelect,
+  acquisitionDate,
+  onAcquisitionDateChange,
   onBack,
   onSubmit,
   submitting,
 }: WearStartStepProps) {
+  const todayIso = new Date().toISOString().slice(0, 10);
   return (
     <div className="bg-surface border border-app rounded-xl shadow p-6 space-y-6">
       <div>
@@ -89,6 +94,23 @@ export function WearStartStep({
             </div>
           </button>
         ))}
+      </div>
+
+      <div className="border-t border-app pt-4">
+        <label htmlFor="acquisition-date" className="block text-sm font-medium text-primary mb-1">
+          When did you get this bike?
+        </label>
+        <p className="text-xs text-muted mb-2">
+          Sets the "installed" date for every stock component. Leave blank to use today.
+        </p>
+        <input
+          id="acquisition-date"
+          type="date"
+          value={acquisitionDate}
+          max={todayIso}
+          onChange={(e) => onAcquisitionDateChange(e.target.value)}
+          className="w-full px-3 py-2 rounded-lg border border-app bg-transparent text-sm text-primary focus:outline-none focus:border-accent"
+        />
       </div>
 
       <div className="flex justify-between pt-2">

--- a/apps/web/src/components/WearStartStep.tsx
+++ b/apps/web/src/components/WearStartStep.tsx
@@ -1,6 +1,7 @@
 import { type AcquisitionCondition } from '@loam/shared';
 import { Sparkles, Clock } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import { todayDateInput } from '@/lib/format';
 
 interface WearStartStepProps {
   selected: AcquisitionCondition | null;
@@ -48,7 +49,7 @@ export function WearStartStep({
   onSubmit,
   submitting,
 }: WearStartStepProps) {
-  const todayIso = new Date().toISOString().slice(0, 10);
+  const todayIso = todayDateInput();
   return (
     <div className="bg-surface border border-app rounded-xl shadow p-6 space-y-6">
       <div>

--- a/apps/web/src/components/WeatherBadge.tsx
+++ b/apps/web/src/components/WeatherBadge.tsx
@@ -1,0 +1,42 @@
+import { renderConditionIcon, conditionTint, celsiusToFahrenheit } from '../lib/weather';
+import type { WeatherCondition } from '../models/Ride';
+
+type Weather = {
+  tempC: number;
+  condition: WeatherCondition;
+};
+
+type Props = {
+  weather?: Weather | null;
+  distanceUnit?: 'mi' | 'km';
+  /** Icon/text size. `small` for list rows, `medium` for summary cards. */
+  size?: 'small' | 'medium';
+};
+
+/**
+ * Compact condition-icon + temperature chip for ride cards and list rows.
+ * Renders nothing when weather is null so callers can drop it inline
+ * without guarding.
+ */
+export default function WeatherBadge({
+  weather,
+  distanceUnit = 'mi',
+  size = 'small',
+}: Props) {
+  if (!weather) return null;
+
+  const isImperial = distanceUnit === 'mi';
+  const temp = isImperial
+    ? `${Math.round(celsiusToFahrenheit(weather.tempC))}°`
+    : `${Math.round(weather.tempC)}°`;
+
+  const iconSize = size === 'small' ? 14 : 16;
+  const tint = conditionTint(weather.condition);
+
+  return (
+    <span className="inline-flex items-center gap-1 text-[color:var(--text-muted)]">
+      {renderConditionIcon(weather.condition, { size: iconSize, color: tint })}
+      <span className={size === 'small' ? 'text-xs' : 'text-sm'}>{temp}</span>
+    </span>
+  );
+}

--- a/apps/web/src/components/dashboard/CompactRideRow.tsx
+++ b/apps/web/src/components/dashboard/CompactRideRow.tsx
@@ -3,6 +3,8 @@ import { formatDurationCompact, formatRideDate } from '../../utils/formatters';
 import { getRideSource, SOURCE_LABELS } from '../../utils/rideSource';
 import { usePreferences } from '../../hooks/usePreferences';
 import EditRideModal from '../EditRideModal';
+import WeatherBadge from '../WeatherBadge';
+import type { RideWeather } from '../../models/Ride';
 
 interface Ride {
   id: string;
@@ -19,6 +21,7 @@ interface Ride {
   garminActivityId?: string | null;
   whoopWorkoutId?: string | null;
   bikeId?: string | null;
+  weather?: RideWeather | null;
 }
 
 interface CompactRideRowProps {
@@ -58,6 +61,12 @@ export function CompactRideRow({ ride, bikeName, onLinkBike }: CompactRideRowPro
             <span>{duration}</span>
             <span className="compact-ride-meta-sep">&bull;</span>
             <span>{climb} {climbUnit}</span>
+            {ride.weather && (
+              <>
+                <span className="compact-ride-meta-sep">&bull;</span>
+                <WeatherBadge weather={ride.weather} distanceUnit={distanceUnit} />
+              </>
+            )}
           </div>
           {bikeName ? (
             <div className="compact-ride-bike">

--- a/apps/web/src/components/dashboard/EditInstallModal.tsx
+++ b/apps/web/src/components/dashboard/EditInstallModal.tsx
@@ -127,7 +127,9 @@ export function EditInstallModal({ event, componentLabel, bikeId, onClose }: Edi
             </Button>
           ) : (
             <div className="flex items-center gap-2">
-              <span className="text-xs text-muted">Delete this install record?</span>
+              <span className="text-xs text-muted">
+                Delete both the install and removal events?
+              </span>
               <Button variant="primary" size="sm" onClick={handleDelete} disabled={busy}>
                 {busy ? 'Deleting…' : 'Yes, delete'}
               </Button>
@@ -154,7 +156,7 @@ export function EditInstallModal({ event, componentLabel, bikeId, onClose }: Edi
         </div>
 
         <p className="text-xs text-muted">
-          Deleting removes the entire install/remove pair for this component.
+          This will remove both the install and removal events for this component.
         </p>
 
         <div>

--- a/apps/web/src/components/dashboard/EditInstallModal.tsx
+++ b/apps/web/src/components/dashboard/EditInstallModal.tsx
@@ -11,6 +11,7 @@ import {
 import { BIKES } from '../../graphql/bikes';
 import { BIKE_HISTORY } from '../../graphql/bikeHistory';
 import { GEAR_QUERY_LIGHT } from '../../graphql/gear';
+import { dateInputToIsoNoon, isoToDateInput } from '../../lib/format';
 
 export interface EditableInstallEvent {
   /** Composite id from BikeHistory (e.g. "abc:installed" or "abc:removed"). */
@@ -23,15 +24,15 @@ interface EditInstallModalProps {
   event: EditableInstallEvent | null;
   componentLabel: string;
   bikeId?: string;
+  /**
+   * True when the underlying BikeComponentInstall row has BOTH installedAt
+   * and removedAt — i.e. the timeline shows both an "Installed" and a
+   * "Removed" entry for this component. Controls the delete-confirmation
+   * copy so we don't claim "removes two events" on a component that was
+   * never taken off the bike.
+   */
+  hasPairedEvent?: boolean;
   onClose: () => void;
-}
-
-function toDateInput(iso: string | null | undefined): string {
-  if (!iso) return '';
-  const d = new Date(iso);
-  if (!Number.isFinite(d.getTime())) return '';
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
 function baseInstallId(compositeId: string): string {
@@ -42,7 +43,13 @@ function baseInstallId(compositeId: string): string {
   return idx > 0 ? compositeId.slice(0, idx) : compositeId;
 }
 
-export function EditInstallModal({ event, componentLabel, bikeId, onClose }: EditInstallModalProps) {
+export function EditInstallModal({
+  event,
+  componentLabel,
+  bikeId,
+  hasPairedEvent = false,
+  onClose,
+}: EditInstallModalProps) {
   const [dateValue, setDateValue] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -59,7 +66,7 @@ export function EditInstallModal({ event, componentLabel, bikeId, onClose }: Edi
 
   useEffect(() => {
     if (event) {
-      setDateValue(toDateInput(event.occurredAt));
+      setDateValue(isoToDateInput(event.occurredAt));
       setError(null);
       setConfirmingDelete(false);
     }
@@ -74,7 +81,7 @@ export function EditInstallModal({ event, componentLabel, bikeId, onClose }: Edi
     setBusy(true);
     setError(null);
     try {
-      const iso = dateValue ? new Date(dateValue).toISOString() : undefined;
+      const iso = dateValue ? dateInputToIsoNoon(dateValue) : undefined;
       if (!iso) {
         setError('Pick a valid date.');
         setBusy(false);
@@ -128,7 +135,9 @@ export function EditInstallModal({ event, componentLabel, bikeId, onClose }: Edi
           ) : (
             <div className="flex items-center gap-2">
               <span className="text-xs text-muted">
-                Delete both the install and removal events?
+                {hasPairedEvent
+                  ? 'Delete both the install and removal events?'
+                  : 'Delete this install event?'}
               </span>
               <Button variant="primary" size="sm" onClick={handleDelete} disabled={busy}>
                 {busy ? 'Deleting…' : 'Yes, delete'}
@@ -156,7 +165,9 @@ export function EditInstallModal({ event, componentLabel, bikeId, onClose }: Edi
         </div>
 
         <p className="text-xs text-muted">
-          This will remove both the install and removal events for this component.
+          {hasPairedEvent
+            ? 'Deleting this entry removes both the install and removal events for this component.'
+            : 'Deleting this entry removes the install record for this component.'}
         </p>
 
         <div>

--- a/apps/web/src/components/dashboard/EditInstallModal.tsx
+++ b/apps/web/src/components/dashboard/EditInstallModal.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState } from 'react';
+import { useMutation } from '@apollo/client';
+import { Trash2, TriangleAlert, Wrench } from 'lucide-react';
+
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import {
+  UPDATE_BIKE_COMPONENT_INSTALL,
+  DELETE_BIKE_COMPONENT_INSTALL,
+} from '../../graphql/componentInstall';
+import { BIKES } from '../../graphql/bikes';
+import { BIKE_HISTORY } from '../../graphql/bikeHistory';
+import { GEAR_QUERY_LIGHT } from '../../graphql/gear';
+
+export interface EditableInstallEvent {
+  /** Composite id from BikeHistory (e.g. "abc:installed" or "abc:removed"). */
+  id: string;
+  eventType: 'INSTALLED' | 'REMOVED';
+  occurredAt: string;
+}
+
+interface EditInstallModalProps {
+  event: EditableInstallEvent | null;
+  componentLabel: string;
+  bikeId?: string;
+  onClose: () => void;
+}
+
+function toDateInput(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function baseInstallId(compositeId: string): string {
+  // The BikeHistory payload suffixes install row ids with ":installed" or
+  // ":removed" so the two timeline rows have distinct keys. Strip the suffix
+  // to talk to the underlying BikeComponentInstall row.
+  const idx = compositeId.lastIndexOf(':');
+  return idx > 0 ? compositeId.slice(0, idx) : compositeId;
+}
+
+export function EditInstallModal({ event, componentLabel, bikeId, onClose }: EditInstallModalProps) {
+  const [dateValue, setDateValue] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const refetch = [
+    { query: BIKES },
+    { query: GEAR_QUERY_LIGHT },
+    ...(bikeId ? [{ query: BIKE_HISTORY, variables: { bikeId } }] : []),
+  ];
+
+  const [updateInstall] = useMutation(UPDATE_BIKE_COMPONENT_INSTALL, { refetchQueries: refetch });
+  const [deleteInstall] = useMutation(DELETE_BIKE_COMPONENT_INSTALL, { refetchQueries: refetch });
+
+  useEffect(() => {
+    if (event) {
+      setDateValue(toDateInput(event.occurredAt));
+      setError(null);
+      setConfirmingDelete(false);
+    }
+  }, [event]);
+
+  if (!event) return null;
+
+  const isInstallEvent = event.eventType === 'INSTALLED';
+  const fieldLabel = isInstallEvent ? 'Install date' : 'Removal date';
+
+  const handleSave = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const iso = dateValue ? new Date(dateValue).toISOString() : undefined;
+      if (!iso) {
+        setError('Pick a valid date.');
+        setBusy(false);
+        return;
+      }
+      const input = isInstallEvent ? { installedAt: iso } : { removedAt: iso };
+      await updateInstall({
+        variables: { id: baseInstallId(event.id), input },
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await deleteInstall({
+        variables: { id: baseInstallId(event.id) },
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      title={isInstallEvent ? 'Edit Install' : 'Edit Removal'}
+      size="sm"
+      footer={
+        <div className="flex items-center justify-between w-full">
+          {!confirmingDelete ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setConfirmingDelete(true)}
+              disabled={busy}
+            >
+              <Trash2 size={12} className="icon-left" />
+              Delete entry
+            </Button>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted">Delete this install record?</span>
+              <Button variant="primary" size="sm" onClick={handleDelete} disabled={busy}>
+                {busy ? 'Deleting…' : 'Yes, delete'}
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => setConfirmingDelete(false)} disabled={busy}>
+                Cancel
+              </Button>
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" onClick={onClose} disabled={busy}>
+              Cancel
+            </Button>
+            <Button variant="primary" size="sm" onClick={handleSave} disabled={busy || confirmingDelete}>
+              {busy ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </div>
+      }
+    >
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 text-sm">
+          <Wrench size={14} className="icon-sage" />
+          <span className="font-medium">{componentLabel}</span>
+        </div>
+
+        <p className="text-xs text-muted">
+          Deleting removes the entire install/remove pair for this component.
+        </p>
+
+        <div>
+          <label htmlFor="edit-install-date" className="block text-xs text-muted mb-1">
+            {fieldLabel}
+          </label>
+          <input
+            id="edit-install-date"
+            type="date"
+            value={dateValue}
+            max={new Date().toISOString().split('T')[0]}
+            onChange={(e) => setDateValue(e.target.value)}
+            className="log-service-date-input w-full"
+          />
+        </div>
+
+        {error && (
+          <div className="alert-inline alert-inline-error">
+            <TriangleAlert size={14} />
+            {error}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/dashboard/EditInstallModal.tsx
+++ b/apps/web/src/components/dashboard/EditInstallModal.tsx
@@ -11,7 +11,7 @@ import {
 import { BIKES } from '../../graphql/bikes';
 import { BIKE_HISTORY } from '../../graphql/bikeHistory';
 import { GEAR_QUERY_LIGHT } from '../../graphql/gear';
-import { dateInputToIsoNoon, isoToDateInput } from '../../lib/format';
+import { dateInputToIsoNoon, isoToDateInput, todayDateInput } from '../../lib/format';
 
 export interface EditableInstallEvent {
   /** Composite id from BikeHistory (e.g. "abc:installed" or "abc:removed"). */
@@ -178,7 +178,7 @@ export function EditInstallModal({
             id="edit-install-date"
             type="date"
             value={dateValue}
-            max={new Date().toISOString().split('T')[0]}
+            max={todayDateInput()}
             onChange={(e) => setDateValue(e.target.value)}
             className="log-service-date-input w-full"
           />

--- a/apps/web/src/components/dashboard/EditServiceModal.tsx
+++ b/apps/web/src/components/dashboard/EditServiceModal.tsx
@@ -7,6 +7,7 @@ import { Button } from '../ui/Button';
 import { UPDATE_SERVICE_LOG, DELETE_SERVICE_LOG } from '../../graphql/serviceLog';
 import { BIKES } from '../../graphql/bikes';
 import { BIKE_HISTORY } from '../../graphql/bikeHistory';
+import { dateInputToIsoNoon, isoToDateInput } from '../../lib/format';
 
 export interface EditableServiceLog {
   id: string;
@@ -20,13 +21,6 @@ interface EditServiceModalProps {
   componentLabel: string;
   bikeId?: string;
   onClose: () => void;
-}
-
-function toDateInput(iso: string): string {
-  const d = new Date(iso);
-  if (!Number.isFinite(d.getTime())) return '';
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
 export function EditServiceModal({ log, componentLabel, bikeId, onClose }: EditServiceModalProps) {
@@ -47,7 +41,7 @@ export function EditServiceModal({ log, componentLabel, bikeId, onClose }: EditS
 
   useEffect(() => {
     if (log) {
-      setPerformedAt(toDateInput(log.performedAt));
+      setPerformedAt(isoToDateInput(log.performedAt));
       setNotes(log.notes ?? '');
       setHours(String(log.hoursAtService ?? 0));
       setError(null);
@@ -71,7 +65,7 @@ export function EditServiceModal({ log, componentLabel, bikeId, onClose }: EditS
         variables: {
           id: log.id,
           input: {
-            performedAt: new Date(performedAt).toISOString(),
+            performedAt: dateInputToIsoNoon(performedAt),
             notes: notes.trim() || null,
             hoursAtService: hoursNum,
           },
@@ -169,7 +163,7 @@ export function EditServiceModal({ log, componentLabel, bikeId, onClose }: EditS
             min="0"
             value={hours}
             onChange={(e) => setHours(e.target.value)}
-            className="log-service-date-input w-full"
+            className="w-full rounded-md border border-app bg-surface px-3 py-2 text-sm text-app focus:border-forest focus:outline-none focus:ring-1 focus:ring-forest"
           />
         </div>
 
@@ -182,7 +176,7 @@ export function EditServiceModal({ log, componentLabel, bikeId, onClose }: EditS
             value={notes}
             onChange={(e) => setNotes(e.target.value)}
             rows={3}
-            className="log-service-date-input w-full"
+            className="w-full rounded-md border border-app bg-surface px-3 py-2 text-sm text-app placeholder:text-muted focus:border-forest focus:outline-none focus:ring-1 focus:ring-forest resize-none"
             placeholder="Optional notes about this service"
           />
         </div>

--- a/apps/web/src/components/dashboard/EditServiceModal.tsx
+++ b/apps/web/src/components/dashboard/EditServiceModal.tsx
@@ -161,6 +161,10 @@ export function EditServiceModal({ log, componentLabel, bikeId, onClose }: EditS
             type="number"
             step="0.1"
             min="0"
+            // Matches the server-side MAX_SERVICE_HOURS cap in resolvers.ts.
+            // Keeps the browser validation in sync so users get immediate
+            // feedback instead of a round-trip error.
+            max="100000"
             value={hours}
             onChange={(e) => setHours(e.target.value)}
             className="w-full rounded-md border border-app bg-surface px-3 py-2 text-sm text-app focus:border-forest focus:outline-none focus:ring-1 focus:ring-forest"

--- a/apps/web/src/components/dashboard/EditServiceModal.tsx
+++ b/apps/web/src/components/dashboard/EditServiceModal.tsx
@@ -7,7 +7,7 @@ import { Button } from '../ui/Button';
 import { UPDATE_SERVICE_LOG, DELETE_SERVICE_LOG } from '../../graphql/serviceLog';
 import { BIKES } from '../../graphql/bikes';
 import { BIKE_HISTORY } from '../../graphql/bikeHistory';
-import { dateInputToIsoNoon, isoToDateInput } from '../../lib/format';
+import { dateInputToIsoNoon, isoToDateInput, todayDateInput } from '../../lib/format';
 
 export interface EditableServiceLog {
   id: string;
@@ -147,7 +147,7 @@ export function EditServiceModal({ log, componentLabel, bikeId, onClose }: EditS
             type="date"
             value={performedAt}
             onChange={(e) => setPerformedAt(e.target.value)}
-            max={new Date().toISOString().split('T')[0]}
+            max={todayDateInput()}
             className="log-service-date-input w-full"
           />
         </div>

--- a/apps/web/src/components/dashboard/EditServiceModal.tsx
+++ b/apps/web/src/components/dashboard/EditServiceModal.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useState } from 'react';
+import { useMutation } from '@apollo/client';
+import { Trash2, TriangleAlert, Wrench } from 'lucide-react';
+
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import { UPDATE_SERVICE_LOG, DELETE_SERVICE_LOG } from '../../graphql/serviceLog';
+import { BIKES } from '../../graphql/bikes';
+import { BIKE_HISTORY } from '../../graphql/bikeHistory';
+
+export interface EditableServiceLog {
+  id: string;
+  performedAt: string;
+  notes?: string | null;
+  hoursAtService: number;
+}
+
+interface EditServiceModalProps {
+  log: EditableServiceLog | null;
+  componentLabel: string;
+  bikeId?: string;
+  onClose: () => void;
+}
+
+function toDateInput(iso: string): string {
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+export function EditServiceModal({ log, componentLabel, bikeId, onClose }: EditServiceModalProps) {
+  const [performedAt, setPerformedAt] = useState('');
+  const [notes, setNotes] = useState('');
+  const [hours, setHours] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const refetch = [
+    { query: BIKES },
+    ...(bikeId ? [{ query: BIKE_HISTORY, variables: { bikeId } }] : []),
+  ];
+
+  const [updateServiceLog] = useMutation(UPDATE_SERVICE_LOG, { refetchQueries: refetch });
+  const [deleteServiceLog] = useMutation(DELETE_SERVICE_LOG, { refetchQueries: refetch });
+
+  useEffect(() => {
+    if (log) {
+      setPerformedAt(toDateInput(log.performedAt));
+      setNotes(log.notes ?? '');
+      setHours(String(log.hoursAtService ?? 0));
+      setError(null);
+      setConfirmingDelete(false);
+    }
+  }, [log]);
+
+  if (!log) return null;
+
+  const handleSave = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const hoursNum = Number(hours);
+      if (!Number.isFinite(hoursNum) || hoursNum < 0) {
+        setError('Hours must be a non-negative number.');
+        setBusy(false);
+        return;
+      }
+      await updateServiceLog({
+        variables: {
+          id: log.id,
+          input: {
+            performedAt: new Date(performedAt).toISOString(),
+            notes: notes.trim() || null,
+            hoursAtService: hoursNum,
+          },
+        },
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await deleteServiceLog({ variables: { id: log.id } });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      title="Edit Service"
+      size="md"
+      footer={
+        <div className="flex items-center justify-between w-full">
+          {!confirmingDelete ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setConfirmingDelete(true)}
+              disabled={busy}
+            >
+              <Trash2 size={12} className="icon-left" />
+              Delete
+            </Button>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted">Delete this service?</span>
+              <Button variant="primary" size="sm" onClick={handleDelete} disabled={busy}>
+                {busy ? 'Deleting…' : 'Yes, delete'}
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => setConfirmingDelete(false)} disabled={busy}>
+                Cancel
+              </Button>
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" onClick={onClose} disabled={busy}>
+              Cancel
+            </Button>
+            <Button variant="primary" size="sm" onClick={handleSave} disabled={busy || confirmingDelete}>
+              {busy ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </div>
+      }
+    >
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 text-sm">
+          <Wrench size={14} className="icon-sage" />
+          <span className="font-medium">{componentLabel}</span>
+        </div>
+
+        <div>
+          <label htmlFor="edit-service-date" className="block text-xs text-muted mb-1">
+            Service date
+          </label>
+          <input
+            id="edit-service-date"
+            type="date"
+            value={performedAt}
+            onChange={(e) => setPerformedAt(e.target.value)}
+            max={new Date().toISOString().split('T')[0]}
+            className="log-service-date-input w-full"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="edit-service-hours" className="block text-xs text-muted mb-1">
+            Hours at service
+          </label>
+          <input
+            id="edit-service-hours"
+            type="number"
+            step="0.1"
+            min="0"
+            value={hours}
+            onChange={(e) => setHours(e.target.value)}
+            className="log-service-date-input w-full"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="edit-service-notes" className="block text-xs text-muted mb-1">
+            Notes
+          </label>
+          <textarea
+            id="edit-service-notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={3}
+            className="log-service-date-input w-full"
+            placeholder="Optional notes about this service"
+          />
+        </div>
+
+        {error && (
+          <div className="alert-inline alert-inline-error">
+            <TriangleAlert size={14} />
+            {error}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/dashboard/LogServiceModal.test.tsx
+++ b/apps/web/src/components/dashboard/LogServiceModal.test.tsx
@@ -101,8 +101,9 @@ const createBike = (
   } as BikePredictionSummary,
 });
 
-// Get today's date in YYYY-MM-DD format
-const getTodayDate = () => new Date().toISOString().split('T')[0];
+// Match the component's behavior — local date, not UTC. See todayDateInput.
+import { todayDateInput } from '../../lib/format';
+const getTodayDate = () => todayDateInput();
 
 describe('LogServiceModal', () => {
   const components = [

--- a/apps/web/src/components/dashboard/LogServiceModal.tsx
+++ b/apps/web/src/components/dashboard/LogServiceModal.tsx
@@ -6,6 +6,7 @@ import { Button } from '../ui/Button';
 import { LOG_COMPONENT_SERVICE } from '../../graphql/logComponentService';
 import { BIKES } from '../../graphql/bikes';
 import { formatComponentLabel, getBikeName } from '../../utils/formatters';
+import { todayDateInput } from '../../lib/format';
 import { useUserTier } from '../../hooks/useUserTier';
 import { isFreeLightComponent } from '@loam/shared';
 import type { BikeWithPredictions } from '../../hooks/usePriorityBike';
@@ -26,7 +27,7 @@ export function LogServiceModal({
 }: LogServiceModalProps) {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [serviceDate, setServiceDate] = useState(() =>
-    new Date().toISOString().split('T')[0]
+    todayDateInput()
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -41,7 +42,7 @@ export function LogServiceModal({
       // Set initial selection based on defaultComponentId
       const initialSelection = defaultComponentId ? new Set([defaultComponentId]) : new Set<string>();
       setSelectedIds(initialSelection);
-      setServiceDate(new Date().toISOString().split('T')[0]);
+      setServiceDate(todayDateInput());
       setError(null);
     }
   }, [isOpen, defaultComponentId]);
@@ -137,7 +138,7 @@ export function LogServiceModal({
             type="date"
             value={serviceDate}
             onChange={(e) => setServiceDate(e.target.value)}
-            max={new Date().toISOString().split('T')[0]}
+            max={todayDateInput()}
             className="log-service-date-input"
           />
         </div>

--- a/apps/web/src/components/dashboard/RecentRidesCard.tsx
+++ b/apps/web/src/components/dashboard/RecentRidesCard.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { Route } from 'lucide-react';
 import { CompactRideRow } from './CompactRideRow';
 import { getBikeName } from '../../utils/formatters';
+import type { RideWeather } from '../../models/Ride';
 
 interface Ride {
   id: string;
@@ -18,6 +19,7 @@ interface Ride {
   garminActivityId?: string | null;
   whoopWorkoutId?: string | null;
   bikeId?: string | null;
+  weather?: RideWeather | null;
 }
 
 interface Bike {

--- a/apps/web/src/components/gear/ComponentDetailRow.tsx
+++ b/apps/web/src/components/gear/ComponentDetailRow.tsx
@@ -29,7 +29,7 @@ type ComponentDto = {
   baselineConfidence?: string | null;
   lastServicedAt?: string | null;
   location?: string | null;
-  serviceLogs?: ServiceLogDto[] | null;
+  latestServiceLog?: ServiceLogDto | null;
 };
 
 type ComponentPrediction = {
@@ -102,11 +102,7 @@ export function ComponentDetailRow({
   const [editingService, setEditingService] = useState<EditableServiceLog | null>(null);
   const { hoursDisplay } = useHoursDisplay();
 
-  const latestServiceLog = component.serviceLogs && component.serviceLogs.length > 0
-    ? [...component.serviceLogs].sort(
-        (a, b) => new Date(b.performedAt).getTime() - new Date(a.performedAt).getTime()
-      )[0]
-    : null;
+  const latestServiceLog = component.latestServiceLog ?? null;
 
   const status = prediction?.status ?? 'ALL_GOOD';
   const hoursRemaining = prediction?.hoursRemaining;
@@ -344,12 +340,17 @@ export function ComponentDetailRow({
         )}
       </AnimatePresence>
 
-      <EditServiceModal
-        log={editingService}
-        componentLabel={fullLabel}
-        bikeId={component.bikeId ?? undefined}
-        onClose={() => setEditingService(null)}
-      />
+      {/* Mount the modal only while an edit is in flight. Avoids calling
+          useMutation() (and therefore requiring an Apollo provider) on every
+          ComponentDetailRow render just to render null. */}
+      {editingService && (
+        <EditServiceModal
+          log={editingService}
+          componentLabel={fullLabel}
+          bikeId={component.bikeId ?? undefined}
+          onClose={() => setEditingService(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/gear/ComponentDetailRow.tsx
+++ b/apps/web/src/components/gear/ComponentDetailRow.tsx
@@ -1,10 +1,18 @@
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
-import { ChevronDown, Pencil, ArrowLeftRight, RefreshCw } from 'lucide-react';
+import { ChevronDown, Pencil, ArrowLeftRight, RefreshCw, Wrench } from 'lucide-react';
 import { StatusDot } from '../dashboard/StatusDot';
 import type { PredictionStatus } from '../../types/prediction';
 import { formatComponentLabel } from '../../utils/formatters';
 import { useHoursDisplay } from '../../hooks/useHoursDisplay';
+import { EditServiceModal, type EditableServiceLog } from '../dashboard/EditServiceModal';
+
+type ServiceLogDto = {
+  id: string;
+  performedAt: string;
+  notes?: string | null;
+  hoursAtService: number;
+};
 
 type ComponentDto = {
   id: string;
@@ -21,6 +29,7 @@ type ComponentDto = {
   baselineConfidence?: string | null;
   lastServicedAt?: string | null;
   location?: string | null;
+  serviceLogs?: ServiceLogDto[] | null;
 };
 
 type ComponentPrediction = {
@@ -90,7 +99,14 @@ export function ComponentDetailRow({
   showSwap = false,
 }: ComponentDetailRowProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [editingService, setEditingService] = useState<EditableServiceLog | null>(null);
   const { hoursDisplay } = useHoursDisplay();
+
+  const latestServiceLog = component.serviceLogs && component.serviceLogs.length > 0
+    ? [...component.serviceLogs].sort(
+        (a, b) => new Date(b.performedAt).getTime() - new Date(a.performedAt).getTime()
+      )[0]
+    : null;
 
   const status = prediction?.status ?? 'ALL_GOOD';
   const hoursRemaining = prediction?.hoursRemaining;
@@ -228,8 +244,22 @@ export function ComponentDetailRow({
               {/* Last Serviced */}
               <div className="component-detail-field">
                 <span className="component-detail-field-label">Last Serviced</span>
-                <span className="component-detail-field-value">
+                <span className="component-detail-field-value flex items-center gap-2">
                   {formatDate(component.lastServicedAt)}
+                  {latestServiceLog && (
+                    <button
+                      type="button"
+                      className="component-detail-edit-btn"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setEditingService(latestServiceLog);
+                      }}
+                      aria-label="Edit last service"
+                    >
+                      <Wrench size={10} />
+                      Edit
+                    </button>
+                  )}
                 </span>
               </div>
 
@@ -313,6 +343,13 @@ export function ComponentDetailRow({
           </motion.div>
         )}
       </AnimatePresence>
+
+      <EditServiceModal
+        log={editingService}
+        componentLabel={fullLabel}
+        bikeId={component.bikeId ?? undefined}
+        onClose={() => setEditingService(null)}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/gear/ReplaceComponentModal.test.tsx
+++ b/apps/web/src/components/gear/ReplaceComponentModal.test.tsx
@@ -243,14 +243,16 @@ describe('ReplaceComponentModal', () => {
       fireEvent.click(screen.getByText('Confirm'));
 
       await waitFor(() => {
+        // objectContaining lets the component thread an optional installedAt
+        // (defaults to today) without pinning the test to a specific date.
         expect(mockInstallComponent).toHaveBeenCalledWith({
           variables: {
-            input: {
+            input: expect.objectContaining({
               bikeId: 'bike-1',
               slotKey: 'FORK_NONE',
               existingComponentId: 'spare-1',
               noteText: null,
-            },
+            }),
           },
         });
       });
@@ -271,12 +273,12 @@ describe('ReplaceComponentModal', () => {
       await waitFor(() => {
         expect(mockInstallComponent).toHaveBeenCalledWith({
           variables: {
-            input: {
+            input: expect.objectContaining({
               bikeId: 'bike-1',
               slotKey: 'FORK_NONE',
               newComponent: { brand: 'Fox', model: '38 Factory' },
               noteText: null,
-            },
+            }),
           },
         });
       });

--- a/apps/web/src/components/gear/ReplaceComponentModal.tsx
+++ b/apps/web/src/components/gear/ReplaceComponentModal.tsx
@@ -58,6 +58,7 @@ export function ReplaceComponentModal({
   const [newBrand, setNewBrand] = useState('');
   const [newModel, setNewModel] = useState('');
   const [noteText, setNoteText] = useState('');
+  const [installedAt, setInstalledAt] = useState(() => new Date().toISOString().slice(0, 10));
   const [error, setError] = useState<string | null>(null);
 
   // ---- derived ------------------------------------------------------------
@@ -87,6 +88,7 @@ export function ReplaceComponentModal({
       setNewBrand('');
       setNewModel('');
       setNoteText('');
+      setInstalledAt(new Date().toISOString().slice(0, 10));
       setError(null);
     }
   }, [isOpen, matchingSpares.length]);
@@ -103,6 +105,7 @@ export function ReplaceComponentModal({
 
     try {
       const trimmedNoteText = noteText.trim() || null;
+      const installedAtIso = installedAt ? new Date(installedAt).toISOString() : undefined;
 
       if (activeTab === 'spare') {
         await installComponent({
@@ -112,6 +115,7 @@ export function ReplaceComponentModal({
               slotKey,
               existingComponentId: selectedSpareId,
               noteText: trimmedNoteText,
+              installedAt: installedAtIso,
             },
           },
         });
@@ -126,6 +130,7 @@ export function ReplaceComponentModal({
                 model: newModel.trim(),
               },
               noteText: trimmedNoteText,
+              installedAt: installedAtIso,
             },
           },
         });
@@ -145,6 +150,7 @@ export function ReplaceComponentModal({
     bikeId,
     canConfirm,
     installComponent,
+    installedAt,
     newBrand,
     newModel,
     noteText,
@@ -313,6 +319,24 @@ export function ReplaceComponentModal({
             </div>
           </div>
         )}
+
+        {/* Install date */}
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="replace-installed-at"
+            className="text-xs font-medium text-muted"
+          >
+            Installed on
+          </label>
+          <input
+            id="replace-installed-at"
+            type="date"
+            value={installedAt}
+            max={new Date().toISOString().slice(0, 10)}
+            onChange={(e) => setInstalledAt(e.target.value)}
+            className="rounded-md border border-app bg-surface px-3 py-2 text-sm text-app focus:border-forest focus:outline-none focus:ring-1 focus:ring-forest"
+          />
+        </div>
 
         {/* Note textarea */}
         <div className="flex flex-col gap-1">

--- a/apps/web/src/components/gear/ReplaceComponentModal.tsx
+++ b/apps/web/src/components/gear/ReplaceComponentModal.tsx
@@ -6,7 +6,7 @@ import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
 import { INSTALL_COMPONENT, GEAR_QUERY_LIGHT } from '../../graphql/gear';
 import { getComponentLabel } from '../../constants/componentLabels';
-import { dateInputToIsoNoon } from '../../lib/format';
+import { dateInputToIsoNoon, todayDateInput } from '../../lib/format';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -59,7 +59,7 @@ export function ReplaceComponentModal({
   const [newBrand, setNewBrand] = useState('');
   const [newModel, setNewModel] = useState('');
   const [noteText, setNoteText] = useState('');
-  const [installedAt, setInstalledAt] = useState(() => new Date().toISOString().slice(0, 10));
+  const [installedAt, setInstalledAt] = useState(() => todayDateInput());
   const [error, setError] = useState<string | null>(null);
 
   // ---- derived ------------------------------------------------------------
@@ -89,7 +89,7 @@ export function ReplaceComponentModal({
       setNewBrand('');
       setNewModel('');
       setNoteText('');
-      setInstalledAt(new Date().toISOString().slice(0, 10));
+      setInstalledAt(todayDateInput());
       setError(null);
     }
   }, [isOpen, matchingSpares.length]);
@@ -333,7 +333,7 @@ export function ReplaceComponentModal({
             id="replace-installed-at"
             type="date"
             value={installedAt}
-            max={new Date().toISOString().slice(0, 10)}
+            max={todayDateInput()}
             onChange={(e) => setInstalledAt(e.target.value)}
             className="rounded-md border border-app bg-surface px-3 py-2 text-sm text-app focus:border-forest focus:outline-none focus:ring-1 focus:ring-forest"
           />

--- a/apps/web/src/components/gear/ReplaceComponentModal.tsx
+++ b/apps/web/src/components/gear/ReplaceComponentModal.tsx
@@ -6,6 +6,7 @@ import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
 import { INSTALL_COMPONENT, GEAR_QUERY_LIGHT } from '../../graphql/gear';
 import { getComponentLabel } from '../../constants/componentLabels';
+import { dateInputToIsoNoon } from '../../lib/format';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -105,7 +106,7 @@ export function ReplaceComponentModal({
 
     try {
       const trimmedNoteText = noteText.trim() || null;
-      const installedAtIso = installedAt ? new Date(installedAt).toISOString() : undefined;
+      const installedAtIso = installedAt ? dateInputToIsoNoon(installedAt) : undefined;
 
       if (activeTab === 'spare') {
         await installComponent({

--- a/apps/web/src/components/gear/SwapComponentModal.test.tsx
+++ b/apps/web/src/components/gear/SwapComponentModal.test.tsx
@@ -228,15 +228,17 @@ describe('SwapComponentModal', () => {
       fireEvent.click(swapButtons[0]);
 
       await waitFor(() => {
+        // objectContaining lets the component thread an optional installedAt
+        // (defaults to today) without pinning the test to a specific date.
         expect(mockSwapComponents).toHaveBeenCalledWith({
           variables: {
-            input: {
+            input: expect.objectContaining({
               bikeIdA: 'bike-1',
               slotKeyA: 'FORK_NONE',
               bikeIdB: 'bike-2',
               slotKeyB: 'FORK_NONE',
               noteText: null,
-            },
+            }),
           },
         });
       });

--- a/apps/web/src/components/gear/SwapComponentModal.tsx
+++ b/apps/web/src/components/gear/SwapComponentModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMutation } from '@apollo/client';
 import { getSlotKey } from '@loam/shared';
 import { Modal } from '../ui/Modal';
@@ -54,6 +54,19 @@ export function SwapComponentModal({
   const [noteText, setNoteText] = useState('');
   const [installedAt, setInstalledAt] = useState(() => todayDateInput());
   const [error, setError] = useState<string | null>(null);
+
+  // Reset state every time the modal re-opens. Without this, a user who
+  // picks a past date (or types a note), closes without submitting, and
+  // reopens for a different swap would see the stale values pre-filled.
+  // Mirrors ReplaceComponentModal's open-reset pattern.
+  useEffect(() => {
+    if (isOpen) {
+      setSwappingTargetId(null);
+      setNoteText('');
+      setInstalledAt(todayDateInput());
+      setError(null);
+    }
+  }, [isOpen]);
 
   const [swapComponents] = useMutation(SWAP_COMPONENTS, {
     refetchQueries: [{ query: GEAR_QUERY_LIGHT }],

--- a/apps/web/src/components/gear/SwapComponentModal.tsx
+++ b/apps/web/src/components/gear/SwapComponentModal.tsx
@@ -51,6 +51,7 @@ export function SwapComponentModal({
 }: SwapComponentModalProps) {
   const [swappingTargetId, setSwappingTargetId] = useState<string | null>(null);
   const [noteText, setNoteText] = useState('');
+  const [installedAt, setInstalledAt] = useState(() => new Date().toISOString().slice(0, 10));
   const [error, setError] = useState<string | null>(null);
 
   const [swapComponents] = useMutation(SWAP_COMPONENTS, {
@@ -97,6 +98,7 @@ export function SwapComponentModal({
             bikeIdB: targetBike.id,
             slotKeyB,
             noteText: trimmedNoteText,
+            installedAt: installedAt ? new Date(installedAt).toISOString() : undefined,
           },
         },
       });
@@ -123,6 +125,24 @@ export function SwapComponentModal({
         <p className="text-sm text-amber-300">
           Compatibility is not validated. Ensure both components fit their destination bikes.
         </p>
+      </div>
+
+      {/* Swap date */}
+      <div className="mb-4 flex flex-col gap-1">
+        <label
+          htmlFor="swap-installed-at"
+          className="text-xs font-medium text-muted"
+        >
+          Swap date
+        </label>
+        <input
+          id="swap-installed-at"
+          type="date"
+          value={installedAt}
+          max={new Date().toISOString().slice(0, 10)}
+          onChange={(e) => setInstalledAt(e.target.value)}
+          className="rounded-md border border-app bg-surface px-3 py-2 text-sm text-app focus:border-forest focus:outline-none focus:ring-1 focus:ring-forest"
+        />
       </div>
 
       {/* Note textarea */}

--- a/apps/web/src/components/gear/SwapComponentModal.tsx
+++ b/apps/web/src/components/gear/SwapComponentModal.tsx
@@ -5,7 +5,7 @@ import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
 import { SWAP_COMPONENTS, GEAR_QUERY_LIGHT } from '../../graphql/gear';
 import { formatComponentLabel, getBikeName } from '../../utils/formatters';
-import { dateInputToIsoNoon } from '../../lib/format';
+import { dateInputToIsoNoon, todayDateInput } from '../../lib/format';
 
 interface SwapComponentModalProps {
   isOpen: boolean;
@@ -52,7 +52,7 @@ export function SwapComponentModal({
 }: SwapComponentModalProps) {
   const [swappingTargetId, setSwappingTargetId] = useState<string | null>(null);
   const [noteText, setNoteText] = useState('');
-  const [installedAt, setInstalledAt] = useState(() => new Date().toISOString().slice(0, 10));
+  const [installedAt, setInstalledAt] = useState(() => todayDateInput());
   const [error, setError] = useState<string | null>(null);
 
   const [swapComponents] = useMutation(SWAP_COMPONENTS, {
@@ -140,7 +140,7 @@ export function SwapComponentModal({
           id="swap-installed-at"
           type="date"
           value={installedAt}
-          max={new Date().toISOString().slice(0, 10)}
+          max={todayDateInput()}
           onChange={(e) => setInstalledAt(e.target.value)}
           className="rounded-md border border-app bg-surface px-3 py-2 text-sm text-app focus:border-forest focus:outline-none focus:ring-1 focus:ring-forest"
         />

--- a/apps/web/src/components/gear/SwapComponentModal.tsx
+++ b/apps/web/src/components/gear/SwapComponentModal.tsx
@@ -5,6 +5,7 @@ import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
 import { SWAP_COMPONENTS, GEAR_QUERY_LIGHT } from '../../graphql/gear';
 import { formatComponentLabel, getBikeName } from '../../utils/formatters';
+import { dateInputToIsoNoon } from '../../lib/format';
 
 interface SwapComponentModalProps {
   isOpen: boolean;
@@ -98,7 +99,7 @@ export function SwapComponentModal({
             bikeIdB: targetBike.id,
             slotKeyB,
             noteText: trimmedNoteText,
-            installedAt: installedAt ? new Date(installedAt).toISOString() : undefined,
+            installedAt: installedAt ? dateInputToIsoNoon(installedAt) : undefined,
           },
         },
       });

--- a/apps/web/src/components/history/BikeHistoryPdf.tsx
+++ b/apps/web/src/components/history/BikeHistoryPdf.tsx
@@ -113,12 +113,12 @@ export function BikeHistoryPdf({ bike, totals, yearGroups, distanceUnit, timefra
           yearGroups.map(({ year, items }) => (
             <View key={year} wrap>
               <Text style={styles.yearHeader}>{year}</Text>
-              {items.map((item, idx) => {
+              {items.map((item) => {
                 if (item.kind === 'ride') {
                   const { ride } = item;
                   const title = ride.trailSystem || ride.location || `${ride.rideType} ride`;
                   return (
-                    <View key={`r-${idx}`} style={[styles.row, styles.rideRow]} wrap={false}>
+                    <View key={`r:${ride.id}`} style={[styles.row, styles.rideRow]} wrap={false}>
                       <Text style={styles.rowIcon}>RIDE</Text>
                       <View style={styles.rowTitle}>
                         <Text>{title}</Text>
@@ -132,7 +132,7 @@ export function BikeHistoryPdf({ bike, totals, yearGroups, distanceUnit, timefra
                 if (item.kind === 'service') {
                   const s = item.service;
                   return (
-                    <View key={`s-${idx}`} style={styles.row} wrap={false}>
+                    <View key={`s:${s.id}`} style={styles.row} wrap={false}>
                       <Text style={styles.rowIcon}>SERVICE</Text>
                       <View style={styles.rowTitle}>
                         <Text>{componentText(s.component)}</Text>
@@ -145,7 +145,7 @@ export function BikeHistoryPdf({ bike, totals, yearGroups, distanceUnit, timefra
                 }
                 const inst = item.install;
                 return (
-                  <View key={`i-${idx}`} style={styles.row} wrap={false}>
+                  <View key={`i:${inst.id}`} style={styles.row} wrap={false}>
                     <Text style={styles.rowIcon}>{inst.eventType === 'INSTALLED' ? 'INSTALL' : 'REMOVE'}</Text>
                     <View style={styles.rowTitle}>
                       <Text>{componentText(inst.component)}</Text>

--- a/apps/web/src/components/history/BikeHistoryPdf.tsx
+++ b/apps/web/src/components/history/BikeHistoryPdf.tsx
@@ -31,6 +31,7 @@ const styles = StyleSheet.create({
   totalValue: { fontSize: 12, fontFamily: 'Helvetica-Bold', marginTop: 2, color: INK },
   yearHeader: { fontSize: 11, fontFamily: 'Helvetica-Bold', color: SAGE, marginTop: 10, marginBottom: 4, borderBottom: `1pt solid ${BORDER}`, paddingBottom: 3 },
   row: { flexDirection: 'row', paddingVertical: 4, borderBottom: `0.5pt solid ${BORDER}` },
+  rideRow: { paddingLeft: 24 },
   rowIcon: { width: 56, color: MUTED, fontSize: 8, fontFamily: 'Helvetica-Bold', letterSpacing: 0.5 },
   rowTitle: { flex: 1, fontSize: 10 },
   rowMeta: { color: MUTED, fontSize: 9 },
@@ -117,7 +118,7 @@ export function BikeHistoryPdf({ bike, totals, yearGroups, distanceUnit, timefra
                   const { ride } = item;
                   const title = ride.trailSystem || ride.location || `${ride.rideType} ride`;
                   return (
-                    <View key={`r-${idx}`} style={styles.row} wrap={false}>
+                    <View key={`r-${idx}`} style={[styles.row, styles.rideRow]} wrap={false}>
                       <Text style={styles.rowIcon}>RIDE</Text>
                       <View style={styles.rowTitle}>
                         <Text>{title}</Text>

--- a/apps/web/src/components/history/BikeHistoryPdf.tsx
+++ b/apps/web/src/components/history/BikeHistoryPdf.tsx
@@ -1,0 +1,167 @@
+import { Document, Image, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
+
+import { getComponentLabel } from '@/constants/componentLabels';
+import { fmtDateTime, fmtDistance, fmtDuration, fmtElevation } from '@/lib/format';
+import { bikeName } from '@/lib/bikeHistory';
+import type {
+  ComponentLite,
+  HistoryBike,
+  HistoryInstallEvent,
+  HistoryRide,
+  HistoryServiceEvent,
+  HistoryTotals,
+} from '@/lib/bikeHistory';
+
+const SAGE = '#788c80';
+const INK = '#0c0c0e';
+const MUTED = '#6b7280';
+const BORDER = '#e5e7eb';
+
+const styles = StyleSheet.create({
+  page: { padding: 36, fontSize: 10, color: INK, fontFamily: 'Helvetica' },
+  headerRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 16 },
+  logo: { width: 44, height: 44, marginRight: 12 },
+  headerMeta: { flex: 1 },
+  brand: { fontSize: 10, color: SAGE, fontFamily: 'Helvetica-Bold', letterSpacing: 1 },
+  title: { fontSize: 18, fontFamily: 'Helvetica-Bold', marginTop: 2, color: INK },
+  subtitle: { fontSize: 10, color: MUTED, marginTop: 2 },
+  totalsRow: { flexDirection: 'row', marginBottom: 16, borderTop: `1pt solid ${BORDER}`, borderBottom: `1pt solid ${BORDER}`, paddingVertical: 8 },
+  total: { flex: 1 },
+  totalLabel: { fontSize: 8, color: MUTED, textTransform: 'uppercase', letterSpacing: 1 },
+  totalValue: { fontSize: 12, fontFamily: 'Helvetica-Bold', marginTop: 2, color: INK },
+  yearHeader: { fontSize: 11, fontFamily: 'Helvetica-Bold', color: SAGE, marginTop: 10, marginBottom: 4, borderBottom: `1pt solid ${BORDER}`, paddingBottom: 3 },
+  row: { flexDirection: 'row', paddingVertical: 4, borderBottom: `0.5pt solid ${BORDER}` },
+  rowIcon: { width: 56, color: MUTED, fontSize: 8, fontFamily: 'Helvetica-Bold', letterSpacing: 0.5 },
+  rowTitle: { flex: 1, fontSize: 10 },
+  rowMeta: { color: MUTED, fontSize: 9 },
+  footer: { position: 'absolute', left: 36, right: 36, bottom: 18, flexDirection: 'row', justifyContent: 'space-between', fontSize: 8, color: MUTED },
+  truncatedNote: { fontSize: 9, color: MUTED, marginBottom: 8, fontStyle: 'italic' },
+});
+
+type YearGroup = {
+  year: number;
+  items: Array<
+    | { kind: 'ride'; date: Date; ride: HistoryRide }
+    | { kind: 'service'; date: Date; service: HistoryServiceEvent }
+    | { kind: 'install'; date: Date; install: HistoryInstallEvent }
+  >;
+};
+
+type Props = {
+  bike: HistoryBike;
+  totals: HistoryTotals;
+  yearGroups: YearGroup[];
+  distanceUnit: 'mi' | 'km';
+  timeframeLabel: string;
+  truncated: boolean;
+  /** URL (typically served from /public) for the Loam Logger logo. */
+  logoSrc?: string;
+};
+
+function componentText(c: ComponentLite): string {
+  const label = getComponentLabel(c.type);
+  const loc = c.location && c.location !== 'NONE' ? ` (${c.location.toLowerCase()})` : '';
+  const brandModel = [c.brand, c.model].filter(Boolean).join(' ');
+  return brandModel ? `${label}${loc} — ${brandModel}` : `${label}${loc}`;
+}
+
+export function BikeHistoryPdf({ bike, totals, yearGroups, distanceUnit, timeframeLabel, truncated, logoSrc }: Props) {
+  const generated = new Date();
+  return (
+    <Document title={`${bikeName(bike)} – Loam Logger history`}>
+      <Page size="LETTER" style={styles.page} wrap>
+        <View style={styles.headerRow} fixed>
+          {logoSrc && <Image src={logoSrc} style={styles.logo} />}
+          <View style={styles.headerMeta}>
+            <Text style={styles.brand}>LOAM LOGGER</Text>
+            <Text style={styles.title}>{bikeName(bike)}</Text>
+            <Text style={styles.subtitle}>
+              {bike.year ? `${bike.year} · ` : ''}{timeframeLabel} · Generated {generated.toLocaleDateString()}
+            </Text>
+          </View>
+        </View>
+
+        <View style={styles.totalsRow}>
+          <View style={styles.total}>
+            <Text style={styles.totalLabel}>Rides</Text>
+            <Text style={styles.totalValue}>{totals.rideCount.toLocaleString()}</Text>
+          </View>
+          <View style={styles.total}>
+            <Text style={styles.totalLabel}>Distance</Text>
+            <Text style={styles.totalValue}>{fmtDistance(totals.totalDistanceMeters, distanceUnit)}</Text>
+          </View>
+          <View style={styles.total}>
+            <Text style={styles.totalLabel}>Elevation</Text>
+            <Text style={styles.totalValue}>{fmtElevation(totals.totalElevationGainMeters, distanceUnit)}</Text>
+          </View>
+          <View style={styles.total}>
+            <Text style={styles.totalLabel}>Service & installs</Text>
+            <Text style={styles.totalValue}>{(totals.serviceEventCount + totals.installEventCount).toLocaleString()}</Text>
+          </View>
+        </View>
+
+        {truncated && (
+          <Text style={styles.truncatedNote}>
+            History was capped to the most recent entries — some older events may not appear.
+          </Text>
+        )}
+
+        {yearGroups.length === 0 ? (
+          <Text style={styles.subtitle}>No events in this timeframe.</Text>
+        ) : (
+          yearGroups.map(({ year, items }) => (
+            <View key={year} wrap>
+              <Text style={styles.yearHeader}>{year}</Text>
+              {items.map((item, idx) => {
+                if (item.kind === 'ride') {
+                  const { ride } = item;
+                  const title = ride.trailSystem || ride.location || `${ride.rideType} ride`;
+                  return (
+                    <View key={`r-${idx}`} style={styles.row} wrap={false}>
+                      <Text style={styles.rowIcon}>RIDE</Text>
+                      <View style={styles.rowTitle}>
+                        <Text>{title}</Text>
+                        <Text style={styles.rowMeta}>
+                          {fmtDateTime(ride.startTime)} · {fmtDuration(ride.durationSeconds)} · {fmtDistance(ride.distanceMeters, distanceUnit)} · {fmtElevation(ride.elevationGainMeters, distanceUnit)}
+                        </Text>
+                      </View>
+                    </View>
+                  );
+                }
+                if (item.kind === 'service') {
+                  const s = item.service;
+                  return (
+                    <View key={`s-${idx}`} style={styles.row} wrap={false}>
+                      <Text style={styles.rowIcon}>SERVICE</Text>
+                      <View style={styles.rowTitle}>
+                        <Text>{componentText(s.component)}</Text>
+                        <Text style={styles.rowMeta}>
+                          {fmtDateTime(s.performedAt)} · {s.hoursAtService.toFixed(0)} hrs{s.notes ? ` · ${s.notes}` : ''}
+                        </Text>
+                      </View>
+                    </View>
+                  );
+                }
+                const inst = item.install;
+                return (
+                  <View key={`i-${idx}`} style={styles.row} wrap={false}>
+                    <Text style={styles.rowIcon}>{inst.eventType === 'INSTALLED' ? 'INSTALL' : 'REMOVE'}</Text>
+                    <View style={styles.rowTitle}>
+                      <Text>{componentText(inst.component)}</Text>
+                      <Text style={styles.rowMeta}>{fmtDateTime(inst.occurredAt)}</Text>
+                    </View>
+                  </View>
+                );
+              })}
+            </View>
+          ))
+        )}
+
+        <View style={styles.footer} fixed>
+          <Text>Generated by Loam Logger · {generated.toLocaleDateString()}</Text>
+          <Text render={({ pageNumber, totalPages }) => `${pageNumber} / ${totalPages}`} />
+        </View>
+      </Page>
+    </Document>
+  );
+}

--- a/apps/web/src/components/history/BikeHistoryPdfButton.tsx
+++ b/apps/web/src/components/history/BikeHistoryPdfButton.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { pdf } from '@react-pdf/renderer';
+import { FileDown } from 'lucide-react';
+
+import { Button } from '@/components/ui/Button';
+import { bikeName, slugify } from '@/lib/bikeHistory';
+import type {
+  HistoryBike,
+  HistoryInstallEvent,
+  HistoryRide,
+  HistoryServiceEvent,
+  HistoryTotals,
+} from '@/lib/bikeHistory';
+import { BikeHistoryPdf } from './BikeHistoryPdf';
+
+type YearGroup = {
+  year: number;
+  items: Array<
+    | { kind: 'ride'; date: Date; ride: HistoryRide }
+    | { kind: 'service'; date: Date; service: HistoryServiceEvent }
+    | { kind: 'install'; date: Date; install: HistoryInstallEvent }
+  >;
+};
+
+type Props = {
+  bike: HistoryBike;
+  totals: HistoryTotals;
+  yearGroups: YearGroup[];
+  distanceUnit: 'mi' | 'km';
+  timeframeLabel: string;
+  truncated: boolean;
+};
+
+const LOGO_SRC = '/loamLoggerLogo_512x512.png';
+
+export default function BikeHistoryPdfButton(props: Props) {
+  const [generating, setGenerating] = useState(false);
+
+  const handleExport = async () => {
+    setGenerating(true);
+    try {
+      const blob = await pdf(
+        <BikeHistoryPdf {...props} logoSrc={LOGO_SRC} />
+      ).toBlob();
+      const url = URL.createObjectURL(blob);
+      const dateStr = new Date().toISOString().slice(0, 10);
+      const filename = `${slugify(bikeName(props.bike))}-history-${dateStr}.pdf`;
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleExport} disabled={generating}>
+      <FileDown size={14} className="icon-left" />
+      {generating ? 'Generating…' : 'Export PDF'}
+    </Button>
+  );
+}

--- a/apps/web/src/components/history/BikeHistoryPdfButton.tsx
+++ b/apps/web/src/components/history/BikeHistoryPdfButton.tsx
@@ -4,6 +4,7 @@ import { FileDown } from 'lucide-react';
 
 import { Button } from '@/components/ui/Button';
 import { bikeName, slugify } from '@/lib/bikeHistory';
+import { todayDateInput } from '@/lib/format';
 import type {
   HistoryBike,
   HistoryInstallEvent,
@@ -43,7 +44,7 @@ export default function BikeHistoryPdfButton(props: Props) {
         <BikeHistoryPdf {...props} logoSrc={LOGO_SRC} />
       ).toBlob();
       const url = URL.createObjectURL(blob);
-      const dateStr = new Date().toISOString().slice(0, 10);
+      const dateStr = todayDateInput();
       const filename = `${slugify(bikeName(props.bike))}-history-${dateStr}.pdf`;
       const link = document.createElement('a');
       link.href = url;

--- a/apps/web/src/graphql/bikeHistory.ts
+++ b/apps/web/src/graphql/bikeHistory.ts
@@ -1,0 +1,60 @@
+import { gql } from '@apollo/client';
+
+export const BIKE_HISTORY = gql`
+  query BikeHistory($bikeId: ID!, $startDate: String, $endDate: String) {
+    bikeHistory(bikeId: $bikeId, startDate: $startDate, endDate: $endDate) {
+      bike {
+        id
+        nickname
+        manufacturer
+        model
+        year
+      }
+      rides {
+        id
+        startTime
+        durationSeconds
+        distanceMeters
+        elevationGainMeters
+        averageHr
+        rideType
+        trailSystem
+        location
+      }
+      serviceEvents {
+        id
+        performedAt
+        notes
+        hoursAtService
+        component {
+          id
+          type
+          location
+          brand
+          model
+        }
+      }
+      installs {
+        id
+        eventType
+        occurredAt
+        component {
+          id
+          type
+          location
+          brand
+          model
+        }
+      }
+      totals {
+        rideCount
+        totalDistanceMeters
+        totalDurationSeconds
+        totalElevationGainMeters
+        serviceEventCount
+        installEventCount
+      }
+      truncated
+    }
+  }
+`;

--- a/apps/web/src/graphql/componentInstall.ts
+++ b/apps/web/src/graphql/componentInstall.ts
@@ -1,0 +1,17 @@
+import { gql } from '@apollo/client';
+
+export const UPDATE_BIKE_COMPONENT_INSTALL = gql`
+  mutation UpdateBikeComponentInstall($id: ID!, $input: UpdateBikeComponentInstallInput!) {
+    updateBikeComponentInstall(id: $id, input: $input) {
+      id
+      installedAt
+      removedAt
+    }
+  }
+`;
+
+export const DELETE_BIKE_COMPONENT_INSTALL = gql`
+  mutation DeleteBikeComponentInstall($id: ID!) {
+    deleteBikeComponentInstall(id: $id)
+  }
+`;

--- a/apps/web/src/graphql/gear.ts
+++ b/apps/web/src/graphql/gear.ts
@@ -18,7 +18,11 @@ export const COMPONENT_FIELDS = gql`
     lastServicedAt
     location
     status
-    serviceLogs {
+    # Only the newest service log — the inline "Edit last service" button
+    # on ComponentDetailRow is the only web consumer. Pulling the full
+    # serviceLogs list here was scaling linearly with per-component history
+    # for no UI win.
+    latestServiceLog {
       id
       performedAt
       notes

--- a/apps/web/src/graphql/gear.ts
+++ b/apps/web/src/graphql/gear.ts
@@ -18,6 +18,12 @@ export const COMPONENT_FIELDS = gql`
     lastServicedAt
     location
     status
+    serviceLogs {
+      id
+      performedAt
+      notes
+      hoursAtService
+    }
   }
 `;
 
@@ -91,6 +97,7 @@ export const BIKE_FIELDS_LIGHT = gql`
     motorTorqueNm
     batteryWh
     acquisitionCondition
+    acquisitionDate
     status
     retiredAt
     components {
@@ -132,6 +139,7 @@ export const BIKE_FIELDS = gql`
     motorTorqueNm
     batteryWh
     acquisitionCondition
+    acquisitionDate
     status
     retiredAt
     components {

--- a/apps/web/src/graphql/serviceLog.ts
+++ b/apps/web/src/graphql/serviceLog.ts
@@ -1,0 +1,18 @@
+import { gql } from '@apollo/client';
+
+export const UPDATE_SERVICE_LOG = gql`
+  mutation UpdateServiceLog($id: ID!, $input: UpdateServiceLogInput!) {
+    updateServiceLog(id: $id, input: $input) {
+      id
+      performedAt
+      notes
+      hoursAtService
+    }
+  }
+`;
+
+export const DELETE_SERVICE_LOG = gql`
+  mutation DeleteServiceLog($id: ID!) {
+    deleteServiceLog(id: $id)
+  }
+`;

--- a/apps/web/src/lib/bikeHistory.ts
+++ b/apps/web/src/lib/bikeHistory.ts
@@ -1,0 +1,121 @@
+export type ComponentLite = {
+  id: string;
+  type: string;
+  location: string;
+  brand: string;
+  model: string;
+};
+
+export type HistoryRide = {
+  id: string;
+  startTime: string;
+  durationSeconds: number;
+  distanceMeters: number;
+  elevationGainMeters: number;
+  averageHr?: number | null;
+  rideType: string;
+  trailSystem?: string | null;
+  location?: string | null;
+};
+
+export type HistoryServiceEvent = {
+  id: string;
+  performedAt: string;
+  notes?: string | null;
+  hoursAtService: number;
+  component: ComponentLite;
+};
+
+export type HistoryInstallEvent = {
+  id: string;
+  eventType: 'INSTALLED' | 'REMOVED';
+  occurredAt: string;
+  component: ComponentLite;
+};
+
+export type HistoryBike = {
+  id: string;
+  nickname?: string | null;
+  manufacturer: string;
+  model: string;
+  year?: number | null;
+};
+
+export type HistoryTotals = {
+  rideCount: number;
+  totalDistanceMeters: number;
+  totalDurationSeconds: number;
+  totalElevationGainMeters: number;
+  serviceEventCount: number;
+  installEventCount: number;
+};
+
+export type TimelineItem =
+  | { kind: 'ride'; date: Date; ride: HistoryRide }
+  | { kind: 'service'; date: Date; service: HistoryServiceEvent }
+  | { kind: 'install'; date: Date; install: HistoryInstallEvent };
+
+export type Timeframe = 'all' | '1y' | '90d' | '30d';
+
+export const TIMEFRAME_LABEL: Record<Timeframe, string> = {
+  all: 'All time',
+  '1y': 'Past year',
+  '90d': 'Past 90 days',
+  '30d': 'Past 30 days',
+};
+
+export function computeTimeframeRange(
+  tf: Timeframe,
+  now = new Date()
+): { startDate?: string; endDate?: string } {
+  if (tf === 'all') return {};
+  const end = now;
+  const start = new Date(end);
+  if (tf === '30d') start.setDate(start.getDate() - 30);
+  else if (tf === '90d') start.setDate(start.getDate() - 90);
+  else if (tf === '1y') start.setFullYear(start.getFullYear() - 1);
+  return { startDate: start.toISOString(), endDate: end.toISOString() };
+}
+
+export function mergeAndGroupByYear(params: {
+  rides: HistoryRide[];
+  serviceEvents: HistoryServiceEvent[];
+  installs: HistoryInstallEvent[];
+  showRides: boolean;
+  showService: boolean;
+}): Array<{ year: number; items: TimelineItem[] }> {
+  const { rides, serviceEvents, installs, showRides, showService } = params;
+  const items: TimelineItem[] = [];
+  if (showRides) {
+    for (const ride of rides) {
+      items.push({ kind: 'ride', date: new Date(ride.startTime), ride });
+    }
+  }
+  if (showService) {
+    for (const service of serviceEvents) {
+      items.push({ kind: 'service', date: new Date(service.performedAt), service });
+    }
+    for (const install of installs) {
+      items.push({ kind: 'install', date: new Date(install.occurredAt), install });
+    }
+  }
+  items.sort((a, b) => b.date.getTime() - a.date.getTime());
+
+  const byYear = new Map<number, TimelineItem[]>();
+  for (const item of items) {
+    const year = item.date.getFullYear();
+    if (!byYear.has(year)) byYear.set(year, []);
+    byYear.get(year)!.push(item);
+  }
+  return Array.from(byYear.entries())
+    .sort((a, b) => b[0] - a[0])
+    .map(([year, items]) => ({ year, items }));
+}
+
+export function bikeName(bike: HistoryBike): string {
+  return bike.nickname || `${bike.manufacturer} ${bike.model}`;
+}
+
+export function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -44,3 +44,28 @@ export function toLocalInputValue(v: string | number | Date): string {
 export function fromLocalInputValue(s: string): string {
   return new Date(s).toISOString();
 }
+
+/**
+ * Convert a `<input type="date">` value (yyyy-mm-dd, timezone-less) to an
+ * ISO string anchored at local noon. `new Date('2021-08-15')` parses as
+ * UTC midnight, which in UTC-5 would shift to 2021-08-14 on the server —
+ * the "my date was saved a day early" bug. Anchoring at local noon keeps
+ * the calendar day stable across reasonable timezones.
+ */
+export function dateInputToIsoNoon(dateValue: string): string {
+  return new Date(`${dateValue}T12:00:00`).toISOString();
+}
+
+/**
+ * Convert an ISO timestamp back to a `<input type="date">` value
+ * (yyyy-mm-dd in the user's local timezone). Returns '' for null,
+ * undefined, or unparseable input so callers can feed it directly into an
+ * `<input value={...}>` without extra null-checks.
+ */
+export function isoToDateInput(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -69,3 +69,13 @@ export function isoToDateInput(iso: string | null | undefined): string {
   const pad = (n: number) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
+
+/**
+ * Today's date as a `<input type="date">` value (yyyy-mm-dd in the user's
+ * local timezone). Use for `max` attributes and default values on date
+ * inputs. The naive `new Date().toISOString().slice(0, 10)` returns UTC
+ * today, which is wrong near midnight for any non-UTC user.
+ */
+export function todayDateInput(): string {
+  return isoToDateInput(new Date().toISOString());
+}

--- a/apps/web/src/models/BikeComponents.ts
+++ b/apps/web/src/models/BikeComponents.ts
@@ -121,6 +121,9 @@ export interface BikeFormValues {
   batteryWh?: number | null;
   // Acquisition condition for baseline tracking
   acquisitionCondition?: 'NEW' | 'USED' | 'MIXED' | null;
+  // ISO date string — when the user acquired the bike. Drives installedAt
+  // for every auto-created stock component + BikeComponentInstall row.
+  acquisitionDate?: string | null;
   // 99spokes components for auto-creation
   spokesComponents?: SpokesComponentsData | null;
   components: Record<BikeComponentKey, GearComponentState>;

--- a/apps/web/src/pages/BikeDetail.tsx
+++ b/apps/web/src/pages/BikeDetail.tsx
@@ -378,6 +378,14 @@ export default function BikeDetail() {
               <Wrench size={12} className="icon-left" />
               Log Service
             </Button>
+            {bikeId && (
+              <Link
+                to={`/gear/${bikeId}/history`}
+                className="text-xs text-mint hover:underline mt-1"
+              >
+                View full history →
+              </Link>
+            )}
           </div>
         </div>
 

--- a/apps/web/src/pages/BikeHistory.tsx
+++ b/apps/web/src/pages/BikeHistory.tsx
@@ -151,8 +151,18 @@ export default function BikeHistory() {
                     {year}
                   </h2>
                   <ul className="space-y-1">
-                    {items.map((item, idx) => (
-                      <li key={`${item.kind}-${idx}`} className="py-2 border-b border-border last:border-b-0">
+                    {items.map((item) => {
+                      // Real id-based keys so re-ordering (timeframe change,
+                      // toggle filter) doesn't leave React reusing DOM nodes
+                      // against the wrong items.
+                      const key =
+                        item.kind === 'ride'
+                          ? `r:${item.ride.id}`
+                          : item.kind === 'service'
+                          ? `s:${item.service.id}`
+                          : `i:${item.install.id}`;
+                      return (
+                      <li key={key} className="py-2 border-b border-border last:border-b-0">
                         {item.kind === 'ride' && <RideRow ride={item.ride} distanceUnit={distanceUnit} />}
                         {item.kind === 'service' && (
                           <ServiceRow
@@ -186,7 +196,8 @@ export default function BikeHistory() {
                           />
                         )}
                       </li>
-                    ))}
+                      );
+                    })}
                   </ul>
                 </section>
               ))}
@@ -195,19 +206,23 @@ export default function BikeHistory() {
         </>
       )}
 
-      <EditServiceModal
-        log={editingService?.log ?? null}
-        componentLabel={editingService?.componentLabel ?? ''}
-        bikeId={bikeId}
-        onClose={() => setEditingService(null)}
-      />
+      {editingService && (
+        <EditServiceModal
+          log={editingService.log}
+          componentLabel={editingService.componentLabel}
+          bikeId={bikeId}
+          onClose={() => setEditingService(null)}
+        />
+      )}
 
-      <EditInstallModal
-        event={editingInstall?.event ?? null}
-        componentLabel={editingInstall?.componentLabel ?? ''}
-        bikeId={bikeId}
-        onClose={() => setEditingInstall(null)}
-      />
+      {editingInstall && (
+        <EditInstallModal
+          event={editingInstall.event}
+          componentLabel={editingInstall.componentLabel}
+          bikeId={bikeId}
+          onClose={() => setEditingInstall(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/pages/BikeHistory.tsx
+++ b/apps/web/src/pages/BikeHistory.tsx
@@ -5,6 +5,8 @@ import { ArrowLeft, Bike as BikeIcon, FileDown, MinusCircle, PlusCircle, Wrench 
 
 import { BIKE_HISTORY } from '@/graphql/bikeHistory';
 import { Button } from '@/components/ui/Button';
+import { EditServiceModal, type EditableServiceLog } from '@/components/dashboard/EditServiceModal';
+import { EditInstallModal, type EditableInstallEvent } from '@/components/dashboard/EditInstallModal';
 import { fmtDateTime, fmtDistance, fmtDuration, fmtElevation } from '@/lib/format';
 import { usePreferences } from '@/hooks/usePreferences';
 import { getComponentLabel } from '@/constants/componentLabels';
@@ -35,6 +37,14 @@ export default function BikeHistory() {
   const [timeframe, setTimeframe] = useState<Timeframe>('all');
   const [showRides, setShowRides] = useState(true);
   const [showService, setShowService] = useState(true);
+  const [editingService, setEditingService] = useState<{
+    log: EditableServiceLog;
+    componentLabel: string;
+  } | null>(null);
+  const [editingInstall, setEditingInstall] = useState<{
+    event: EditableInstallEvent;
+    componentLabel: string;
+  } | null>(null);
 
   const range = useMemo(() => computeTimeframeRange(timeframe), [timeframe]);
 
@@ -144,8 +154,37 @@ export default function BikeHistory() {
                     {items.map((item, idx) => (
                       <li key={`${item.kind}-${idx}`} className="py-2 border-b border-border last:border-b-0">
                         {item.kind === 'ride' && <RideRow ride={item.ride} distanceUnit={distanceUnit} />}
-                        {item.kind === 'service' && <ServiceRow service={item.service} />}
-                        {item.kind === 'install' && <InstallRow install={item.install} />}
+                        {item.kind === 'service' && (
+                          <ServiceRow
+                            service={item.service}
+                            onEdit={() =>
+                              setEditingService({
+                                log: {
+                                  id: item.service.id,
+                                  performedAt: item.service.performedAt,
+                                  notes: item.service.notes,
+                                  hoursAtService: item.service.hoursAtService,
+                                },
+                                componentLabel: componentDisplay(item.service.component),
+                              })
+                            }
+                          />
+                        )}
+                        {item.kind === 'install' && (
+                          <InstallRow
+                            install={item.install}
+                            onEdit={() =>
+                              setEditingInstall({
+                                event: {
+                                  id: item.install.id,
+                                  eventType: item.install.eventType,
+                                  occurredAt: item.install.occurredAt,
+                                },
+                                componentLabel: componentDisplay(item.install.component),
+                              })
+                            }
+                          />
+                        )}
                       </li>
                     ))}
                   </ul>
@@ -155,6 +194,20 @@ export default function BikeHistory() {
           )}
         </>
       )}
+
+      <EditServiceModal
+        log={editingService?.log ?? null}
+        componentLabel={editingService?.componentLabel ?? ''}
+        bikeId={bikeId}
+        onClose={() => setEditingService(null)}
+      />
+
+      <EditInstallModal
+        event={editingInstall?.event ?? null}
+        componentLabel={editingInstall?.componentLabel ?? ''}
+        bikeId={bikeId}
+        onClose={() => setEditingInstall(null)}
+      />
     </div>
   );
 }
@@ -195,9 +248,14 @@ function RideRow({ ride, distanceUnit }: { ride: HistoryRide; distanceUnit: 'mi'
   );
 }
 
-function ServiceRow({ service }: { service: HistoryServiceEvent }) {
+function ServiceRow({ service, onEdit }: { service: HistoryServiceEvent; onEdit?: () => void }) {
   return (
-    <div className="flex items-baseline justify-between gap-3">
+    <button
+      type="button"
+      onClick={onEdit}
+      className="w-full text-left flex items-baseline justify-between gap-3 hover:bg-surface-2/40 rounded px-1 -mx-1 py-0.5"
+      aria-label={`Edit service for ${componentDisplay(service.component)}`}
+    >
       <div className="min-w-0">
         <div className="text-sm font-medium truncate">
           Service · {componentDisplay(service.component)}
@@ -208,15 +266,20 @@ function ServiceRow({ service }: { service: HistoryServiceEvent }) {
         </div>
       </div>
       <Wrench size={14} className="text-muted shrink-0" />
-    </div>
+    </button>
   );
 }
 
-function InstallRow({ install }: { install: HistoryInstallEvent }) {
+function InstallRow({ install, onEdit }: { install: HistoryInstallEvent; onEdit?: () => void }) {
   const Icon = install.eventType === 'INSTALLED' ? PlusCircle : MinusCircle;
   const verb = install.eventType === 'INSTALLED' ? 'Installed' : 'Removed';
   return (
-    <div className="flex items-baseline justify-between gap-3">
+    <button
+      type="button"
+      onClick={onEdit}
+      className="w-full text-left flex items-baseline justify-between gap-3 hover:bg-surface-2/40 rounded px-1 -mx-1 py-0.5"
+      aria-label={`Edit ${verb.toLowerCase()} event for ${componentDisplay(install.component)}`}
+    >
       <div className="min-w-0">
         <div className="text-sm font-medium truncate">
           {verb} · {componentDisplay(install.component)}
@@ -224,6 +287,6 @@ function InstallRow({ install }: { install: HistoryInstallEvent }) {
         <div className="text-xs text-muted">{fmtDateTime(install.occurredAt)}</div>
       </div>
       <Icon size={14} className="text-muted shrink-0" />
-    </div>
+    </button>
   );
 }

--- a/apps/web/src/pages/BikeHistory.tsx
+++ b/apps/web/src/pages/BikeHistory.tsx
@@ -44,6 +44,7 @@ export default function BikeHistory() {
   const [editingInstall, setEditingInstall] = useState<{
     event: EditableInstallEvent;
     componentLabel: string;
+    hasPairedEvent: boolean;
   } | null>(null);
 
   const range = useMemo(() => computeTimeframeRange(timeframe), [timeframe]);
@@ -55,6 +56,24 @@ export default function BikeHistory() {
   });
 
   const payload = data?.bikeHistory;
+
+  // Base install-row ids that have BOTH an INSTALLED and a REMOVED event in
+  // the timeline. Used so the delete-confirmation copy on EditInstallModal
+  // can accurately say "one event" vs "both events."
+  const pairedBaseIds = useMemo(() => {
+    if (!payload) return new Set<string>();
+    const baseOf = (id: string) => {
+      const i = id.lastIndexOf(':');
+      return i > 0 ? id.slice(0, i) : id;
+    };
+    const seen = new Map<string, number>();
+    for (const ev of payload.installs) {
+      const base = baseOf(ev.id);
+      seen.set(base, (seen.get(base) ?? 0) + 1);
+    }
+    return new Set(Array.from(seen).filter(([, n]) => n >= 2).map(([b]) => b));
+  }, [payload]);
+
   const yearGroups = useMemo(() => {
     if (!payload) return [];
     return mergeAndGroupByYear({
@@ -183,7 +202,10 @@ export default function BikeHistory() {
                         {item.kind === 'install' && (
                           <InstallRow
                             install={item.install}
-                            onEdit={() =>
+                            onEdit={() => {
+                              const baseIdx = item.install.id.lastIndexOf(':');
+                              const baseId =
+                                baseIdx > 0 ? item.install.id.slice(0, baseIdx) : item.install.id;
                               setEditingInstall({
                                 event: {
                                   id: item.install.id,
@@ -191,8 +213,9 @@ export default function BikeHistory() {
                                   occurredAt: item.install.occurredAt,
                                 },
                                 componentLabel: componentDisplay(item.install.component),
-                              })
-                            }
+                                hasPairedEvent: pairedBaseIds.has(baseId),
+                              });
+                            }}
                           />
                         )}
                       </li>
@@ -220,6 +243,7 @@ export default function BikeHistory() {
           event={editingInstall.event}
           componentLabel={editingInstall.componentLabel}
           bikeId={bikeId}
+          hasPairedEvent={editingInstall.hasPairedEvent}
           onClose={() => setEditingInstall(null)}
         />
       )}

--- a/apps/web/src/pages/BikeHistory.tsx
+++ b/apps/web/src/pages/BikeHistory.tsx
@@ -1,0 +1,229 @@
+import { Suspense, lazy, useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useQuery } from '@apollo/client';
+import { ArrowLeft, Bike as BikeIcon, FileDown, MinusCircle, PlusCircle, Wrench } from 'lucide-react';
+
+import { BIKE_HISTORY } from '@/graphql/bikeHistory';
+import { Button } from '@/components/ui/Button';
+import { fmtDateTime, fmtDistance, fmtDuration, fmtElevation } from '@/lib/format';
+import { usePreferences } from '@/hooks/usePreferences';
+import { getComponentLabel } from '@/constants/componentLabels';
+import {
+  bikeName,
+  computeTimeframeRange,
+  mergeAndGroupByYear,
+  TIMEFRAME_LABEL,
+  type ComponentLite,
+  type HistoryInstallEvent,
+  type HistoryRide,
+  type HistoryServiceEvent,
+  type Timeframe,
+} from '@/lib/bikeHistory';
+
+const BikeHistoryPdfButton = lazy(() => import('@/components/history/BikeHistoryPdfButton'));
+
+function componentDisplay(component: ComponentLite): string {
+  const label = getComponentLabel(component.type);
+  const loc = component.location && component.location !== 'NONE' ? ` (${component.location.toLowerCase()})` : '';
+  const brandModel = [component.brand, component.model].filter(Boolean).join(' ');
+  return brandModel ? `${label}${loc} — ${brandModel}` : `${label}${loc}`;
+}
+
+export default function BikeHistory() {
+  const { bikeId } = useParams<{ bikeId: string }>();
+  const { distanceUnit } = usePreferences();
+  const [timeframe, setTimeframe] = useState<Timeframe>('all');
+  const [showRides, setShowRides] = useState(true);
+  const [showService, setShowService] = useState(true);
+
+  const range = useMemo(() => computeTimeframeRange(timeframe), [timeframe]);
+
+  const { data, loading, error } = useQuery(BIKE_HISTORY, {
+    variables: { bikeId, ...range },
+    skip: !bikeId,
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const payload = data?.bikeHistory;
+  const yearGroups = useMemo(() => {
+    if (!payload) return [];
+    return mergeAndGroupByYear({
+      rides: payload.rides,
+      serviceEvents: payload.serviceEvents,
+      installs: payload.installs,
+      showRides,
+      showService,
+    });
+  }, [payload, showRides, showService]);
+
+  if (!bikeId) {
+    return <div className="p-6">Missing bike id.</div>;
+  }
+
+  return (
+    <div className="bike-history-page mx-auto max-w-3xl px-4 py-6">
+      <div className="mb-4">
+        <Link to={`/gear/${bikeId}`} className="text-sm text-muted hover:underline inline-flex items-center gap-1">
+          <ArrowLeft size={14} /> Back to bike
+        </Link>
+      </div>
+
+      {loading && !payload && (
+        <div className="text-muted">Loading history…</div>
+      )}
+      {error && (
+        <div className="text-danger">Couldn't load history: {error.message}</div>
+      )}
+
+      {payload && (
+        <>
+          <div className="flex items-start justify-between gap-4 mb-4">
+            <div>
+              <h1 className="text-2xl font-semibold">{bikeName(payload.bike)}</h1>
+              <div className="text-muted text-sm">
+                {payload.bike.year ? `${payload.bike.year} · ` : ''}History
+              </div>
+            </div>
+            <Suspense fallback={<Button variant="outline" size="sm" disabled><FileDown size={14} className="icon-left" /> Preparing…</Button>}>
+              <BikeHistoryPdfButton
+                bike={payload.bike}
+                totals={payload.totals}
+                yearGroups={yearGroups}
+                distanceUnit={distanceUnit}
+                timeframeLabel={TIMEFRAME_LABEL[timeframe]}
+                truncated={payload.truncated}
+              />
+            </Suspense>
+          </div>
+
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
+            <TotalChip label="Rides" value={payload.totals.rideCount.toLocaleString()} />
+            <TotalChip label="Distance" value={fmtDistance(payload.totals.totalDistanceMeters, distanceUnit)} />
+            <TotalChip label="Elevation" value={fmtElevation(payload.totals.totalElevationGainMeters, distanceUnit)} />
+            <TotalChip label="Service events" value={(payload.totals.serviceEventCount + payload.totals.installEventCount).toLocaleString()} />
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2 mb-4">
+            <label className="text-xs text-muted mr-1">Timeframe</label>
+            <select
+              value={timeframe}
+              onChange={(e) => setTimeframe(e.target.value as Timeframe)}
+              className="timeframe-select"
+            >
+              {(Object.keys(TIMEFRAME_LABEL) as Timeframe[]).map((tf) => (
+                <option key={tf} value={tf}>{TIMEFRAME_LABEL[tf]}</option>
+              ))}
+            </select>
+            <div className="mx-2 h-4 w-px bg-border" />
+            <TogglePill active={showRides} onClick={() => setShowRides((v) => !v)}>
+              Rides
+            </TogglePill>
+            <TogglePill active={showService} onClick={() => setShowService((v) => !v)}>
+              Service & Installs
+            </TogglePill>
+          </div>
+
+          {payload.truncated && (
+            <div className="text-xs text-muted mb-3">
+              Showing the most recent entries. Some older events may be cut off for very long histories.
+            </div>
+          )}
+
+          {yearGroups.length === 0 ? (
+            <div className="bike-history-empty border border-border rounded-lg p-8 text-center text-muted">
+              No events in this timeframe.
+            </div>
+          ) : (
+            <div className="bike-history-timeline space-y-6">
+              {yearGroups.map(({ year, items }) => (
+                <section key={year}>
+                  <h2 className="text-sm font-semibold text-muted uppercase tracking-wider mb-2">
+                    {year}
+                  </h2>
+                  <ul className="space-y-1">
+                    {items.map((item, idx) => (
+                      <li key={`${item.kind}-${idx}`} className="py-2 border-b border-border last:border-b-0">
+                        {item.kind === 'ride' && <RideRow ride={item.ride} distanceUnit={distanceUnit} />}
+                        {item.kind === 'service' && <ServiceRow service={item.service} />}
+                        {item.kind === 'install' && <InstallRow install={item.install} />}
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function TotalChip({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-surface-2 px-3 py-2">
+      <div className="text-xs text-muted">{label}</div>
+      <div className="text-sm font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function TogglePill({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1 rounded-full text-xs border ${active ? 'bg-mint/10 border-mint text-mint' : 'border-border text-muted'}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function RideRow({ ride, distanceUnit }: { ride: HistoryRide; distanceUnit: 'mi' | 'km' }) {
+  const title = ride.trailSystem || ride.location || `${ride.rideType} ride`;
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <div className="min-w-0">
+        <div className="text-sm font-medium truncate">{title}</div>
+        <div className="text-xs text-muted">
+          {fmtDateTime(ride.startTime)} · {fmtDuration(ride.durationSeconds)} · {fmtDistance(ride.distanceMeters, distanceUnit)} · {fmtElevation(ride.elevationGainMeters, distanceUnit)}
+        </div>
+      </div>
+      <BikeIcon size={14} className="text-muted shrink-0" />
+    </div>
+  );
+}
+
+function ServiceRow({ service }: { service: HistoryServiceEvent }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <div className="min-w-0">
+        <div className="text-sm font-medium truncate">
+          Service · {componentDisplay(service.component)}
+        </div>
+        <div className="text-xs text-muted truncate">
+          {fmtDateTime(service.performedAt)} · {service.hoursAtService.toFixed(0)} hrs
+          {service.notes ? ` · ${service.notes}` : ''}
+        </div>
+      </div>
+      <Wrench size={14} className="text-muted shrink-0" />
+    </div>
+  );
+}
+
+function InstallRow({ install }: { install: HistoryInstallEvent }) {
+  const Icon = install.eventType === 'INSTALLED' ? PlusCircle : MinusCircle;
+  const verb = install.eventType === 'INSTALLED' ? 'Installed' : 'Removed';
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <div className="min-w-0">
+        <div className="text-sm font-medium truncate">
+          {verb} · {componentDisplay(install.component)}
+        </div>
+        <div className="text-xs text-muted">{fmtDateTime(install.occurredAt)}</div>
+      </div>
+      <Icon size={14} className="text-muted shrink-0" />
+    </div>
+  );
+}

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -46,6 +46,11 @@ interface Ride {
   stravaActivityId?: string | null;
   garminActivityId?: string | null;
   whoopWorkoutId?: string | null;
+  weather?: {
+    id: string;
+    tempC: number;
+    condition: import('../models/Ride').WeatherCondition;
+  } | null;
 }
 
 const RECENT_COUNT = 20;

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -46,11 +46,7 @@ interface Ride {
   stravaActivityId?: string | null;
   garminActivityId?: string | null;
   whoopWorkoutId?: string | null;
-  weather?: {
-    id: string;
-    tempC: number;
-    condition: import('../models/Ride').WeatherCondition;
-  } | null;
+  weather?: import('../models/Ride').RideWeather | null;
 }
 
 const RECENT_COUNT = 20;

--- a/apps/web/src/pages/Gear.tsx
+++ b/apps/web/src/pages/Gear.tsx
@@ -244,6 +244,8 @@ export default function Gear() {
       motorPowerW: form.motorPowerW || undefined,
       motorTorqueNm: form.motorTorqueNm || undefined,
       batteryWh: form.batteryWh || undefined,
+      acquisitionCondition: form.acquisitionCondition ?? undefined,
+      acquisitionDate: form.acquisitionDate ?? undefined,
       spokesComponents: form.spokesComponents || undefined,
       fork: componentInput(form.components.fork),
       shock: componentInput(form.components.shock),

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "@eslint/js": "^9.39.4",
         "@nx/esbuild": "^22.6.1",
         "@nx/vite": "^22.6.1",
+        "@sentry/vite-plugin": "^5.2.0",
         "@types/bcryptjs": "^2.4.6",
         "@types/body-parser": "^1.19.6",
         "@types/cookie-parser": "^1.4.10",
@@ -152,6 +153,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@react-oauth/google": "^0.13.4",
+        "@react-pdf/renderer": "^4.5.1",
         "@sentry/react": "^10.48.0",
         "@vercel/analytics": "^2.0.1",
         "date-fns": "^4.1.0",
@@ -2756,7 +2758,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -7388,6 +7389,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
@@ -8932,6 +8945,195 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.3.tgz",
+      "integrity": "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.8.tgz",
+      "integrity": "sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/types": "^2.11.1",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.1.0.tgz",
+      "integrity": "sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/svg": "^1.1.0",
+        "jay-peg": "^1.1.1",
+        "png-js": "^2.0.0"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.6.1.tgz",
+      "integrity": "sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/image": "^3.1.0",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-5.1.1.tgz",
+      "integrity": "sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "browserify-zlib": "^0.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.1.1",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^2.0.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/pdfkit/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.3.0.tgz",
+      "integrity": "sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.5.1.tgz",
+      "integrity": "sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^2.1.4",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.5.1.tgz",
+      "integrity": "sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/layout": "^4.6.1",
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.5.1",
+        "@react-pdf/types": "^2.11.1",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.2.1.tgz",
+      "integrity": "sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/types": "^2.11.1",
+        "color-string": "^2.1.4",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/svg/-/svg-1.1.0.tgz",
+      "integrity": "sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/primitives": "^4.3.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.3.0.tgz",
+      "integrity": "sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.11.1.tgz",
+      "integrity": "sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -10892,7 +11094,6 @@
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -12693,6 +12894,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -13500,7 +13707,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -13581,6 +13787,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -14206,6 +14430,27 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -15218,6 +15463,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/diff": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
@@ -15487,6 +15738,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
     },
     "node_modules/empathic": {
@@ -16119,7 +16376,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -16532,7 +16788,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -16669,6 +16924,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -16880,6 +17141,32 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/fontkit/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/for-each": {
@@ -17917,6 +18204,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -18089,6 +18391,12 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/hyphen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz",
+      "integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==",
+      "license": "ISC"
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -18660,6 +18968,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
     "node_modules/is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -18791,6 +19105,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
       }
     },
     "node_modules/jest": {
@@ -20228,6 +20551,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -20866,6 +21195,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
@@ -21313,6 +21661,12 @@
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -21846,6 +22200,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -22263,6 +22626,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -22337,6 +22706,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -22826,6 +23201,14 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/png-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
+      "integrity": "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
     "node_modules/portfinder": {
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
@@ -22985,7 +23368,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/postgres-array": {
@@ -23278,6 +23660,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -24059,7 +24450,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24210,6 +24600,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -25160,7 +25556,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -25410,6 +25805,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
     },
     "node_modules/svg-parser": {
       "version": "2.0.4",
@@ -25766,6 +26167,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -26336,6 +26743,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/unicode-property-aliases-ecmascript": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
@@ -26345,6 +26762,22 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
     },
     "node_modules/union": {
       "version": "0.5.0",
@@ -26502,7 +26935,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -26656,6 +27088,20 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/vite-node": {
@@ -27249,6 +27695,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zen-observable": {
       "version": "0.8.15",


### PR DESCRIPTION
# Component install dates: user-specified, retroactively editable

Closes the data-integrity bug where every component on a bike was stamped with an install date of "today" — the moment the bike was added to Loam Logger. For users migrating bikes they've owned for years, this made the new BikeHistory timeline useless (every stock component showed as installed the day they signed up).

## Why

The BikeHistory timeline surfaces every `BikeComponentInstall` row as an "Installed X" event. But every code path that writes those rows — `addBike`, `addComponent`, `replaceComponent`, `installComponent`, `swapComponents` — hardcoded `installedAt: new Date()`. Nobody ever asked the user "when did this actually happen?"

Result for real users: a bike I've owned since 2021 with my custom fork, custom drivetrain, and a few swaps over the years would render as a single 2026 pile-up on the history timeline. Worthless for a resale PDF, misleading for wear predictions (since `hoursUsed` anchors off install/service dates).

## Summary of changes

**Bike acquisition date.**
- New `Bike.acquisitionDate DateTime?` column ([migration](apps/api/prisma/migrations/20260417120000_add_bike_acquisition_date/migration.sql)).
- `AddBikeInput.acquisitionDate` threaded through `buildBikeComponents` so every auto-created stock component and its `BikeComponentInstall` row get stamped with the user's chosen date. Falls back to today when omitted — existing behavior preserved for old callers.
- Web: new "When did you get this bike?" date input on the final step of [BikeForm](apps/web/src/components/WearStartStep.tsx) + threaded through [Gear.tsx](apps/web/src/pages/Gear.tsx).

**Per-install-event dates on add/replace/install/swap.**
- Optional `installedAt: String` added to `AddComponentInput`, `ReplaceComponentInput`, `InstallComponentInput`, `SwapComponentsInput`. All validated: parseable ISO, not in the future.
- Web: date picker ("Installed on" / "Swap date") added to [ReplaceComponentModal](apps/web/src/components/gear/ReplaceComponentModal.tsx) and [SwapComponentModal](apps/web/src/components/gear/SwapComponentModal.tsx).

**Retroactive edits.**
- New `updateBikeComponentInstall(id, input)` and `deleteBikeComponentInstall(id)` mutations in [resolvers.ts](apps/api/src/graphql/resolvers.ts). Ownership guard via the install row's `userId`; prediction cache invalidated before + after; rate-limited at 30/min/user.
- New [EditInstallModal.tsx](apps/web/src/components/dashboard/EditInstallModal.tsx) — mirrors EditServiceModal. Wired into the [BikeHistory timeline](apps/web/src/pages/BikeHistory.tsx): install/remove rows are now clickable, opening the modal for the underlying `BikeComponentInstall` row. Date-picker-based edit for whichever field the user clicked on (installed vs removed), with a Delete entry button for wholesale removal.

**ServiceLog edit/delete (from the previous branch iteration, rolled in here).**
- New `updateServiceLog` / `deleteServiceLog` mutations with the same ownership + prediction-cache pattern.
- [EditServiceModal.tsx](apps/web/src/components/dashboard/EditServiceModal.tsx) surfaced on BikeHistory service rows and on [ComponentDetailRow](apps/web/src/components/gear/ComponentDetailRow.tsx) (inline pencil icon next to the "Last Serviced" line).

**Side bug fixed in `replaceComponent`.**
Previously the replace flow created a new `Component` but never an accompanying `BikeComponentInstall` row. This meant replacements silently disappeared from the history timeline. Fixed: each replacement now closes the retired component's open install row (sets `removedAt`) and creates a new install row for the replacement — so the "Removed X / Installed Y" pair actually shows up in the timeline.

## Tests

396 new lines of resolver tests. All 167 resolver tests pass.

Coverage added:
- `updateServiceLog`: ownership rejection; non-latest edits don't recompute anchor; latest-edit re-aggregates ride hours; prediction cache invalidated before + after.
- `deleteServiceLog`: ownership; delete non-latest → no anchor change; delete latest with prior → rollback + recompute; delete last remaining → anchor nulled + full-history recompute; `clearServiceNotificationLogs` fires.
- `updateBikeComponentInstall`: ownership; future-date rejection; prediction cache bracketing; clearing `removedAt` with `null`.
- `deleteBikeComponentInstall`: ownership; cache bracketing.
- Existing `replaceComponent` tests updated to mock the new `bikeComponentInstall.{updateMany,create}` calls.

## Verification

```
cd loam-logger/apps/api && npx prisma migrate deploy
cd loam-logger && npx nx run api:test
cd loam-logger && npx nx run web:lint
cd loam-logger/apps/web && npx tsc --noEmit -p tsconfig.json
```

Manual smoke test plan:
1. Add a new bike, set "Acquired on" to 6 months ago → BikeHistory shows every stock component installed on that date.
2. Open BikeHistory for an existing bike, click an "Installed" row for a wrong-dated stock component → date picker appears, save, confirm row moves.
3. On BikeDetail, expand a component row, click the pencil next to "Last Serviced" → edit modal opens for the newest service log.
4. Replace a component via the ReplaceComponentModal with a backdated "Installed on" → new install row appears at that date in history, old component shows a matching "Removed" event.

## Scope I deliberately didn't include

- **No backfill for existing `Bike.acquisitionDate`.** The column stays `null` on bikes created before this PR — we don't know the truth, and guessing would be worse than leaving it blank. Users fix their own bikes via the edit-install UI on the timeline.
- **No bulk "reset all installs on bike X to date Y" helper.** Adds complexity and risk of wiping real data. Per-event edits are enough.
- **No `hoursUsed` retroactive recompute when editing an `installedAt`.** Install dates are audit-trail-only; they don't feed wear math the way service-log dates do. No anchor logic needs to change.

## Risks

- Existing bikes keep the legacy behavior (stock components stamped with bike creation date). Users have to actively open BikeHistory and fix the ones they care about. This is the tradeoff for `acquisitionDate` being nullable — acceptable since the alternative was forcing a mandatory "when did you buy this?" prompt on every existing bike.
- `replaceComponent`'s newly created `BikeComponentInstall` rows mean the history timeline will suddenly fill in for users who've done a lot of replacements. This is a feature (the installs should have been there all along) but the visual noise is worth flagging.
