### PR TITLE
Retroactive acquisition date + bulk install-date edits

### DIFF
--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -3613,9 +3613,11 @@ describe('GraphQL Resolvers', () => {
       mockFindMany.mockReset();
       mockUpdateMany.mockReset().mockResolvedValue({ count: 0 });
       mockServiceLogUpdateMany.mockReset().mockResolvedValue({ count: 0 });
+      // findMany is now called via the transaction client (race-closure
+      // fix), so the tx mock needs to expose it alongside updateMany.
       mockTransaction.mockReset().mockImplementation(async (fn: (tx: unknown) => unknown) =>
         fn({
-          bikeComponentInstall: { updateMany: mockUpdateMany },
+          bikeComponentInstall: { findMany: mockFindMany, updateMany: mockUpdateMany },
           serviceLog: { updateMany: mockServiceLogUpdateMany },
         })
       );

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -42,6 +42,7 @@ jest.mock('../../lib/prisma', () => ({
       findUnique: jest.fn(),
       findFirst: jest.fn(),
       update: jest.fn(),
+      updateMany: jest.fn().mockResolvedValue({ count: 0 }),
       delete: jest.fn(),
     },
     termsAcceptance: {
@@ -3466,6 +3467,254 @@ describe('GraphQL Resolvers', () => {
         (c) => c[1] === 'bike-9'
       );
       expect(calls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('Mutation.updateBikeAcquisition', () => {
+    const mutation = resolvers.Mutation.updateBikeAcquisition;
+    const mockBikeFindFirst = mockPrisma.bike.findFirst as jest.Mock;
+    const mockBikeFindUnique = mockPrisma.bike.findUnique as jest.Mock;
+    const mockBikeUpdate = mockPrisma.bike.update as jest.Mock;
+    const mockInstallFindMany = mockPrisma.bikeComponentInstall.findMany as jest.Mock;
+    const mockInstallUpdateMany = mockPrisma.bikeComponentInstall.updateMany as jest.Mock;
+    const mockComponentUpdateMany = mockPrisma.component.updateMany as jest.Mock;
+    const mockServiceLogUpdateMany = mockPrisma.serviceLog.updateMany as jest.Mock;
+    const mockTransaction = mockPrisma.$transaction as jest.Mock;
+
+    const setTransactionPassthrough = () => {
+      mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
+        return fn({
+          bike: { update: mockBikeUpdate },
+          bikeComponentInstall: {
+            findMany: mockInstallFindMany,
+            updateMany: mockInstallUpdateMany,
+          },
+          component: { updateMany: mockComponentUpdateMany },
+          serviceLog: { updateMany: mockServiceLogUpdateMany },
+        });
+      });
+    };
+
+    beforeEach(() => {
+      mockBikeFindFirst.mockReset();
+      mockBikeFindUnique.mockReset();
+      mockBikeUpdate.mockReset().mockResolvedValue({ id: 'bike-1' });
+      mockInstallFindMany.mockReset().mockResolvedValue([]);
+      mockInstallUpdateMany.mockReset().mockResolvedValue({ count: 0 });
+      mockComponentUpdateMany.mockReset().mockResolvedValue({ count: 0 });
+      mockServiceLogUpdateMany.mockReset().mockResolvedValue({ count: 0 });
+      mockTransaction.mockReset();
+      setTransactionPassthrough();
+    });
+
+    it('rejects when the bike is not owned by the viewer', async () => {
+      mockBikeFindFirst.mockResolvedValueOnce(null);
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        mutation(
+          {},
+          { bikeId: 'bike-stolen', input: { acquisitionDate: '2023-01-01T00:00:00Z' } },
+          ctx as never
+        )
+      ).rejects.toThrow('Bike not found');
+      expect(mockBikeUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects future acquisition dates', async () => {
+      mockBikeFindFirst.mockResolvedValueOnce({
+        id: 'bike-1',
+        userId: 'user-123',
+        createdAt: new Date('2026-04-01T00:00:00Z'),
+      });
+      const future = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        mutation({}, { bikeId: 'bike-1', input: { acquisitionDate: future } }, ctx as never)
+      ).rejects.toThrow('acquisitionDate cannot be in the future');
+    });
+
+    it('cascades to eligible installs and groups baseline service logs by old date', async () => {
+      // Two components with the same buggy creation date (common migration
+      // case) + one pre-existing install on a later date that must NOT be
+      // moved by the cascade.
+      mockBikeFindFirst.mockResolvedValueOnce({
+        id: 'bike-1',
+        userId: 'user-123',
+        createdAt: new Date('2026-04-01T00:00:00Z'),
+      });
+      const oldDate = new Date('2026-04-01T00:00:05Z');
+      mockInstallFindMany.mockResolvedValueOnce([
+        { id: 'i1', componentId: 'c1', installedAt: oldDate },
+        { id: 'i2', componentId: 'c2', installedAt: oldDate },
+      ]);
+      mockInstallUpdateMany.mockResolvedValueOnce({ count: 2 });
+      mockComponentUpdateMany.mockResolvedValueOnce({ count: 2 });
+      mockServiceLogUpdateMany.mockResolvedValueOnce({ count: 2 });
+      mockBikeFindUnique.mockResolvedValueOnce({ id: 'bike-1', acquisitionDate: new Date('2024-05-10') });
+
+      const ctx = createMockContext('user-123');
+      const result = await mutation(
+        {},
+        { bikeId: 'bike-1', input: { acquisitionDate: '2024-05-10T00:00:00Z' } },
+        ctx as never
+      );
+
+      expect(result.installsMoved).toBe(2);
+      expect(result.serviceLogsMoved).toBe(2);
+
+      // Single updateMany call because both installs share the same old
+      // date — grouping collapsed them.
+      expect(mockServiceLogUpdateMany).toHaveBeenCalledTimes(1);
+      expect(mockServiceLogUpdateMany).toHaveBeenCalledWith({
+        where: {
+          componentId: { in: ['c1', 'c2'] },
+          performedAt: oldDate,
+          hoursAtService: 0,
+        },
+        data: { performedAt: new Date('2024-05-10T00:00:00Z') },
+      });
+    });
+
+    it('skips the cascade when cascadeInstalls is false', async () => {
+      mockBikeFindFirst.mockResolvedValueOnce({
+        id: 'bike-1',
+        userId: 'user-123',
+        createdAt: new Date('2026-04-01T00:00:00Z'),
+      });
+      mockBikeFindUnique.mockResolvedValueOnce({ id: 'bike-1' });
+
+      const ctx = createMockContext('user-123');
+      const result = await mutation(
+        {},
+        {
+          bikeId: 'bike-1',
+          input: { acquisitionDate: '2024-05-10T00:00:00Z', cascadeInstalls: false },
+        },
+        ctx as never
+      );
+
+      expect(mockInstallFindMany).not.toHaveBeenCalled();
+      expect(mockInstallUpdateMany).not.toHaveBeenCalled();
+      expect(result.installsMoved).toBe(0);
+      expect(result.serviceLogsMoved).toBe(0);
+    });
+  });
+
+  describe('Mutation.bulkUpdateBikeComponentInstalls', () => {
+    const mutation = resolvers.Mutation.bulkUpdateBikeComponentInstalls;
+    const mockFindMany = mockPrisma.bikeComponentInstall.findMany as jest.Mock;
+    const mockUpdateMany = mockPrisma.bikeComponentInstall.updateMany as jest.Mock;
+    const mockServiceLogUpdateMany = mockPrisma.serviceLog.updateMany as jest.Mock;
+    const mockTransaction = mockPrisma.$transaction as jest.Mock;
+
+    beforeEach(() => {
+      mockFindMany.mockReset();
+      mockUpdateMany.mockReset().mockResolvedValue({ count: 0 });
+      mockServiceLogUpdateMany.mockReset().mockResolvedValue({ count: 0 });
+      mockTransaction.mockReset().mockImplementation(async (fn: (tx: unknown) => unknown) =>
+        fn({
+          bikeComponentInstall: { updateMany: mockUpdateMany },
+          serviceLog: { updateMany: mockServiceLogUpdateMany },
+        })
+      );
+    });
+
+    it('rejects the whole batch when any id is not owned by the viewer', async () => {
+      // Two ids requested, one belongs to someone else — the batch is
+      // all-or-nothing so the whole thing fails with NOT_FOUND.
+      mockFindMany.mockResolvedValueOnce([
+        { id: 'i1', userId: 'user-123', bikeId: 'bike-1', componentId: 'c1', installedAt: new Date(), removedAt: null },
+        { id: 'i2', userId: 'other', bikeId: 'bike-1', componentId: 'c2', installedAt: new Date(), removedAt: null },
+      ]);
+
+      const ctx = createMockContext('user-123');
+      await expect(
+        mutation(
+          {},
+          { input: { ids: ['i1', 'i2'], installedAt: '2024-05-10T00:00:00Z' } },
+          ctx as never
+        )
+      ).rejects.toThrow('Install record not found');
+      expect(mockUpdateMany).not.toHaveBeenCalled();
+    });
+
+    it('rejects when an id does not exist (length mismatch)', async () => {
+      mockFindMany.mockResolvedValueOnce([
+        { id: 'i1', userId: 'user-123', bikeId: 'bike-1', componentId: 'c1', installedAt: new Date(), removedAt: null },
+      ]);
+
+      const ctx = createMockContext('user-123');
+      await expect(
+        mutation(
+          {},
+          { input: { ids: ['i1', 'i-missing'], installedAt: '2024-05-10T00:00:00Z' } },
+          ctx as never
+        )
+      ).rejects.toThrow('Install record not found');
+    });
+
+    it('rejects when any row has a removedAt earlier than the target date', async () => {
+      mockFindMany.mockResolvedValueOnce([
+        {
+          id: 'i1',
+          userId: 'user-123',
+          bikeId: 'bike-1',
+          componentId: 'c1',
+          installedAt: new Date('2020-01-01'),
+          removedAt: new Date('2024-01-01'),
+        },
+      ]);
+
+      const ctx = createMockContext('user-123');
+      await expect(
+        mutation(
+          {},
+          { input: { ids: ['i1'], installedAt: '2024-06-01T00:00:00Z' } },
+          ctx as never
+        )
+      ).rejects.toThrow('Removal date cannot be before install date');
+      expect(mockUpdateMany).not.toHaveBeenCalled();
+    });
+
+    it('rejects batches larger than the cap', async () => {
+      const ids = Array.from({ length: 101 }, (_, i) => `i${i}`);
+      const ctx = createMockContext('user-123');
+      await expect(
+        mutation(
+          {},
+          { input: { ids, installedAt: '2024-05-10T00:00:00Z' } },
+          ctx as never
+        )
+      ).rejects.toThrow('Cannot update more than 100');
+      expect(mockFindMany).not.toHaveBeenCalled();
+    });
+
+    it('updates installs and moves baseline service logs grouped by old date', async () => {
+      const oldDateA = new Date('2024-02-01T00:00:00Z');
+      const oldDateB = new Date('2024-03-10T00:00:00Z');
+      mockFindMany.mockResolvedValueOnce([
+        { id: 'i1', userId: 'user-123', bikeId: 'bike-1', componentId: 'c1', installedAt: oldDateA, removedAt: null },
+        { id: 'i2', userId: 'user-123', bikeId: 'bike-1', componentId: 'c2', installedAt: oldDateA, removedAt: null },
+        { id: 'i3', userId: 'user-123', bikeId: 'bike-1', componentId: 'c3', installedAt: oldDateB, removedAt: null },
+      ]);
+      mockUpdateMany.mockResolvedValueOnce({ count: 3 });
+      mockServiceLogUpdateMany
+        .mockResolvedValueOnce({ count: 2 })
+        .mockResolvedValueOnce({ count: 1 });
+
+      const ctx = createMockContext('user-123');
+      const result = await mutation(
+        {},
+        { input: { ids: ['i1', 'i2', 'i3'], installedAt: '2024-06-01T00:00:00Z' } },
+        ctx as never
+      );
+
+      expect(result.updatedCount).toBe(3);
+      expect(result.serviceLogsMoved).toBe(3);
+      // Two groups → two serviceLog.updateMany calls.
+      expect(mockServiceLogUpdateMany).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -3693,6 +3693,38 @@ describe('GraphQL Resolvers', () => {
       expect(mockFindMany).not.toHaveBeenCalled();
     });
 
+    it('deduplicates repeated ids before validation (no spurious NOT_FOUND)', async () => {
+      // Client submits the same id twice. After dedup, findMany returns
+      // one row and the length check passes — the mutation proceeds
+      // rather than throwing NOT_FOUND on a length mismatch.
+      mockFindMany.mockResolvedValueOnce([
+        {
+          id: 'i1',
+          userId: 'user-123',
+          bikeId: 'bike-1',
+          componentId: 'c1',
+          installedAt: new Date('2024-02-01T00:00:00Z'),
+          removedAt: null,
+        },
+      ]);
+      mockUpdateMany.mockResolvedValueOnce({ count: 1 });
+
+      const ctx = createMockContext('user-123');
+      const result = await mutation(
+        {},
+        { input: { ids: ['i1', 'i1'], installedAt: '2024-06-01T00:00:00Z' } },
+        ctx as never
+      );
+
+      expect(result.updatedCount).toBe(1);
+      // findMany queried with the deduped set, not the raw duplicates.
+      expect(mockFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: { in: ['i1'] } }),
+        })
+      );
+    });
+
     it('updates installs and moves baseline service logs grouped by old date', async () => {
       const oldDateA = new Date('2024-02-01T00:00:00Z');
       const oldDateB = new Date('2024-03-10T00:00:00Z');

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -2903,12 +2903,18 @@ export const resolvers = {
         });
       }
 
-      if (input.ids.length === 0) {
+      // Deduplicate first: a repeated id would make findMany return fewer
+      // rows than input.ids.length and trip the ownership check below with
+      // a misleading NOT_FOUND. Dedupe also tightens the batch-size cap
+      // against a client that pads the array with duplicates.
+      const ids = [...new Set(input.ids)];
+
+      if (ids.length === 0) {
         return { updatedCount: 0, serviceLogsMoved: 0 };
       }
       // Defensive cap. Realistic bikes have <20 installs. 100 gives wide
       // headroom without letting a malicious client sweep the table.
-      if (input.ids.length > 100) {
+      if (ids.length > 100) {
         throw new GraphQLError('Cannot update more than 100 install rows at once', {
           extensions: { code: 'BATCH_TOO_LARGE' },
         });
@@ -2942,7 +2948,7 @@ export const resolvers = {
       const { updatedCount, serviceLogsMoved, affectedBikeIds } = await prisma.$transaction(
         async (tx) => {
           const existing = await tx.bikeComponentInstall.findMany({
-            where: { id: { in: input.ids } },
+            where: { id: { in: ids } },
             select: {
               id: true,
               userId: true,
@@ -2958,7 +2964,7 @@ export const resolvers = {
           // catches the shorter-than-expected result that happens when
           // an id doesn't exist at all.
           if (
-            existing.length !== input.ids.length ||
+            existing.length !== ids.length ||
             existing.some((row) => row.userId !== userId)
           ) {
             throw new GraphQLError('Install record not found', {
@@ -2980,7 +2986,7 @@ export const resolvers = {
           }
 
           const { count: updated } = await tx.bikeComponentInstall.updateMany({
-            where: { id: { in: input.ids } },
+            where: { id: { in: ids } },
             data: { installedAt },
           });
 

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -2768,10 +2768,14 @@ export const resolvers = {
       const now = new Date();
       const acquisitionDate = parseISO(input.acquisitionDate);
       if (isNaN(acquisitionDate.getTime())) {
-        throw new Error('Invalid acquisitionDate');
+        throw new GraphQLError('Invalid acquisitionDate', {
+          extensions: { code: 'INVALID_INPUT' },
+        });
       }
       if (acquisitionDate > now) {
-        throw new Error('acquisitionDate cannot be in the future');
+        throw new GraphQLError('acquisitionDate cannot be in the future', {
+          extensions: { code: 'FUTURE_DATE' },
+        });
       }
 
       const cascade = input.cascadeInstalls !== false;
@@ -2822,12 +2826,26 @@ export const resolvers = {
           data: { installedAt: acquisitionDate },
         });
 
-        // Move Component.installedAt too, but only for still-active
-        // installs (removedAt is null). If a component has been swapped
-        // off since, Component.installedAt tracks a newer install and
-        // shouldn't be touched by this migration.
+        // Move Component.installedAt too — but only for components that
+        // are still currently installed on THIS bike and haven't been
+        // retired. Two separate semantic filters:
+        //   * `retiredAt: null` — skip sold/discarded components. Per the
+        //     schema, retired components have bikeId=null already, but
+        //     filtering explicitly guards against drift.
+        //   * `bikeId` — skip components that have since been swapped to
+        //     a different bike. Their Component.installedAt tracks the
+        //     new bike's install, which shouldn't be overwritten by
+        //     THIS bike's acquisition date.
+        // BikeComponentInstall.removedAt is a different concept and lives
+        // on the install row, not the component. The install row's
+        // installedAt gets moved above regardless; this filter only gates
+        // the denormalized Component.installedAt mirror.
         await tx.component.updateMany({
-          where: { id: { in: componentIds }, retiredAt: null },
+          where: {
+            id: { in: componentIds },
+            retiredAt: null,
+            bikeId,
+          },
           data: { installedAt: acquisitionDate },
         });
 
@@ -2891,91 +2909,122 @@ export const resolvers = {
       // Defensive cap. Realistic bikes have <20 installs. 100 gives wide
       // headroom without letting a malicious client sweep the table.
       if (input.ids.length > 100) {
-        throw new Error('Cannot update more than 100 install rows at once');
+        throw new GraphQLError('Cannot update more than 100 install rows at once', {
+          extensions: { code: 'BATCH_TOO_LARGE' },
+        });
       }
 
       const now = new Date();
       const installedAt = parseISO(input.installedAt);
       if (isNaN(installedAt.getTime())) {
-        throw new Error('Invalid installedAt date');
+        throw new GraphQLError('Invalid installedAt date', {
+          extensions: { code: 'INVALID_INPUT' },
+        });
       }
       if (installedAt > now) {
-        throw new Error('Install date cannot be in the future');
+        throw new GraphQLError('Install date cannot be in the future', {
+          extensions: { code: 'FUTURE_DATE' },
+        });
       }
 
-      const existing = await prisma.bikeComponentInstall.findMany({
-        where: { id: { in: input.ids } },
-        select: {
-          id: true,
-          userId: true,
-          bikeId: true,
-          componentId: true,
-          installedAt: true,
-          removedAt: true,
-        },
-      });
+      // Ownership + chronology validation and the mutating writes all
+      // happen inside a single transaction, so the snapshot we validate
+      // against is the same one the updateMany lands on. Under Postgres
+      // READ COMMITTED (Prisma's default) there's still a micro-window
+      // between the intra-transaction findMany and updateMany, but it's
+      // bounded by the transaction's own latency rather than including
+      // network round-trip + client-side checks as it did before.
+      //
+      // If stronger guarantees are ever needed (e.g. defending against a
+      // user racing themselves from two tabs), escalate to raw SQL with
+      // `SELECT ... FOR UPDATE` — Prisma doesn't expose row-level locks
+      // through its query builder today.
+      const { updatedCount, serviceLogsMoved, affectedBikeIds } = await prisma.$transaction(
+        async (tx) => {
+          const existing = await tx.bikeComponentInstall.findMany({
+            where: { id: { in: input.ids } },
+            select: {
+              id: true,
+              userId: true,
+              bikeId: true,
+              componentId: true,
+              installedAt: true,
+              removedAt: true,
+            },
+          });
 
-      // All-or-nothing ownership: if any id isn't owned, reject the whole
-      // batch with NOT_FOUND (don't leak which one). Also catches the
-      // shorter-than-expected result that happens when an id doesn't
-      // exist at all.
-      if (
-        existing.length !== input.ids.length ||
-        existing.some((row) => row.userId !== userId)
-      ) {
-        throw new GraphQLError('Install record not found', { extensions: { code: 'NOT_FOUND' } });
-      }
+          // All-or-nothing ownership: if any id isn't owned, reject the
+          // whole batch with NOT_FOUND (don't leak which one). Also
+          // catches the shorter-than-expected result that happens when
+          // an id doesn't exist at all.
+          if (
+            existing.length !== input.ids.length ||
+            existing.some((row) => row.userId !== userId)
+          ) {
+            throw new GraphQLError('Install record not found', {
+              extensions: { code: 'NOT_FOUND' },
+            });
+          }
 
-      // Chronology guard: a component can't come off before it went on.
-      // For each selected row, the proposed new installedAt must be <=
-      // the row's existing removedAt (if any). If ANY row fails this,
-      // reject the whole batch so the user can fix their selection.
-      for (const row of existing) {
-        if (row.removedAt && installedAt > row.removedAt) {
-          throw new Error('Removal date cannot be before install date');
+          // Chronology guard: a component can't come off before it went
+          // on. For each selected row, the proposed new installedAt must
+          // be <= the row's existing removedAt (if any). If ANY row fails
+          // this, reject the whole batch so the user can fix their
+          // selection.
+          for (const row of existing) {
+            if (row.removedAt && installedAt > row.removedAt) {
+              throw new GraphQLError('Removal date cannot be before install date', {
+                extensions: { code: 'CHRONOLOGY_VIOLATION' },
+              });
+            }
+          }
+
+          const { count: updated } = await tx.bikeComponentInstall.updateMany({
+            where: { id: { in: input.ids } },
+            data: { installedAt },
+          });
+
+          // Same baseline-log-migration logic as updateBikeAcquisition:
+          // group by old date to minimize UPDATE count.
+          const byOldDate = new Map<number, string[]>();
+          for (const row of existing) {
+            const key = row.installedAt.getTime();
+            const list = byOldDate.get(key) ?? [];
+            list.push(row.componentId);
+            byOldDate.set(key, list);
+          }
+
+          let movedLogs = 0;
+          for (const [ts, compIds] of byOldDate) {
+            const { count } = await tx.serviceLog.updateMany({
+              where: {
+                componentId: { in: compIds },
+                performedAt: new Date(ts),
+                hoursAtService: 0,
+              },
+              data: { performedAt: installedAt },
+            });
+            movedLogs += count;
+          }
+
+          const bikeIds = Array.from(
+            new Set(existing.map((r) => r.bikeId).filter((id): id is string => id !== null))
+          );
+
+          return {
+            updatedCount: updated,
+            serviceLogsMoved: movedLogs,
+            affectedBikeIds: bikeIds,
+          };
         }
-      }
-
-      const affectedBikeIds = Array.from(
-        new Set(existing.map((r) => r.bikeId).filter((id): id is string => id !== null))
       );
 
-      for (const bikeId of affectedBikeIds) {
-        await invalidateBikePrediction(userId, bikeId);
-      }
-
-      const { updatedCount, serviceLogsMoved } = await prisma.$transaction(async (tx) => {
-        const { count: updated } = await tx.bikeComponentInstall.updateMany({
-          where: { id: { in: input.ids } },
-          data: { installedAt },
-        });
-
-        // Same baseline-log-migration logic as updateBikeAcquisition:
-        // group by old date to minimize UPDATE count.
-        const byOldDate = new Map<number, string[]>();
-        for (const row of existing) {
-          const key = row.installedAt.getTime();
-          const list = byOldDate.get(key) ?? [];
-          list.push(row.componentId);
-          byOldDate.set(key, list);
-        }
-
-        let movedLogs = 0;
-        for (const [ts, compIds] of byOldDate) {
-          const { count } = await tx.serviceLog.updateMany({
-            where: {
-              componentId: { in: compIds },
-              performedAt: new Date(ts),
-              hoursAtService: 0,
-            },
-            data: { performedAt: installedAt },
-          });
-          movedLogs += count;
-        }
-
-        return { updatedCount: updated, serviceLogsMoved: movedLogs };
-      });
-
+      // Post-transaction invalidation only. The usual "bracket before +
+      // after" pattern (see updateBikeAcquisition / updateServiceLog)
+      // requires knowing the affected bikes up front — which means a
+      // separate pre-tx read that would reintroduce the race we just
+      // closed. A single post-tx invalidation is fine because the tx
+      // itself hasn't populated anything into the prediction cache.
       for (const bikeId of affectedBikeIds) {
         await invalidateBikePrediction(userId, bikeId);
       }

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -2740,6 +2740,249 @@ export const resolvers = {
       return true;
     },
 
+    updateBikeAcquisition: async (
+      _: unknown,
+      {
+        bikeId,
+        input,
+      }: {
+        bikeId: string;
+        input: { acquisitionDate: string; cascadeInstalls?: boolean | null };
+      },
+      ctx: GraphQLContext
+    ) => {
+      const userId = requireUserId(ctx);
+
+      const rateLimit = await checkMutationRateLimit('updateBikeAcquisition', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(`Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`, {
+          extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
+        });
+      }
+
+      const bike = await prisma.bike.findFirst({ where: { id: bikeId, userId } });
+      if (!bike) {
+        throw new GraphQLError('Bike not found', { extensions: { code: 'NOT_FOUND' } });
+      }
+
+      const now = new Date();
+      const acquisitionDate = parseISO(input.acquisitionDate);
+      if (isNaN(acquisitionDate.getTime())) {
+        throw new Error('Invalid acquisitionDate');
+      }
+      if (acquisitionDate > now) {
+        throw new Error('acquisitionDate cannot be in the future');
+      }
+
+      const cascade = input.cascadeInstalls !== false;
+
+      await invalidateBikePrediction(userId, bikeId);
+
+      const result = await prisma.$transaction(async (tx) => {
+        await tx.bike.update({
+          where: { id: bikeId },
+          data: { acquisitionDate },
+        });
+
+        if (!cascade) {
+          return { installsMoved: 0, serviceLogsMoved: 0 };
+        }
+
+        // "Buggy auto-date" predicate: the old code path always stamped
+        // the install within the bike-creation transaction, so every
+        // affected row sits within a narrow window after bike.createdAt.
+        // 60s is generous — real user-driven installs happen minutes to
+        // years later, so the window comfortably discriminates. Widening
+        // this just means catching slower-than-usual creations, narrowing
+        // risks missing legitimate migration rows.
+        const windowEnd = new Date(bike.createdAt.getTime() + 60_000);
+
+        const eligible = await tx.bikeComponentInstall.findMany({
+          where: {
+            userId,
+            bikeId,
+            OR: [
+              { component: { isStock: true } },
+              { installedAt: { gte: bike.createdAt, lte: windowEnd } },
+            ],
+          },
+          select: { id: true, componentId: true, installedAt: true },
+        });
+
+        if (eligible.length === 0) {
+          return { installsMoved: 0, serviceLogsMoved: 0 };
+        }
+
+        const installIds = eligible.map((e) => e.id);
+        const componentIds = Array.from(new Set(eligible.map((e) => e.componentId)));
+
+        // Move all install rows in one query.
+        const { count: installsMoved } = await tx.bikeComponentInstall.updateMany({
+          where: { id: { in: installIds } },
+          data: { installedAt: acquisitionDate },
+        });
+
+        // Move Component.installedAt too, but only for still-active
+        // installs (removedAt is null). If a component has been swapped
+        // off since, Component.installedAt tracks a newer install and
+        // shouldn't be touched by this migration.
+        await tx.component.updateMany({
+          where: { id: { in: componentIds }, retiredAt: null },
+          data: { installedAt: acquisitionDate },
+        });
+
+        // Move the paired baseline ServiceLog (hoursAtService=0, same
+        // performedAt as the old install date). Group by old-installedAt
+        // so the common migration case (one shared date) collapses to a
+        // single UPDATE; multi-select across different dates would pay
+        // one UPDATE per group.
+        const byOldDate = new Map<number, string[]>();
+        for (const e of eligible) {
+          const key = e.installedAt.getTime();
+          const list = byOldDate.get(key) ?? [];
+          list.push(e.componentId);
+          byOldDate.set(key, list);
+        }
+
+        let serviceLogsMoved = 0;
+        for (const [ts, compIds] of byOldDate) {
+          const { count } = await tx.serviceLog.updateMany({
+            where: {
+              componentId: { in: compIds },
+              performedAt: new Date(ts),
+              hoursAtService: 0,
+            },
+            data: { performedAt: acquisitionDate },
+          });
+          serviceLogsMoved += count;
+        }
+
+        return { installsMoved, serviceLogsMoved };
+      });
+
+      await invalidateBikePrediction(userId, bikeId);
+
+      const updatedBike = await prisma.bike.findUnique({ where: { id: bikeId } });
+
+      return {
+        bike: updatedBike,
+        installsMoved: result.installsMoved,
+        serviceLogsMoved: result.serviceLogsMoved,
+      };
+    },
+
+    bulkUpdateBikeComponentInstalls: async (
+      _: unknown,
+      { input }: { input: { ids: string[]; installedAt: string } },
+      ctx: GraphQLContext
+    ) => {
+      const userId = requireUserId(ctx);
+
+      const rateLimit = await checkMutationRateLimit('bulkUpdateBikeComponentInstalls', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(`Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`, {
+          extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
+        });
+      }
+
+      if (input.ids.length === 0) {
+        return { updatedCount: 0, serviceLogsMoved: 0 };
+      }
+      // Defensive cap. Realistic bikes have <20 installs. 100 gives wide
+      // headroom without letting a malicious client sweep the table.
+      if (input.ids.length > 100) {
+        throw new Error('Cannot update more than 100 install rows at once');
+      }
+
+      const now = new Date();
+      const installedAt = parseISO(input.installedAt);
+      if (isNaN(installedAt.getTime())) {
+        throw new Error('Invalid installedAt date');
+      }
+      if (installedAt > now) {
+        throw new Error('Install date cannot be in the future');
+      }
+
+      const existing = await prisma.bikeComponentInstall.findMany({
+        where: { id: { in: input.ids } },
+        select: {
+          id: true,
+          userId: true,
+          bikeId: true,
+          componentId: true,
+          installedAt: true,
+          removedAt: true,
+        },
+      });
+
+      // All-or-nothing ownership: if any id isn't owned, reject the whole
+      // batch with NOT_FOUND (don't leak which one). Also catches the
+      // shorter-than-expected result that happens when an id doesn't
+      // exist at all.
+      if (
+        existing.length !== input.ids.length ||
+        existing.some((row) => row.userId !== userId)
+      ) {
+        throw new GraphQLError('Install record not found', { extensions: { code: 'NOT_FOUND' } });
+      }
+
+      // Chronology guard: a component can't come off before it went on.
+      // For each selected row, the proposed new installedAt must be <=
+      // the row's existing removedAt (if any). If ANY row fails this,
+      // reject the whole batch so the user can fix their selection.
+      for (const row of existing) {
+        if (row.removedAt && installedAt > row.removedAt) {
+          throw new Error('Removal date cannot be before install date');
+        }
+      }
+
+      const affectedBikeIds = Array.from(
+        new Set(existing.map((r) => r.bikeId).filter((id): id is string => id !== null))
+      );
+
+      for (const bikeId of affectedBikeIds) {
+        await invalidateBikePrediction(userId, bikeId);
+      }
+
+      const { updatedCount, serviceLogsMoved } = await prisma.$transaction(async (tx) => {
+        const { count: updated } = await tx.bikeComponentInstall.updateMany({
+          where: { id: { in: input.ids } },
+          data: { installedAt },
+        });
+
+        // Same baseline-log-migration logic as updateBikeAcquisition:
+        // group by old date to minimize UPDATE count.
+        const byOldDate = new Map<number, string[]>();
+        for (const row of existing) {
+          const key = row.installedAt.getTime();
+          const list = byOldDate.get(key) ?? [];
+          list.push(row.componentId);
+          byOldDate.set(key, list);
+        }
+
+        let movedLogs = 0;
+        for (const [ts, compIds] of byOldDate) {
+          const { count } = await tx.serviceLog.updateMany({
+            where: {
+              componentId: { in: compIds },
+              performedAt: new Date(ts),
+              hoursAtService: 0,
+            },
+            data: { performedAt: installedAt },
+          });
+          movedLogs += count;
+        }
+
+        return { updatedCount: updated, serviceLogsMoved: movedLogs };
+      });
+
+      for (const bikeId of affectedBikeIds) {
+        await invalidateBikePrediction(userId, bikeId);
+      }
+
+      return { updatedCount, serviceLogsMoved };
+    },
+
     snoozeComponent: async (
       _: unknown,
       { id, hours }: { id: string; hours?: number },

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -543,6 +543,44 @@ export const typeDefs = gql`
   }
 
   """
+  Retroactively fix a bike's acquisition date and, when requested, the
+  install dates of every stock component + any install whose date was
+  auto-stamped at bike creation. Built for users who added bikes before
+  the acquisition-date feature existed and now see every stock part
+  installed on the same day on BikeHistory.
+  """
+  input UpdateBikeAcquisitionInput {
+    acquisitionDate: String!
+    """
+    When true (default), move the installedAt on every BikeComponentInstall
+    matching the "buggy auto-date" predicate to the new acquisitionDate,
+    and move the corresponding synthetic baseline ServiceLog alongside.
+    """
+    cascadeInstalls: Boolean = true
+  }
+
+  type UpdateBikeAcquisitionResult {
+    bike: Bike!
+    installsMoved: Int!
+    serviceLogsMoved: Int!
+  }
+
+  """
+  Apply the same installedAt to multiple BikeComponentInstall rows in a
+  single mutation. All rows must belong to the viewer — the batch is
+  all-or-nothing to avoid leaking which ids they don't own.
+  """
+  input BulkUpdateBikeComponentInstallsInput {
+    ids: [ID!]!
+    installedAt: String!
+  }
+
+  type BulkUpdateBikeComponentInstallsResult {
+    updatedCount: Int!
+    serviceLogsMoved: Int!
+  }
+
+  """
   Patch fields on a BikeComponentInstall row.
 
   **Null handling is asymmetric**, mirroring the underlying Prisma schema:
@@ -911,6 +949,8 @@ export const typeDefs = gql`
     deleteBikeNote(id: ID!): DeleteResult!
     updateBikeComponentInstall(id: ID!, input: UpdateBikeComponentInstallInput!): BikeComponentInstall!
     deleteBikeComponentInstall(id: ID!): Boolean!
+    updateBikeAcquisition(bikeId: ID!, input: UpdateBikeAcquisitionInput!): UpdateBikeAcquisitionResult!
+    bulkUpdateBikeComponentInstalls(input: BulkUpdateBikeComponentInstallsInput!): BulkUpdateBikeComponentInstallsResult!
     createCheckoutSession(plan: StripePlan!, platform: CheckoutPlatform): CheckoutSessionResult!
     createBillingPortalSession(platform: CheckoutPlatform): BillingPortalResult!
     selectBikeForDowngrade(bikeId: ID!): Bike!

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -40,6 +40,10 @@ export const MUTATION_RATE_LIMITS = {
   updateBikeComponentInstall: { windowSeconds: 60, maxRequests: 30 },
   /** deleteBikeComponentInstall: max 30 requests per minute per user */
   deleteBikeComponentInstall: { windowSeconds: 60, maxRequests: 30 },
+  /** updateBikeAcquisition: max 20 requests per minute per user */
+  updateBikeAcquisition: { windowSeconds: 60, maxRequests: 20 },
+  /** bulkUpdateBikeComponentInstalls: max 20 requests per minute per user */
+  bulkUpdateBikeComponentInstalls: { windowSeconds: 60, maxRequests: 20 },
   /**
    * bikeHistory query: max 60 requests per minute per user. Higher than
    * mutations because it's a read (filter toggling, timeframe changes,

--- a/apps/web/src/components/gear/BikeOverviewCard.test.tsx
+++ b/apps/web/src/components/gear/BikeOverviewCard.test.tsx
@@ -380,16 +380,16 @@ describe('BikeOverviewCard', () => {
       expect(onLogService).toHaveBeenCalledTimes(1);
     });
 
-    it('renders Edit details link', () => {
+    it('renders Bike Details link', () => {
       renderWithRouter(<BikeOverviewCard {...defaultProps} />);
 
-      expect(screen.getByText('Edit details')).toBeInTheDocument();
+      expect(screen.getByText('Bike Details')).toBeInTheDocument();
     });
 
-    it('Edit details links to correct path', () => {
+    it('Bike Details links to correct path', () => {
       renderWithRouter(<BikeOverviewCard {...defaultProps} />);
 
-      const link = screen.getByText('Edit details').closest('a');
+      const link = screen.getByText('Bike Details').closest('a');
       expect(link).toHaveAttribute('href', '/gear/bike-1');
     });
 

--- a/apps/web/src/components/gear/BikeOverviewCard.tsx
+++ b/apps/web/src/components/gear/BikeOverviewCard.tsx
@@ -241,9 +241,13 @@ export function BikeOverviewCard({
 
           {/* Actions */}
           <div className="bike-card-actions">
+            <Link to={`/gear/${bike.id}`} className="btn-primary btn-sm">
+              <Bike size={12} className="icon-left" />
+              Bike Details
+            </Link>
             {onLogService && (
               <Button
-                variant="primary"
+                variant="outline"
                 size="sm"
                 onClick={onLogService}
               >
@@ -251,10 +255,6 @@ export function BikeOverviewCard({
                 Log service
               </Button>
             )}
-            <Link to={`/gear/${bike.id}`} className="btn-secondary btn-sm">
-              <Pencil size={12} className="icon-left" />
-              Edit details
-            </Link>
             {isValid99SpokesUrl(bike.spokesUrl) && (
               <a
                 href={bike.spokesUrl!}

--- a/apps/web/src/components/gear/UpdateAcquisitionModal.test.tsx
+++ b/apps/web/src/components/gear/UpdateAcquisitionModal.test.tsx
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { UpdateAcquisitionModal } from './UpdateAcquisitionModal';
+
+// Apollo mock — single shared mutation fn so tests can assert calls and
+// swap resolved/rejected values per-test.
+const mockUpdateAcquisition = vi.fn();
+vi.mock('@apollo/client', () => ({
+  useMutation: vi.fn(() => [mockUpdateAcquisition, { loading: false }]),
+  gql: vi.fn((strings: TemplateStringsArray) => strings[0]),
+}));
+
+// Modal mock — pass-through that only renders when open. Keeps footer in
+// the DOM so we can click Cancel / Update buttons.
+vi.mock('../ui/Modal', () => ({
+  Modal: ({
+    isOpen,
+    onClose,
+    title,
+    subtitle,
+    children,
+    footer,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    title: string;
+    subtitle?: string;
+    children: React.ReactNode;
+    footer?: React.ReactNode;
+    size?: string;
+  }) =>
+    isOpen ? (
+      <div data-testid="modal">
+        <h2>{title}</h2>
+        {subtitle && <p data-testid="modal-subtitle">{subtitle}</p>}
+        <button onClick={onClose} data-testid="modal-close">
+          Close
+        </button>
+        {children}
+        {footer && <div data-testid="modal-footer">{footer}</div>}
+      </div>
+    ) : null,
+}));
+
+vi.mock('../ui/Button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    variant,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    variant?: string;
+    size?: string;
+  }) => (
+    <button onClick={onClick} disabled={disabled} data-variant={variant}>
+      {children}
+    </button>
+  ),
+}));
+
+// Stub query document imports — we only need the mutation to exist; the
+// mocked useMutation doesn't care about the schema.
+vi.mock('../../graphql/bike', () => ({ UPDATE_BIKE_ACQUISITION: 'UPDATE_BIKE_ACQUISITION' }));
+vi.mock('../../graphql/bikes', () => ({ BIKES: 'BIKES' }));
+vi.mock('../../graphql/gear', () => ({ GEAR_QUERY_LIGHT: 'GEAR_QUERY_LIGHT' }));
+vi.mock('../../graphql/bikeHistory', () => ({ BIKE_HISTORY: 'BIKE_HISTORY' }));
+
+describe('UpdateAcquisitionModal', () => {
+  const baseProps = {
+    bikeId: 'bike-1',
+    bikeName: '2024 Slash',
+    isOpen: true,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateAcquisition.mockResolvedValue({
+      data: {
+        updateBikeAcquisition: {
+          installsMoved: 5,
+          serviceLogsMoved: 5,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('rendering', () => {
+    it('does not render when closed', () => {
+      render(<UpdateAcquisitionModal {...baseProps} isOpen={false} />);
+      expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+    });
+
+    it('shows title and bike name subtitle', () => {
+      render(<UpdateAcquisitionModal {...baseProps} />);
+      expect(screen.getByText('Update acquisition date')).toBeInTheDocument();
+      expect(screen.getByTestId('modal-subtitle')).toHaveTextContent('2024 Slash');
+    });
+  });
+
+  describe('date seeding', () => {
+    it("seeds the input with today's date when no current acquisition date", () => {
+      // Freeze the clock for this one check so the seeded value is stable.
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-19T12:00:00'));
+      try {
+        render(<UpdateAcquisitionModal {...baseProps} currentAcquisitionDate={null} />);
+        const input = screen.getByLabelText('Acquired on') as HTMLInputElement;
+        expect(input.value).toBe('2026-04-19');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('seeds the input with the existing acquisition date when present', () => {
+      render(
+        <UpdateAcquisitionModal
+          {...baseProps}
+          currentAcquisitionDate="2021-05-10T12:00:00.000Z"
+        />
+      );
+      const input = screen.getByLabelText('Acquired on') as HTMLInputElement;
+      expect(input.value).toBe('2021-05-10');
+    });
+  });
+
+  describe('cascade toggle', () => {
+    it('defaults cascade to on', () => {
+      render(<UpdateAcquisitionModal {...baseProps} />);
+      const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+    });
+
+    it('sends cascadeInstalls:false when the user unchecks the box', async () => {
+      render(<UpdateAcquisitionModal {...baseProps} />);
+      fireEvent.click(screen.getByRole('checkbox'));
+      fireEvent.click(screen.getByText('Update'));
+      await waitFor(() => {
+        expect(mockUpdateAcquisition).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variables: expect.objectContaining({
+              input: expect.objectContaining({ cascadeInstalls: false }),
+            }),
+          })
+        );
+      });
+    });
+
+    it('sends cascadeInstalls:true by default', async () => {
+      render(<UpdateAcquisitionModal {...baseProps} />);
+      fireEvent.click(screen.getByText('Update'));
+      await waitFor(() => {
+        expect(mockUpdateAcquisition).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variables: expect.objectContaining({
+              input: expect.objectContaining({ cascadeInstalls: true }),
+            }),
+          })
+        );
+      });
+    });
+  });
+
+  describe('submit', () => {
+    it('serializes the date at noon local when submitting', async () => {
+      render(<UpdateAcquisitionModal {...baseProps} />);
+      fireEvent.change(screen.getByLabelText('Acquired on'), {
+        target: { value: '2022-03-12' },
+      });
+      fireEvent.click(screen.getByText('Update'));
+      await waitFor(() => {
+        expect(mockUpdateAcquisition).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variables: expect.objectContaining({
+              bikeId: 'bike-1',
+              input: expect.objectContaining({
+                // Noon-anchored ISO — the exact UTC hour varies with the
+                // test machine's timezone, so assert only the date + noon
+                // pattern in local time via a regex on the serialized ISO.
+                acquisitionDate: expect.stringMatching(/^2022-03-12T\d{2}:00:00\.000Z$/),
+              }),
+            }),
+          })
+        );
+      });
+    });
+
+    it('shows "Pick a date" error when the date field is empty', async () => {
+      render(<UpdateAcquisitionModal {...baseProps} />);
+      fireEvent.change(screen.getByLabelText('Acquired on'), { target: { value: '' } });
+      fireEvent.click(screen.getByText('Update'));
+      expect(await screen.findByText('Pick a date.')).toBeInTheDocument();
+      expect(mockUpdateAcquisition).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('success summary', () => {
+    it('replaces the form with a summary showing installs moved', async () => {
+      render(<UpdateAcquisitionModal {...baseProps} />);
+      fireEvent.click(screen.getByText('Update'));
+      await waitFor(() => {
+        expect(screen.getByText(/install dates/)).toBeInTheDocument();
+      });
+      // Count is rendered as a standalone number; check it appears.
+      expect(screen.getByText('5')).toBeInTheDocument();
+      // Form controls should be gone.
+      expect(screen.queryByLabelText('Acquired on')).not.toBeInTheDocument();
+      // Footer swaps to "Done".
+      expect(screen.getByText('Done')).toBeInTheDocument();
+    });
+
+    it('shows the baseline-anchors note when serviceLogsMoved > 0', async () => {
+      render(<UpdateAcquisitionModal {...baseProps} />);
+      fireEvent.click(screen.getByText('Update'));
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Baseline service anchors/)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('hides the baseline-anchors note when serviceLogsMoved is 0', async () => {
+      mockUpdateAcquisition.mockResolvedValue({
+        data: { updateBikeAcquisition: { installsMoved: 3, serviceLogsMoved: 0 } },
+      });
+      render(<UpdateAcquisitionModal {...baseProps} />);
+      fireEvent.click(screen.getByText('Update'));
+      await waitFor(() => {
+        expect(screen.getByText(/install dates/)).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/Baseline service anchors/)).not.toBeInTheDocument();
+    });
+
+    it('uses singular copy when installsMoved is 1', async () => {
+      mockUpdateAcquisition.mockResolvedValue({
+        data: { updateBikeAcquisition: { installsMoved: 1, serviceLogsMoved: 0 } },
+      });
+      render(<UpdateAcquisitionModal {...baseProps} />);
+      fireEvent.click(screen.getByText('Update'));
+      await waitFor(() => {
+        // "install date" (singular, no trailing 's')
+        expect(screen.getByText(/install date\s/)).toBeInTheDocument();
+      });
+    });
+
+    it('calls onClose when Done is clicked', async () => {
+      const onClose = vi.fn();
+      render(<UpdateAcquisitionModal {...baseProps} onClose={onClose} />);
+      fireEvent.click(screen.getByText('Update'));
+      const doneBtn = await screen.findByText('Done');
+      fireEvent.click(doneBtn);
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('error display', () => {
+    it('shows the mutation error message inline on failure', async () => {
+      mockUpdateAcquisition.mockRejectedValue(new Error('Rate limited'));
+      render(<UpdateAcquisitionModal {...baseProps} />);
+      fireEvent.click(screen.getByText('Update'));
+      expect(await screen.findByText('Rate limited')).toBeInTheDocument();
+      // Form stays on screen so the user can retry.
+      expect(screen.getByLabelText('Acquired on')).toBeInTheDocument();
+    });
+
+    it('falls back to generic copy when error is not an Error', async () => {
+      mockUpdateAcquisition.mockRejectedValue('boom');
+      render(<UpdateAcquisitionModal {...baseProps} />);
+      fireEvent.click(screen.getByText('Update'));
+      expect(
+        await screen.findByText('Failed to update acquisition date.')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/gear/UpdateAcquisitionModal.tsx
+++ b/apps/web/src/components/gear/UpdateAcquisitionModal.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useState } from 'react';
+import { useMutation } from '@apollo/client';
+import { Calendar, TriangleAlert } from 'lucide-react';
+
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import { UPDATE_BIKE_ACQUISITION } from '../../graphql/bike';
+import { BIKES } from '../../graphql/bikes';
+import { GEAR_QUERY_LIGHT } from '../../graphql/gear';
+import { BIKE_HISTORY } from '../../graphql/bikeHistory';
+import { dateInputToIsoNoon, isoToDateInput, todayDateInput } from '../../lib/format';
+
+interface UpdateAcquisitionModalProps {
+  bikeId: string;
+  bikeName: string;
+  currentAcquisitionDate?: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function UpdateAcquisitionModal({
+  bikeId,
+  bikeName,
+  currentAcquisitionDate,
+  isOpen,
+  onClose,
+}: UpdateAcquisitionModalProps) {
+  const [dateValue, setDateValue] = useState('');
+  const [cascade, setCascade] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<{ installsMoved: number; serviceLogsMoved: number } | null>(
+    null
+  );
+
+  const [updateAcquisition] = useMutation(UPDATE_BIKE_ACQUISITION, {
+    refetchQueries: [
+      { query: BIKES },
+      { query: GEAR_QUERY_LIGHT },
+      { query: BIKE_HISTORY, variables: { bikeId } },
+    ],
+  });
+
+  useEffect(() => {
+    if (isOpen) {
+      // Prefer the bike's existing acquisitionDate as the starting point
+      // (a user clearing up a recent typo shouldn't have to retype the
+      // whole date). Falls back to today for first-time setters.
+      setDateValue(isoToDateInput(currentAcquisitionDate) || todayDateInput());
+      setCascade(true);
+      setBusy(false);
+      setError(null);
+      setResult(null);
+    }
+  }, [isOpen, currentAcquisitionDate]);
+
+  const handleConfirm = async () => {
+    if (!dateValue) {
+      setError('Pick a date.');
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const { data } = await updateAcquisition({
+        variables: {
+          bikeId,
+          input: {
+            acquisitionDate: dateInputToIsoNoon(dateValue),
+            cascadeInstalls: cascade,
+          },
+        },
+      });
+      if (data?.updateBikeAcquisition) {
+        setResult({
+          installsMoved: data.updateBikeAcquisition.installsMoved,
+          serviceLogsMoved: data.updateBikeAcquisition.serviceLogsMoved,
+        });
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update acquisition date.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Update acquisition date"
+      subtitle={bikeName}
+      size="sm"
+      footer={
+        result ? (
+          <Button variant="primary" size="sm" onClick={onClose}>
+            Done
+          </Button>
+        ) : (
+          <>
+            <Button variant="outline" size="sm" onClick={onClose} disabled={busy}>
+              Cancel
+            </Button>
+            <Button variant="primary" size="sm" onClick={handleConfirm} disabled={busy}>
+              {busy ? 'Updating…' : 'Update'}
+            </Button>
+          </>
+        )
+      }
+    >
+      {result ? (
+        <div className="space-y-2">
+          <p className="text-sm">
+            Moved <span className="font-semibold">{result.installsMoved}</span> install date
+            {result.installsMoved === 1 ? '' : 's'} to{' '}
+            <span className="font-semibold">
+              {new Date(dateInputToIsoNoon(dateValue)).toLocaleDateString()}
+            </span>
+            .
+          </p>
+          {result.serviceLogsMoved > 0 && (
+            <p className="text-xs text-muted">
+              Baseline service anchors for {result.serviceLogsMoved} component
+              {result.serviceLogsMoved === 1 ? '' : 's'} moved alongside so wear predictions stay
+              accurate.
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="flex items-start gap-2 text-sm text-muted">
+            <Calendar size={14} className="mt-0.5 shrink-0 icon-sage" />
+            <span>
+              Sets the acquisition date on this bike. If enabled below, also moves the install
+              dates of every stock component (and any install that was auto-stamped when the bike
+              was added).
+            </span>
+          </div>
+
+          <div>
+            <label htmlFor="acquisition-date" className="block text-xs text-muted mb-1">
+              Acquired on
+            </label>
+            <input
+              id="acquisition-date"
+              type="date"
+              value={dateValue}
+              max={todayDateInput()}
+              onChange={(e) => setDateValue(e.target.value)}
+              className="log-service-date-input w-full"
+            />
+          </div>
+
+          <label className="flex items-start gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={cascade}
+              onChange={(e) => setCascade(e.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              Also update install dates for stock components
+              <span className="block text-xs text-muted">
+                Post-creation swaps you've dated yourself won't be touched.
+              </span>
+            </span>
+          </label>
+
+          {error && (
+            <div className="alert-inline alert-inline-error">
+              <TriangleAlert size={14} />
+              {error}
+            </div>
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/apps/web/src/graphql/bike.ts
+++ b/apps/web/src/graphql/bike.ts
@@ -1,0 +1,28 @@
+import { gql } from '@apollo/client';
+
+export const UPDATE_BIKE_ACQUISITION = gql`
+  mutation UpdateBikeAcquisition(
+    $bikeId: ID!
+    $input: UpdateBikeAcquisitionInput!
+  ) {
+    updateBikeAcquisition(bikeId: $bikeId, input: $input) {
+      bike {
+        id
+        acquisitionDate
+      }
+      installsMoved
+      serviceLogsMoved
+    }
+  }
+`;
+
+export const BULK_UPDATE_BIKE_COMPONENT_INSTALLS = gql`
+  mutation BulkUpdateBikeComponentInstalls(
+    $input: BulkUpdateBikeComponentInstallsInput!
+  ) {
+    bulkUpdateBikeComponentInstalls(input: $input) {
+      updatedCount
+      serviceLogsMoved
+    }
+  }
+`;

--- a/apps/web/src/pages/BikeDetail.test.tsx
+++ b/apps/web/src/pages/BikeDetail.test.tsx
@@ -104,6 +104,7 @@ vi.mock('@/components/SpareComponentForm', () => ({
 
 vi.mock('@/graphql/gear', () => ({
   GEAR_QUERY: 'GEAR_QUERY',
+  GEAR_QUERY_LIGHT: 'GEAR_QUERY_LIGHT',
   UPDATE_BIKE: 'UPDATE_BIKE',
   UPDATE_COMPONENT: 'UPDATE_COMPONENT',
   BIKE_NOTES_QUERY: 'BIKE_NOTES_QUERY',

--- a/apps/web/src/pages/BikeDetail.tsx
+++ b/apps/web/src/pages/BikeDetail.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from 'motion/react';
 import {
   ArrowLeft,
   Bike,
+  CalendarClock,
   Pencil,
   Wrench,
   ExternalLink,
@@ -17,6 +18,7 @@ import { Button } from '@/components/ui/Button';
 import { Modal } from '@/components/ui/Modal';
 import { StatusPill } from '@/components/dashboard/StatusPill';
 import { LogServiceModal } from '@/components/dashboard/LogServiceModal';
+import { UpdateAcquisitionModal } from '@/components/gear/UpdateAcquisitionModal';
 import { ComponentDetailRow } from '@/components/gear/ComponentDetailRow';
 import { ReplaceComponentModal } from '@/components/gear/ReplaceComponentModal';
 import { SwapComponentModal } from '@/components/gear/SwapComponentModal';
@@ -88,6 +90,7 @@ type BikeDto = {
   motorPowerW?: number | null;
   motorTorqueNm?: number | null;
   batteryWh?: number | null;
+  acquisitionDate?: string | null;
   components: ComponentDto[];
   predictions?: BikePredictionSummary | null;
   servicePreferences?: BikeServicePreferenceDto[];
@@ -158,6 +161,7 @@ export default function BikeDetail() {
 
   // Modal states
   const [serviceModalOpen, setServiceModalOpen] = useState(false);
+  const [acquisitionModalOpen, setAcquisitionModalOpen] = useState(false);
   const [editingComponent, setEditingComponent] = useState<ComponentDto | null>(null);
   const [editingTravel, setEditingTravel] = useState<'fork' | 'shock' | null>(null);
   const [travelValue, setTravelValue] = useState('');
@@ -377,6 +381,14 @@ export default function BikeDetail() {
             <Button variant="primary" size="sm" onClick={() => setServiceModalOpen(true)}>
               <Wrench size={12} className="icon-left" />
               Log Service
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setAcquisitionModalOpen(true)}
+            >
+              <CalendarClock size={12} className="icon-left" />
+              Update acquisition date
             </Button>
             {bikeId && (
               <Link
@@ -606,6 +618,17 @@ export default function BikeDetail() {
             sortOrder: 0,
             predictions: bike.predictions ?? null,
           }}
+        />
+      )}
+
+      {/* Update Acquisition Modal */}
+      {bike && bikeId && (
+        <UpdateAcquisitionModal
+          isOpen={acquisitionModalOpen}
+          onClose={() => setAcquisitionModalOpen(false)}
+          bikeId={bikeId}
+          bikeName={bike.nickname || `${bike.manufacturer} ${bike.model}`}
+          currentAcquisitionDate={bike.acquisitionDate ?? null}
         />
       )}
 

--- a/apps/web/src/pages/BikeHistory.test.tsx
+++ b/apps/web/src/pages/BikeHistory.test.tsx
@@ -1,0 +1,397 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import BikeHistory from './BikeHistory';
+
+// Apollo — useQuery returns the fixed fixture below; useMutation returns
+// a shared mock fn so each test can assert the bulk-update payload.
+const mockBulkUpdate = vi.fn();
+const mockUseQuery = vi.fn();
+vi.mock('@apollo/client', () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useMutation: vi.fn(() => [mockBulkUpdate, { loading: false }]),
+  gql: vi.fn((strings: TemplateStringsArray) => strings[0]),
+}));
+
+// Pin the bikeId so the query fixture is reachable.
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom'
+  );
+  return {
+    ...actual,
+    useParams: () => ({ bikeId: 'bike-1' }),
+  };
+});
+
+// Modal + Button pass-throughs.
+vi.mock('@/components/ui/Modal', () => ({
+  Modal: ({
+    isOpen,
+    onClose,
+    title,
+    children,
+    footer,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    title: string;
+    children: React.ReactNode;
+    footer?: React.ReactNode;
+  }) =>
+    isOpen ? (
+      <div data-testid="modal" aria-label={title}>
+        <h2>{title}</h2>
+        <button onClick={onClose} data-testid="modal-close">
+          Close
+        </button>
+        {children}
+        {footer && <div data-testid="modal-footer">{footer}</div>}
+      </div>
+    ) : null,
+}));
+
+vi.mock('@/components/ui/Button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    variant,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    variant?: string;
+    size?: string;
+  }) => (
+    <button onClick={onClick} disabled={disabled} data-variant={variant}>
+      {children}
+    </button>
+  ),
+}));
+
+// Child modals — stubbed out; these tests don't care about their internals.
+vi.mock('@/components/dashboard/EditServiceModal', () => ({
+  EditServiceModal: () => <div data-testid="edit-service-modal" />,
+}));
+vi.mock('@/components/dashboard/EditInstallModal', () => ({
+  EditInstallModal: () => <div data-testid="edit-install-modal" />,
+}));
+
+// Lazy PDF button — the real module is lazy-loaded via Suspense.
+vi.mock('@/components/history/BikeHistoryPdfButton', () => ({
+  default: () => <button data-testid="pdf-btn">PDF</button>,
+}));
+
+vi.mock('@/hooks/usePreferences', () => ({
+  usePreferences: () => ({ distanceUnit: 'mi' }),
+}));
+
+vi.mock('@/constants/componentLabels', () => ({
+  getComponentLabel: (type: string) => type,
+}));
+
+vi.mock('@/graphql/bikeHistory', () => ({ BIKE_HISTORY: 'BIKE_HISTORY' }));
+vi.mock('@/graphql/bike', () => ({
+  BULK_UPDATE_BIKE_COMPONENT_INSTALLS: 'BULK_UPDATE_BIKE_COMPONENT_INSTALLS',
+}));
+
+// Fixture: one INSTALLED, one REMOVED, one paired INSTALLED/REMOVED set.
+// Base ids strip the ":installed" / ":removed" suffix, matching the
+// production id convention the backend resolver emits.
+const fixture = {
+  bikeHistory: {
+    bike: {
+      id: 'bike-1',
+      manufacturer: 'Santa Cruz',
+      model: 'Bronson',
+      year: 2024,
+      nickname: null,
+    },
+    totals: {
+      rideCount: 0,
+      totalDistanceMeters: 0,
+      totalDurationSeconds: 0,
+      totalElevationGainMeters: 0,
+      serviceEventCount: 0,
+      installEventCount: 3,
+    },
+    truncated: false,
+    rides: [],
+    serviceEvents: [],
+    installs: [
+      {
+        id: 'inst-A:installed',
+        eventType: 'INSTALLED',
+        occurredAt: '2024-06-01T12:00:00.000Z',
+        component: {
+          id: 'c-A',
+          type: 'TIRE',
+          location: 'FRONT',
+          brand: 'Maxxis',
+          model: 'DHF',
+        },
+      },
+      {
+        id: 'inst-B:installed',
+        eventType: 'INSTALLED',
+        occurredAt: '2024-06-02T12:00:00.000Z',
+        component: {
+          id: 'c-B',
+          type: 'TIRE',
+          location: 'REAR',
+          brand: 'Maxxis',
+          model: 'DHR',
+        },
+      },
+      {
+        id: 'inst-B:removed',
+        eventType: 'REMOVED',
+        occurredAt: '2024-07-01T12:00:00.000Z',
+        component: {
+          id: 'c-B',
+          type: 'TIRE',
+          location: 'REAR',
+          brand: 'Maxxis',
+          model: 'DHR',
+        },
+      },
+    ],
+  },
+};
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <BikeHistory />
+    </MemoryRouter>
+  );
+}
+
+// Scope queries to the bottom action bar so TotalChip counts ("0 rides",
+// "3 service events") don't collide with "N selected" text.
+function actionBar() {
+  const setDateBtn = screen.queryByText('Set date');
+  const bar = setDateBtn?.closest('div.fixed') as HTMLElement | null;
+  if (!bar) throw new Error('Action bar not in DOM');
+  return within(bar);
+}
+
+describe('BikeHistory multi-select', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseQuery.mockReturnValue({ data: fixture, loading: false, error: undefined });
+    mockBulkUpdate.mockResolvedValue({
+      data: {
+        bulkUpdateBikeComponentInstalls: { updatedCount: 2, serviceLogsMoved: 2 },
+      },
+    });
+  });
+
+  const enterSelectionMode = () => {
+    fireEvent.click(screen.getByText('Edit dates'));
+  };
+
+  describe('entering and exiting selection mode', () => {
+    it('shows "Edit dates" button by default, no action bar', () => {
+      renderPage();
+      expect(screen.getByText('Edit dates')).toBeInTheDocument();
+      expect(screen.queryByText(/selected/)).not.toBeInTheDocument();
+    });
+
+    it('enters selection mode — action bar appears with zero count and hint', () => {
+      renderPage();
+      enterSelectionMode();
+      const bar = actionBar();
+      expect(bar.getByText('0')).toBeInTheDocument();
+      expect(bar.getByText(/tap install events to select/)).toBeInTheDocument();
+      expect(bar.getByText('Set date')).toBeDisabled();
+    });
+
+    it('swaps the "Edit dates" button for "Cancel" in the header', () => {
+      renderPage();
+      enterSelectionMode();
+      expect(screen.queryByText('Edit dates')).not.toBeInTheDocument();
+      // Two Cancel buttons now: header + bottom action bar. Both exit mode.
+      const cancels = screen.getAllByText('Cancel');
+      expect(cancels.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('Cancel in the header exits selection mode and clears selections', () => {
+      renderPage();
+      enterSelectionMode();
+      fireEvent.click(
+        screen.getByLabelText(/Edit installed event for TIRE \(front\)/)
+      );
+      // Header cancel is the first Cancel in the DOM.
+      fireEvent.click(screen.getAllByText('Cancel')[0]);
+      // Action bar gone → no "selected" text.
+      expect(screen.queryByText(/selected/)).not.toBeInTheDocument();
+      // Re-entering shows count back at 0.
+      enterSelectionMode();
+      expect(actionBar().getByText('0')).toBeInTheDocument();
+    });
+  });
+
+  describe('row selectability', () => {
+    it('INSTALLED rows toggle selection on tap; count updates', () => {
+      renderPage();
+      enterSelectionMode();
+      const rowA = screen.getByLabelText(/Edit installed event for TIRE \(front\)/);
+      fireEvent.click(rowA);
+      expect(actionBar().getByText('1')).toBeInTheDocument();
+      // Hint copy goes away once the count is non-zero.
+      expect(
+        screen.queryByText(/tap install events to select/)
+      ).not.toBeInTheDocument();
+      expect(actionBar().getByText('Set date')).not.toBeDisabled();
+      // Tap again → deselect.
+      fireEvent.click(rowA);
+      expect(actionBar().getByText('0')).toBeInTheDocument();
+      expect(actionBar().getByText('Set date')).toBeDisabled();
+    });
+
+    it('REMOVED rows do not toggle selection', () => {
+      renderPage();
+      enterSelectionMode();
+      const removedRow = screen.getByLabelText(/Edit removed event for TIRE \(rear\)/);
+      fireEvent.click(removedRow);
+      expect(actionBar().getByText('0')).toBeInTheDocument();
+      expect(actionBar().getByText('Set date')).toBeDisabled();
+    });
+
+    it('selecting multiple INSTALLED rows accumulates the count', () => {
+      renderPage();
+      enterSelectionMode();
+      fireEvent.click(
+        screen.getByLabelText(/Edit installed event for TIRE \(front\)/)
+      );
+      fireEvent.click(
+        screen.getByLabelText(/Edit installed event for TIRE \(rear\)/)
+      );
+      expect(actionBar().getByText('2')).toBeInTheDocument();
+    });
+  });
+
+  describe('Set date → BulkDateModal flow', () => {
+    it('opens the modal when Set date is clicked', () => {
+      renderPage();
+      enterSelectionMode();
+      fireEvent.click(
+        screen.getByLabelText(/Edit installed event for TIRE \(front\)/)
+      );
+      fireEvent.click(actionBar().getByText('Set date'));
+      expect(
+        screen.getByRole('heading', { name: /Set date for 1 install$/ })
+      ).toBeInTheDocument();
+    });
+
+    it('pluralizes the modal title when multiple installs are selected', () => {
+      renderPage();
+      enterSelectionMode();
+      fireEvent.click(
+        screen.getByLabelText(/Edit installed event for TIRE \(front\)/)
+      );
+      fireEvent.click(
+        screen.getByLabelText(/Edit installed event for TIRE \(rear\)/)
+      );
+      fireEvent.click(actionBar().getByText('Set date'));
+      expect(
+        screen.getByRole('heading', { name: /Set date for 2 installs$/ })
+      ).toBeInTheDocument();
+    });
+
+    it('Apply submits the selected ids with noon-anchored iso and exits mode', async () => {
+      renderPage();
+      enterSelectionMode();
+      fireEvent.click(
+        screen.getByLabelText(/Edit installed event for TIRE \(front\)/)
+      );
+      fireEvent.click(
+        screen.getByLabelText(/Edit installed event for TIRE \(rear\)/)
+      );
+      fireEvent.click(actionBar().getByText('Set date'));
+
+      const modal = screen.getByTestId('modal');
+      const dateInput = within(modal).getByDisplayValue(
+        /\d{4}-\d{2}-\d{2}/
+      ) as HTMLInputElement;
+      fireEvent.change(dateInput, { target: { value: '2022-05-10' } });
+
+      fireEvent.click(within(modal).getByText('Apply'));
+
+      await waitFor(() => {
+        expect(mockBulkUpdate).toHaveBeenCalledTimes(1);
+      });
+      expect(mockBulkUpdate).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            // Order isn't guaranteed because Set iteration order matches
+            // insertion order, but both clicks are present.
+            ids: expect.arrayContaining(['inst-A', 'inst-B']),
+            installedAt: expect.stringMatching(/^2022-05-10T\d{2}:00:00\.000Z$/),
+          },
+        },
+      });
+      // After success: selection mode exited, action bar gone.
+      await waitFor(() => {
+        expect(screen.queryByText(/selected/)).not.toBeInTheDocument();
+      });
+      expect(screen.getByText('Edit dates')).toBeInTheDocument();
+    });
+
+    it('sends only the base ids (":installed" suffix stripped)', async () => {
+      renderPage();
+      enterSelectionMode();
+      fireEvent.click(
+        screen.getByLabelText(/Edit installed event for TIRE \(front\)/)
+      );
+      fireEvent.click(actionBar().getByText('Set date'));
+      fireEvent.click(
+        within(screen.getByTestId('modal')).getByText('Apply')
+      );
+      await waitFor(() => {
+        expect(mockBulkUpdate).toHaveBeenCalled();
+      });
+      const call = mockBulkUpdate.mock.calls[0][0];
+      expect(call.variables.input.ids).toEqual(['inst-A']);
+    });
+  });
+
+  describe('handleBulkSetDate error path', () => {
+    it('shows the mutation error inline and keeps selection mode active', async () => {
+      mockBulkUpdate.mockRejectedValue(new Error('Removal date conflict'));
+      renderPage();
+      enterSelectionMode();
+      fireEvent.click(
+        screen.getByLabelText(/Edit installed event for TIRE \(front\)/)
+      );
+      fireEvent.click(actionBar().getByText('Set date'));
+      fireEvent.click(
+        within(screen.getByTestId('modal')).getByText('Apply')
+      );
+
+      expect(await screen.findByText('Removal date conflict')).toBeInTheDocument();
+      // Selection preserved so the user can retry without re-picking rows.
+      expect(actionBar().getByText('1')).toBeInTheDocument();
+      // Bulk modal still open.
+      expect(screen.getByTestId('modal')).toBeInTheDocument();
+    });
+
+    it('falls back to generic copy when the thrown value is not an Error', async () => {
+      mockBulkUpdate.mockRejectedValue('unknown');
+      renderPage();
+      enterSelectionMode();
+      fireEvent.click(
+        screen.getByLabelText(/Edit installed event for TIRE \(front\)/)
+      );
+      fireEvent.click(actionBar().getByText('Set date'));
+      fireEvent.click(
+        within(screen.getByTestId('modal')).getByText('Apply')
+      );
+      expect(
+        await screen.findByText('Failed to update install dates.')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/pages/BikeHistory.tsx
+++ b/apps/web/src/pages/BikeHistory.tsx
@@ -1,13 +1,15 @@
 import { Suspense, lazy, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { useQuery } from '@apollo/client';
-import { ArrowLeft, Bike as BikeIcon, FileDown, MinusCircle, PlusCircle, Wrench } from 'lucide-react';
+import { useMutation, useQuery } from '@apollo/client';
+import { ArrowLeft, Bike as BikeIcon, CalendarClock, Check, FileDown, MinusCircle, PlusCircle, TriangleAlert, Wrench } from 'lucide-react';
 
 import { BIKE_HISTORY } from '@/graphql/bikeHistory';
+import { BULK_UPDATE_BIKE_COMPONENT_INSTALLS } from '@/graphql/bike';
+import { Modal } from '@/components/ui/Modal';
 import { Button } from '@/components/ui/Button';
 import { EditServiceModal, type EditableServiceLog } from '@/components/dashboard/EditServiceModal';
 import { EditInstallModal, type EditableInstallEvent } from '@/components/dashboard/EditInstallModal';
-import { fmtDateTime, fmtDistance, fmtDuration, fmtElevation } from '@/lib/format';
+import { fmtDateTime, fmtDistance, fmtDuration, fmtElevation, dateInputToIsoNoon, todayDateInput } from '@/lib/format';
 import { usePreferences } from '@/hooks/usePreferences';
 import { getComponentLabel } from '@/constants/componentLabels';
 import {
@@ -46,6 +48,18 @@ export default function BikeHistory() {
     componentLabel: string;
     hasPairedEvent: boolean;
   } | null>(null);
+  // Multi-select state — enabled via "Edit dates" button. Only INSTALLED
+  // events are selectable; the backend's bulk mutation only moves
+  // installedAt (not removedAt), and mixing both in one selection would
+  // create ambiguous "apply this date to what?" semantics. REMOVED
+  // events remain individually editable via the single-event modal.
+  // Stored as install base ids (composite id with the ":installed" suffix
+  // stripped) so we can send them straight to the backend.
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedInstallIds, setSelectedInstallIds] = useState<Set<string>>(new Set());
+  const [bulkDateOpen, setBulkDateOpen] = useState(false);
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const [bulkError, setBulkError] = useState<string | null>(null);
 
   const range = useMemo(() => computeTimeframeRange(timeframe), [timeframe]);
 
@@ -54,6 +68,45 @@ export default function BikeHistory() {
     skip: !bikeId,
     fetchPolicy: 'cache-and-network',
   });
+
+  const [bulkUpdateInstalls] = useMutation(BULK_UPDATE_BIKE_COMPONENT_INSTALLS, {
+    refetchQueries: bikeId ? [{ query: BIKE_HISTORY, variables: { bikeId } }] : [],
+  });
+
+  const exitSelectionMode = () => {
+    setSelectionMode(false);
+    setSelectedInstallIds(new Set());
+  };
+
+  const toggleInstallSelection = (baseId: string) => {
+    setSelectedInstallIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(baseId)) next.delete(baseId);
+      else next.add(baseId);
+      return next;
+    });
+  };
+
+  const handleBulkSetDate = async (isoDate: string) => {
+    setBulkBusy(true);
+    setBulkError(null);
+    try {
+      await bulkUpdateInstalls({
+        variables: {
+          input: {
+            ids: Array.from(selectedInstallIds),
+            installedAt: isoDate,
+          },
+        },
+      });
+      setBulkDateOpen(false);
+      exitSelectionMode();
+    } catch (err) {
+      setBulkError(err instanceof Error ? err.message : 'Failed to update install dates.');
+    } finally {
+      setBulkBusy(false);
+    }
+  };
 
   const payload = data?.bikeHistory;
 
@@ -113,16 +166,28 @@ export default function BikeHistory() {
                 {payload.bike.year ? `${payload.bike.year} · ` : ''}History
               </div>
             </div>
-            <Suspense fallback={<Button variant="outline" size="sm" disabled><FileDown size={14} className="icon-left" /> Preparing…</Button>}>
-              <BikeHistoryPdfButton
-                bike={payload.bike}
-                totals={payload.totals}
-                yearGroups={yearGroups}
-                distanceUnit={distanceUnit}
-                timeframeLabel={TIMEFRAME_LABEL[timeframe]}
-                truncated={payload.truncated}
-              />
-            </Suspense>
+            <div className="flex items-center gap-2">
+              {!selectionMode ? (
+                <Button variant="outline" size="sm" onClick={() => setSelectionMode(true)}>
+                  <CalendarClock size={14} className="icon-left" />
+                  Edit dates
+                </Button>
+              ) : (
+                <Button variant="outline" size="sm" onClick={exitSelectionMode}>
+                  Cancel
+                </Button>
+              )}
+              <Suspense fallback={<Button variant="outline" size="sm" disabled><FileDown size={14} className="icon-left" /> Preparing…</Button>}>
+                <BikeHistoryPdfButton
+                  bike={payload.bike}
+                  totals={payload.totals}
+                  yearGroups={yearGroups}
+                  distanceUnit={distanceUnit}
+                  timeframeLabel={TIMEFRAME_LABEL[timeframe]}
+                  truncated={payload.truncated}
+                />
+              </Suspense>
+            </div>
           </div>
 
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
@@ -199,25 +264,36 @@ export default function BikeHistory() {
                             }
                           />
                         )}
-                        {item.kind === 'install' && (
-                          <InstallRow
-                            install={item.install}
-                            onEdit={() => {
-                              const baseIdx = item.install.id.lastIndexOf(':');
-                              const baseId =
-                                baseIdx > 0 ? item.install.id.slice(0, baseIdx) : item.install.id;
-                              setEditingInstall({
-                                event: {
-                                  id: item.install.id,
-                                  eventType: item.install.eventType,
-                                  occurredAt: item.install.occurredAt,
-                                },
-                                componentLabel: componentDisplay(item.install.component),
-                                hasPairedEvent: pairedBaseIds.has(baseId),
-                              });
-                            }}
-                          />
-                        )}
+                        {item.kind === 'install' && (() => {
+                          const baseIdx = item.install.id.lastIndexOf(':');
+                          const baseId =
+                            baseIdx > 0 ? item.install.id.slice(0, baseIdx) : item.install.id;
+                          const isInstallEvent = item.install.eventType === 'INSTALLED';
+                          const isSelectable = selectionMode && isInstallEvent;
+                          const isSelected = isSelectable && selectedInstallIds.has(baseId);
+                          return (
+                            <InstallRow
+                              install={item.install}
+                              selectable={isSelectable}
+                              selected={isSelected}
+                              onEdit={() => {
+                                if (selectionMode) {
+                                  if (isSelectable) toggleInstallSelection(baseId);
+                                  return;
+                                }
+                                setEditingInstall({
+                                  event: {
+                                    id: item.install.id,
+                                    eventType: item.install.eventType,
+                                    occurredAt: item.install.occurredAt,
+                                  },
+                                  componentLabel: componentDisplay(item.install.component),
+                                  hasPairedEvent: pairedBaseIds.has(baseId),
+                                });
+                              }}
+                            />
+                          );
+                        })()}
                       </li>
                       );
                     })}
@@ -247,7 +323,105 @@ export default function BikeHistory() {
           onClose={() => setEditingInstall(null)}
         />
       )}
+
+      {/* Bulk action bar, pinned to the bottom of the viewport while in
+          selection mode. Always rendered (not conditional) so the
+          transition in/out feels intentional; visibility is gated by
+          the `hidden` class swap. */}
+      {selectionMode && (
+        <div className="fixed inset-x-0 bottom-0 z-20 border-t border-border bg-surface-2/95 backdrop-blur px-4 py-3">
+          <div className="mx-auto max-w-3xl flex items-center justify-between gap-3">
+            <span className="text-sm">
+              <span className="font-semibold">{selectedInstallIds.size}</span> selected
+              {selectedInstallIds.size === 0 && (
+                <span className="text-muted"> &middot; tap install events to select</span>
+              )}
+            </span>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" onClick={exitSelectionMode}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => {
+                  setBulkError(null);
+                  setBulkDateOpen(true);
+                }}
+                disabled={selectedInstallIds.size === 0}
+              >
+                <CalendarClock size={14} className="icon-left" />
+                Set date
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <BulkDateModal
+        isOpen={bulkDateOpen}
+        count={selectedInstallIds.size}
+        busy={bulkBusy}
+        error={bulkError}
+        onClose={() => setBulkDateOpen(false)}
+        onConfirm={handleBulkSetDate}
+      />
     </div>
+  );
+}
+
+function BulkDateModal({
+  isOpen,
+  count,
+  busy,
+  error,
+  onClose,
+  onConfirm,
+}: {
+  isOpen: boolean;
+  count: number;
+  busy: boolean;
+  error: string | null;
+  onClose: () => void;
+  onConfirm: (isoDate: string) => void;
+}) {
+  // Seeded with today; if the user enters a date, closes, reopens — they
+  // get their last entry back, which matches iOS/Android native forms.
+  const [dateValue, setDateValue] = useState(todayDateInput());
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={`Set date for ${count} install${count === 1 ? '' : 's'}`} size="sm" footer={
+      <>
+        <Button variant="outline" size="sm" onClick={onClose} disabled={busy}>Cancel</Button>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => dateValue && onConfirm(dateInputToIsoNoon(dateValue))}
+          disabled={busy || !dateValue}
+        >
+          {busy ? 'Updating…' : 'Apply'}
+        </Button>
+      </>
+    }>
+      <div className="space-y-3">
+        <input
+          type="date"
+          value={dateValue}
+          max={todayDateInput()}
+          onChange={(e) => setDateValue(e.target.value)}
+          className="log-service-date-input w-full"
+        />
+        <p className="text-xs text-muted">
+          Updates the installed date for all selected install events. Matching baseline service
+          anchors move alongside automatically.
+        </p>
+        {error && (
+          <div className="alert-inline alert-inline-error">
+            <TriangleAlert size={14} />
+            {error}
+          </div>
+        )}
+      </div>
+    </Modal>
   );
 }
 
@@ -309,17 +483,35 @@ function ServiceRow({ service, onEdit }: { service: HistoryServiceEvent; onEdit?
   );
 }
 
-function InstallRow({ install, onEdit }: { install: HistoryInstallEvent; onEdit?: () => void }) {
+function InstallRow({
+  install,
+  onEdit,
+  selectable = false,
+  selected = false,
+}: {
+  install: HistoryInstallEvent;
+  onEdit?: () => void;
+  selectable?: boolean;
+  selected?: boolean;
+}) {
   const Icon = install.eventType === 'INSTALLED' ? PlusCircle : MinusCircle;
   const verb = install.eventType === 'INSTALLED' ? 'Installed' : 'Removed';
   return (
     <button
       type="button"
       onClick={onEdit}
-      className="w-full text-left flex items-baseline justify-between gap-3 hover:bg-surface-2/40 rounded px-1 -mx-1 py-0.5"
+      className={`w-full text-left flex items-baseline justify-between gap-3 hover:bg-surface-2/40 rounded px-1 -mx-1 py-0.5 ${selected ? 'bg-mint/10' : ''}`}
       aria-label={`Edit ${verb.toLowerCase()} event for ${componentDisplay(install.component)}`}
     >
-      <div className="min-w-0">
+      {selectable && (
+        <span
+          className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border ${selected ? 'bg-mint border-mint' : 'border-border'}`}
+          aria-hidden
+        >
+          {selected && <Check size={10} className="text-white" />}
+        </span>
+      )}
+      <div className="min-w-0 flex-1">
         <div className="text-sm font-medium truncate">
           {verb} · {componentDisplay(install.component)}
         </div>

--- a/apps/web/src/pages/BikeHistory.tsx
+++ b/apps/web/src/pages/BikeHistory.tsx
@@ -138,6 +138,36 @@ export default function BikeHistory() {
     });
   }, [payload, showRides, showService]);
 
+  const renderInstallRow = (install: HistoryInstallEvent) => {
+    const baseIdx = install.id.lastIndexOf(':');
+    const baseId = baseIdx > 0 ? install.id.slice(0, baseIdx) : install.id;
+    const isInstallEvent = install.eventType === 'INSTALLED';
+    const isSelectable = selectionMode && isInstallEvent;
+    const isSelected = isSelectable && selectedInstallIds.has(baseId);
+    return (
+      <InstallRow
+        install={install}
+        selectable={isSelectable}
+        selected={isSelected}
+        onEdit={() => {
+          if (selectionMode) {
+            if (isSelectable) toggleInstallSelection(baseId);
+            return;
+          }
+          setEditingInstall({
+            event: {
+              id: install.id,
+              eventType: install.eventType,
+              occurredAt: install.occurredAt,
+            },
+            componentLabel: componentDisplay(install.component),
+            hasPairedEvent: pairedBaseIds.has(baseId),
+          });
+        }}
+      />
+    );
+  };
+
   if (!bikeId) {
     return <div className="p-6">Missing bike id.</div>;
   }
@@ -264,36 +294,7 @@ export default function BikeHistory() {
                             }
                           />
                         )}
-                        {item.kind === 'install' && (() => {
-                          const baseIdx = item.install.id.lastIndexOf(':');
-                          const baseId =
-                            baseIdx > 0 ? item.install.id.slice(0, baseIdx) : item.install.id;
-                          const isInstallEvent = item.install.eventType === 'INSTALLED';
-                          const isSelectable = selectionMode && isInstallEvent;
-                          const isSelected = isSelectable && selectedInstallIds.has(baseId);
-                          return (
-                            <InstallRow
-                              install={item.install}
-                              selectable={isSelectable}
-                              selected={isSelected}
-                              onEdit={() => {
-                                if (selectionMode) {
-                                  if (isSelectable) toggleInstallSelection(baseId);
-                                  return;
-                                }
-                                setEditingInstall({
-                                  event: {
-                                    id: item.install.id,
-                                    eventType: item.install.eventType,
-                                    occurredAt: item.install.occurredAt,
-                                  },
-                                  componentLabel: componentDisplay(item.install.component),
-                                  hasPairedEvent: pairedBaseIds.has(baseId),
-                                });
-                              }}
-                            />
-                          );
-                        })()}
+                        {item.kind === 'install' && renderInstallRow(item.install)}
                       </li>
                       );
                     })}


### PR DESCRIPTION
# Retroactive acquisition date + bulk install-date edits

Closes the "I got my bike years ago, why is every component installed yesterday?" migration bug for users who added bikes before `Bike.acquisitionDate` existed. Ships two complementary flows so users can fix the data with either one tap (acquisition button) or a surgical multi-select.

Also promotes "Bike Details" to the primary action on the bike overview card (small UX win bundled in).

## Why

After the prior `installedAt` feature landed, existing users — bikes and all — inherited bad timeline data: every stock component stamped with the bike's `createdAt` moment. Per-event edit sheets from the last PR let people fix this one row at a time, but a user with 14 stock components on a 5-year-old bike won't do that. Two new flows cover the realistic scenarios:

1. **Update acquisition date** — one date, one tap, cascades to every install matching the "buggy auto-date" predicate. Handles 99% of migration cases in ~5 seconds.
2. **Multi-select bulk edit** on BikeHistory — enter a selection mode, tick N install rows, apply one date. Handles the long tail: a user who actually swapped three tires on the same day last spring, etc.

Decisions baked into this PR:
- **Cascade scope:** `Component.isStock = true` OR `installedAt` within 60 s of `bike.createdAt`. Targets rows stamped by the old buggy code path while sparing custom post-creation swaps.
- **Baseline ServiceLog migration:** when an install moves, the synthetic `hoursAtService: 0` ServiceLog that anchors wear predictions moves alongside. Predictions stay correct.

## Summary of changes

**Backend** ([schema.ts](apps/api/src/graphql/schema.ts), [resolvers.ts](apps/api/src/graphql/resolvers.ts), [rate-limit.ts](apps/api/src/lib/rate-limit.ts))

- **`updateBikeAcquisition(bikeId, input: { acquisitionDate, cascadeInstalls })`** — sets `Bike.acquisitionDate`. If `cascadeInstalls` (default true), bulk-updates every matching `BikeComponentInstall.installedAt`, moves still-active `Component.installedAt`, and shifts the baseline `ServiceLog` rows. Baseline moves are grouped by old date so the common migration case (one shared date) collapses to a single `UPDATE`. Returns `installsMoved` + `serviceLogsMoved` counts for the client toast.
- **`bulkUpdateBikeComponentInstalls(ids, installedAt)`** — applies one `installedAt` to up to 100 install rows. All-or-nothing ownership check (rejects with `NOT_FOUND` if any id doesn't belong to viewer — doesn't leak which). Chronology guard: rejects the whole batch if any row's target date would move past its existing `removedAt`. Same baseline-log grouping as above.
- Prediction cache invalidated before + after each mutation's transaction. Both rate-limited at 20 req/min per user.
- 9 new resolver tests covering ownership rejection, future-date rejection, cascade grouping, cascade-off short-circuit, cross-user all-or-nothing batch rejection, missing-id length mismatch, chronology violation, and the >100-id cap.

**Web — Update acquisition flow** ([bike.ts](apps/web/src/graphql/bike.ts), [UpdateAcquisitionModal.tsx](apps/web/src/components/gear/UpdateAcquisitionModal.tsx), [BikeDetail.tsx](apps/web/src/pages/BikeDetail.tsx))

- New `UpdateAcquisitionModal`: date input (seeded with current `acquisitionDate` if set, else today), checkbox "Also update stock component install dates" (default on). On success, swaps to a summary view showing how many installs + service logs moved.
- "Update acquisition date" button added to BikeDetail's hero-actions block next to Log Service.
- Refetches `BIKES` / `GEAR_QUERY_LIGHT` / `BIKE_HISTORY` on success — all three surfaces that render `acquisitionDate` or install timestamps update immediately.
- [BikeDetail.test.tsx](apps/web/src/pages/BikeDetail.test.tsx) mock updated to expose `GEAR_QUERY_LIGHT` now that BikeDetail imports from the modal.

**Web — Multi-select mode on BikeHistory** ([BikeHistory.tsx](apps/web/src/pages/BikeHistory.tsx))

- "Edit dates" button in the page header toggles selection mode.
- In selection mode: INSTALLED rows grow a checkbox; REMOVED rows stay non-selectable (backend only updates `installedAt`, and mixing both would create ambiguous "apply this date to what?" semantics — REMOVED edits still work one-at-a-time via the existing modal).
- A pinned bottom action bar shows `N selected · [Set date] [Cancel]`. "Set date" opens a small `BulkDateModal` that calls `bulkUpdateBikeComponentInstalls` and refetches `BIKE_HISTORY`.
- Selection state is a `Set<string>` of install base ids (composite `:installed`/`:removed` suffix stripped), so the set maps directly to the mutation payload without translation.

**Web — UX polish** ([BikeOverviewCard.tsx](apps/web/src/components/gear/BikeOverviewCard.tsx))

- "Edit details" → **"Bike Details"** with a `Bike` icon, promoted to **primary** button. "Log service" demoted to secondary. Rest of the card unchanged. Test updated.

## Verification

```bash
cd loam-logger/apps/api && npx prisma migrate deploy
cd loam-logger && npx nx run api:test
cd loam-logger && npx nx run web:test
cd loam-logger && npx nx run web:lint
cd loam-logger/apps/web && npx tsc --noEmit -p tsconfig.json
```

All clean locally:
- API tests: **188 passing** (9 new).
- Web tests: **775 passing**.
- Web lint + typecheck: clean.

Manual smoke tests to run post-deploy:

1. **Migration happy path.** Open an existing (pre-feature) bike whose installs all sit on the bike-creation date → tap "Update acquisition date" → pick a past date → confirm. BikeHistory shows every stock install on that date; the summary toast shows the right counts. Bike detail "Last serviced" reflections and wear predictions are untouched (baseline anchors moved alongside).
2. **Cascade-off.** Same bike, uncheck "Also update stock install dates" → only `Bike.acquisitionDate` moves; install timeline unchanged.
3. **Custom swap is spared.** On a bike with one custom tire swap dated 3 months after creation, run the cascade → the custom swap's install date does NOT move.
4. **Multi-select a subset.** On a fresh bike with three tire swaps on different dates, click "Edit dates" → tick two of them → "Set date" → confirm. Only those two moved; the third stays.
5. **Chronology guard on bulk.** Select an install whose paired `removedAt` is *before* the target date → confirm the mutation rejects with "Removal date cannot be before install date" and no rows change.
6. **Ownership guard on bulk.** (Covered by tests.) Submitting a batch with one id owned by a different user fails the whole batch.

## Scope deliberately out

- **No undo.** A user who bulk-moves 15 installs to the wrong date has to fix them manually via per-row edit. If this becomes painful, a follow-up could add a 10 s "Undo" toast that snapshots old dates client-side.
- **No REMOVED event bulk edit.** Only INSTALLED events are selectable in multi-select. The backend's bulk mutation only moves `installedAt`; REMOVED-date-only edits continue via the single-event sheet.
- **No acquisition-date *detection* heuristic.** The cascade's 60 s window is the best simple signal we have for "which rows came from the buggy auto-date path." A smarter analyzer (e.g., "bike has `acquisitionDate: null` AND all stock installs sit at the same timestamp, so this is definitely migration-buggy") would be overkill for v1.
- **No mobile changes in this branch.** Mobile counterpart ships in its own PR ([../loam-logger-mobile/PR_DESCRIPTION.md](../loam-logger-mobile/PR_DESCRIPTION.md)) so each platform reviews independently.

## Risks

- **Window heuristic for "buggy" rows** is threshold-based (`bike.createdAt + 60 s`). If a user's bike creation was slow (bad network, Nominatim retries), components installed at `createdAt + 70 s` would fall outside the window. Acceptable for v1 — the user can still fix outliers with multi-select.
- **Cascade on a bike with many post-creation custom installs** could surprise users if they expected the button to also fix those. The checkbox copy and explainer text both say "stock components" explicitly; the summary toast reports counts so users can sanity-check.
- **Prediction recompute semantics:** install dates are audit-trail-only for the prediction engine (ServiceLog dates drive anchor math), but moving the baseline ServiceLog alongside an install IS an anchor change. The transaction + cache invalidation handle this correctly, but worth exercising once on a bike with recorded ride hours post-deploy.

