### PR TITLE
Suunto Integration

### DIFF
--- a/apps/api/prisma/migrations/20260422161058_add_suunto_provider/migration.sql
+++ b/apps/api/prisma/migrations/20260422161058_add_suunto_provider/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[suuntoWorkoutId]` on the table `Ride` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[suuntoUserId]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterEnum
+ALTER TYPE "AuthProvider" ADD VALUE 'suunto';
+
+-- AlterEnum
+ALTER TYPE "IntegrationProvider" ADD VALUE 'SUUNTO';
+
+-- AlterTable
+ALTER TABLE "Ride" ADD COLUMN     "suuntoWorkoutId" TEXT;
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "suuntoUserId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ride_suuntoWorkoutId_key" ON "Ride"("suuntoWorkoutId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_suuntoUserId_key" ON "User"("suuntoUserId");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -26,6 +26,7 @@ model User {
   onboardingCompleted Boolean             @default(false)
   activeDataSource    AuthProvider?
   stravaUserId        String?             @unique
+  suuntoUserId        String?             @unique
   whoopUserId         String?             @unique
   role                UserRole            @default(WAITLIST)
   mustChangePassword  Boolean             @default(false)
@@ -125,6 +126,7 @@ model Ride {
   stravaActivityId  String?         @unique
   stravaGearId      String?
   whoopWorkoutId    String?         @unique
+  suuntoWorkoutId   String?         @unique
   importSessionId   String?
   startLat          Float?
   startLng          Float?
@@ -336,12 +338,14 @@ enum AuthProvider {
   garmin
   google
   strava
+  suunto
   whoop
 }
 
 enum IntegrationProvider {
   GARMIN
   STRAVA
+  SUUNTO
   WHOOP
 }
 

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -493,6 +493,7 @@ enum EmailType {
   founding_welcome
   founding_post_activation_info
   strava_integration_live
+  suunto_integration_live
   beta_feature_roundup
   password_added
   password_changed

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -147,6 +147,7 @@ export const typeDefs = gql`
     garminActivityId: String
     stravaActivityId: String
     whoopWorkoutId: String
+    suuntoWorkoutId: String
     stravaGearId: String
     startTime: String!
     durationSeconds: Int!

--- a/apps/api/src/lib/component-hours.ts
+++ b/apps/api/src/lib/component-hours.ts
@@ -2,6 +2,8 @@ import type { PrismaClient, Prisma } from '@prisma/client';
 
 type TransactionClient = Omit<PrismaClient, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>;
 
+const secondsToHours = (seconds: number | null | undefined) => Math.max(0, seconds ?? 0) / 3600;
+
 /**
  * Increment hoursUsed for all currently-installed components on a bike.
  * Skips if hoursDelta is zero or negative.
@@ -36,4 +38,47 @@ export async function decrementBikeComponentHours(
     where: { userId: opts.userId, bikeId: opts.bikeId, hoursUsed: { lt: 0 } },
     data: { hoursUsed: 0 },
   });
+}
+
+/**
+ * Diff-based sync of component hours across an upsert.
+ *
+ * Given the previous (bikeId, durationSeconds) and next state of a ride,
+ * credit/debit component hours correctly:
+ *  - Bike changed: decrement the old bike's components by the full previous
+ *    duration, increment the new bike's components by the full new duration.
+ *  - Same bike, longer ride: increment by the delta.
+ *  - Same bike, shorter ride: decrement by the absolute delta.
+ *  - No bike on either side: no-op.
+ *
+ * Previously duplicated inline in [webhooks.strava.ts] and [workers/sync.worker.ts].
+ */
+export async function syncBikeComponentHours(
+  tx: Prisma.TransactionClient,
+  userId: string,
+  previous: { bikeId: string | null; durationSeconds: number | null | undefined },
+  next: { bikeId: string | null; durationSeconds: number | null | undefined }
+): Promise<void> {
+  const prevBikeId = previous.bikeId;
+  const nextBikeId = next.bikeId;
+  const prevHours = secondsToHours(previous.durationSeconds);
+  const nextHours = secondsToHours(next.durationSeconds);
+  const bikeChanged = prevBikeId !== nextBikeId;
+  const hoursDiff = nextHours - prevHours;
+
+  if (prevBikeId) {
+    if (bikeChanged) {
+      await decrementBikeComponentHours(tx, { userId, bikeId: prevBikeId, hoursDelta: prevHours });
+    } else if (hoursDiff < 0) {
+      await decrementBikeComponentHours(tx, { userId, bikeId: prevBikeId, hoursDelta: Math.abs(hoursDiff) });
+    }
+  }
+
+  if (nextBikeId) {
+    if (bikeChanged) {
+      await incrementBikeComponentHours(tx, { userId, bikeId: nextBikeId, hoursDelta: nextHours });
+    } else if (hoursDiff > 0) {
+      await incrementBikeComponentHours(tx, { userId, bikeId: nextBikeId, hoursDelta: hoursDiff });
+    }
+  }
 }

--- a/apps/api/src/lib/duplicate-detector.test.ts
+++ b/apps/api/src/lib/duplicate-detector.test.ts
@@ -219,4 +219,77 @@ describe('isDuplicateActivity', () => {
       expect(isDuplicateActivity(morningRide, eveningRide)).toBe(false);
     });
   });
+
+  describe('Suunto cross-provider matching', () => {
+    const baseSuuntoRide: DuplicateCandidate = {
+      id: 'suunto-1',
+      startTime: new Date('2026-01-15T10:03:00Z'),
+      durationSeconds: 3580,
+      distanceMeters: 24200,
+      elevationGainMeters: 460,
+      garminActivityId: null,
+      stravaActivityId: null,
+      whoopWorkoutId: null,
+      suuntoWorkoutId: 'suunto-key-abc',
+    };
+
+    it('should detect Suunto vs Garmin duplicates', () => {
+      expect(isDuplicateActivity(baseSuuntoRide, baseGarminRide)).toBe(true);
+      expect(isDuplicateActivity(baseGarminRide, baseSuuntoRide)).toBe(true);
+    });
+
+    it('should detect Suunto vs Strava duplicates', () => {
+      expect(isDuplicateActivity(baseSuuntoRide, baseStravaRide)).toBe(true);
+      expect(isDuplicateActivity(baseStravaRide, baseSuuntoRide)).toBe(true);
+    });
+
+    it('should detect Suunto vs WHOOP duplicates', () => {
+      const whoopRide: DuplicateCandidate = {
+        id: 'whoop-1',
+        startTime: new Date('2026-01-15T10:02:00Z'),
+        durationSeconds: 3620,
+        distanceMeters: 24050,
+        elevationGainMeters: 455,
+        garminActivityId: null,
+        stravaActivityId: null,
+        whoopWorkoutId: 'whoop-uuid-xyz',
+        suuntoWorkoutId: null,
+      };
+      expect(isDuplicateActivity(baseSuuntoRide, whoopRide)).toBe(true);
+      expect(isDuplicateActivity(whoopRide, baseSuuntoRide)).toBe(true);
+    });
+
+    it('should NOT flag two Suunto rides as duplicates', () => {
+      const suuntoRide2: DuplicateCandidate = {
+        ...baseSuuntoRide,
+        id: 'suunto-2',
+        suuntoWorkoutId: 'suunto-key-def',
+      };
+      expect(isDuplicateActivity(baseSuuntoRide, suuntoRide2)).toBe(false);
+    });
+
+    it('should reject Suunto vs Garmin on different UTC days', () => {
+      const nextDaySuunto: DuplicateCandidate = {
+        ...baseSuuntoRide,
+        startTime: new Date('2026-01-16T00:02:00Z'),
+      };
+      expect(isDuplicateActivity(nextDaySuunto, baseGarminRide)).toBe(false);
+    });
+
+    it('should reject Suunto vs Strava with distance beyond threshold', () => {
+      const tooFarSuunto: DuplicateCandidate = {
+        ...baseSuuntoRide,
+        distanceMeters: 26000, // ~7% difference from Strava's 24300
+      };
+      expect(isDuplicateActivity(tooFarSuunto, baseStravaRide)).toBe(false);
+    });
+
+    it('should reject Suunto vs Garmin with elevation beyond threshold', () => {
+      const tooMuchElevSuunto: DuplicateCandidate = {
+        ...baseSuuntoRide,
+        elevationGainMeters: 520, // ~14% difference from Garmin's 457
+      };
+      expect(isDuplicateActivity(tooMuchElevSuunto, baseGarminRide)).toBe(false);
+    });
+  });
 });

--- a/apps/api/src/lib/duplicate-detector.ts
+++ b/apps/api/src/lib/duplicate-detector.ts
@@ -9,6 +9,7 @@ export interface DuplicateCandidate {
   garminActivityId: string | null;
   stravaActivityId: string | null;
   whoopWorkoutId: string | null;
+  suuntoWorkoutId: string | null;
 }
 
 /**
@@ -23,12 +24,14 @@ export function isDuplicateActivity(
     newRide.garminActivityId,
     newRide.stravaActivityId,
     newRide.whoopWorkoutId,
+    newRide.suuntoWorkoutId,
   ].filter(Boolean);
 
   const existingProviders = [
     existingRide.garminActivityId,
     existingRide.stravaActivityId,
     existingRide.whoopWorkoutId,
+    existingRide.suuntoWorkoutId,
   ].filter(Boolean);
 
   // Each ride should have exactly one provider
@@ -38,14 +41,17 @@ export function isDuplicateActivity(
   const newIsGarmin = !!newRide.garminActivityId;
   const newIsStrava = !!newRide.stravaActivityId;
   const newIsWhoop = !!newRide.whoopWorkoutId;
+  const newIsSuunto = !!newRide.suuntoWorkoutId;
   const existingIsGarmin = !!existingRide.garminActivityId;
   const existingIsStrava = !!existingRide.stravaActivityId;
   const existingIsWhoop = !!existingRide.whoopWorkoutId;
+  const existingIsSuunto = !!existingRide.suuntoWorkoutId;
 
   const differentProviders =
     (newIsGarmin && !existingIsGarmin) ||
     (newIsStrava && !existingIsStrava) ||
-    (newIsWhoop && !existingIsWhoop);
+    (newIsWhoop && !existingIsWhoop) ||
+    (newIsSuunto && !existingIsSuunto);
 
   if (!differentProviders) return false;
 
@@ -94,22 +100,31 @@ export async function findPotentialDuplicates(
       },
       // Exclude rides that are already marked as duplicates
       isDuplicate: false,
-      // Must be from a single provider (Garmin, Strava, or WHOOP only)
+      // Must be from a single provider (Garmin, Strava, WHOOP, or Suunto only)
       OR: [
         {
           garminActivityId: { not: null },
           stravaActivityId: null,
           whoopWorkoutId: null,
+          suuntoWorkoutId: null,
         },
         {
           stravaActivityId: { not: null },
           garminActivityId: null,
           whoopWorkoutId: null,
+          suuntoWorkoutId: null,
         },
         {
           whoopWorkoutId: { not: null },
           garminActivityId: null,
           stravaActivityId: null,
+          suuntoWorkoutId: null,
+        },
+        {
+          suuntoWorkoutId: { not: null },
+          garminActivityId: null,
+          stravaActivityId: null,
+          whoopWorkoutId: null,
         },
       ],
     },
@@ -122,6 +137,7 @@ export async function findPotentialDuplicates(
       garminActivityId: true,
       stravaActivityId: true,
       whoopWorkoutId: true,
+      suuntoWorkoutId: true,
     },
   });
 

--- a/apps/api/src/lib/location.test.ts
+++ b/apps/api/src/lib/location.test.ts
@@ -158,6 +158,17 @@ describe('shouldApplyAutoLocation', () => {
 });
 
 describe('reverseGeocode', () => {
+  // Several tests in this block deliberately exercise the error paths in
+  // location.ts, which call console.warn(). Stub it so the test output
+  // stays clean without losing the production-side logging behavior.
+  let warnSpy: jest.SpyInstance;
+  beforeAll(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterAll(() => {
+    warnSpy.mockRestore();
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockGeoCache.findUnique.mockResolvedValue(null);
@@ -719,6 +730,16 @@ describe('reverseGeocode', () => {
 });
 
 describe('deriveLocationAsync', () => {
+  // Same console.warn stub as reverseGeocode — tests here also exercise
+  // the network-error / non-OK-response paths in location.ts.
+  let warnSpy: jest.SpyInstance;
+  beforeAll(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterAll(() => {
+    warnSpy.mockRestore();
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockGeoCache.findUnique.mockResolvedValue(null);

--- a/apps/api/src/lib/queue/backfill.queue.ts
+++ b/apps/api/src/lib/queue/backfill.queue.ts
@@ -14,7 +14,7 @@ const COMPLETED_JOBS_TO_KEEP = 50;
 const FAILED_JOBS_TO_KEEP = 100;
 const LOW_PRIORITY = 10; // Lower priority than sync jobs (which are 1)
 
-export type BackfillProvider = 'garmin';
+export type BackfillProvider = 'garmin' | 'suunto';
 
 export type BackfillJobName = 'backfillYear' | 'processCallback';
 

--- a/apps/api/src/lib/suunto-sync.ts
+++ b/apps/api/src/lib/suunto-sync.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared types + helpers for talking to Suunto's workout API. Used by
+ * `routes/suunto.backfill.ts` (synchronous single-year import),
+ * `workers/sync.worker.ts` (on-demand sync), and `workers/backfill.worker.ts`
+ * (queued multi-year backfill).
+ *
+ * Keeping the API base, payload types, and header builder in one file prevents
+ * drift between the three call sites.
+ */
+
+export const SUUNTO_API_BASE = 'https://cloudapi.suunto.com/v3';
+
+// Shape of an individual workout as returned by GET /v3/workouts. Mirrors the
+// webhook WORKOUT_CREATED payload — timestamps are epoch ms, distances meters,
+// durations seconds.
+export type SuuntoWorkout = {
+  workoutKey: string;
+  activityId: number;
+  startTime: number;
+  totalTime: number;
+  totalDistance?: number;
+  totalAscent?: number;
+  totalDescent?: number;
+  startPosition?: { x: number; y: number }; // x = longitude, y = latitude
+  hrdata?: { workoutAvgHR?: number; workoutMaxHR?: number };
+  timeOffsetInMinutes?: number;
+};
+
+// Suunto CloudAPI wraps list responses in { error, metadata, payload }.
+export type SuuntoWorkoutsResponse = {
+  error: unknown;
+  metadata?: { totalCount?: number } & Record<string, unknown>;
+  payload: SuuntoWorkout[];
+};
+
+/**
+ * Standard headers for every data-API call. The APIM gateway requires the
+ * subscription key on top of the per-user bearer token; without it, requests
+ * 401 before ever reaching the workout service.
+ */
+export function suuntoApiHeaders(accessToken: string): HeadersInit {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: 'application/json',
+  };
+  const subscriptionKey = process.env.SUUNTO_SUBSCRIPTION_KEY;
+  if (subscriptionKey) {
+    headers['Ocp-Apim-Subscription-Key'] = subscriptionKey;
+  }
+  return headers;
+}

--- a/apps/api/src/lib/suunto-sync.ts
+++ b/apps/api/src/lib/suunto-sync.ts
@@ -37,15 +37,21 @@ export type SuuntoWorkoutsResponse = {
  * Standard headers for every data-API call. The APIM gateway requires the
  * subscription key on top of the per-user bearer token; without it, requests
  * 401 before ever reaching the workout service.
+ *
+ * We throw instead of silently falling back — a missing env var would cause
+ * every Suunto API call to fail with an opaque 401 from the APIM gateway,
+ * which is much harder to diagnose than a clear startup-time error. Callers
+ * are worker handlers and route handlers with normal error handling (BullMQ
+ * retry + Sentry, or 500 response), so throwing here propagates cleanly.
  */
 export function suuntoApiHeaders(accessToken: string): HeadersInit {
-  const headers: Record<string, string> = {
+  const subscriptionKey = process.env.SUUNTO_SUBSCRIPTION_KEY;
+  if (!subscriptionKey) {
+    throw new Error('SUUNTO_SUBSCRIPTION_KEY is not set');
+  }
+  return {
     Authorization: `Bearer ${accessToken}`,
     Accept: 'application/json',
+    'Ocp-Apim-Subscription-Key': subscriptionKey,
   };
-  const subscriptionKey = process.env.SUUNTO_SUBSCRIPTION_KEY;
-  if (subscriptionKey) {
-    headers['Ocp-Apim-Subscription-Key'] = subscriptionKey;
-  }
-  return headers;
 }

--- a/apps/api/src/lib/suunto-sync.ts
+++ b/apps/api/src/lib/suunto-sync.ts
@@ -33,6 +33,18 @@ export type SuuntoWorkoutsResponse = {
   payload: SuuntoWorkout[];
 };
 
+// OAuth token-endpoint response shape used by both the initial code exchange
+// (in `auth.suunto.ts`) and the refresh flow (in `suunto-token.ts`). Suunto's
+// JWT `access_token` can be decoded for a `user` claim containing the Suunto
+// username; see `extractSuuntoUsername` for the trust model.
+export type SuuntoTokenResp = {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: string;
+  scope?: string;
+};
+
 /**
  * Standard headers for every data-API call. The APIM gateway requires the
  * subscription key on top of the per-user bearer token; without it, requests

--- a/apps/api/src/lib/suunto-token.ts
+++ b/apps/api/src/lib/suunto-token.ts
@@ -1,0 +1,189 @@
+// TODO: Migrate to read from UserIntegration (encrypted tokens) instead of
+// OauthToken (plaintext). Once migrated, stop dual-writing to OauthToken in
+// auth.suunto.ts and drop the OauthToken table. Mirrors strava-token.ts.
+import { prisma } from './prisma';
+import { createLogger } from './logger';
+
+const log = createLogger('suunto-token');
+
+const SUUNTO_TOKEN_URL = 'https://cloudapi-oauth.suunto.com/oauth/token';
+const SUUNTO_DEAUTH_URL = 'https://cloudapi-oauth.suunto.com/oauth/deauthorize';
+
+interface CacheEntry {
+  promise: Promise<string | null>;
+  timestamp: number;
+}
+const refreshPromiseCache = new Map<string, CacheEntry>();
+const REFRESH_TIMEOUT_MS = 30_000;
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [userId, entry] of refreshPromiseCache.entries()) {
+    if (now - entry.timestamp > REFRESH_TIMEOUT_MS) {
+      log.warn({ userId }, 'Cleaning up stale cache entry');
+      refreshPromiseCache.delete(userId);
+    }
+  }
+}, 60_000).unref();
+
+/**
+ * Revoke Suunto access for a user via GET /oauth/deauthorize?client_id=...
+ * The user's bearer token authenticates the request so Suunto knows whose
+ * grant to revoke. A 401 means the token was already invalid — treat as
+ * success so disconnect proceeds.
+ */
+export async function revokeSuuntoTokenForUser(userId: string): Promise<boolean> {
+  try {
+    const CLIENT_ID = process.env.SUUNTO_CLIENT_ID;
+    if (!CLIENT_ID) {
+      log.error('Missing SUUNTO_CLIENT_ID');
+      return false;
+    }
+
+    const token = await prisma.oauthToken.findUnique({
+      where: { userId_provider: { userId, provider: 'suunto' } },
+    });
+    if (!token) {
+      log.info({ userId }, 'No token found for user');
+      return true;
+    }
+
+    const url = `${SUUNTO_DEAUTH_URL}?client_id=${encodeURIComponent(CLIENT_ID)}`;
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${token.accessToken}` },
+    });
+
+    if (res.ok || res.status === 401) {
+      log.info({ userId, status: res.status }, 'Suunto token revoked (or already invalid)');
+      return true;
+    }
+
+    let body = '';
+    try { body = (await res.text()).slice(0, 200); } catch { body = '(unread)'; }
+    log.error({ userId, status: res.status, body }, 'Suunto revoke failed');
+    return false;
+  } catch (err) {
+    log.error({ err, userId }, 'Suunto revoke error');
+    return false;
+  }
+}
+
+export async function getValidSuuntoToken(userId: string): Promise<string | null> {
+  const token = await prisma.oauthToken.findUnique({
+    where: {
+      userId_provider: {
+        userId,
+        provider: 'suunto',
+      },
+    },
+  });
+
+  if (!token) {
+    return null;
+  }
+
+  const now = new Date();
+  const expiryBuffer = new Date(token.expiresAt.getTime() - 5 * 60 * 1000);
+
+  if (now < expiryBuffer) {
+    return token.accessToken;
+  }
+
+  if (!token.refreshToken) {
+    log.error({ userId }, 'No refresh token available');
+    return null;
+  }
+
+  const existingEntry = refreshPromiseCache.get(userId);
+  if (existingEntry) {
+    const age = Date.now() - existingEntry.timestamp;
+    if (age < REFRESH_TIMEOUT_MS) {
+      log.debug({ userId }, 'Waiting for existing refresh');
+      return existingEntry.promise;
+    }
+    log.warn({ userId, age }, 'Removing stale cache entry');
+    refreshPromiseCache.delete(userId);
+  }
+
+  const refreshPromise = refreshSuuntoToken(userId, token.refreshToken);
+  refreshPromiseCache.set(userId, { promise: refreshPromise, timestamp: Date.now() });
+
+  try {
+    return await refreshPromise;
+  } finally {
+    refreshPromiseCache.delete(userId);
+  }
+}
+
+async function refreshSuuntoToken(userId: string, refreshToken: string): Promise<string | null> {
+  try {
+    const CLIENT_ID = process.env.SUUNTO_CLIENT_ID;
+    const CLIENT_SECRET = process.env.SUUNTO_CLIENT_SECRET;
+
+    if (!CLIENT_ID || !CLIENT_SECRET) {
+      log.error('Missing SUUNTO_CLIENT_ID or SUUNTO_CLIENT_SECRET');
+      return null;
+    }
+
+    log.info({ userId }, 'Refreshing expired token');
+
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    });
+
+    const basicAuth = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64');
+
+    const refreshRes = await fetch(SUUNTO_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        authorization: `Basic ${basicAuth}`,
+      },
+      body,
+    });
+
+    if (!refreshRes.ok) {
+      let body = '';
+      try {
+        body = await refreshRes.text();
+      } catch {
+        body = '(failed to read response body)';
+      }
+      log.error({ status: refreshRes.status, userId, body }, 'Token refresh failed');
+      return null;
+    }
+
+    type SuuntoTokenResp = {
+      access_token: string;
+      refresh_token: string;
+      expires_in: number;
+      token_type: string;
+      scope?: string;
+    };
+
+    const newTokens = (await refreshRes.json()) as SuuntoTokenResp;
+    const newExpiresAt = new Date(Date.now() + newTokens.expires_in * 1000);
+
+    await prisma.oauthToken.update({
+      where: {
+        userId_provider: {
+          userId,
+          provider: 'suunto',
+        },
+      },
+      data: {
+        accessToken: newTokens.access_token,
+        refreshToken: newTokens.refresh_token,
+        expiresAt: newExpiresAt,
+      },
+    });
+
+    log.info({ userId }, 'Token refreshed successfully');
+    return newTokens.access_token;
+  } catch (error) {
+    log.error({ err: error, userId }, 'Token refresh error');
+    return null;
+  }
+}

--- a/apps/api/src/lib/suunto-token.ts
+++ b/apps/api/src/lib/suunto-token.ts
@@ -3,6 +3,7 @@
 // auth.suunto.ts and drop the OauthToken table. Mirrors strava-token.ts.
 import { prisma } from './prisma';
 import { createLogger } from './logger';
+import type { SuuntoTokenResp } from './suunto-sync';
 
 const log = createLogger('suunto-token');
 
@@ -154,14 +155,6 @@ async function refreshSuuntoToken(userId: string, refreshToken: string): Promise
       log.error({ status: refreshRes.status, userId, body }, 'Token refresh failed');
       return null;
     }
-
-    type SuuntoTokenResp = {
-      access_token: string;
-      refresh_token: string;
-      expires_in: number;
-      token_type: string;
-      scope?: string;
-    };
 
     const newTokens = (await refreshRes.json()) as SuuntoTokenResp;
     const newExpiresAt = new Date(Date.now() + newTokens.expires_in * 1000);

--- a/apps/api/src/routes/auth.suunto.ts
+++ b/apps/api/src/routes/auth.suunto.ts
@@ -1,5 +1,6 @@
 import { Router as createRouter, type Router, type Request, type Response } from 'express';
 import { Prisma } from '@prisma/client';
+import { decodeJwt } from 'jose';
 import { prisma } from '../lib/prisma';
 import { randomString } from '../lib/pcke';
 import { sendBadRequest, sendUnauthorized, sendInternalError, sendSuccess, sendTooManyRequests } from '../lib/api-response';
@@ -21,16 +22,23 @@ const TOKEN_URL = 'https://cloudapi-oauth.suunto.com/oauth/token';
 const SCOPE = 'workout';
 
 // Suunto's JWT access tokens carry a `user` claim holding the username; we use
-// that as the providerUserId. This is a plain base64-url decode — we trust the
-// token because we just received it from the OAuth exchange.
+// that as the providerUserId. We rely on TLS to Suunto's token endpoint for
+// authenticity — if an attacker ever controls the token-exchange response
+// (SSRF, rogue proxy, etc.) they could inject an arbitrary `user` claim here.
+//
+// We use `jose.decodeJwt` for structural validation (proper header.payload.sig
+// shape, valid base64url, JSON body) rather than hand-rolled parsing — safer
+// against malformed inputs without changing the trust model.
+//
+// TODO: upgrade to full signature verification (`jose.jwtVerify` with a
+// JWKS via `createRemoteJWKSet`) if/when Suunto publishes a JWKS endpoint.
+// None is documented as of the public Cloud API docs.
 function extractSuuntoUsername(accessToken: string): string | null {
   try {
-    const parts = accessToken.split('.');
-    if (parts.length !== 3) return null;
-    const payload = JSON.parse(
-      Buffer.from(parts[1].replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf-8')
-    ) as { user?: string };
-    return typeof payload.user === 'string' ? payload.user : null;
+    const payload = decodeJwt(accessToken) as { user?: unknown };
+    return typeof payload.user === 'string' && payload.user.length > 0
+      ? payload.user
+      : null;
   } catch {
     return null;
   }

--- a/apps/api/src/routes/auth.suunto.ts
+++ b/apps/api/src/routes/auth.suunto.ts
@@ -11,6 +11,7 @@ import { createOAuthAttempt, consumeOAuthAttempt } from '../lib/oauthState';
 import { encrypt } from '../lib/crypto';
 import { renderOAuthCompletionPage } from '../lib/oauthCompletionPage';
 import { captureServerEvent } from '../lib/posthog';
+import type { SuuntoTokenResp } from '../lib/suunto-sync';
 
 const log = createLogger('suunto-oauth');
 
@@ -142,6 +143,13 @@ r.get<Empty, void, Empty, { code?: string; state?: string }>(
     const { code, state } = req.query;
 
     function redirectError(reason: string) {
+      // Clear the web-flow state cookie on every failure path so a retry
+      // starts clean. Safe to call for the mobile flow too — no cookie was
+      // set there, so the clear is a no-op. (State replay is already blocked
+      // by the state-vs-cookie match check, but leaving dead cookies around
+      // for their 10-minute TTL is noise that confuses later debugging.)
+      res.clearCookie('ll_suunto_state', { path: '/' });
+
       if (isMobileFlow) {
         return res.redirect(`/auth/suunto/mobile/complete?status=error&reason=${encodeURIComponent(reason)}`);
       }
@@ -221,14 +229,6 @@ r.get<Empty, void, Empty, { code?: string; state?: string }>(
         log.error({ status: tokenRes.status, userId, attemptId, body: body.slice(0, 200) }, 'Suunto token exchange failed');
         return redirectError('token_exchange_failed');
       }
-
-      type SuuntoTokenResp = {
-        access_token: string;
-        refresh_token: string;
-        expires_in: number;
-        token_type: string;
-        scope?: string;
-      };
 
       const t = (await tokenRes.json()) as SuuntoTokenResp;
       const suuntoUsername = extractSuuntoUsername(t.access_token);

--- a/apps/api/src/routes/auth.suunto.ts
+++ b/apps/api/src/routes/auth.suunto.ts
@@ -1,0 +1,477 @@
+import { Router as createRouter, type Router, type Request, type Response } from 'express';
+import { Prisma } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { randomString } from '../lib/pcke';
+import { sendBadRequest, sendUnauthorized, sendInternalError, sendSuccess, sendTooManyRequests } from '../lib/api-response';
+import { checkMutationRateLimit } from '../lib/rate-limit';
+import { createLogger } from '../lib/logger';
+import { revokeSuuntoTokenForUser } from '../lib/suunto-token';
+import { createOAuthAttempt, consumeOAuthAttempt } from '../lib/oauthState';
+import { encrypt } from '../lib/crypto';
+import { renderOAuthCompletionPage } from '../lib/oauthCompletionPage';
+import { captureServerEvent } from '../lib/posthog';
+
+const log = createLogger('suunto-oauth');
+
+type Empty = Record<string, never>;
+const r: Router = createRouter();
+
+const AUTH_URL = 'https://cloudapi-oauth.suunto.com/oauth/authorize';
+const TOKEN_URL = 'https://cloudapi-oauth.suunto.com/oauth/token';
+const SCOPE = 'workout';
+
+// Suunto's JWT access tokens carry a `user` claim holding the username; we use
+// that as the providerUserId. This is a plain base64-url decode — we trust the
+// token because we just received it from the OAuth exchange.
+function extractSuuntoUsername(accessToken: string): string | null {
+  try {
+    const parts = accessToken.split('.');
+    if (parts.length !== 3) return null;
+    const payload = JSON.parse(
+      Buffer.from(parts[1].replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf-8')
+    ) as { user?: string };
+    return typeof payload.user === 'string' ? payload.user : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1) Web Start
+// ---------------------------------------------------------------------------
+r.get<Empty, void, Empty>('/suunto/start', async (_req: Request, res: Response) => {
+  const CLIENT_ID = process.env.SUUNTO_CLIENT_ID;
+  const REDIRECT_URI = process.env.SUUNTO_REDIRECT_URI;
+
+  if (!CLIENT_ID || !REDIRECT_URI) {
+    const missing = [
+      !CLIENT_ID && 'SUUNTO_CLIENT_ID',
+      !REDIRECT_URI && 'SUUNTO_REDIRECT_URI',
+    ].filter(Boolean).join(', ');
+    log.error({ missing }, 'Missing env vars for Suunto start (web)');
+    return sendInternalError(res, 'Suunto OAuth is not configured');
+  }
+
+  const state = randomString(24);
+
+  res.cookie('ll_suunto_state', state, {
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    secure: process.env.NODE_ENV !== 'development',
+    maxAge: 10 * 60 * 1000,
+    path: '/',
+  });
+
+  const url = new URL(AUTH_URL);
+  url.searchParams.set('client_id', CLIENT_ID);
+  url.searchParams.set('redirect_uri', REDIRECT_URI);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('scope', SCOPE);
+  url.searchParams.set('state', state);
+
+  return res.redirect(url.toString());
+});
+
+// ---------------------------------------------------------------------------
+// 2) Mobile Start
+// ---------------------------------------------------------------------------
+r.post<Empty, unknown, Empty>('/suunto/start', async (req: Request, res: Response) => {
+  const userId = req.sessionUser?.uid;
+  if (!userId) {
+    return sendUnauthorized(res, 'Not authenticated');
+  }
+
+  const rateLimit = await checkMutationRateLimit('oauthStart', userId);
+  if (!rateLimit.allowed) {
+    return sendTooManyRequests(res, 'Too many OAuth attempts. Please try again later.', rateLimit.retryAfter);
+  }
+
+  const CLIENT_ID = process.env.SUUNTO_CLIENT_ID;
+  const REDIRECT_URI = process.env.SUUNTO_REDIRECT_URI;
+
+  if (!CLIENT_ID || !REDIRECT_URI) {
+    const missing = [
+      !CLIENT_ID && 'SUUNTO_CLIENT_ID',
+      !REDIRECT_URI && 'SUUNTO_REDIRECT_URI',
+    ].filter(Boolean).join(', ');
+    log.error({ missing }, 'Missing env vars for Suunto start (mobile)');
+    return sendInternalError(res, 'Suunto OAuth is not configured');
+  }
+
+  try {
+    const { state, attempt } = await createOAuthAttempt({
+      userId,
+      provider: 'SUUNTO',
+      platform: 'MOBILE',
+      includeVerifier: false,
+    });
+
+    const url = new URL(AUTH_URL);
+    url.searchParams.set('client_id', CLIENT_ID);
+    url.searchParams.set('redirect_uri', REDIRECT_URI);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('scope', SCOPE);
+    url.searchParams.set('state', state);
+
+    log.info({ userId, attemptId: attempt.id, provider: 'SUUNTO' }, 'Suunto OAuth start (mobile)');
+    return sendSuccess(res, { authorizeUrl: url.toString() });
+  } catch (err) {
+    log.error({ err, userId }, 'Failed to create Suunto OAuth attempt');
+    return sendInternalError(res);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3) Callback
+// ---------------------------------------------------------------------------
+r.get<Empty, void, Empty, { code?: string; state?: string }>(
+  '/suunto/callback',
+  async (req: Request<Empty, void, Empty, { code?: string; state?: string }>, res: Response) => {
+    let userId: string | undefined;
+    let isMobileFlow = false;
+    let attemptId: string | undefined;
+
+    const { code, state } = req.query;
+
+    function redirectError(reason: string) {
+      if (isMobileFlow) {
+        return res.redirect(`/auth/suunto/mobile/complete?status=error&reason=${encodeURIComponent(reason)}`);
+      }
+      const appBase = process.env.APP_BASE_URL ?? 'http://localhost:5173';
+      const message = reason === 'account_already_linked'
+        ? 'This Suunto account is already linked to another user.'
+        : 'Suunto connection failed. Please try again.';
+      return res.redirect(
+        `${appBase}/auth/error?message=${encodeURIComponent(message)}`
+      );
+    }
+
+    try {
+      const CLIENT_ID = process.env.SUUNTO_CLIENT_ID;
+      const CLIENT_SECRET = process.env.SUUNTO_CLIENT_SECRET;
+      const REDIRECT_URI = process.env.SUUNTO_REDIRECT_URI;
+
+      if (!CLIENT_ID || !CLIENT_SECRET || !REDIRECT_URI) {
+        const missing = [
+          !CLIENT_ID && 'SUUNTO_CLIENT_ID',
+          !CLIENT_SECRET && 'SUUNTO_CLIENT_SECRET',
+          !REDIRECT_URI && 'SUUNTO_REDIRECT_URI',
+        ].filter(Boolean).join(', ');
+        log.error({ missing }, 'Missing env vars for Suunto callback');
+        return sendInternalError(res, 'Suunto OAuth is not configured');
+      }
+
+      if (!code || !state) {
+        return sendBadRequest(res, 'Missing code or state');
+      }
+
+      const dbAttempt = await consumeOAuthAttempt({ state, provider: 'SUUNTO' });
+      if (dbAttempt) {
+        isMobileFlow = true;
+        userId = dbAttempt.attempt.userId;
+        attemptId = dbAttempt.attempt.id;
+        log.info({ userId, attemptId }, 'Suunto callback: mobile flow (DB state)');
+      } else {
+        const cookieState = req.cookies['ll_suunto_state'];
+        if (!cookieState || state !== cookieState) {
+          log.warn({ hasState: !!cookieState, statesMatch: state === cookieState }, 'Suunto callback: invalid state');
+          return redirectError('invalid_state');
+        }
+        userId = req.user?.id || req.sessionUser?.uid;
+        log.info({ userId }, 'Suunto callback: web flow (cookie state)');
+      }
+
+      if (!userId) {
+        log.warn('Suunto callback: no authenticated user');
+        return redirectError('invalid_state');
+      }
+
+      const authenticatedUserId = userId;
+
+      // Token exchange (Authorization Code, no PKCE).
+      // Suunto requires HTTP Basic auth with client_id:client_secret per RFC7617;
+      // the form body must NOT contain the client credentials.
+      const body = new URLSearchParams({
+        code,
+        grant_type: 'authorization_code',
+        redirect_uri: REDIRECT_URI,
+      });
+
+      const basicAuth = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64');
+
+      const tokenRes = await fetch(TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          authorization: `Basic ${basicAuth}`,
+        },
+        body,
+      });
+
+      if (!tokenRes.ok) {
+        const body = await tokenRes.text();
+        log.error({ status: tokenRes.status, userId, attemptId, body: body.slice(0, 200) }, 'Suunto token exchange failed');
+        return redirectError('token_exchange_failed');
+      }
+
+      type SuuntoTokenResp = {
+        access_token: string;
+        refresh_token: string;
+        expires_in: number;
+        token_type: string;
+        scope?: string;
+      };
+
+      const t = (await tokenRes.json()) as SuuntoTokenResp;
+      const suuntoUsername = extractSuuntoUsername(t.access_token);
+      if (!suuntoUsername) {
+        log.error({ userId }, 'Failed to extract user claim from Suunto JWT');
+        return redirectError('token_exchange_failed');
+      }
+      const expiresAt = new Date(Date.now() + t.expires_in * 1000);
+
+      const existingIntegration = await prisma.userIntegration.findUnique({
+        where: { userId_provider: { userId: authenticatedUserId, provider: 'SUUNTO' } },
+        select: { id: true },
+      });
+      const isReconnect = Boolean(existingIntegration);
+
+      // TODO: Remove OauthToken dual-write once webhooks/token helpers are
+      // migrated to read from UserIntegration. Matches strava-token.ts plan.
+      await prisma.$transaction(async (tx) => {
+        await tx.oauthToken.upsert({
+          where: { userId_provider: { userId: authenticatedUserId, provider: 'suunto' } },
+          create: {
+            userId: authenticatedUserId,
+            provider: 'suunto',
+            accessToken: t.access_token,
+            refreshToken: t.refresh_token,
+            expiresAt,
+          },
+          update: {
+            accessToken: t.access_token,
+            refreshToken: t.refresh_token,
+            expiresAt,
+          },
+        });
+
+        await tx.userAccount.upsert({
+          where: {
+            provider_providerUserId: {
+              provider: 'suunto',
+              providerUserId: suuntoUsername,
+            },
+          },
+          create: {
+            userId: authenticatedUserId,
+            provider: 'suunto',
+            providerUserId: suuntoUsername,
+          },
+          update: {
+            userId: authenticatedUserId,
+          },
+        });
+
+        await tx.user.update({
+          where: { id: authenticatedUserId },
+          data: { suuntoUserId: suuntoUsername },
+        });
+
+        await tx.userIntegration.upsert({
+          where: { userId_provider: { userId: authenticatedUserId, provider: 'SUUNTO' } },
+          create: {
+            userId: authenticatedUserId,
+            provider: 'SUUNTO',
+            externalUserId: suuntoUsername,
+            accessTokenEnc: encrypt(t.access_token),
+            refreshTokenEnc: encrypt(t.refresh_token),
+            expiresAt,
+            scopes: t.scope ?? SCOPE,
+            connectedAt: new Date(),
+          },
+          update: {
+            externalUserId: suuntoUsername,
+            accessTokenEnc: encrypt(t.access_token),
+            refreshTokenEnc: encrypt(t.refresh_token),
+            expiresAt,
+            scopes: t.scope ?? SCOPE,
+            revokedAt: null,
+          },
+        });
+      });
+
+      captureServerEvent(authenticatedUserId, 'provider_connected', { provider: 'suunto', isReconnect });
+
+      if (isMobileFlow && attemptId) {
+        log.info({ userId, attemptId }, 'Suunto OAuth callback success (mobile)');
+        return res.redirect(`/auth/suunto/mobile/complete?status=success`);
+      }
+
+      res.clearCookie('ll_suunto_state', { path: '/' });
+
+      const appBase = process.env.APP_BASE_URL ?? 'http://localhost:5173';
+      const user = await prisma.user.findUnique({ where: { id: userId } });
+
+      const redirectPath = !user?.onboardingCompleted
+        ? '/onboarding?step=6'
+        : '/settings?suunto=connected';
+
+      log.info({ userId }, 'Suunto OAuth callback success (web)');
+      return res.redirect(`${appBase.replace(/\/$/, '')}${redirectPath}`);
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === 'P2002' &&
+        Array.isArray(err.meta?.target) && err.meta.target.includes('suuntoUserId')
+      ) {
+        log.warn({ userId, attemptId }, 'Suunto account already linked to another user');
+        return redirectError('account_already_linked');
+      }
+      log.error({ err, userId, attemptId }, 'Suunto callback failed');
+      return redirectError('internal_error');
+    }
+  }
+);
+
+// ---------------------------------------------------------------------------
+// 4) Mobile completion page — deep link trampoline
+// ---------------------------------------------------------------------------
+r.get('/suunto/mobile/complete', (req: Request, res: Response) => {
+  const VALID_STATUSES = ['success', 'error'] as const;
+  const VALID_REASONS = ['invalid_state', 'token_exchange_failed', 'account_already_linked', 'internal_error'] as const;
+
+  const rawStatus = req.query.status as string | undefined;
+  const rawReason = req.query.reason as string | undefined;
+
+  const status = (VALID_STATUSES as readonly string[]).includes(rawStatus!) ? rawStatus! : 'error';
+  const reason = (VALID_REASONS as readonly string[]).includes(rawReason!) ? rawReason! : undefined;
+  const scheme = process.env.MOBILE_DEEP_LINK_SCHEME || 'loamlogger';
+
+  log.debug({ status, reason }, 'Rendering Suunto mobile completion page');
+
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+
+  res.send(renderOAuthCompletionPage({
+    provider: 'Suunto',
+    status,
+    reason,
+    scheme,
+    brandColor: '#0072ce',
+  }));
+});
+
+// ---------------------------------------------------------------------------
+// 5) Status
+// ---------------------------------------------------------------------------
+r.get('/suunto/status', async (req: Request, res: Response) => {
+  const userId = req.sessionUser?.uid;
+  if (!userId) {
+    return sendUnauthorized(res, 'Not authenticated');
+  }
+
+  try {
+    const integration = await prisma.userIntegration.findUnique({
+      where: { userId_provider: { userId, provider: 'SUUNTO' } },
+    });
+
+    if (integration && !integration.revokedAt) {
+      return sendSuccess(res, {
+        connected: true,
+        connectedAt: integration.connectedAt.toISOString(),
+        revokedAt: null,
+        lastSyncAt: integration.lastSyncAt?.toISOString() ?? null,
+        scopes: integration.scopes,
+      });
+    }
+
+    const oauthToken = await prisma.oauthToken.findUnique({
+      where: { userId_provider: { userId, provider: 'suunto' } },
+    });
+
+    if (oauthToken) {
+      return sendSuccess(res, {
+        connected: true,
+        connectedAt: oauthToken.createdAt.toISOString(),
+        revokedAt: null,
+        lastSyncAt: null,
+        scopes: null,
+      });
+    }
+
+    return sendSuccess(res, { connected: false });
+  } catch (err) {
+    log.error({ err, userId }, 'Failed to get Suunto status');
+    return sendInternalError(res);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6/7) Disconnect — shared logic for POST (mobile) and DELETE (web)
+// ---------------------------------------------------------------------------
+async function handleSuuntoDisconnect(userId: string): Promise<boolean> {
+  const revoked = await revokeSuuntoTokenForUser(userId);
+  if (!revoked) {
+    log.warn({ userId }, 'Suunto token revocation failed, proceeding with local cleanup');
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.userIntegration.updateMany({
+      where: { userId, provider: 'SUUNTO' },
+      data: { revokedAt: new Date() },
+    });
+    const user = await tx.user.findUnique({
+      where: { id: userId },
+      select: { activeDataSource: true },
+    });
+    await tx.oauthToken.deleteMany({
+      where: { userId, provider: 'suunto' },
+    });
+    await tx.userAccount.deleteMany({
+      where: { userId, provider: 'suunto' },
+    });
+    await tx.user.update({
+      where: { id: userId },
+      data: {
+        suuntoUserId: null,
+        ...(user?.activeDataSource === 'suunto' ? { activeDataSource: null } : {}),
+      },
+    });
+  });
+
+  return revoked;
+}
+
+r.post('/suunto/disconnect', async (req: Request, res: Response) => {
+  const userId = req.sessionUser?.uid;
+  if (!userId) {
+    return sendUnauthorized(res, 'Not authenticated');
+  }
+
+  try {
+    const revoked = await handleSuuntoDisconnect(userId);
+    log.info({ userId, revoked }, 'Suunto disconnected (mobile)');
+    return sendSuccess(res, { ok: true });
+  } catch (err) {
+    log.error({ err, userId }, 'Suunto disconnect failed');
+    return sendInternalError(res, 'Failed to disconnect');
+  }
+});
+
+r.delete<Empty, void, Empty>('/suunto/disconnect', async (req: Request, res: Response) => {
+  const userId = req.user?.id || req.sessionUser?.uid;
+  if (!userId) {
+    return sendUnauthorized(res, 'Not authenticated');
+  }
+
+  try {
+    const revoked = await handleSuuntoDisconnect(userId);
+    log.info({ userId, revoked }, 'Suunto disconnected (web)');
+    return res.status(200).json({ success: true });
+  } catch (err) {
+    log.error({ err, userId }, 'Suunto disconnect failed');
+    return sendInternalError(res, 'Failed to disconnect');
+  }
+});
+
+export default r;

--- a/apps/api/src/routes/data-source.ts
+++ b/apps/api/src/routes/data-source.ts
@@ -41,9 +41,12 @@ r.get<Empty, void, Empty, Empty>(
 /**
  * Set user's active data source preference
  */
-r.post<Empty, void, { provider: 'garmin' | 'strava' }>(
+type DataSourceProvider = 'garmin' | 'strava' | 'whoop' | 'suunto';
+const VALID_PROVIDERS: readonly DataSourceProvider[] = ['garmin', 'strava', 'whoop', 'suunto'];
+
+r.post<Empty, void, { provider: DataSourceProvider }>(
   '/data-source/preference',
-  async (req: Request<Empty, void, { provider: 'garmin' | 'strava' }>, res: Response) => {
+  async (req: Request<Empty, void, { provider: DataSourceProvider }>, res: Response) => {
     const userId = req.user?.id || req.sessionUser?.uid;
     if (!userId) {
       return sendUnauthorized(res, 'Not authenticated');
@@ -51,13 +54,13 @@ r.post<Empty, void, { provider: 'garmin' | 'strava' }>(
 
     const { provider } = req.body;
 
-    if (!provider || (provider !== 'garmin' && provider !== 'strava')) {
-      return sendBadRequest(res, 'Invalid provider. Must be "garmin" or "strava"');
+    if (!provider || !VALID_PROVIDERS.includes(provider)) {
+      return sendBadRequest(res, `Invalid provider. Must be one of: ${VALID_PROVIDERS.join(', ')}`);
     }
 
     try {
       // Verify user has this provider connected (check integrations, not login accounts)
-      const integrationProvider = provider.toUpperCase() as 'GARMIN' | 'STRAVA';
+      const integrationProvider = provider.toUpperCase() as 'GARMIN' | 'STRAVA' | 'WHOOP' | 'SUUNTO';
       const integration = await prisma.userIntegration.findFirst({
         where: {
           userId,

--- a/apps/api/src/routes/duplicates.test.ts
+++ b/apps/api/src/routes/duplicates.test.ts
@@ -1,0 +1,239 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+const mockFindMany = jest.fn();
+const mockTransaction = jest.fn();
+const mockUpdate = jest.fn();
+
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    ride: {
+      findMany: mockFindMany,
+      update: mockUpdate,
+    },
+    $transaction: mockTransaction,
+  },
+}));
+
+jest.mock('../lib/logger', () => ({
+  logError: jest.fn(),
+}));
+
+import router from './duplicates';
+
+interface RouteLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: RequestHandler }>;
+  };
+}
+
+function getHandler(path: string, method: string): RequestHandler | undefined {
+  const stack = (router as unknown as { stack: RouteLayer[] }).stack;
+  const layer = stack.find((l) => l.route?.path === path && l.route?.methods?.[method]);
+  return layer?.route?.stack?.[layer.route.stack.length - 1]?.handle;
+}
+
+async function invokeHandler(
+  h: RequestHandler | undefined,
+  req: Request,
+  res: Response
+): Promise<void> {
+  if (!h) throw new Error('Handler not found');
+  await h(req, res, jest.fn() as NextFunction);
+}
+
+type TestRide = {
+  id: string;
+  startTime: Date;
+  durationSeconds: number;
+  distanceMeters: number;
+  elevationGainMeters: number;
+  garminActivityId: string | null;
+  stravaActivityId: string | null;
+  whoopWorkoutId: string | null;
+  suuntoWorkoutId: string | null;
+};
+
+function makeRide(overrides: Partial<TestRide> & { id: string }): TestRide {
+  return {
+    startTime: new Date('2026-03-15T10:00:00Z'),
+    durationSeconds: 3600,
+    distanceMeters: 25000,
+    elevationGainMeters: 400,
+    garminActivityId: null,
+    stravaActivityId: null,
+    whoopWorkoutId: null,
+    suuntoWorkoutId: null,
+    ...overrides,
+  };
+}
+
+describe('POST /duplicates/scan', () => {
+  let handler: RequestHandler | undefined;
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let jsonResponse: unknown;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handler = getHandler('/duplicates/scan', 'post');
+    jsonResponse = undefined;
+
+    mockReq = { user: { id: 'user-123' }, sessionUser: undefined };
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockImplementation((data) => {
+        jsonResponse = data;
+        return mockRes;
+      }),
+    };
+
+    mockFindMany.mockResolvedValue([]);
+    mockTransaction.mockResolvedValue([]);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    mockReq.user = undefined;
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(mockRes.status).toHaveBeenCalledWith(401);
+  });
+
+  it('returns 0 duplicates when no rides exist', async () => {
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(jsonResponse).toMatchObject({ success: true, duplicatesFound: 0 });
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('pairs a Garmin ride with a same-day Strava match (regression)', async () => {
+    const garmin = makeRide({ id: 'g1', garminActivityId: 'G-100' });
+    const strava = makeRide({
+      id: 's1',
+      stravaActivityId: 'S-100',
+      startTime: new Date('2026-03-15T10:05:00Z'),
+      distanceMeters: 25100,
+    });
+    mockFindMany.mockResolvedValue([garmin, strava]);
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(jsonResponse).toMatchObject({ success: true, duplicatesFound: 1 });
+    // Earliest ride (garmin) is primary; later same-day ride (strava) is the duplicate.
+    expect(mockTransaction).toHaveBeenCalled();
+  });
+
+  it('pairs Suunto with Garmin on the same day', async () => {
+    const garmin = makeRide({ id: 'g1', garminActivityId: 'G-100' });
+    const suunto = makeRide({
+      id: 'su1',
+      suuntoWorkoutId: 'SU-100',
+      startTime: new Date('2026-03-15T10:06:00Z'),
+      distanceMeters: 25200,
+    });
+    mockFindMany.mockResolvedValue([garmin, suunto]);
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(jsonResponse).toMatchObject({ success: true, duplicatesFound: 1 });
+  });
+
+  it('pairs Suunto with Strava on the same day', async () => {
+    const strava = makeRide({ id: 's1', stravaActivityId: 'S-100' });
+    const suunto = makeRide({
+      id: 'su1',
+      suuntoWorkoutId: 'SU-100',
+      startTime: new Date('2026-03-15T10:07:00Z'),
+    });
+    mockFindMany.mockResolvedValue([strava, suunto]);
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(jsonResponse).toMatchObject({ success: true, duplicatesFound: 1 });
+  });
+
+  it('pairs Suunto with WHOOP on the same day', async () => {
+    const whoop = makeRide({ id: 'w1', whoopWorkoutId: 'W-100' });
+    const suunto = makeRide({
+      id: 'su1',
+      suuntoWorkoutId: 'SU-100',
+      startTime: new Date('2026-03-15T10:08:00Z'),
+    });
+    mockFindMany.mockResolvedValue([whoop, suunto]);
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(jsonResponse).toMatchObject({ success: true, duplicatesFound: 1 });
+  });
+
+  it('links multiple same-day providers to a single earliest primary', async () => {
+    const garmin = makeRide({ id: 'g1', garminActivityId: 'G-100' });
+    const strava = makeRide({
+      id: 's1',
+      stravaActivityId: 'S-100',
+      startTime: new Date('2026-03-15T10:05:00Z'),
+    });
+    const suunto = makeRide({
+      id: 'su1',
+      suuntoWorkoutId: 'SU-100',
+      startTime: new Date('2026-03-15T10:10:00Z'),
+    });
+    mockFindMany.mockResolvedValue([garmin, strava, suunto]);
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(jsonResponse).toMatchObject({ success: true, duplicatesFound: 2 });
+  });
+
+  it('does not pair rides with mismatched metrics', async () => {
+    const garmin = makeRide({ id: 'g1', garminActivityId: 'G-100' });
+    const suunto = makeRide({
+      id: 'su1',
+      suuntoWorkoutId: 'SU-100',
+      distanceMeters: 50000, // far outside the 5%/160m tolerance
+    });
+    mockFindMany.mockResolvedValue([garmin, suunto]);
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(jsonResponse).toMatchObject({ success: true, duplicatesFound: 0 });
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('does not pair rides from different UTC days', async () => {
+    const garmin = makeRide({
+      id: 'g1',
+      garminActivityId: 'G-100',
+      startTime: new Date('2026-03-15T23:59:00Z'),
+    });
+    const suunto = makeRide({
+      id: 'su1',
+      suuntoWorkoutId: 'SU-100',
+      startTime: new Date('2026-03-16T00:01:00Z'),
+    });
+    mockFindMany.mockResolvedValue([garmin, suunto]);
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(jsonResponse).toMatchObject({ success: true, duplicatesFound: 0 });
+  });
+
+  it('queries only single-provider non-duplicate rides', async () => {
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: 'user-123',
+          isDuplicate: false,
+          OR: expect.arrayContaining([
+            expect.objectContaining({ suuntoWorkoutId: { not: null } }),
+            expect.objectContaining({ whoopWorkoutId: { not: null } }),
+          ]),
+        }),
+      })
+    );
+  });
+});

--- a/apps/api/src/routes/duplicates.test.ts
+++ b/apps/api/src/routes/duplicates.test.ts
@@ -3,12 +3,21 @@ import type { Request, Response, NextFunction, RequestHandler } from 'express';
 const mockFindMany = jest.fn();
 const mockTransaction = jest.fn();
 const mockUpdate = jest.fn();
+const mockUserFindUnique = jest.fn();
+const mockDeleteMany = jest.fn();
+const mockUpdateMany = jest.fn();
+const mockExecuteRaw = jest.fn();
 
 jest.mock('../lib/prisma', () => ({
   prisma: {
     ride: {
       findMany: mockFindMany,
       update: mockUpdate,
+      deleteMany: mockDeleteMany,
+      updateMany: mockUpdateMany,
+    },
+    user: {
+      findUnique: mockUserFindUnique,
     },
     $transaction: mockTransaction,
   },
@@ -235,5 +244,153 @@ describe('POST /duplicates/scan', () => {
         }),
       })
     );
+  });
+});
+
+describe('POST /duplicates/auto-merge', () => {
+  let handler: RequestHandler | undefined;
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let jsonResponse: unknown;
+
+  type DupRow = TestRide & { duplicateOfId: string | null };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handler = getHandler('/duplicates/auto-merge', 'post');
+    jsonResponse = undefined;
+
+    mockReq = { user: { id: 'user-123' }, sessionUser: undefined };
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockImplementation((data) => {
+        jsonResponse = data;
+        return mockRes;
+      }),
+    };
+
+    // Transaction runs the callback against a tx object exposing the same shape
+    mockTransaction.mockImplementation(async (fn) =>
+      fn({
+        $executeRaw: mockExecuteRaw,
+        ride: { deleteMany: mockDeleteMany, updateMany: mockUpdateMany },
+      })
+    );
+    mockExecuteRaw.mockResolvedValue(undefined);
+    mockDeleteMany.mockResolvedValue({ count: 0 });
+    mockUpdateMany.mockResolvedValue({ count: 0 });
+  });
+
+  function seedRides(preferred: string, dups: DupRow[], primaries: TestRide[]) {
+    mockUserFindUnique.mockResolvedValue({ activeDataSource: preferred });
+    // First findMany call = duplicates; second = primaries.
+    mockFindMany
+      .mockResolvedValueOnce(dups)
+      .mockResolvedValueOnce(primaries);
+  }
+
+  it('rejects unauthenticated requests', async () => {
+    mockReq.user = undefined;
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(mockRes.status).toHaveBeenCalledWith(401);
+  });
+
+  it('rejects when activeDataSource is null', async () => {
+    mockUserFindUnique.mockResolvedValue({ activeDataSource: null });
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(jsonResponse).toMatchObject({ error: expect.stringContaining('No active data source') });
+  });
+
+  it('rejects non-fitness activeDataSource (apple/google)', async () => {
+    mockUserFindUnique.mockResolvedValue({ activeDataSource: 'google' });
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(jsonResponse).toMatchObject({ error: expect.stringContaining('fitness provider') });
+  });
+
+  it('returns 0 when there are no duplicate rides', async () => {
+    mockUserFindUnique.mockResolvedValue({ activeDataSource: 'suunto' });
+    mockFindMany.mockResolvedValueOnce([]);
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(jsonResponse).toMatchObject({ success: true, merged: 0 });
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('keeps Suunto and deletes the Garmin primary when Suunto is preferred', async () => {
+    const dup: DupRow = {
+      ...makeRide({ id: 'su-dup', suuntoWorkoutId: 'SU-1' }),
+      duplicateOfId: 'g-primary',
+    };
+    const primary: TestRide = makeRide({ id: 'g-primary', garminActivityId: 'G-1' });
+    seedRides('suunto', [dup], [primary]);
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(jsonResponse).toMatchObject({ success: true, merged: 1, preferredSource: 'suunto' });
+    expect(mockDeleteMany).toHaveBeenCalledWith({ where: { id: { in: ['g-primary'] } } });
+  });
+
+  it('keeps WHOOP and deletes the Strava primary when WHOOP is preferred', async () => {
+    const dup: DupRow = {
+      ...makeRide({ id: 'w-dup', whoopWorkoutId: 'W-1' }),
+      duplicateOfId: 's-primary',
+    };
+    const primary: TestRide = makeRide({ id: 's-primary', stravaActivityId: 'S-1' });
+    seedRides('whoop', [dup], [primary]);
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(jsonResponse).toMatchObject({ success: true, merged: 1, preferredSource: 'whoop' });
+    expect(mockDeleteMany).toHaveBeenCalledWith({ where: { id: { in: ['s-primary'] } } });
+  });
+
+  it('deletes the duplicate when neither side matches the preferred provider', async () => {
+    const dup: DupRow = {
+      ...makeRide({ id: 's-dup', stravaActivityId: 'S-1' }),
+      duplicateOfId: 'g-primary',
+    };
+    const primary: TestRide = makeRide({ id: 'g-primary', garminActivityId: 'G-1' });
+    seedRides('suunto', [dup], [primary]);
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(jsonResponse).toMatchObject({ success: true, merged: 1 });
+    expect(mockDeleteMany).toHaveBeenCalledWith({ where: { id: { in: ['s-dup'] } } });
+  });
+
+  it('labels the success message with the correct provider name', async () => {
+    mockUserFindUnique.mockResolvedValue({ activeDataSource: 'whoop' });
+    mockFindMany.mockResolvedValueOnce([]);
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    // Empty-duplicates path returns a simple message, but on success it uses PROVIDER_LABELS.
+    // Re-run with a real pair to hit the labeled message.
+    jest.clearAllMocks();
+    mockTransaction.mockImplementation(async (fn) =>
+      fn({
+        $executeRaw: mockExecuteRaw,
+        ride: { deleteMany: mockDeleteMany, updateMany: mockUpdateMany },
+      })
+    );
+    const dup: DupRow = {
+      ...makeRide({ id: 'su-dup', suuntoWorkoutId: 'SU-1' }),
+      duplicateOfId: 'g-primary',
+    };
+    const primary: TestRide = makeRide({ id: 'g-primary', garminActivityId: 'G-1' });
+    seedRides('suunto', [dup], [primary]);
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(jsonResponse).toMatchObject({ message: expect.stringContaining('Suunto data') });
   });
 });

--- a/apps/api/src/routes/duplicates.ts
+++ b/apps/api/src/routes/duplicates.ts
@@ -338,8 +338,39 @@ r.post('/duplicates/scan', async (req: Request, res: Response) => {
 });
 
 /**
- * Auto-merge all duplicates based on user's preferred data source
+ * Auto-merge all duplicates based on user's preferred data source.
+ * Supported preferences: garmin, strava, whoop, suunto. Non-fitness auth
+ * providers on `activeDataSource` (apple/google) are rejected.
  */
+
+// activeDataSource is an `AuthProvider` enum including apple/google, but only
+// the four fitness providers have ride-data IDs to prefer.
+const FITNESS_PROVIDERS = ['garmin', 'strava', 'whoop', 'suunto'] as const;
+type FitnessProvider = (typeof FITNESS_PROVIDERS)[number];
+
+const PROVIDER_LABELS: Record<FitnessProvider, string> = {
+  garmin: 'Garmin',
+  strava: 'Strava',
+  whoop: 'WHOOP',
+  suunto: 'Suunto',
+};
+
+type RideProviderIds = {
+  garminActivityId: string | null;
+  stravaActivityId: string | null;
+  whoopWorkoutId: string | null;
+  suuntoWorkoutId: string | null;
+};
+
+function isFromProvider(ride: RideProviderIds, provider: FitnessProvider): boolean {
+  switch (provider) {
+    case 'garmin': return !!ride.garminActivityId;
+    case 'strava': return !!ride.stravaActivityId;
+    case 'whoop':  return !!ride.whoopWorkoutId;
+    case 'suunto': return !!ride.suuntoWorkoutId;
+  }
+}
+
 r.post('/duplicates/auto-merge', async (req: Request, res: Response) => {
   const userId = req.user?.id || req.sessionUser?.uid;
   if (!userId) {
@@ -347,7 +378,6 @@ r.post('/duplicates/auto-merge', async (req: Request, res: Response) => {
   }
 
   try {
-    // Get user's preferred data source
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: { activeDataSource: true },
@@ -357,9 +387,12 @@ r.post('/duplicates/auto-merge', async (req: Request, res: Response) => {
       return sendBadRequest(res, 'No active data source set. Please set your preferred data source in Settings before auto-merging.');
     }
 
-    const preferredSource = user.activeDataSource;
+    if (!FITNESS_PROVIDERS.includes(user.activeDataSource as FitnessProvider)) {
+      return sendBadRequest(res, 'Active data source must be a fitness provider (Garmin, Strava, WHOOP, or Suunto) to auto-merge.');
+    }
 
-    // Find all rides marked as duplicates with their primary ride info
+    const preferredSource = user.activeDataSource as FitnessProvider;
+
     const duplicateRides = await prisma.ride.findMany({
       where: {
         userId,
@@ -372,6 +405,8 @@ r.post('/duplicates/auto-merge', async (req: Request, res: Response) => {
         bikeId: true,
         garminActivityId: true,
         stravaActivityId: true,
+        whoopWorkoutId: true,
+        suuntoWorkoutId: true,
         duplicateOfId: true,
       },
     });
@@ -396,6 +431,8 @@ r.post('/duplicates/auto-merge', async (req: Request, res: Response) => {
         bikeId: true,
         garminActivityId: true,
         stravaActivityId: true,
+        whoopWorkoutId: true,
+        suuntoWorkoutId: true,
       },
     });
     const primaryRideMap = new Map(primaryRides.map(r => [r.id, r]));
@@ -407,13 +444,9 @@ r.post('/duplicates/auto-merge', async (req: Request, res: Response) => {
       const primaryRide = primaryRideMap.get(dupRide.duplicateOfId!);
       if (!primaryRide) continue;
 
-      // Determine which is from preferred source
-      const dupIsFromPreferred = preferredSource === 'garmin'
-        ? !!dupRide.garminActivityId
-        : !!dupRide.stravaActivityId;
-      const primaryIsFromPreferred = preferredSource === 'garmin'
-        ? !!primaryRide.garminActivityId
-        : !!primaryRide.stravaActivityId;
+      // Determine which side comes from the preferred source
+      const dupIsFromPreferred = isFromProvider(dupRide, preferredSource);
+      const primaryIsFromPreferred = isFromProvider(primaryRide, preferredSource);
 
       let rideToDelete: typeof dupRide | typeof primaryRide;
 
@@ -421,7 +454,9 @@ r.post('/duplicates/auto-merge', async (req: Request, res: Response) => {
         // Keep duplicate, delete primary
         rideToDelete = primaryRide;
       } else {
-        // Keep primary, delete duplicate
+        // Keep primary, delete duplicate (covers: both-preferred, neither-preferred,
+        // and primary-only-preferred). Falling through to the primary when neither
+        // side matches preserves the scan's earliest-seen primary choice.
         rideToDelete = dupRide;
       }
 
@@ -479,7 +514,7 @@ r.post('/duplicates/auto-merge', async (req: Request, res: Response) => {
       success: true,
       merged: ridesToDelete.length,
       preferredSource,
-      message: `Merged ${ridesToDelete.length} duplicate rides, keeping ${preferredSource === 'garmin' ? 'Garmin' : 'Strava'} data`,
+      message: `Merged ${ridesToDelete.length} duplicate rides, keeping ${PROVIDER_LABELS[preferredSource]} data`,
     });
   } catch (error) {
     logError('Duplicates auto-merge', error);

--- a/apps/api/src/routes/duplicates.ts
+++ b/apps/api/src/routes/duplicates.ts
@@ -35,6 +35,8 @@ r.get('/duplicates', async (req: Request, res: Response) => {
             elevationGainMeters: true,
             garminActivityId: true,
             stravaActivityId: true,
+            whoopWorkoutId: true,
+            suuntoWorkoutId: true,
             rideType: true,
             notes: true,
             createdAt: true,
@@ -202,7 +204,10 @@ r.post<Empty, void, { rideId: string }>(
 );
 
 /**
- * Scan all user's rides and mark duplicate pairs
+ * Scan all user's rides and mark duplicate pairs across any pair of
+ * providers (Garmin / Strava / WHOOP / Suunto). Earliest-seen ride in a
+ * same-day match becomes the primary; subsequent provider duplicates on
+ * the same day point at it.
  */
 r.post('/duplicates/scan', async (req: Request, res: Response) => {
   const userId = req.user?.id || req.sessionUser?.uid;
@@ -211,14 +216,38 @@ r.post('/duplicates/scan', async (req: Request, res: Response) => {
   }
 
   try {
-    // Get all non-duplicate rides from both providers
+    // Pull all non-duplicate single-provider rides. `isDuplicateActivity`
+    // enforces "exactly one provider per side", so mixed-provider rows are
+    // filtered out here for symmetry.
     const allRides = await prisma.ride.findMany({
       where: {
         userId,
         isDuplicate: false,
         OR: [
-          { garminActivityId: { not: null }, stravaActivityId: null },
-          { stravaActivityId: { not: null }, garminActivityId: null },
+          {
+            garminActivityId: { not: null },
+            stravaActivityId: null,
+            whoopWorkoutId: null,
+            suuntoWorkoutId: null,
+          },
+          {
+            stravaActivityId: { not: null },
+            garminActivityId: null,
+            whoopWorkoutId: null,
+            suuntoWorkoutId: null,
+          },
+          {
+            whoopWorkoutId: { not: null },
+            garminActivityId: null,
+            stravaActivityId: null,
+            suuntoWorkoutId: null,
+          },
+          {
+            suuntoWorkoutId: { not: null },
+            garminActivityId: null,
+            stravaActivityId: null,
+            whoopWorkoutId: null,
+          },
         ],
       },
       select: {
@@ -230,41 +259,41 @@ r.post('/duplicates/scan', async (req: Request, res: Response) => {
         garminActivityId: true,
         stravaActivityId: true,
         whoopWorkoutId: true,
+        suuntoWorkoutId: true,
       },
       orderBy: { startTime: 'asc' },
     });
 
-    // Separate by provider
-    const garminRides = allRides.filter(r => r.garminActivityId);
-    const stravaRides = allRides.filter(r => r.stravaActivityId);
-
-    // Index Strava rides by date (YYYY-MM-DD) for O(1) lookup
-    const stravaByDate = new Map<string, typeof stravaRides>();
-    for (const ride of stravaRides) {
+    // Index by UTC date for O(1) same-day lookup.
+    const ridesByDate = new Map<string, typeof allRides>();
+    for (const ride of allRides) {
       const dateKey = ride.startTime.toISOString().split('T')[0];
-      if (!stravaByDate.has(dateKey)) stravaByDate.set(dateKey, []);
-      stravaByDate.get(dateKey)!.push(ride);
+      if (!ridesByDate.has(dateKey)) ridesByDate.set(dateKey, []);
+      ridesByDate.get(dateKey)!.push(ride);
     }
 
     const duplicatePairs: Array<{ primaryId: string; duplicateId: string }> = [];
-    const matchedStravaIds = new Set<string>();
+    const matchedIds = new Set<string>();
 
-    // Compare each Garmin ride only against Strava rides on same date
-    for (const garminRide of garminRides) {
-      const dateKey = garminRide.startTime.toISOString().split('T')[0];
-      const candidates = stravaByDate.get(dateKey) ?? [];
+    // Walk rides chronologically. The first occurrence of a real-world
+    // ride (earliest startTime) becomes the primary; same-day rides from
+    // a different provider that match within tolerance get linked to it.
+    for (const primary of allRides) {
+      if (matchedIds.has(primary.id)) continue;
 
-      for (const stravaRide of candidates) {
-        // Skip if this Strava ride is already matched
-        if (matchedStravaIds.has(stravaRide.id)) continue;
+      const dateKey = primary.startTime.toISOString().split('T')[0];
+      const candidates = ridesByDate.get(dateKey) ?? [];
 
-        if (isDuplicateActivity(garminRide, stravaRide)) {
-          duplicatePairs.push({
-            primaryId: garminRide.id,
-            duplicateId: stravaRide.id,
-          });
-          matchedStravaIds.add(stravaRide.id);
-          break; // Move to next Garmin ride
+      for (const candidate of candidates) {
+        if (candidate.id === primary.id) continue;
+        if (matchedIds.has(candidate.id)) continue;
+
+        if (isDuplicateActivity(primary, candidate)) {
+          duplicatePairs.push({ primaryId: primary.id, duplicateId: candidate.id });
+          matchedIds.add(candidate.id);
+          // Don't break — a single primary can match duplicates from
+          // multiple other providers on the same day (e.g., a Garmin
+          // ride could be recorded on both Strava and Suunto).
         }
       }
     }

--- a/apps/api/src/routes/garmin.backfill.ts
+++ b/apps/api/src/routes/garmin.backfill.ts
@@ -443,14 +443,26 @@ r.post<Empty, void, { years: string[] }, Empty>(
           create: { userId, provider: 'garmin', year, status: 'pending' },
         });
 
-        // Queue the job
-        const result = await enqueueBackfillJob({
-          userId,
-          provider: 'garmin',
-          year,
-        });
-
-        results.push({ year, status: result.status, jobId: result.jobId });
+        // If enqueue fails (Redis down, BullMQ error, etc.) the BackfillRequest
+        // row already says 'pending' but no worker job exists to process it,
+        // leaving it phantom-pending forever. Catch here so we can mark this
+        // year failed and continue queuing the rest — partial success is
+        // better than silent corruption + a 500.
+        try {
+          const result = await enqueueBackfillJob({
+            userId,
+            provider: 'garmin',
+            year,
+          });
+          results.push({ year, status: result.status, jobId: result.jobId });
+        } catch (enqueueErr) {
+          logError(`Garmin Backfill Batch enqueue ${year}`, enqueueErr);
+          await prisma.backfillRequest.updateMany({
+            where: { userId, provider: 'garmin', year },
+            data: { status: 'failed', updatedAt: new Date() },
+          });
+          results.push({ year, status: 'failed' });
+        }
       }
 
       const skipped = years.filter(y => !yearsToProcess.includes(y));

--- a/apps/api/src/routes/strava.backfill.ts
+++ b/apps/api/src/routes/strava.backfill.ts
@@ -7,6 +7,7 @@ import { sendBadRequest, sendUnauthorized, sendNotFound, sendInternalError } fro
 import { incrementBikeComponentHours, decrementBikeComponentHours } from '../lib/component-hours';
 import { logError } from '../lib/logger';
 import { enqueueWeatherJob } from '../lib/queue';
+import { requireAdmin } from '../auth/adminMiddleware';
 
 type Empty = Record<string, never>;
 const r: Router = createRouter();
@@ -499,9 +500,15 @@ r.get<{ gearId: string }, void, Empty, Empty>(
 /**
  * Testing/utility endpoint: Delete all Strava-imported rides for the current user.
  * Also removes the recorded hours from associated bikes/components.
+ *
+ * Admin-gated: the "testing" path component does not provide any access
+ * control on its own; the UI hides the button behind isAdmin, but the
+ * backend must enforce the same boundary to prevent accidental or
+ * malicious wipes (e.g., a frontend bug or a non-admin discovering the route).
  */
 r.delete<Empty, void, Empty>(
   '/strava/testing/delete-imported-rides',
+  requireAdmin,
   async (req: Request, res: Response) => {
     const userId = req.user?.id || req.sessionUser?.uid;
     if (!userId) {

--- a/apps/api/src/routes/suunto.backfill.test.ts
+++ b/apps/api/src/routes/suunto.backfill.test.ts
@@ -1,0 +1,638 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+// Mock dependencies before imports
+const mockGetValidSuuntoToken = jest.fn();
+jest.mock('../lib/suunto-token', () => ({
+  getValidSuuntoToken: mockGetValidSuuntoToken,
+}));
+
+const mockFindUnique = jest.fn();
+const mockFindMany = jest.fn();
+const mockCreate = jest.fn();
+const mockCount = jest.fn();
+const mockUpsert = jest.fn();
+const mockUpdateMany = jest.fn();
+const mockDeleteMany = jest.fn();
+const mockTransaction = jest.fn();
+
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    ride: {
+      findUnique: mockFindUnique,
+      findMany: mockFindMany,
+      create: mockCreate,
+      count: mockCount,
+      deleteMany: mockDeleteMany,
+    },
+    bike: {
+      findMany: mockFindMany,
+    },
+    component: {
+      updateMany: mockUpdateMany,
+    },
+    backfillRequest: {
+      findUnique: mockFindUnique,
+      upsert: mockUpsert,
+      deleteMany: mockDeleteMany,
+    },
+    $transaction: mockTransaction,
+  },
+}));
+
+jest.mock('../lib/logger', () => ({
+  logError: jest.fn(),
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const mockAcquireLock = jest.fn();
+const mockReleaseLock = jest.fn();
+jest.mock('../lib/rate-limit', () => ({
+  acquireLock: mockAcquireLock,
+  releaseLock: mockReleaseLock,
+}));
+
+const mockFindPotentialDuplicates = jest.fn();
+jest.mock('../lib/duplicate-detector', () => ({
+  findPotentialDuplicates: mockFindPotentialDuplicates,
+}));
+
+const mockIncrementBikeComponentHours = jest.fn();
+const mockDecrementBikeComponentHours = jest.fn();
+jest.mock('../lib/component-hours', () => ({
+  incrementBikeComponentHours: mockIncrementBikeComponentHours,
+  decrementBikeComponentHours: mockDecrementBikeComponentHours,
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+import router from './suunto.backfill';
+
+interface RouteLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: RequestHandler }>;
+  };
+}
+
+function getHandler(path: string, method: string): RequestHandler | undefined {
+  const routerStack = (router as unknown as { stack: RouteLayer[] }).stack;
+  const layer = routerStack.find(
+    (l) => l.route?.path === path && l.route?.methods?.[method]
+  );
+  return layer?.route?.stack?.[layer.route.stack.length - 1]?.handle;
+}
+
+async function invokeHandler(
+  h: RequestHandler | undefined,
+  req: Request,
+  res: Response
+): Promise<void> {
+  if (!h) throw new Error('Handler not found');
+  await h(req, res, jest.fn() as NextFunction);
+}
+
+// Sample Suunto workouts — activityId 2 = Cycling, 1 = Running, 10 = MTB.
+const sampleCyclingWorkout = {
+  workoutKey: 'suunto-key-abc',
+  activityId: 2,
+  startTime: new Date('2024-06-15T10:00:00Z').getTime(),
+  totalTime: 3600,
+  totalDistance: 25000,
+  totalAscent: 300,
+  totalDescent: 300,
+  startPosition: { x: -79.38, y: 43.65 },
+  hrdata: { workoutAvgHR: 145, workoutMaxHR: 175 },
+};
+
+const sampleMtbWorkout = {
+  ...sampleCyclingWorkout,
+  workoutKey: 'suunto-key-mtb',
+  activityId: 10,
+};
+
+const sampleRunningWorkout = {
+  ...sampleCyclingWorkout,
+  workoutKey: 'suunto-key-run',
+  activityId: 1,
+};
+
+describe('suunto.backfill routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /suunto/backfill/fetch', () => {
+    let handler: RequestHandler | undefined;
+    let mockReq: Partial<Request>;
+    let mockRes: Partial<Response>;
+    let jsonResponse: unknown;
+
+    beforeEach(() => {
+      handler = getHandler('/suunto/backfill/fetch', 'get');
+      jsonResponse = undefined;
+
+      mockReq = {
+        user: { id: 'user-123' },
+        sessionUser: undefined,
+        query: { year: 'ytd' },
+      };
+
+      mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockImplementation((data) => {
+          jsonResponse = data;
+          return mockRes;
+        }),
+      };
+
+      mockGetValidSuuntoToken.mockResolvedValue('valid-token');
+      mockFindMany.mockResolvedValue([]); // No bikes by default
+      mockFindUnique.mockResolvedValue(null); // No existing rides / YTD checkpoint
+      mockUpsert.mockResolvedValue({});
+      mockTransaction.mockImplementation(async (fn) => fn({
+        ride: { create: mockCreate },
+        component: { updateMany: mockUpdateMany },
+      }));
+      mockCreate.mockResolvedValue({});
+      mockAcquireLock.mockResolvedValue({ acquired: true, lockKey: 'lk', lockValue: 'lv' });
+      mockReleaseLock.mockResolvedValue(undefined);
+      mockFindPotentialDuplicates.mockResolvedValue(null);
+      mockIncrementBikeComponentHours.mockResolvedValue(undefined);
+    });
+
+    it('should return error if not authenticated', async () => {
+      mockReq.user = undefined;
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+      expect(jsonResponse).toMatchObject({ error: 'Not authenticated' });
+    });
+
+    it('should return error if lock cannot be acquired', async () => {
+      mockAcquireLock.mockResolvedValue({ acquired: false, lockKey: null, lockValue: null });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(jsonResponse).toMatchObject({
+        error: expect.stringContaining('already in progress'),
+      });
+    });
+
+    it('should return error if Suunto token is not available', async () => {
+      mockGetValidSuuntoToken.mockResolvedValue(null);
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(jsonResponse).toMatchObject({
+        error: expect.stringContaining('Suunto not connected'),
+      });
+    });
+
+    it('should release the lock even on token-missing error', async () => {
+      mockGetValidSuuntoToken.mockResolvedValue(null);
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockReleaseLock).toHaveBeenCalledWith('lk', 'lv');
+    });
+
+    it('should call Suunto /v3/workouts with since/until/limit/offset', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ payload: [sampleCyclingWorkout] }),
+      });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('https://cloudapi.suunto.com/v3/workouts'),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer valid-token' }),
+        })
+      );
+      const fetchUrl = mockFetch.mock.calls[0][0] as string;
+      expect(fetchUrl).toContain('since=');
+      expect(fetchUrl).toContain('until=');
+      expect(fetchUrl).toContain('limit=100');
+      expect(fetchUrl).toContain('offset=0');
+    });
+
+    it('should filter non-cycling activities out', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          payload: [sampleCyclingWorkout, sampleRunningWorkout, sampleMtbWorkout],
+        }),
+      });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(jsonResponse).toMatchObject({
+        success: true,
+        totalWorkouts: 3,
+        cyclingWorkouts: 2,
+        imported: 2,
+      });
+    });
+
+    it('should paginate via offset until a page returns fewer than the page limit', async () => {
+      const firstPage = Array.from({ length: 100 }, (_, i) => ({
+        ...sampleCyclingWorkout,
+        workoutKey: `page1-${i}`,
+      }));
+      const secondPage = [{ ...sampleCyclingWorkout, workoutKey: 'page2-0' }];
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ payload: firstPage }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ payload: secondPage }),
+        });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const secondUrl = mockFetch.mock.calls[1][0] as string;
+      expect(secondUrl).toContain('offset=100');
+      expect(jsonResponse).toMatchObject({ totalWorkouts: 101 });
+    });
+
+    it('should skip workouts already present by suuntoWorkoutId', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ payload: [sampleCyclingWorkout] }),
+      });
+      // Both backfillRequest.findUnique and ride.findUnique share the mock.
+      // First call (YTD checkpoint) → null; second call (existing ride) → hit.
+      mockFindUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: 'existing-ride' });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockTransaction).not.toHaveBeenCalled();
+      expect(jsonResponse).toMatchObject({
+        success: true,
+        imported: 0,
+        skipped: 1,
+      });
+    });
+
+    it('should skip cross-provider duplicates and count them', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ payload: [sampleCyclingWorkout] }),
+      });
+      mockFindPotentialDuplicates.mockResolvedValue({ id: 'garmin-ride-matching' });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockTransaction).not.toHaveBeenCalled();
+      expect(jsonResponse).toMatchObject({
+        success: true,
+        imported: 0,
+        skipped: 1,
+        duplicatesDetected: 1,
+      });
+    });
+
+    it('should auto-assign bike if user has exactly one', async () => {
+      mockFindMany.mockResolvedValue([{ id: 'single-bike-id' }]);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ payload: [sampleCyclingWorkout] }),
+      });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(jsonResponse).toMatchObject({ autoAssignedBike: true });
+      expect(mockIncrementBikeComponentHours).toHaveBeenCalled();
+    });
+
+    it('should not auto-assign bike when user has multiple bikes', async () => {
+      mockFindMany.mockResolvedValue([{ id: 'b1' }, { id: 'b2' }]);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ payload: [sampleCyclingWorkout] }),
+      });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(jsonResponse).toMatchObject({ autoAssignedBike: false });
+      expect(mockIncrementBikeComponentHours).not.toHaveBeenCalled();
+    });
+
+    it('should stamp canonical rideType via getSuuntoRideType', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ payload: [sampleMtbWorkout] }),
+      });
+
+      let createdRideData: Record<string, unknown> | undefined;
+      mockTransaction.mockImplementation(async (fn) => fn({
+        ride: {
+          create: jest.fn().mockImplementation((args) => {
+            createdRideData = args.data;
+            return {};
+          }),
+        },
+        component: { updateMany: jest.fn() },
+      }));
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(createdRideData?.rideType).toBe('Mountain Bike');
+      expect(createdRideData?.suuntoWorkoutId).toBe('suunto-key-mtb');
+    });
+
+    it('should resume YTD from backfilledUpTo checkpoint when completed', async () => {
+      const checkpoint = new Date('2024-09-01T00:00:00Z');
+      mockFindUnique.mockResolvedValueOnce({
+        backfilledUpTo: checkpoint,
+        status: 'completed',
+      });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ payload: [] }),
+      });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      const fetchUrl = mockFetch.mock.calls[0][0] as string;
+      const sinceMatch = fetchUrl.match(/since=(\d+)/);
+      expect(sinceMatch).not.toBeNull();
+      const sinceMs = Number(sinceMatch![1]);
+      // Resume is checkpoint + 1000ms
+      expect(sinceMs).toBe(checkpoint.getTime() + 1000);
+    });
+
+    it('should short-circuit with an up-to-date message when start >= end', async () => {
+      const futureCheckpoint = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      mockFindUnique.mockResolvedValueOnce({
+        backfilledUpTo: futureCheckpoint,
+        status: 'completed',
+      });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(jsonResponse).toMatchObject({
+        success: true,
+        totalWorkouts: 0,
+        cyclingWorkouts: 0,
+        imported: 0,
+      });
+    });
+
+    it('should reject year out of range', async () => {
+      mockReq.query = { year: '1990' };
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(jsonResponse).toMatchObject({
+        error: expect.stringContaining('Year must be between'),
+      });
+    });
+
+    it('should accept a specific historical year', async () => {
+      mockReq.query = { year: '2023' };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ payload: [] }),
+      });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      const fetchUrl = mockFetch.mock.calls[0][0] as string;
+      const since = Number(fetchUrl.match(/since=(\d+)/)![1]);
+      // 2023-01-01 local-time start
+      expect(new Date(since).getFullYear()).toBe(2023);
+    });
+
+    it('should write a completed BackfillRequest on success', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ payload: [sampleCyclingWorkout] }),
+      });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId_provider_year: { userId: 'user-123', provider: 'suunto', year: 'ytd' } },
+          update: expect.objectContaining({ status: 'completed' }),
+          create: expect.objectContaining({ provider: 'suunto', status: 'completed' }),
+        })
+      );
+    });
+
+    it('should write a failed BackfillRequest when Suunto API errors', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 502,
+        text: () => Promise.resolve('Bad gateway'),
+      });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: { status: 'failed', updatedAt: expect.any(Date) },
+          create: expect.objectContaining({ provider: 'suunto', status: 'failed' }),
+        })
+      );
+    });
+
+    it('should release the lock after a successful run', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ payload: [] }),
+      });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockReleaseLock).toHaveBeenCalledWith('lk', 'lv');
+    });
+  });
+
+  describe('GET /suunto/backfill/status', () => {
+    let handler: RequestHandler | undefined;
+    let mockReq: Partial<Request>;
+    let mockRes: Partial<Response>;
+    let jsonResponse: unknown;
+
+    beforeEach(() => {
+      handler = getHandler('/suunto/backfill/status', 'get');
+      jsonResponse = undefined;
+
+      mockReq = {
+        user: { id: 'user-123' },
+        sessionUser: undefined,
+      };
+      mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockImplementation((data) => {
+          jsonResponse = data;
+          return mockRes;
+        }),
+      };
+
+      mockFindMany.mockResolvedValue([]);
+      mockCount.mockResolvedValue(0);
+      mockFindUnique.mockResolvedValue(null);
+    });
+
+    it('should return error if not authenticated', async () => {
+      mockReq.user = undefined;
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+    });
+
+    it('should query rides filtered by suuntoWorkoutId', async () => {
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            userId: 'user-123',
+            suuntoWorkoutId: { not: null },
+          }),
+        })
+      );
+    });
+
+    it('should return recent rides and total', async () => {
+      const recent = [
+        {
+          id: 'r1',
+          suuntoWorkoutId: 'suunto-key-abc',
+          startTime: new Date(),
+          rideType: 'Cycling',
+          distanceMeters: 25000,
+          createdAt: new Date(),
+        },
+      ];
+      mockFindMany.mockResolvedValueOnce(recent);
+      mockCount.mockResolvedValue(3);
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(jsonResponse).toMatchObject({
+        success: true,
+        recentRides: recent,
+        totalRides: 3,
+      });
+    });
+  });
+
+  describe('DELETE /suunto/testing/delete-imported-rides', () => {
+    let handler: RequestHandler | undefined;
+    let mockReq: Partial<Request>;
+    let mockRes: Partial<Response>;
+    let jsonResponse: unknown;
+
+    beforeEach(() => {
+      handler = getHandler('/suunto/testing/delete-imported-rides', 'delete');
+      jsonResponse = undefined;
+
+      mockReq = {
+        user: { id: 'user-123' },
+        sessionUser: undefined,
+      };
+      mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockImplementation((data) => {
+          jsonResponse = data;
+          return mockRes;
+        }),
+      };
+
+      mockFindMany.mockResolvedValue([]);
+      mockDeleteMany.mockResolvedValue({ count: 0 });
+      mockDecrementBikeComponentHours.mockResolvedValue(undefined);
+      mockTransaction.mockImplementation(async (fn) => fn({
+        component: { updateMany: mockUpdateMany },
+        ride: { deleteMany: mockDeleteMany },
+        backfillRequest: { deleteMany: mockDeleteMany },
+      }));
+    });
+
+    it('should return error if not authenticated', async () => {
+      mockReq.user = undefined;
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+    });
+
+    it('should return early when no Suunto rides exist', async () => {
+      mockFindMany.mockResolvedValue([]);
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(jsonResponse).toMatchObject({
+        success: true,
+        deletedRides: 0,
+        message: 'No Suunto rides to delete',
+      });
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('should delete rides and decrement component hours by bike', async () => {
+      mockFindMany.mockResolvedValue([
+        { id: 'r1', durationSeconds: 3600, bikeId: 'bike-1' },
+        { id: 'r2', durationSeconds: 3600, bikeId: 'bike-1' },
+        { id: 'r3', durationSeconds: 3600, bikeId: 'bike-2' },
+      ]);
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockTransaction).toHaveBeenCalled();
+      expect(mockDecrementBikeComponentHours).toHaveBeenCalledTimes(2);
+      expect(jsonResponse).toMatchObject({
+        success: true,
+        deletedRides: 3,
+        adjustedBikes: 2,
+      });
+    });
+
+    it('should skip component decrement for unassigned rides', async () => {
+      mockFindMany.mockResolvedValue([
+        { id: 'r1', durationSeconds: 3600, bikeId: null },
+      ]);
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockDecrementBikeComponentHours).not.toHaveBeenCalled();
+      expect(jsonResponse).toMatchObject({
+        success: true,
+        deletedRides: 1,
+        adjustedBikes: 0,
+      });
+    });
+
+    it('should 500 on transaction failure', async () => {
+      mockFindMany.mockResolvedValue([
+        { id: 'r1', durationSeconds: 3600, bikeId: 'bike-1' },
+      ]);
+      mockTransaction.mockRejectedValue(new Error('DB error'));
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+    });
+  });
+});

--- a/apps/api/src/routes/suunto.backfill.test.ts
+++ b/apps/api/src/routes/suunto.backfill.test.ts
@@ -124,6 +124,22 @@ const sampleRunningWorkout = {
 };
 
 describe('suunto.backfill routes', () => {
+  const originalSubscriptionKey = process.env.SUUNTO_SUBSCRIPTION_KEY;
+
+  beforeAll(() => {
+    // suuntoApiHeaders() throws if this isn't set; the route calls fetch()
+    // in tests with a mocked global fetch, but the header builder still runs.
+    process.env.SUUNTO_SUBSCRIPTION_KEY = 'test-subscription-key';
+  });
+
+  afterAll(() => {
+    if (originalSubscriptionKey === undefined) {
+      delete process.env.SUUNTO_SUBSCRIPTION_KEY;
+    } else {
+      process.env.SUUNTO_SUBSCRIPTION_KEY = originalSubscriptionKey;
+    }
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/apps/api/src/routes/suunto.backfill.test.ts
+++ b/apps/api/src/routes/suunto.backfill.test.ts
@@ -54,6 +54,9 @@ const mockReleaseLock = jest.fn();
 jest.mock('../lib/rate-limit', () => ({
   acquireLock: mockAcquireLock,
   releaseLock: mockReleaseLock,
+  // Lock-renewal calls during the long backfill loops — no-op in tests.
+  extendLock: jest.fn().mockResolvedValue(true),
+  LOCK_TTL: { sync: 300, backfill: 600 },
 }));
 
 const mockFindPotentialDuplicates = jest.fn();

--- a/apps/api/src/routes/suunto.backfill.ts
+++ b/apps/api/src/routes/suunto.backfill.ts
@@ -405,6 +405,19 @@ r.post<Empty, void, { years: string[] }, Empty>(
       }
     }
 
+    // Acquire the same distributed lock the synchronous /fetch endpoint uses.
+    // Without this, two simultaneous batch requests could both pass the
+    // ImportSession existence check, both create an ImportSession row, and
+    // race on BackfillRequest upserts. Job-level dedup via BullMQ jobId
+    // would still reject duplicate jobs, but the DB state would be muddled.
+    const lockResult = await acquireLock('backfill', 'suunto', userId);
+    if (!lockResult.acquired) {
+      return res.status(409).json({
+        error: 'Import already in progress',
+        message: 'A Suunto import is already in progress. Please wait for it to complete before starting another.',
+      });
+    }
+
     try {
       const existingImportSession = await prisma.importSession.findFirst({
         where: { userId, provider: 'suunto', status: 'running' },
@@ -496,6 +509,10 @@ r.post<Empty, void, { years: string[] }, Empty>(
     } catch (error) {
       logError('Suunto Backfill Batch', error);
       return sendInternalError(res, 'Failed to queue backfill requests');
+    } finally {
+      // Release the enqueue-time lock. The worker reacquires its own lock
+      // per job at execution time, so jobs remain serialized after this returns.
+      await releaseLock(lockResult.lockKey, lockResult.lockValue);
     }
   }
 );

--- a/apps/api/src/routes/suunto.backfill.ts
+++ b/apps/api/src/routes/suunto.backfill.ts
@@ -468,13 +468,26 @@ r.post<Empty, void, { years: string[] }, Empty>(
           create: { userId, provider: 'suunto', year, status: 'pending' },
         });
 
-        const result = await enqueueBackfillJob({
-          userId,
-          provider: 'suunto',
-          year,
-        });
-
-        results.push({ year, status: result.status, jobId: result.jobId });
+        // If enqueue fails (Redis down, BullMQ error, etc.) the BackfillRequest
+        // row already says 'pending' but no worker job exists to process it,
+        // leaving it phantom-pending forever. Catch here so we can mark this
+        // year failed and continue queuing the rest — partial success is
+        // better than silent corruption + a 500.
+        try {
+          const result = await enqueueBackfillJob({
+            userId,
+            provider: 'suunto',
+            year,
+          });
+          results.push({ year, status: result.status, jobId: result.jobId });
+        } catch (enqueueErr) {
+          logError(`Suunto Backfill Batch enqueue ${year}`, enqueueErr);
+          await prisma.backfillRequest.updateMany({
+            where: { userId, provider: 'suunto', year },
+            data: { status: 'failed', updatedAt: new Date() },
+          });
+          results.push({ year, status: 'failed' });
+        }
       }
 
       const skipped = years.filter((y) => !yearsToProcess.includes(y));

--- a/apps/api/src/routes/suunto.backfill.ts
+++ b/apps/api/src/routes/suunto.backfill.ts
@@ -20,6 +20,7 @@ import {
 import { isSuuntoCyclingActivity, getSuuntoRideType } from '../types/suunto';
 import { suuntoApiHeaders } from '../lib/suunto-sync';
 import { enqueueBackfillJob } from '../lib/queue/backfill.queue';
+import { requireAdmin } from '../auth/adminMiddleware';
 
 type Empty = Record<string, never>;
 const r: Router = createRouter();
@@ -557,8 +558,14 @@ r.get<Empty, void, Empty, Empty>(
   }
 );
 
+// Admin-gated: bulk-deletes every Suunto ride for the caller. The "testing"
+// path component does not provide any access control on its own; the UI hides
+// the button behind isAdmin, but the backend must enforce the same boundary
+// to prevent accidental or malicious wipes (e.g., a frontend bug or a
+// non-admin discovering the route).
 r.delete<Empty, void, Empty>(
   '/suunto/testing/delete-imported-rides',
+  requireAdmin,
   async (req: Request, res: Response) => {
     const userId = req.user?.id || req.sessionUser?.uid;
     if (!userId) {

--- a/apps/api/src/routes/suunto.backfill.ts
+++ b/apps/api/src/routes/suunto.backfill.ts
@@ -1,0 +1,489 @@
+import { Router as createRouter, type Router, type Request, type Response } from 'express';
+import { subDays } from 'date-fns';
+import { prisma } from '../lib/prisma';
+import { getValidSuuntoToken } from '../lib/suunto-token';
+import {
+  sendBadRequest,
+  sendUnauthorized,
+  sendInternalError,
+} from '../lib/api-response';
+import {
+  incrementBikeComponentHours,
+  decrementBikeComponentHours,
+} from '../lib/component-hours';
+import { logError, logger } from '../lib/logger';
+import { acquireLock, releaseLock } from '../lib/rate-limit';
+import {
+  findPotentialDuplicates,
+  type DuplicateCandidate,
+} from '../lib/duplicate-detector';
+import { isSuuntoCyclingActivity, getSuuntoRideType } from '../types/suunto';
+
+type Empty = Record<string, never>;
+const r: Router = createRouter();
+
+const SUUNTO_API_BASE = 'https://cloudapi.suunto.com/v3';
+const MIN_BACKFILL_YEAR = 2015;
+const PAGE_LIMIT = 100;
+const MAX_PAGES = 100;
+
+// Shape of an individual workout as returned by GET /v3/workouts. Matches the
+// webhook WORKOUT_CREATED payload — timestamps are epoch ms, distances meters,
+// durations seconds.
+interface SuuntoWorkout {
+  workoutKey: string;
+  activityId: number;
+  startTime: number;
+  totalTime: number;
+  totalDistance?: number;
+  totalAscent?: number;
+  totalDescent?: number;
+  startPosition?: { x: number; y: number };
+  hrdata?: { workoutAvgHR?: number; workoutMaxHR?: number };
+  timeOffsetInMinutes?: number;
+}
+
+// Suunto CloudAPI v3 wraps list responses in { error, metadata, payload }.
+interface SuuntoWorkoutsResponse {
+  error: unknown;
+  metadata?: { totalCount?: number } & Record<string, unknown>;
+  payload: SuuntoWorkout[];
+}
+
+/**
+ * Fetch historical workouts from Suunto for a given year or YTD.
+ *
+ * - Uses GET /v3/workouts with since/until in epoch ms
+ * - Paginates via limit/offset (Suunto does not return a cursor)
+ * - Omits filter-by-modification-time so since/until filter by start time
+ * - Incremental YTD backfill with BackfillRequest.backfilledUpTo checkpoint
+ * - Distributed lock prevents overlapping backfills per user
+ * - Cross-provider duplicate detection against Garmin/Strava/WHOOP rides
+ * - Filters to cycling activities only (road, MTB, indoor) via isSuuntoCyclingActivity
+ */
+r.get<Empty, void, Empty, { year?: string }>(
+  '/suunto/backfill/fetch',
+  async (
+    req: Request<Empty, void, Empty, { year?: string }>,
+    res: Response
+  ) => {
+    const userId = req.user?.id || req.sessionUser?.uid;
+    if (!userId) {
+      return sendUnauthorized(res, 'Not authenticated');
+    }
+
+    const lockResult = await acquireLock('backfill', 'suunto', userId);
+    if (!lockResult.acquired) {
+      return sendBadRequest(
+        res,
+        'A Suunto backfill is already in progress. Please wait for it to complete.'
+      );
+    }
+
+    try {
+      const currentYear = new Date().getFullYear();
+      const yearParam = req.query.year;
+
+      let startDate: Date;
+      let endDate: Date;
+
+      if (yearParam === 'ytd') {
+        const existingYtd = await prisma.backfillRequest.findUnique({
+          where: {
+            userId_provider_year: { userId, provider: 'suunto', year: 'ytd' },
+          },
+        });
+
+        if (existingYtd?.backfilledUpTo && existingYtd.status === 'completed') {
+          startDate = new Date(existingYtd.backfilledUpTo.getTime() + 1000);
+          logger.info(
+            { userId, startDate: startDate.toISOString() },
+            '[Suunto Backfill] Resuming YTD from checkpoint'
+          );
+        } else {
+          startDate = new Date(currentYear, 0, 1);
+        }
+        endDate = new Date();
+      } else {
+        const year = parseInt(yearParam || String(currentYear), 10);
+        if (isNaN(year) || year < MIN_BACKFILL_YEAR || year > currentYear) {
+          return sendBadRequest(
+            res,
+            `Year must be between ${MIN_BACKFILL_YEAR} and ${currentYear}, or 'ytd'`
+          );
+        }
+        startDate = new Date(year, 0, 1);
+        endDate = new Date(year, 11, 31, 23, 59, 59);
+      }
+
+      if (startDate >= endDate) {
+        return res.json({
+          success: true,
+          message: 'YTD backfill is already up to date.',
+          totalWorkouts: 0,
+          cyclingWorkouts: 0,
+          imported: 0,
+          skipped: 0,
+          duplicatesDetected: 0,
+          autoAssignedBike: false,
+        });
+      }
+
+      const accessToken = await getValidSuuntoToken(userId);
+      if (!accessToken) {
+        return sendBadRequest(
+          res,
+          'Suunto not connected or token expired. Please reconnect your Suunto account.'
+        );
+      }
+
+      logger.info(
+        {
+          userId,
+          yearParam: yearParam || currentYear,
+          startDate: startDate.toISOString(),
+          endDate: endDate.toISOString(),
+        },
+        '[Suunto Backfill] Starting fetch'
+      );
+
+      const workouts: SuuntoWorkout[] = [];
+      let offset = 0;
+      let pageCount = 0;
+
+      while (pageCount < MAX_PAGES) {
+        const url = new URL(`${SUUNTO_API_BASE}/workouts`);
+        url.searchParams.set('since', String(startDate.getTime()));
+        url.searchParams.set('until', String(endDate.getTime()));
+        url.searchParams.set('limit', String(PAGE_LIMIT));
+        url.searchParams.set('offset', String(offset));
+
+        const apiRes = await fetch(url.toString(), {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            Accept: 'application/json',
+          },
+        });
+
+        if (!apiRes.ok) {
+          const text = await apiRes.text();
+          logger.error(
+            { status: apiRes.status, text: text.slice(0, 500) },
+            '[Suunto Backfill] Failed to fetch workouts'
+          );
+          throw new Error(`Failed to fetch workouts: ${apiRes.status}`);
+        }
+
+        const page = (await apiRes.json()) as SuuntoWorkoutsResponse;
+        const records = page.payload ?? [];
+        workouts.push(...records);
+        pageCount++;
+
+        logger.debug(
+          { pageCount, offset, recordsOnPage: records.length },
+          '[Suunto Backfill] Fetched page'
+        );
+
+        if (records.length < PAGE_LIMIT) break;
+        offset += PAGE_LIMIT;
+      }
+
+      if (pageCount >= MAX_PAGES) {
+        logger.warn(
+          { maxPages: MAX_PAGES, totalFetched: workouts.length },
+          '[Suunto Backfill] Hit page cap; some workouts may be missing'
+        );
+      }
+
+      logger.info(
+        { totalWorkouts: workouts.length },
+        '[Suunto Backfill] Total workouts fetched'
+      );
+
+      const cyclingWorkouts = workouts.filter((w) =>
+        isSuuntoCyclingActivity(w.activityId)
+      );
+
+      logger.info(
+        { cyclingWorkouts: cyclingWorkouts.length },
+        '[Suunto Backfill] Cycling workouts found'
+      );
+
+      // Suunto has no gear tagging in the list response. Auto-assign to the
+      // only bike if the user has exactly one, matching WHOOP behavior.
+      const userBikes = await prisma.bike.findMany({
+        where: { userId },
+        select: { id: true },
+      });
+      const autoAssignBikeId = userBikes.length === 1 ? userBikes[0].id : null;
+
+      let importedCount = 0;
+      let skippedCount = 0;
+      let duplicatesDetected = 0;
+
+      for (const workout of cyclingWorkouts) {
+        // Same-provider dedup via suuntoWorkoutId unique index.
+        const existing = await prisma.ride.findUnique({
+          where: { suuntoWorkoutId: workout.workoutKey },
+        });
+        if (existing) {
+          skippedCount++;
+          continue;
+        }
+
+        const startTime = new Date(workout.startTime);
+        const durationSeconds = workout.totalTime;
+        const durationHours = Math.max(0, durationSeconds) / 3600;
+        const distanceMeters = workout.totalDistance ?? 0;
+        const elevationGainMeters = workout.totalAscent ?? 0;
+        const averageHr =
+          workout.hrdata?.workoutAvgHR != null
+            ? Math.round(workout.hrdata.workoutAvgHR)
+            : null;
+        const startLat = workout.startPosition?.y ?? null;
+        const startLng = workout.startPosition?.x ?? null;
+
+        // Cross-provider dedup against Garmin/Strava/WHOOP rides on the same day.
+        const duplicateCandidate: DuplicateCandidate = {
+          id: '',
+          startTime,
+          durationSeconds,
+          distanceMeters,
+          elevationGainMeters,
+          garminActivityId: null,
+          stravaActivityId: null,
+          whoopWorkoutId: null,
+          suuntoWorkoutId: workout.workoutKey,
+        };
+
+        const duplicate = await findPotentialDuplicates(
+          userId,
+          duplicateCandidate,
+          prisma
+        );
+        if (duplicate) {
+          logger.info(
+            { workoutKey: workout.workoutKey, duplicateRideId: duplicate.id },
+            '[Suunto Backfill] Skipping duplicate of existing ride'
+          );
+          duplicatesDetected++;
+          skippedCount++;
+          continue;
+        }
+
+        await prisma.$transaction(async (tx) => {
+          await tx.ride.create({
+            data: {
+              userId,
+              suuntoWorkoutId: workout.workoutKey,
+              startTime,
+              durationSeconds,
+              distanceMeters,
+              elevationGainMeters,
+              averageHr,
+              rideType: getSuuntoRideType(workout.activityId),
+              startLat,
+              startLng,
+              bikeId: autoAssignBikeId,
+            },
+          });
+
+          if (autoAssignBikeId) {
+            await incrementBikeComponentHours(tx, {
+              userId,
+              bikeId: autoAssignBikeId,
+              hoursDelta: durationHours,
+            });
+          }
+        });
+
+        importedCount++;
+      }
+
+      logger.info(
+        { imported: importedCount, skipped: skippedCount, duplicatesDetected },
+        '[Suunto Backfill] Import complete'
+      );
+
+      const yearKey = yearParam || 'ytd';
+      try {
+        await prisma.backfillRequest.upsert({
+          where: {
+            userId_provider_year: { userId, provider: 'suunto', year: yearKey },
+          },
+          update: {
+            status: 'completed',
+            ridesFound: { increment: importedCount },
+            backfilledUpTo: endDate,
+            completedAt: new Date(),
+            updatedAt: new Date(),
+          },
+          create: {
+            userId,
+            provider: 'suunto',
+            year: yearKey,
+            status: 'completed',
+            ridesFound: importedCount,
+            backfilledUpTo: endDate,
+            completedAt: new Date(),
+          },
+        });
+      } catch (dbError) {
+        logError('Suunto Backfill DB tracking', dbError);
+      }
+
+      return res.json({
+        success: true,
+        message: `Successfully imported ${importedCount} rides from Suunto.`,
+        totalWorkouts: workouts.length,
+        cyclingWorkouts: cyclingWorkouts.length,
+        imported: importedCount,
+        skipped: skippedCount,
+        duplicatesDetected,
+        autoAssignedBike: autoAssignBikeId !== null,
+      });
+    } catch (error) {
+      const yearKey = req.query.year || 'ytd';
+      try {
+        await prisma.backfillRequest.upsert({
+          where: {
+            userId_provider_year: { userId, provider: 'suunto', year: yearKey },
+          },
+          update: { status: 'failed', updatedAt: new Date() },
+          create: {
+            userId,
+            provider: 'suunto',
+            year: yearKey,
+            status: 'failed',
+          },
+        });
+      } catch {
+        // Ignore tracking errors
+      }
+      logError('Suunto Backfill', error);
+      return sendInternalError(res, 'Failed to fetch workouts');
+    } finally {
+      await releaseLock(lockResult.lockKey, lockResult.lockValue);
+    }
+  }
+);
+
+r.get<Empty, void, Empty, Empty>(
+  '/suunto/backfill/status',
+  async (req: Request<Empty, void, Empty, Empty>, res: Response) => {
+    const userId = req.user?.id || req.sessionUser?.uid;
+    if (!userId) {
+      return sendUnauthorized(res, 'Not authenticated');
+    }
+
+    try {
+      const thirtyDaysAgo = subDays(new Date(), 30);
+      const recentRides = await prisma.ride.findMany({
+        where: {
+          userId,
+          suuntoWorkoutId: { not: null },
+          startTime: { gte: thirtyDaysAgo },
+        },
+        orderBy: { startTime: 'desc' },
+        take: 50,
+        select: {
+          id: true,
+          suuntoWorkoutId: true,
+          startTime: true,
+          rideType: true,
+          distanceMeters: true,
+          createdAt: true,
+        },
+      });
+
+      const totalRides = await prisma.ride.count({
+        where: { userId, suuntoWorkoutId: { not: null } },
+      });
+
+      const ytdBackfill = await prisma.backfillRequest.findUnique({
+        where: {
+          userId_provider_year: { userId, provider: 'suunto', year: 'ytd' },
+        },
+        select: {
+          status: true,
+          backfilledUpTo: true,
+          ridesFound: true,
+          completedAt: true,
+        },
+      });
+
+      return res.json({
+        success: true,
+        recentRides,
+        totalRides,
+        ytdBackfill,
+        message: `Found ${recentRides.length} recent Suunto rides (last 30 days), ${totalRides} total`,
+      });
+    } catch (error) {
+      logError('Suunto Backfill Status', error);
+      return sendInternalError(res, 'Failed to fetch backfill status');
+    }
+  }
+);
+
+r.delete<Empty, void, Empty>(
+  '/suunto/testing/delete-imported-rides',
+  async (req: Request, res: Response) => {
+    const userId = req.user?.id || req.sessionUser?.uid;
+    if (!userId) {
+      return sendUnauthorized(res, 'Not authenticated');
+    }
+
+    try {
+      const rides = await prisma.ride.findMany({
+        where: { userId, suuntoWorkoutId: { not: null } },
+        select: { id: true, durationSeconds: true, bikeId: true },
+      });
+
+      if (rides.length === 0) {
+        return res.json({
+          success: true,
+          deletedRides: 0,
+          message: 'No Suunto rides to delete',
+        });
+      }
+
+      const hoursByBike = rides.reduce<Map<string, number>>((map, ride) => {
+        if (ride.bikeId) {
+          const hours = Math.max(0, ride.durationSeconds ?? 0) / 3600;
+          map.set(ride.bikeId, (map.get(ride.bikeId) ?? 0) + hours);
+        }
+        return map;
+      }, new Map());
+
+      await prisma.$transaction(async (tx) => {
+        for (const [bikeId, hours] of hoursByBike.entries()) {
+          await decrementBikeComponentHours(tx, {
+            userId,
+            bikeId,
+            hoursDelta: hours,
+          });
+        }
+
+        await tx.ride.deleteMany({
+          where: { userId, suuntoWorkoutId: { not: null } },
+        });
+
+        await tx.backfillRequest.deleteMany({
+          where: { userId, provider: 'suunto' },
+        });
+      });
+
+      return res.json({
+        success: true,
+        deletedRides: rides.length,
+        adjustedBikes: hoursByBike.size,
+      });
+    } catch (error) {
+      logError('Suunto Delete Rides', error);
+      return sendInternalError(res, 'Failed to delete Suunto rides');
+    }
+  }
+);
+
+export default r;

--- a/apps/api/src/routes/suunto.backfill.ts
+++ b/apps/api/src/routes/suunto.backfill.ts
@@ -12,7 +12,7 @@ import {
   decrementBikeComponentHours,
 } from '../lib/component-hours';
 import { logError, logger } from '../lib/logger';
-import { acquireLock, releaseLock } from '../lib/rate-limit';
+import { acquireLock, releaseLock, extendLock, LOCK_TTL } from '../lib/rate-limit';
 import {
   findPotentialDuplicates,
   type DuplicateCandidate,
@@ -165,6 +165,11 @@ r.get<Empty, void, Empty, { year?: string }>(
           '[Suunto Backfill] Fetched page'
         );
 
+        // Refresh the lock TTL on every page so a slow Suunto API can't let
+        // the lock expire mid-fetch and allow a concurrent backfill in.
+        // No-op when Redis is unavailable (lockKey/lockValue are null).
+        await extendLock(lockResult.lockKey, lockResult.lockValue, LOCK_TTL.backfill);
+
         if (records.length < PAGE_LIMIT) break;
         offset += PAGE_LIMIT;
       }
@@ -279,6 +284,15 @@ r.get<Empty, void, Empty, { year?: string }>(
         });
 
         importedCount++;
+
+        // Periodically refresh the lock during the upsert loop too.
+        // Pre-write extension prevents a stuck-DB scenario from letting the
+        // TTL elapse while we hold the lock. Every 25 imports keeps the
+        // Redis-traffic overhead tiny while staying well inside the 10-min
+        // TTL even on extremely slow DBs.
+        if (importedCount % 25 === 0) {
+          await extendLock(lockResult.lockKey, lockResult.lockValue, LOCK_TTL.backfill);
+        }
       }
 
       logger.info(

--- a/apps/api/src/routes/suunto.backfill.ts
+++ b/apps/api/src/routes/suunto.backfill.ts
@@ -18,6 +18,8 @@ import {
   type DuplicateCandidate,
 } from '../lib/duplicate-detector';
 import { isSuuntoCyclingActivity, getSuuntoRideType } from '../types/suunto';
+import { suuntoApiHeaders } from '../lib/suunto-sync';
+import { enqueueBackfillJob } from '../lib/queue/backfill.queue';
 
 type Empty = Record<string, never>;
 const r: Router = createRouter();
@@ -159,10 +161,7 @@ r.get<Empty, void, Empty, { year?: string }>(
         url.searchParams.set('offset', String(offset));
 
         const apiRes = await fetch(url.toString(), {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            Accept: 'application/json',
-          },
+          headers: suuntoApiHeaders(accessToken),
         });
 
         if (!apiRes.ok) {
@@ -364,6 +363,138 @@ r.get<Empty, void, Empty, { year?: string }>(
       return sendInternalError(res, 'Failed to fetch workouts');
     } finally {
       await releaseLock(lockResult.lockKey, lockResult.lockValue);
+    }
+  }
+);
+
+/**
+ * Queue multi-year backfill jobs into the backfill worker.
+ *
+ * The synchronous `/suunto/backfill/fetch` endpoint above blocks for the whole
+ * fetch; this endpoint returns immediately after enqueueing one job per year.
+ * Mirrors the Garmin pattern so the UI can treat providers uniformly.
+ */
+r.post<Empty, void, { years: string[] }, Empty>(
+  '/suunto/backfill/batch',
+  async (req: Request<Empty, void, { years: string[] }, Empty>, res: Response) => {
+    const userId = req.user?.id || req.sessionUser?.uid;
+    if (!userId) {
+      return sendUnauthorized(res, 'Not authenticated');
+    }
+
+    const { years } = req.body;
+    if (!Array.isArray(years) || years.length === 0) {
+      return sendBadRequest(res, 'At least one year is required');
+    }
+
+    if (years.length > 10) {
+      return sendBadRequest(res, 'Maximum 10 years can be queued at once');
+    }
+
+    const currentYear = new Date().getFullYear();
+    for (const year of years) {
+      if (year !== 'ytd') {
+        const yearNum = parseInt(year, 10);
+        if (isNaN(yearNum) || yearNum < MIN_BACKFILL_YEAR || yearNum > currentYear) {
+          return sendBadRequest(
+            res,
+            `Invalid year: ${year}. Must be between ${MIN_BACKFILL_YEAR} and ${currentYear}, or 'ytd'`
+          );
+        }
+      }
+    }
+
+    try {
+      const existingImportSession = await prisma.importSession.findFirst({
+        where: { userId, provider: 'suunto', status: 'running' },
+      });
+
+      if (existingImportSession) {
+        return res.status(409).json({
+          error: 'Import already in progress',
+          message: 'A Suunto import is already in progress. Please wait for it to complete before starting another.',
+        });
+      }
+
+      const existingBackfills = await prisma.backfillRequest.findMany({
+        where: {
+          userId,
+          provider: 'suunto',
+          year: { in: years.filter((y) => y !== 'ytd') },
+          status: { notIn: ['failed'] },
+        },
+        select: { year: true, status: true },
+      });
+
+      const alreadyBackfilled = new Map(existingBackfills.map((b) => [b.year, b.status]));
+
+      if (years.includes('ytd')) {
+        const ytdBackfill = await prisma.backfillRequest.findUnique({
+          where: { userId_provider_year: { userId, provider: 'suunto', year: 'ytd' } },
+          select: { status: true },
+        });
+        if (ytdBackfill?.status === 'in_progress') {
+          alreadyBackfilled.set('ytd', 'in_progress');
+        }
+      }
+
+      const yearsToProcess = years.filter((y) => {
+        if (y === 'ytd') {
+          return alreadyBackfilled.get('ytd') !== 'in_progress';
+        }
+        return !alreadyBackfilled.has(y);
+      });
+
+      if (yearsToProcess.length === 0) {
+        return res.status(409).json({
+          error: 'All years already backfilled or in progress',
+          message: 'All selected years have already been imported or are currently being processed.',
+          skipped: years,
+        });
+      }
+
+      const importSession = await prisma.importSession.create({
+        data: {
+          userId,
+          provider: 'suunto',
+          status: 'running',
+          startedAt: new Date(),
+        },
+      });
+
+      logger.info({ importSessionId: importSession.id }, '[Suunto Backfill Batch] Created import session');
+
+      const results: Array<{ year: string; status: string; jobId?: string }> = [];
+
+      for (const year of yearsToProcess) {
+        await prisma.backfillRequest.upsert({
+          where: { userId_provider_year: { userId, provider: 'suunto', year } },
+          update: { status: 'pending', updatedAt: new Date() },
+          create: { userId, provider: 'suunto', year, status: 'pending' },
+        });
+
+        const result = await enqueueBackfillJob({
+          userId,
+          provider: 'suunto',
+          year,
+        });
+
+        results.push({ year, status: result.status, jobId: result.jobId });
+      }
+
+      const skipped = years.filter((y) => !yearsToProcess.includes(y));
+
+      logger.info({ userId, count: results.length }, '[Suunto Backfill Batch] Jobs queued');
+
+      return res.json({
+        success: true,
+        message: `Queued ${results.length} backfill request(s). Your rides will sync automatically in the background.`,
+        queued: results,
+        skipped: skipped.length > 0 ? skipped : undefined,
+      });
+    } catch (error) {
+      logError('Suunto Backfill Batch', error);
+      return sendInternalError(res, 'Failed to queue backfill requests');
     }
   }
 );

--- a/apps/api/src/routes/suunto.backfill.ts
+++ b/apps/api/src/routes/suunto.backfill.ts
@@ -18,40 +18,21 @@ import {
   type DuplicateCandidate,
 } from '../lib/duplicate-detector';
 import { isSuuntoCyclingActivity, getSuuntoRideType } from '../types/suunto';
-import { suuntoApiHeaders } from '../lib/suunto-sync';
+import {
+  SUUNTO_API_BASE,
+  suuntoApiHeaders,
+  type SuuntoWorkout,
+  type SuuntoWorkoutsResponse,
+} from '../lib/suunto-sync';
 import { enqueueBackfillJob } from '../lib/queue/backfill.queue';
 import { requireAdmin } from '../auth/adminMiddleware';
 
 type Empty = Record<string, never>;
 const r: Router = createRouter();
 
-const SUUNTO_API_BASE = 'https://cloudapi.suunto.com/v3';
 const MIN_BACKFILL_YEAR = 2015;
 const PAGE_LIMIT = 100;
 const MAX_PAGES = 100;
-
-// Shape of an individual workout as returned by GET /v3/workouts. Matches the
-// webhook WORKOUT_CREATED payload — timestamps are epoch ms, distances meters,
-// durations seconds.
-interface SuuntoWorkout {
-  workoutKey: string;
-  activityId: number;
-  startTime: number;
-  totalTime: number;
-  totalDistance?: number;
-  totalAscent?: number;
-  totalDescent?: number;
-  startPosition?: { x: number; y: number };
-  hrdata?: { workoutAvgHR?: number; workoutMaxHR?: number };
-  timeOffsetInMinutes?: number;
-}
-
-// Suunto CloudAPI v3 wraps list responses in { error, metadata, payload }.
-interface SuuntoWorkoutsResponse {
-  error: unknown;
-  metadata?: { totalCount?: number } & Record<string, unknown>;
-  payload: SuuntoWorkout[];
-}
 
 /**
  * Fetch historical workouts from Suunto for a given year or YTD.

--- a/apps/api/src/routes/webhooks.garmin.ts
+++ b/apps/api/src/routes/webhooks.garmin.ts
@@ -249,7 +249,12 @@ r.post<Empty, void, GarminPingPayload>(
             return { status: 'skipped', reason: 'unknown_user' };
           }
 
-          // Check user's active data source
+          // Active-source policy (shared with Strava/WHOOP/Suunto webhooks):
+          // when a user has multiple providers connected, only the
+          // `activeDataSource` one writes rides. Prevents duplicate imports
+          // when e.g. a Suunto watch also auto-syncs to Garmin. Users
+          // configure this via the DataSourceSelector in Settings, which
+          // explains the behavior. No-active-source → every provider passes.
           if (!await isActiveSource(userAccount.userId, 'garmin')) {
             logger.info(
               { requestId, garminUserId },
@@ -342,7 +347,8 @@ r.post<Empty, void, GarminPingPayload>(
             return { status: 'skipped', summaryId, reason: 'unknown_user' };
           }
 
-          // Check user's active data source
+          // Active-source policy (see callback branch above for the full
+          // explanation — same gate applied to PING-mode activity deliveries).
           if (!await isActiveSource(userAccount.userId, 'garmin')) {
             logger.info(
               { requestId, garminUserId, summaryId },

--- a/apps/api/src/routes/webhooks.strava.ts
+++ b/apps/api/src/routes/webhooks.strava.ts
@@ -3,7 +3,7 @@ import type { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { getValidStravaToken } from '../lib/strava-token';
 import { deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
-import { incrementBikeComponentHours, decrementBikeComponentHours } from '../lib/component-hours';
+import { syncBikeComponentHours } from '../lib/component-hours';
 import { logError } from '../lib/logger';
 import { fireRideNotifications } from '../services/notification.service';
 import { enqueueWeatherJob } from '../lib/queue';
@@ -183,38 +183,6 @@ r.post<Empty, void, { athlete_id: number }>(
     }
   }
 );
-
-const secondsToHours = (seconds: number | null | undefined) => Math.max(0, seconds ?? 0) / 3600;
-
-async function syncBikeComponentHours(
-  tx: Prisma.TransactionClient,
-  userId: string,
-  previous: { bikeId: string | null; durationSeconds: number | null | undefined },
-  next: { bikeId: string | null; durationSeconds: number | null | undefined }
-) {
-  const prevBikeId = previous.bikeId;
-  const nextBikeId = next.bikeId;
-  const prevHours = secondsToHours(previous.durationSeconds);
-  const nextHours = secondsToHours(next.durationSeconds);
-  const bikeChanged = prevBikeId !== nextBikeId;
-  const hoursDiff = nextHours - prevHours;
-
-  if (prevBikeId) {
-    if (bikeChanged) {
-      await decrementBikeComponentHours(tx, { userId, bikeId: prevBikeId, hoursDelta: prevHours });
-    } else if (hoursDiff < 0) {
-      await decrementBikeComponentHours(tx, { userId, bikeId: prevBikeId, hoursDelta: Math.abs(hoursDiff) });
-    }
-  }
-
-  if (nextBikeId) {
-    if (bikeChanged) {
-      await incrementBikeComponentHours(tx, { userId, bikeId: nextBikeId, hoursDelta: nextHours });
-    } else if (hoursDiff > 0) {
-      await incrementBikeComponentHours(tx, { userId, bikeId: nextBikeId, hoursDelta: hoursDiff });
-    }
-  }
-}
 
 /**
  * Process a single Strava activity event

--- a/apps/api/src/routes/webhooks.strava.ts
+++ b/apps/api/src/routes/webhooks.strava.ts
@@ -209,7 +209,13 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
 
   console.log(`[Strava Activity Event] Found user: ${userAccount.userId}`);
 
-  // Check user's active data source
+  // Active-source policy (applied across all provider webhooks — Strava,
+  // Garmin, WHOOP, Suunto): when a user has multiple providers connected,
+  // only the `activeDataSource` one writes rides. Prevents duplicate imports
+  // when e.g. a Suunto watch also auto-syncs to Strava. The policy is
+  // surfaced to users via the DataSourceSelector in Settings, which explains
+  // the behavior and lets them switch. When no source is set, `isActiveSource`
+  // returns true for every provider (first-connected wins).
   if (!await isActiveSource(userAccount.userId, 'strava')) {
     console.log('[Strava Activity Event] User active source is not Strava, skipping');
     return;

--- a/apps/api/src/routes/webhooks.suunto.ts
+++ b/apps/api/src/routes/webhooks.suunto.ts
@@ -4,6 +4,7 @@ import { prisma } from '../lib/prisma';
 import { createLogger, logError } from '../lib/logger';
 import { isActiveSource } from '../lib/active-source';
 import { isSuuntoCyclingActivity, getSuuntoRideType } from '../types/suunto';
+import { syncBikeComponentHours } from '../lib/component-hours';
 
 const log = createLogger('suunto-webhook');
 const r: Router = createRouter();
@@ -149,33 +150,64 @@ async function processWorkoutCreated(event: WorkoutCreatedEvent): Promise<void> 
     : null;
   const rideType = getSuuntoRideType(workout.activityId);
 
-  await prisma.ride.upsert({
+  // Read existing ride before upsert so we can diff bikeId/duration into
+  // component hours. A missing record means this is a new ride; in that
+  // case we also auto-assign the user's single active bike to keep webhook
+  // behavior aligned with the sync worker and backfill paths.
+  const existing = await prisma.ride.findUnique({
     where: { suuntoWorkoutId: workout.workoutKey },
-    create: {
-      userId: userAccount.userId,
-      suuntoWorkoutId: workout.workoutKey,
-      startTime,
-      durationSeconds: workout.totalTime,
-      distanceMeters,
-      elevationGainMeters,
-      averageHr,
-      rideType,
-      startLat,
-      startLng,
-    },
-    update: {
-      startTime,
-      durationSeconds: workout.totalTime,
-      distanceMeters,
-      elevationGainMeters,
-      averageHr,
-      rideType,
-      ...(startLat != null ? { startLat } : {}),
-      ...(startLng != null ? { startLng } : {}),
-    },
+    select: { id: true, durationSeconds: true, bikeId: true },
   });
 
-  log.info({ userId: userAccount.userId, workoutKey: workout.workoutKey, activityId: workout.activityId }, 'Suunto workout upserted');
+  const isNewRide = !existing;
+  let bikeId: string | null = null;
+  if (isNewRide) {
+    const userBikes = await prisma.bike.findMany({
+      where: { userId: userAccount.userId, status: 'ACTIVE' },
+      select: { id: true },
+    });
+    if (userBikes.length === 1) {
+      bikeId = userBikes[0].id;
+    }
+  }
+
+  await prisma.$transaction(async (tx) => {
+    const ride = await tx.ride.upsert({
+      where: { suuntoWorkoutId: workout.workoutKey },
+      create: {
+        userId: userAccount.userId,
+        suuntoWorkoutId: workout.workoutKey,
+        startTime,
+        durationSeconds: workout.totalTime,
+        distanceMeters,
+        elevationGainMeters,
+        averageHr,
+        rideType,
+        bikeId,
+        startLat,
+        startLng,
+      },
+      update: {
+        startTime,
+        durationSeconds: workout.totalTime,
+        distanceMeters,
+        elevationGainMeters,
+        averageHr,
+        rideType,
+        ...(startLat != null ? { startLat } : {}),
+        ...(startLng != null ? { startLng } : {}),
+      },
+    });
+
+    await syncBikeComponentHours(
+      tx,
+      userAccount.userId,
+      { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
+      { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds }
+    );
+  });
+
+  log.info({ userId: userAccount.userId, workoutKey: workout.workoutKey, activityId: workout.activityId, isNewRide }, 'Suunto workout upserted');
 }
 
 export default r;

--- a/apps/api/src/routes/webhooks.suunto.ts
+++ b/apps/api/src/routes/webhooks.suunto.ts
@@ -127,6 +127,13 @@ async function processWorkoutCreated(event: WorkoutCreatedEvent): Promise<void> 
     return;
   }
 
+  // Active-source policy (applied consistently across Strava, Garmin, WHOOP,
+  // Suunto webhooks): when a user has multiple providers connected, only the
+  // one they've chosen as `activeDataSource` writes rides. This prevents
+  // duplicate imports when e.g. a Suunto watch also auto-syncs to Strava.
+  // Users select the active source via the DataSourceSelector in Settings,
+  // and the helper text there explains the behavior. When no source is set,
+  // `isActiveSource` returns true for every provider (first-connected wins).
   if (!await isActiveSource(userAccount.userId, 'suunto')) {
     log.info({ userId: userAccount.userId }, 'Suunto webhook: user active source is not Suunto, skipping');
     return;

--- a/apps/api/src/routes/webhooks.suunto.ts
+++ b/apps/api/src/routes/webhooks.suunto.ts
@@ -1,0 +1,181 @@
+import { Router as createRouter, type Router, type Request, type Response } from 'express';
+import { createHmac, timingSafeEqual } from 'crypto';
+import { prisma } from '../lib/prisma';
+import { createLogger, logError } from '../lib/logger';
+import { isActiveSource } from '../lib/active-source';
+import { isSuuntoCyclingActivity, getSuuntoRideType } from '../types/suunto';
+
+const log = createLogger('suunto-webhook');
+const r: Router = createRouter();
+
+// ---------------------------------------------------------------------------
+// Webhook receiver
+// ---------------------------------------------------------------------------
+// Mounted in server.ts at `/webhooks/suunto` with `express.raw()` so that
+// `req.body` is the raw Buffer needed for HMAC-SHA256 signature verification.
+//
+// Suunto webhook contract (from API docs):
+//   - Header: `X-HMAC-SHA256-Signature` = hex(HMAC-SHA256(body, NOTIFICATION_SECRET))
+//   - Body: JSON `{ type, username, ...payload }`. Type discriminates between
+//     WORKOUT_CREATED, ROUTE_CREATED, and three SUUNTO_247_* variants.
+//   - Must respond 2xx within 2s or Suunto retries with backoff and may trip
+//     a circuit breaker that pauses all notifications for the app.
+//
+// We currently only process WORKOUT_CREATED — Loam Logger is a ride tracker
+// and the other notification types (routes, 24/7 metrics) are out of scope.
+// The other URLs aren't registered in the Suunto portal, so they shouldn't
+// arrive in practice; logging them as "ignored" keeps the receiver robust if
+// the portal config changes.
+// ---------------------------------------------------------------------------
+
+type WorkoutCreatedEvent = {
+  type: 'WORKOUT_CREATED';
+  username: string;
+  workout: {
+    workoutKey: string;
+    activityId: number;
+    startTime: number; // Unix epoch ms
+    totalTime: number; // seconds
+    energyConsumption?: number;
+    startPosition?: { x: number; y: number }; // x = longitude, y = latitude
+    stepCount?: number;
+    totalAscent?: number;
+    totalDescent?: number;
+    totalDistance?: number; // meters
+    hrdata?: { workoutAvgHR?: number; workoutMaxHR?: number };
+    avgSpeed?: number;
+    maxSpeed?: number;
+    timeOffsetInMinutes?: number;
+  };
+  gear?: {
+    manufacturer?: string;
+    name?: string;
+    productType?: string;
+  };
+};
+
+type SuuntoWebhookEvent =
+  | WorkoutCreatedEvent
+  | { type: 'ROUTE_CREATED'; username: string; [k: string]: unknown }
+  | { type: 'SUUNTO_247_ACTIVITY_CREATED'; username: string; [k: string]: unknown }
+  | { type: 'SUUNTO_247_SLEEP_CREATED'; username: string; [k: string]: unknown }
+  | { type: 'SUUNTO_247_RECOVERY_CREATED'; username: string; [k: string]: unknown };
+
+function verifySignature(rawBody: Buffer, signatureHeader: string | undefined, secret: string): boolean {
+  if (!signatureHeader) return false;
+  const computed = createHmac('sha256', secret).update(rawBody).digest('hex');
+  let provided: Buffer;
+  try {
+    provided = Buffer.from(signatureHeader, 'hex');
+  } catch {
+    return false;
+  }
+  const expected = Buffer.from(computed, 'hex');
+  if (provided.length !== expected.length) return false;
+  return timingSafeEqual(provided, expected);
+}
+
+r.post('/workouts', async (req: Request, res: Response) => {
+  const rawBody = req.body as Buffer;
+  const signature = req.header('X-HMAC-SHA256-Signature');
+  const secret = process.env.SUUNTO_NOTIFICATION_SECRET;
+
+  if (!secret) {
+    log.error('SUUNTO_NOTIFICATION_SECRET not set');
+    return res.status(500).send('server misconfigured');
+  }
+
+  if (!Buffer.isBuffer(rawBody) || !verifySignature(rawBody, signature, secret)) {
+    log.warn({ hasSig: !!signature, bodyType: typeof rawBody }, 'Suunto webhook: signature mismatch');
+    return res.status(403).send('forbidden');
+  }
+
+  let event: SuuntoWebhookEvent;
+  try {
+    event = JSON.parse(rawBody.toString('utf-8')) as SuuntoWebhookEvent;
+  } catch (err) {
+    log.warn({ err }, 'Suunto webhook: invalid JSON');
+    return res.status(400).send('invalid json');
+  }
+
+  // Respond immediately so we beat Suunto's 2s deadline.
+  res.status(200).send('OK');
+
+  try {
+    switch (event.type) {
+      case 'WORKOUT_CREATED':
+        await processWorkoutCreated(event);
+        break;
+      default:
+        log.info({ type: event.type, username: event.username }, 'Suunto event ignored (not subscribed)');
+    }
+  } catch (err) {
+    logError('Suunto webhook processing', err);
+  }
+});
+
+async function processWorkoutCreated(event: WorkoutCreatedEvent): Promise<void> {
+  const { username, workout } = event;
+
+  const userAccount = await prisma.userAccount.findUnique({
+    where: { provider_providerUserId: { provider: 'suunto', providerUserId: username } },
+  });
+
+  if (!userAccount) {
+    log.warn({ username }, 'Suunto webhook: unknown username');
+    return;
+  }
+
+  if (!await isActiveSource(userAccount.userId, 'suunto')) {
+    log.info({ userId: userAccount.userId }, 'Suunto webhook: user active source is not Suunto, skipping');
+    return;
+  }
+
+  if (!isSuuntoCyclingActivity(workout.activityId)) {
+    log.info(
+      { userId: userAccount.userId, activityId: workout.activityId, workoutKey: workout.workoutKey },
+      'Suunto webhook: non-cycling activity, skipping'
+    );
+    return;
+  }
+
+  const startTime = new Date(workout.startTime);
+  const distanceMeters = workout.totalDistance ?? 0;
+  const elevationGainMeters = workout.totalAscent ?? 0;
+  const startLat = workout.startPosition?.y ?? null;
+  const startLng = workout.startPosition?.x ?? null;
+  const averageHr = workout.hrdata?.workoutAvgHR != null
+    ? Math.round(workout.hrdata.workoutAvgHR)
+    : null;
+  const rideType = getSuuntoRideType(workout.activityId);
+
+  await prisma.ride.upsert({
+    where: { suuntoWorkoutId: workout.workoutKey },
+    create: {
+      userId: userAccount.userId,
+      suuntoWorkoutId: workout.workoutKey,
+      startTime,
+      durationSeconds: workout.totalTime,
+      distanceMeters,
+      elevationGainMeters,
+      averageHr,
+      rideType,
+      startLat,
+      startLng,
+    },
+    update: {
+      startTime,
+      durationSeconds: workout.totalTime,
+      distanceMeters,
+      elevationGainMeters,
+      averageHr,
+      rideType,
+      ...(startLat != null ? { startLat } : {}),
+      ...(startLng != null ? { startLng } : {}),
+    },
+  });
+
+  log.info({ userId: userAccount.userId, workoutKey: workout.workoutKey, activityId: workout.activityId }, 'Suunto workout upserted');
+}
+
+export default r;

--- a/apps/api/src/routes/webhooks.whoop.ts
+++ b/apps/api/src/routes/webhooks.whoop.ts
@@ -80,7 +80,12 @@ r.post('/whoop', async (req: Request, res: Response) => {
       return;
     }
 
-    // Check user's active data source
+    // Active-source policy (shared with Strava/Garmin/Suunto webhooks): when
+    // a user has multiple providers connected, only the `activeDataSource`
+    // one writes rides. Prevents duplicate imports when e.g. a Suunto watch
+    // also auto-syncs to WHOOP. Users configure this via the DataSourceSelector
+    // in Settings, which explains the behavior. No-active-source → every
+    // provider passes.
     if (!await isActiveSource(user.id, 'whoop')) {
       logger.info(
         { whoopUserId: user_id },

--- a/apps/api/src/routes/whoop.backfill.ts
+++ b/apps/api/src/routes/whoop.backfill.ts
@@ -201,6 +201,7 @@ r.get<Empty, void, Empty, { year?: string }>(
           garminActivityId: null,
           stravaActivityId: null,
           whoopWorkoutId: workout.id,
+          suuntoWorkoutId: null,
         };
 
         const duplicate = await findPotentialDuplicates(userId, duplicateCandidate, prisma);

--- a/apps/api/src/routes/whoop.backfill.ts
+++ b/apps/api/src/routes/whoop.backfill.ts
@@ -14,6 +14,7 @@ import {
   type WhoopWorkout,
   type WhoopPaginatedResponse,
 } from '../types/whoop';
+import { requireAdmin } from '../auth/adminMiddleware';
 
 type Empty = Record<string, never>;
 const r: Router = createRouter();
@@ -371,9 +372,15 @@ r.get<Empty, void, Empty, Empty>(
 /**
  * Testing/utility endpoint: Delete all WHOOP-imported rides for the current user.
  * Also removes the recorded hours from associated bikes/components.
+ *
+ * Admin-gated: the "testing" path component does not provide any access
+ * control on its own; the UI hides the button behind isAdmin, but the
+ * backend must enforce the same boundary to prevent accidental or
+ * malicious wipes (e.g., a frontend bug or a non-admin discovering the route).
  */
 r.delete<Empty, void, Empty>(
   '/whoop/testing/delete-imported-rides',
+  requireAdmin,
   async (req: Request, res: Response) => {
     const userId = req.user?.id || req.sessionUser?.uid;
     if (!userId) {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -29,14 +29,17 @@ import {
 
 import authGarmin from './routes/auth.garmin';
 import authStrava from './routes/auth.strava';
+import authSuunto from './routes/auth.suunto';
 import authWhoop from './routes/auth.whoop';
 import { createDataLoaders, type DataLoaders } from './graphql/dataloaders';
 import webhooksGarmin from './routes/webhooks.garmin';
 import webhooksStrava from './routes/webhooks.strava';
+import webhooksSuunto from './routes/webhooks.suunto';
 import webhooksWhoop from './routes/webhooks.whoop';
 import garminBackfill from './routes/garmin.backfill';
 import stravaBackfill from './routes/strava.backfill';
 import whoopBackfill from './routes/whoop.backfill';
+import suuntoBackfill from './routes/suunto.backfill';
 import backfillHistory from './routes/backfill.history';
 import dataSourceRouter from './routes/data-source';
 import duplicatesRouter from './routes/duplicates';
@@ -157,6 +160,10 @@ const startServer = async () => {
     app.use('/webhooks/revenuecat', express.json(), webhooksRevenueCat);
   }
 
+  // Suunto webhook needs raw body for HMAC-SHA256 signature verification,
+  // so it must be registered before the global express.json() consumes it.
+  app.use('/webhooks/suunto', express.raw({ type: 'application/json' }), webhooksSuunto);
+
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
   app.use(cookieParser(process.env.COOKIE_SECRET || 'dev-secret'));
@@ -257,11 +264,13 @@ const startServer = async () => {
   app.use('/auth', mobileAuthRouter);
   app.use('/auth', authGarmin);
   app.use('/auth', authStrava);
+  app.use('/auth', authSuunto);
   app.use('/auth', authWhoop);
 
   app.use('/api', garminBackfill);
   app.use('/api', stravaBackfill);
   app.use('/api', whoopBackfill);
+  app.use('/api', suuntoBackfill);
   app.use('/api', backfillHistory);
   app.use('/api', dataSourceRouter);
   app.use('/api', duplicatesRouter);

--- a/apps/api/src/templates/emails/index.ts
+++ b/apps/api/src/templates/emails/index.ts
@@ -9,6 +9,7 @@ import { templateConfig as announcementConfig } from './announcement';
 import { templateConfig as foundingRidersConfig } from './founding-riders';
 import { templateConfig as preAccessConfig } from './pre-access';
 import { templateConfig as stravaEnabledConfig } from './strava-enabled';
+import { templateConfig as suuntoEnabledConfig } from './suunto-enabled';
 import { templateConfig as betaFeatureRoundupConfig } from './beta-feature-roundup';
 import { templateConfig as mobileAppLaunchConfig } from './mobile-app-launch';
 import { templateConfig as foundingRidersAprilUpdateConfig } from './founding-riders-april-2026';
@@ -25,6 +26,7 @@ const allTemplates: TemplateConfig[] = [
   foundingRidersConfig,
   preAccessConfig,
   stravaEnabledConfig,
+  suuntoEnabledConfig,
   betaFeatureRoundupConfig,
   mobileAppLaunchConfig,
   foundingRidersAprilUpdateConfig,

--- a/apps/api/src/templates/emails/suunto-enabled.tsx
+++ b/apps/api/src/templates/emails/suunto-enabled.tsx
@@ -1,0 +1,401 @@
+import * as React from "react";
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+import { sanitizeUserInput } from "../../lib/html";
+import type { TemplateConfig } from "./types";
+
+export const SUUNTO_INTEGRATION_LIVE_TEMPLATE_VERSION = "1.0.0";
+
+export type SuuntoIntegrationLiveEmailProps = {
+  recipientFirstName?: string;
+  settingsUrl?: string;
+  unsubscribeUrl?: string;
+  supportEmail?: string;
+};
+
+const TOKENS = {
+  bg: "#FBFAF2",
+  card: "#F4F7F5",
+  border: "#D4DDD9",
+  text: "#121816",
+  muted: "#5A6661",
+  subCard: "#F0F5F2",
+  subBorder: "#D4DDD9",
+  ctaBg: "#7FAF95",
+  ctaText: "#FFFFFF",
+  footer: "#8A9590",
+  faint: "#6A7571",
+};
+
+const DARK_TOKENS = {
+  bg: "#0B0F0E",
+  card: "#121816",
+  border: "#26302D",
+  text: "#C8D4CE",
+  muted: "#B8C5BF",
+  subCard: "#0E1412",
+  subBorder: "#22302A",
+  ctaBg: "#7FAF95",
+  ctaText: "#0B0F0E",
+  footer: "#5F6B66",
+  faint: "#7F8C86",
+};
+
+const darkModeStyles = `
+  @media (prefers-color-scheme: dark) {
+    html, body, .ll-body, .ll-container { background-color: ${DARK_TOKENS.bg} !important; }
+    .ll-card { background-color: ${DARK_TOKENS.card} !important; border-color: ${DARK_TOKENS.border} !important; }
+    .ll-callout { background-color: ${DARK_TOKENS.subCard} !important; border-color: ${DARK_TOKENS.subBorder} !important; }
+    .ll-h1, .ll-h2, .ll-emph, .ll-brand, .ll-signature { color: ${DARK_TOKENS.text} !important; }
+    .ll-p, .ll-bullets, .ll-link { color: ${DARK_TOKENS.muted} !important; }
+    .ll-hr { border-color: ${DARK_TOKENS.border} !important; margin-bottom: 25px !important; }
+    .ll-button { background-color: ${DARK_TOKENS.ctaBg} !important; color: ${DARK_TOKENS.ctaText} !important; }
+    .ll-footer { color: ${DARK_TOKENS.footer} !important; }
+    .ll-footer-link { color: ${DARK_TOKENS.faint} !important; }
+  }
+`;
+
+export default function SuuntoIntegrationLiveEmail({
+  recipientFirstName,
+  settingsUrl = "https://loamlogger.app/settings",
+  unsubscribeUrl,
+  supportEmail = "ryan.lecours@loamlogger.app",
+}: SuuntoIntegrationLiveEmailProps) {
+  const safeName = sanitizeUserInput(recipientFirstName);
+  const safeSettingsUrl = sanitizeUserInput(settingsUrl, 200);
+  const safeSupportEmail = sanitizeUserInput(supportEmail, 200);
+
+  const hello = safeName ? `Hello ${safeName},` : "Hello,";
+
+  const mailFeedbackHref = `mailto:${encodeURIComponent(
+    safeSupportEmail
+  )}?subject=${encodeURIComponent("Suunto Integration Feedback")}`;
+
+  const mailBugHref = `mailto:${encodeURIComponent(
+    safeSupportEmail
+  )}?subject=${encodeURIComponent("Suunto Integration Bug Report")}`;
+
+  return (
+    <Html>
+      <Head>
+        <meta name="color-scheme" content="light dark" />
+        <meta name="supported-color-schemes" content="light dark" />
+        <style dangerouslySetInnerHTML={{ __html: darkModeStyles }} />
+      </Head>
+
+      <Preview>{`Suunto integration is live — direct workout sync for Suunto watches.`}</Preview>
+
+      <Body className="ll-body" style={styles.body}>
+        <Container className="ll-container" style={styles.container}>
+          <Section style={{ padding: "8px 6px 14px 6px" }}>
+            <Text className="ll-brand" style={styles.brand}>
+              LoamLogger
+            </Text>
+          </Section>
+
+          <Section className="ll-card" style={styles.card}>
+            <Heading className="ll-h1" style={styles.h1}>
+              Suunto integration is live for everyone
+            </Heading>
+
+            <Text className="ll-p" style={styles.p}>
+              {hello}
+            </Text>
+
+            <Text className="ll-p" style={styles.p}>
+              Suunto integration is now available for all Loam Logger users.
+            </Text>
+            <Text className="ll-p" style={styles.p}>
+              If you ride with a Suunto watch, your rides can now flow straight
+              from Suunto to Loam Logger — no Strava middleman required.
+            </Text>
+
+            <Section className="ll-callout" style={styles.callout}>
+              <Text className="ll-p" style={{ ...styles.p, margin: 0 }}>
+                <span className="ll-emph" style={styles.emph}>
+                  The big win:
+                </span>
+                <br />
+                Connect once, and every new Suunto ride shows up in Loam Logger
+                automatically — with distance, elevation, heart rate, and start
+                location already filled in.
+              </Text>
+            </Section>
+
+            <Section style={styles.imageContainer}>
+              <Img
+                src="https://loamlogger.app/RyanAbenaki.jpg"
+                alt="Mountain biker riding through lush ferns"
+                width="60%"
+                style={styles.heroImage}
+              />
+            </Section>
+
+            <Hr className="ll-hr" style={styles.hr} />
+
+            <Heading as="h2" className="ll-h2" style={styles.h2}>
+              How it works
+            </Heading>
+
+            <Text className="ll-bullets" style={styles.bullets}>
+              • Connect Suunto once in{" "}
+              <Link href={safeSettingsUrl} className="ll-link" style={styles.link}>
+                Settings → Integrations
+              </Link>
+            </Text>
+
+            <Text className="ll-bullets" style={styles.bullets}>
+              • New rides usually appear in Loam Logger{" "}
+              <span className="ll-emph" style={styles.emph}>
+                within a few seconds
+              </span>{" "}
+              after your watch finishes uploading to Suunto
+            </Text>
+
+            <Text className="ll-bullets" style={styles.bullets}>
+              • If you only ride one bike, Loam Logger auto-assigns the ride to
+              it. Multiple bikes? You can pick the right one after the ride lands.
+            </Text>
+
+            <Text className="ll-bullets" style={styles.bullets}>
+              • Want to pull in your Suunto ride history too? Use{" "}
+              <span className="ll-emph" style={styles.emph}>
+                Sync Previous Rides
+              </span>{" "}
+              in Settings to backfill any year back to 2015.
+            </Text>
+
+            <Section style={{ paddingTop: 8, paddingBottom: 12, textAlign: "center" }}>
+              <Button href={safeSettingsUrl} className="ll-button" style={styles.button}>
+                🔗 Connect Suunto
+              </Button>
+            </Section>
+
+            <Hr className="ll-hr" style={styles.hr} />
+
+            <Heading as="h2" className="ll-h2" style={styles.h2}>
+              Using multiple providers?
+            </Heading>
+
+            <Text className="ll-p" style={styles.p}>
+              If you were routing Suunto rides through Strava before, Loam Logger
+              will detect the overlap and avoid importing the same ride twice.
+              To review, head to{" "}
+              <Link href={safeSettingsUrl} className="ll-link" style={styles.link}>
+                Settings
+              </Link>{" "}
+              and run{" "}
+              <span className="ll-emph" style={styles.emph}>
+                Scan for duplicate rides
+              </span>
+              .
+            </Text>
+
+            <Section className="ll-callout" style={styles.callout}>
+              <Text className="ll-p" style={{ ...styles.p, marginBottom: 0 }}>
+                Suunto is new here — feedback on edge cases, missing data, or
+                anything that looks off is especially useful while the
+                integration settles in.
+              </Text>
+            </Section>
+
+            <Section style={{ paddingTop: 8, paddingBottom: 12, textAlign: "center" }}>
+              <Button href={mailFeedbackHref} className="ll-button" style={styles.button}>
+                💡 Share Feedback
+              </Button>
+            </Section>
+
+            <Section style={{ paddingBottom: 12, textAlign: "center" }}>
+              <Button href={mailBugHref} className="ll-button" style={styles.button}>
+                🐛 Report a Bug
+              </Button>
+            </Section>
+
+            <Text className="ll-p" style={styles.p}>
+              One more step toward the “ride, sync, forget about it” experience
+              — now native for Suunto riders too.
+            </Text>
+
+            <Text
+              className="ll-signature"
+              style={{
+                ...styles.p,
+                marginTop: 14,
+                marginBottom: 0,
+                color: TOKENS.text,
+                fontWeight: 800,
+              }}
+            >
+              Ryan LeCours
+            </Text>
+
+            <Text className="ll-p" style={{ ...styles.p, marginBottom: 0 }}>
+              Founder, Loam Logger
+            </Text>
+
+            <Text className="ll-p" style={{ ...styles.p, marginBottom: 0 }}>
+              Loam Labs LLC
+            </Text>
+          </Section>
+
+          <Section style={styles.footer}>
+            <Text className="ll-footer" style={{ ...styles.footerText, marginBottom: 0 }}>
+              Loam Logger is a product of Loam Labs LLC. You are receiving this
+              because you signed up for beta access.
+            </Text>
+
+            {unsubscribeUrl ? (
+              <Text className="ll-footer" style={{ ...styles.footerText, marginTop: 6 }}>
+                <Link href={unsubscribeUrl} className="ll-footer-link" style={styles.footerLink}>
+                  Unsubscribe
+                </Link>
+              </Text>
+            ) : null}
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  body: {
+    margin: 0,
+    padding: 0,
+    backgroundColor: TOKENS.bg,
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif',
+  },
+  container: {
+    width: "100%",
+    maxWidth: 800,
+    margin: "0 auto",
+    padding: "22px 14px 28px",
+  },
+  brand: {
+    fontSize: 14,
+    letterSpacing: 0.2,
+    fontWeight: 800,
+    color: TOKENS.text,
+    margin: 0,
+  },
+  card: {
+    backgroundColor: TOKENS.card,
+    border: `1px solid ${TOKENS.border}`,
+    borderRadius: 18,
+    padding: "22px 20px",
+  },
+  h1: {
+    fontSize: 22,
+    lineHeight: "1.25",
+    color: TOKENS.text,
+    fontWeight: 800,
+    margin: "0 0 12px 0",
+  },
+  h2: {
+    fontSize: 16,
+    lineHeight: "1.35",
+    color: TOKENS.text,
+    fontWeight: 800,
+    margin: "0 0 10px 0",
+  },
+  p: {
+    fontSize: 14,
+    lineHeight: "1.75",
+    color: TOKENS.muted,
+    margin: "0 0 12px 0",
+  },
+  bullets: {
+    fontSize: 14,
+    lineHeight: "1.75",
+    color: TOKENS.muted,
+    margin: "0 0 8px 0",
+    paddingLeft: 16,
+    textIndent: -16,
+  },
+  emph: {
+    color: TOKENS.text,
+    fontWeight: 800,
+  },
+  callout: {
+    backgroundColor: TOKENS.subCard,
+    border: `1px solid ${TOKENS.subBorder}`,
+    borderRadius: 14,
+    padding: "12px 12px",
+    margin: "10px 0 14px",
+  },
+  hr: {
+    borderColor: TOKENS.border,
+    margin: "14px 0 10px",
+  },
+  imageContainer: {
+    margin: "16px 0",
+    textAlign: "center" as const,
+  },
+  heroImage: {
+    borderRadius: 12,
+    maxWidth: "100%",
+    height: "auto",
+    display: "inline-block",
+    margin: "0 auto",
+  },
+  button: {
+    display: "inline-block",
+    backgroundColor: TOKENS.ctaBg,
+    color: TOKENS.ctaText,
+    borderRadius: 999,
+    padding: "12px 16px",
+    fontSize: 14,
+    fontWeight: 800,
+    textDecoration: "none",
+  },
+  link: {
+    color: TOKENS.muted,
+    textDecoration: "underline",
+  },
+  footer: {
+    padding: "14px 6px 0 6px",
+  },
+  footerText: {
+    fontSize: 11,
+    lineHeight: "1.6",
+    color: TOKENS.footer,
+    margin: 0,
+  },
+  footerLink: {
+    color: TOKENS.faint,
+    textDecoration: "underline",
+  },
+};
+
+/** Template configuration for admin email UI */
+export const templateConfig: TemplateConfig = {
+  id: "suunto-integration-live",
+  displayName: "Suunto Integration Live",
+  description:
+    "Announces Suunto integration, direct workout sync from Suunto watches, and historical backfill",
+  defaultSubject: "Suunto integration is live for everyone",
+  emailType: "suunto_integration_live",
+  templateVersion: SUUNTO_INTEGRATION_LIVE_TEMPLATE_VERSION,
+  adminVisible: true,
+  parameters: [
+    { key: "recipientFirstName", label: "First Name", type: "text", required: false, autoFill: "recipientFirstName" },
+    { key: "settingsUrl", label: "Settings URL", type: "url", required: false, defaultValue: "https://loamlogger.app/settings" },
+    { key: "supportEmail", label: "Support Email", type: "text", required: false, defaultValue: "ryan.lecours@loamlogger.app" },
+    { key: "unsubscribeUrl", label: "Unsubscribe URL", type: "hidden", required: false, autoFill: "unsubscribeUrl" },
+  ],
+  render: (props) =>
+    React.createElement(SuuntoIntegrationLiveEmail, props as SuuntoIntegrationLiveEmailProps),
+};

--- a/apps/api/src/types/suunto.test.ts
+++ b/apps/api/src/types/suunto.test.ts
@@ -1,0 +1,48 @@
+import {
+  SUUNTO_CYCLING_ACTIVITY_IDS,
+  isSuuntoCyclingActivity,
+  getSuuntoRideType,
+} from './suunto';
+
+describe('SUUNTO_CYCLING_ACTIVITY_IDS', () => {
+  it('includes road, MTB, and indoor cycling', () => {
+    expect(SUUNTO_CYCLING_ACTIVITY_IDS).toEqual([2, 10, 37]);
+  });
+});
+
+describe('isSuuntoCyclingActivity', () => {
+  it.each([2, 10, 37])('returns true for cycling activity id %i', (id) => {
+    expect(isSuuntoCyclingActivity(id)).toBe(true);
+  });
+
+  it.each([
+    [0, 'walking'],
+    [1, 'running'],
+    [11, 'hiking'],
+    [21, 'swimming'],
+    [22, 'trail running'],
+    [31, 'skiing'],
+    [47, 'triathlon'],
+    [9999, 'unknown future id'],
+  ])('returns false for non-cycling activity id %i (%s)', (id) => {
+    expect(isSuuntoCyclingActivity(id)).toBe(false);
+  });
+});
+
+describe('getSuuntoRideType', () => {
+  it('returns "Mountain Bike" for activityId 10', () => {
+    expect(getSuuntoRideType(10)).toBe('Mountain Bike');
+  });
+
+  it('returns "Indoor Cycling" for activityId 37', () => {
+    expect(getSuuntoRideType(37)).toBe('Indoor Cycling');
+  });
+
+  it('returns "Cycling" for activityId 2', () => {
+    expect(getSuuntoRideType(2)).toBe('Cycling');
+  });
+
+  it('falls back to "Cycling" for unknown ids (defensive)', () => {
+    expect(getSuuntoRideType(9999)).toBe('Cycling');
+  });
+});

--- a/apps/api/src/types/suunto.test.ts
+++ b/apps/api/src/types/suunto.test.ts
@@ -5,13 +5,25 @@ import {
 } from './suunto';
 
 describe('SUUNTO_CYCLING_ACTIVITY_IDS', () => {
-  it('includes road, MTB, and indoor cycling', () => {
-    expect(SUUNTO_CYCLING_ACTIVITY_IDS).toEqual([2, 10, 37]);
+  it('contains the eight cycling IDs from Suunto\'s official Activities reference', () => {
+    // Source: Suunto's Activities.pdf. Entries whose FIT sport is CYCLING or
+    // E_BIKING: 2 Cycling, 10 MTB, 52 Indoor cycling, 99 Gravel, 105 E-bike,
+    // 106 E-MTB, 109 Hand cycling, 114 Cyclocross.
+    expect(SUUNTO_CYCLING_ACTIVITY_IDS).toEqual([2, 10, 52, 99, 105, 106, 109, 114]);
   });
 });
 
 describe('isSuuntoCyclingActivity', () => {
-  it.each([2, 10, 37])('returns true for cycling activity id %i', (id) => {
+  it.each([
+    [2, 'cycling'],
+    [10, 'mountain biking'],
+    [52, 'indoor cycling'],
+    [99, 'gravel cycling'],
+    [105, 'e-biking'],
+    [106, 'e-MTB'],
+    [109, 'hand cycling'],
+    [114, 'cyclocross'],
+  ])('returns true for cycling activity id %i (%s)', (id) => {
     expect(isSuuntoCyclingActivity(id)).toBe(true);
   });
 
@@ -21,8 +33,11 @@ describe('isSuuntoCyclingActivity', () => {
     [11, 'hiking'],
     [21, 'swimming'],
     [22, 'trail running'],
-    [31, 'skiing'],
-    [47, 'triathlon'],
+    [30, 'snowboarding'],
+    [37, 'baseball (previously misclassified as indoor cycling)'],
+    [47, 'cricket'],
+    [50, 'ice hockey'],
+    [74, 'triathlon'],
     [9999, 'unknown future id'],
   ])('returns false for non-cycling activity id %i (%s)', (id) => {
     expect(isSuuntoCyclingActivity(id)).toBe(false);
@@ -30,16 +45,36 @@ describe('isSuuntoCyclingActivity', () => {
 });
 
 describe('getSuuntoRideType', () => {
+  it('returns "Cycling" for activityId 2', () => {
+    expect(getSuuntoRideType(2)).toBe('Cycling');
+  });
+
   it('returns "Mountain Bike" for activityId 10', () => {
     expect(getSuuntoRideType(10)).toBe('Mountain Bike');
   });
 
-  it('returns "Indoor Cycling" for activityId 37', () => {
-    expect(getSuuntoRideType(37)).toBe('Indoor Cycling');
+  it('returns "Indoor Cycling" for activityId 52', () => {
+    expect(getSuuntoRideType(52)).toBe('Indoor Cycling');
   });
 
-  it('returns "Cycling" for activityId 2', () => {
-    expect(getSuuntoRideType(2)).toBe('Cycling');
+  it('returns "Gravel" for activityId 99', () => {
+    expect(getSuuntoRideType(99)).toBe('Gravel');
+  });
+
+  it('returns "E-Bike" for activityId 105', () => {
+    expect(getSuuntoRideType(105)).toBe('E-Bike');
+  });
+
+  it('returns "E-Mountain Bike" for activityId 106', () => {
+    expect(getSuuntoRideType(106)).toBe('E-Mountain Bike');
+  });
+
+  it('returns "Hand Cycling" for activityId 109', () => {
+    expect(getSuuntoRideType(109)).toBe('Hand Cycling');
+  });
+
+  it('returns "Cyclocross" for activityId 114', () => {
+    expect(getSuuntoRideType(114)).toBe('Cyclocross');
   });
 
   it('falls back to "Cycling" for unknown ids (defensive)', () => {

--- a/apps/api/src/types/suunto.ts
+++ b/apps/api/src/types/suunto.ts
@@ -5,19 +5,29 @@
  * Only a subset of IDs are cycling — the rest (running, swimming, etc.) should
  * not become rides in Loam Logger.
  *
- * Activity IDs are documented in Suunto's public API reference; only the
- * cycling-related IDs we consume are declared here. Extend this list if Suunto
- * adds new cycling sub-types (e.g. gravel, BMX) that we want to track.
+ * Source of truth: Suunto's official activity ID reference
+ * https://aspartnercontent.blob.core.windows.net/apizone/docs/Activities.pdf
+ * When Suunto adds new cycling sub-types, add the ID here and to
+ * `getSuuntoRideType` below.
  */
 
 /**
  * Suunto activity IDs that represent cycling.
  *
- * - 2:  Cycling (road / general)
- * - 10: Mountain biking
- * - 37: Indoor cycling (trainer / spin class)
+ * Pulled from the FIT-file mapping table where `sport` is either `CYCLING`
+ * or `E_BIKING` (e-bikes get their own FIT sport but are still rides from
+ * our perspective, same as [backfill.worker.ts GARMIN_CYCLING_TYPES]).
+ *
+ * - 2:   Cycling (road / general)
+ * - 10:  Mountain biking
+ * - 52:  Indoor cycling (trainer / spin class)
+ * - 99:  Gravel cycling
+ * - 105: E-biking
+ * - 106: E-MTB
+ * - 109: Hand cycling
+ * - 114: Cyclocross
  */
-export const SUUNTO_CYCLING_ACTIVITY_IDS = [2, 10, 37] as const;
+export const SUUNTO_CYCLING_ACTIVITY_IDS = [2, 10, 52, 99, 105, 106, 109, 114] as const;
 
 type SuuntoCyclingActivityId = (typeof SUUNTO_CYCLING_ACTIVITY_IDS)[number];
 
@@ -37,12 +47,14 @@ export function isSuuntoCyclingActivity(activityId: number): boolean {
  */
 export function getSuuntoRideType(activityId: number): string {
   switch (activityId) {
-    case 10:
-      return 'Mountain Bike';
-    case 37:
-      return 'Indoor Cycling';
+    case 10:  return 'Mountain Bike';
+    case 52:  return 'Indoor Cycling';
+    case 99:  return 'Gravel';
+    case 105: return 'E-Bike';
+    case 106: return 'E-Mountain Bike';
+    case 109: return 'Hand Cycling';
+    case 114: return 'Cyclocross';
     case 2:
-    default:
-      return 'Cycling';
+    default:  return 'Cycling';
   }
 }

--- a/apps/api/src/types/suunto.ts
+++ b/apps/api/src/types/suunto.ts
@@ -1,0 +1,48 @@
+/**
+ * Suunto API Type Definitions
+ *
+ * Suunto CloudAPI workouts carry a numeric `activityId` that encodes the sport.
+ * Only a subset of IDs are cycling — the rest (running, swimming, etc.) should
+ * not become rides in Loam Logger.
+ *
+ * Activity IDs are documented in Suunto's public API reference; only the
+ * cycling-related IDs we consume are declared here. Extend this list if Suunto
+ * adds new cycling sub-types (e.g. gravel, BMX) that we want to track.
+ */
+
+/**
+ * Suunto activity IDs that represent cycling.
+ *
+ * - 2:  Cycling (road / general)
+ * - 10: Mountain biking
+ * - 37: Indoor cycling (trainer / spin class)
+ */
+export const SUUNTO_CYCLING_ACTIVITY_IDS = [2, 10, 37] as const;
+
+type SuuntoCyclingActivityId = (typeof SUUNTO_CYCLING_ACTIVITY_IDS)[number];
+
+/**
+ * True if the given Suunto activity ID is one of our tracked cycling sports.
+ */
+export function isSuuntoCyclingActivity(activityId: number): boolean {
+  return SUUNTO_CYCLING_ACTIVITY_IDS.includes(
+    activityId as SuuntoCyclingActivityId
+  );
+}
+
+/**
+ * Canonical ride type label for a Suunto cycling activity. Callers should only
+ * invoke this after `isSuuntoCyclingActivity` returns true; unknown activity
+ * IDs fall back to the generic "Cycling" label.
+ */
+export function getSuuntoRideType(activityId: number): string {
+  switch (activityId) {
+    case 10:
+      return 'Mountain Bike';
+    case 37:
+      return 'Indoor Cycling';
+    case 2:
+    default:
+      return 'Cycling';
+  }
+}

--- a/apps/api/src/workers/backfill.worker.test.ts
+++ b/apps/api/src/workers/backfill.worker.test.ts
@@ -17,22 +17,34 @@ jest.mock('../lib/rate-limit', () => ({
   releaseLock: jest.fn(),
 }));
 
-jest.mock('../lib/prisma', () => ({
-  prisma: {
+jest.mock('../lib/prisma', () => {
+  const prisma: Record<string, unknown> = {
     backfillRequest: {
       updateMany: jest.fn(),
       findUnique: jest.fn(),
+      upsert: jest.fn(),
     },
     ride: {
       findUnique: jest.fn(),
       upsert: jest.fn(),
+      create: jest.fn(),
     },
     importSession: {
       findFirst: jest.fn(),
       update: jest.fn(),
+      create: jest.fn(),
     },
-  },
-}));
+    // Needed by syncBikeComponentHours, which now runs inside the Garmin
+    // callback's $transaction wrapper as part of the component-hour fix.
+    component: { updateMany: jest.fn() },
+    bike: { findMany: jest.fn() },
+    userAccount: { findUnique: jest.fn() },
+    // Pass the same mock as the transaction client so any tx.* calls hit the
+    // same jest.fn instances the tests configure.
+    $transaction: jest.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(prisma)),
+  };
+  return { prisma };
+});
 
 jest.mock('../lib/garmin-token', () => ({
   getValidGarminToken: jest.fn(),
@@ -51,6 +63,15 @@ jest.mock('../lib/logger', () => ({
     error: jest.fn(),
   },
   logError: jest.fn(),
+  // suunto-token.ts (loaded transitively via backfill.worker → suunto handlers)
+  // calls createLogger at module load. Without this mock the test suite fails
+  // before any test runs.
+  createLogger: jest.fn(() => ({
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
 }));
 
 jest.mock('../config/env', () => ({

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -514,11 +514,15 @@ async function processSuuntoBackfill(userId: string, year: string): Promise<void
     });
   }
 
+  // Increment rather than overwrite so the cumulative count survives
+  // re-runs (e.g. YTD backfill called multiple times to pick up new
+  // workouts since the last checkpoint). Matches the synchronous
+  // /suunto/backfill/fetch endpoint's behavior.
   await prisma.backfillRequest.updateMany({
     where: { userId, provider: 'suunto', year },
     data: {
       status: 'completed',
-      ridesFound: importedCount,
+      ridesFound: { increment: importedCount },
       backfilledUpTo: endDate,
       completedAt: new Date(),
       updatedAt: new Date(),

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -5,12 +5,22 @@ import { getQueueConnection } from '../lib/queue/connection';
 import { acquireLock, releaseLock } from '../lib/rate-limit';
 import { prisma } from '../lib/prisma';
 import { getValidGarminToken } from '../lib/garmin-token';
+import { getValidSuuntoToken } from '../lib/suunto-token';
 import { deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
 import { logError, logger } from '../lib/logger';
 import { config } from '../config/env';
 import type { BackfillJobData, BackfillJobName } from '../lib/queue/backfill.queue';
 import { enqueueWeatherJob } from '../lib/queue';
 import { captureServerEvent } from '../lib/posthog';
+import { incrementBikeComponentHours, syncBikeComponentHours } from '../lib/component-hours';
+import { isSuuntoCyclingActivity, getSuuntoRideType } from '../types/suunto';
+import {
+  SUUNTO_API_BASE,
+  suuntoApiHeaders,
+  type SuuntoWorkout,
+  type SuuntoWorkoutsResponse,
+} from '../lib/suunto-sync';
+import { findPotentialDuplicates, type DuplicateCandidate } from '../lib/duplicate-detector';
 
 // Garmin API limits backfill requests to 30-day chunks
 const CHUNK_DAYS = 30;
@@ -110,6 +120,8 @@ async function processBackfillJob(job: Job<BackfillJobData, void, BackfillJobNam
   try {
     if (provider === 'garmin') {
       await processGarminBackfill(userId, year);
+    } else if (provider === 'suunto') {
+      await processSuuntoBackfill(userId, year);
     } else {
       throw new Error(`Unsupported provider for backfill: ${provider}`);
     }
@@ -286,6 +298,239 @@ async function processGarminBackfill(userId: string, year: string): Promise<void
   // when all activities have been delivered
 }
 
+// ============================================================================
+// SUUNTO BACKFILL
+// ============================================================================
+
+const SUUNTO_PAGE_LIMIT = 100;
+const SUUNTO_MAX_PAGES = 100;
+const SUUNTO_MIN_BACKFILL_YEAR = 2015;
+
+/**
+ * Process Suunto backfill for a specific year.
+ *
+ * Unlike Garmin, Suunto has no webhook-driven backfill mechanism. We page
+ * through GET /v3/workouts synchronously and upsert cycling rides directly.
+ * Cross-provider duplicate detection skips rides that already exist from
+ * Garmin/Strava/WHOOP on the same day.
+ */
+async function processSuuntoBackfill(userId: string, year: string): Promise<void> {
+  const accessToken = await getValidSuuntoToken(userId);
+
+  if (!accessToken) {
+    throw new Error('Suunto token expired or not connected');
+  }
+
+  const currentYear = new Date().getFullYear();
+  let startDate: Date;
+  let endDate: Date;
+
+  if (year === 'ytd') {
+    const existingYtd = await prisma.backfillRequest.findUnique({
+      where: { userId_provider_year: { userId, provider: 'suunto', year: 'ytd' } },
+    });
+
+    // Resume YTD from the last checkpoint if there is one. Note: status was
+    // already flipped to in_progress before we got here, so we rely solely on
+    // backfilledUpTo to tell us whether a prior run left us a checkpoint.
+    if (existingYtd?.backfilledUpTo) {
+      startDate = new Date(existingYtd.backfilledUpTo.getTime() + 1000);
+    } else {
+      startDate = new Date(currentYear, 0, 1);
+    }
+    endDate = new Date();
+  } else {
+    const yearNum = parseInt(year, 10);
+    if (isNaN(yearNum) || yearNum < SUUNTO_MIN_BACKFILL_YEAR || yearNum > currentYear) {
+      throw new Error(
+        `Invalid year: ${year}. Must be between ${SUUNTO_MIN_BACKFILL_YEAR} and ${currentYear}, or "ytd".`
+      );
+    }
+    startDate = new Date(yearNum, 0, 1);
+    endDate = new Date(yearNum, 11, 31, 23, 59, 59);
+  }
+
+  if (startDate >= endDate) {
+    logger.info({ userId, year }, '[BackfillWorker] Suunto backfill already up to date');
+    await prisma.backfillRequest.updateMany({
+      where: { userId, provider: 'suunto', year },
+      data: { status: 'completed', completedAt: new Date(), updatedAt: new Date() },
+    });
+    return;
+  }
+
+  logger.info(
+    { userId, year, startDate: startDate.toISOString(), endDate: endDate.toISOString() },
+    '[BackfillWorker] Starting Suunto backfill'
+  );
+
+  const workouts: SuuntoWorkout[] = [];
+  let offset = 0;
+  let pageCount = 0;
+
+  while (pageCount < SUUNTO_MAX_PAGES) {
+    const url = new URL(`${SUUNTO_API_BASE}/workouts`);
+    url.searchParams.set('since', String(startDate.getTime()));
+    url.searchParams.set('until', String(endDate.getTime()));
+    url.searchParams.set('limit', String(SUUNTO_PAGE_LIMIT));
+    url.searchParams.set('offset', String(offset));
+
+    const apiRes = await fetch(url.toString(), {
+      headers: suuntoApiHeaders(accessToken),
+    });
+
+    if (!apiRes.ok) {
+      const text = await apiRes.text();
+      throw new Error(`Suunto API error: ${apiRes.status} ${text.slice(0, 200)}`);
+    }
+
+    const page = (await apiRes.json()) as SuuntoWorkoutsResponse;
+    const records = page.payload ?? [];
+    workouts.push(...records);
+    pageCount++;
+
+    if (records.length < SUUNTO_PAGE_LIMIT) break;
+    offset += SUUNTO_PAGE_LIMIT;
+  }
+
+  if (pageCount >= SUUNTO_MAX_PAGES) {
+    logger.warn(
+      { userId, year, totalFetched: workouts.length },
+      '[BackfillWorker] Suunto page cap hit; some workouts may be missing'
+    );
+  }
+
+  const cyclingWorkouts = workouts.filter((w) => isSuuntoCyclingActivity(w.activityId));
+
+  // Auto-assign to the single active bike if the user has exactly one; Suunto
+  // has no gear tagging in the workout list so this is our only signal.
+  const userBikes = await prisma.bike.findMany({
+    where: { userId, status: 'ACTIVE' },
+    select: { id: true },
+  });
+  const autoAssignBikeId = userBikes.length === 1 ? userBikes[0].id : null;
+
+  // Look up running ImportSession so new rides get tagged for progress tracking.
+  const runningSession = await prisma.importSession.findFirst({
+    where: { userId, provider: 'suunto', status: 'running' },
+    select: { id: true },
+  });
+
+  let importedCount = 0;
+  let skippedCount = 0;
+  let duplicatesDetected = 0;
+
+  for (const workout of cyclingWorkouts) {
+    // Same-provider dedup via the unique index on suuntoWorkoutId.
+    const existing = await prisma.ride.findUnique({
+      where: { suuntoWorkoutId: workout.workoutKey },
+    });
+    if (existing) {
+      skippedCount++;
+      continue;
+    }
+
+    const startTime = new Date(workout.startTime);
+    const durationSeconds = workout.totalTime;
+    const durationHours = Math.max(0, durationSeconds) / 3600;
+    const distanceMeters = workout.totalDistance ?? 0;
+    const elevationGainMeters = workout.totalAscent ?? 0;
+    const averageHr = workout.hrdata?.workoutAvgHR != null
+      ? Math.round(workout.hrdata.workoutAvgHR)
+      : null;
+    const startLat = workout.startPosition?.y ?? null;
+    const startLng = workout.startPosition?.x ?? null;
+
+    // Cross-provider dedup: skip if an overlapping ride already came from
+    // Garmin/Strava/WHOOP on the same day.
+    const duplicateCandidate: DuplicateCandidate = {
+      id: '',
+      startTime,
+      durationSeconds,
+      distanceMeters,
+      elevationGainMeters,
+      garminActivityId: null,
+      stravaActivityId: null,
+      whoopWorkoutId: null,
+      suuntoWorkoutId: workout.workoutKey,
+    };
+
+    const duplicate = await findPotentialDuplicates(userId, duplicateCandidate, prisma);
+    if (duplicate) {
+      duplicatesDetected++;
+      skippedCount++;
+      continue;
+    }
+
+    let createdRideId: string | null = null;
+
+    await prisma.$transaction(async (tx) => {
+      const ride = await tx.ride.create({
+        data: {
+          userId,
+          suuntoWorkoutId: workout.workoutKey,
+          startTime,
+          durationSeconds,
+          distanceMeters,
+          elevationGainMeters,
+          averageHr,
+          rideType: getSuuntoRideType(workout.activityId),
+          startLat,
+          startLng,
+          bikeId: autoAssignBikeId,
+          importSessionId: runningSession?.id ?? null,
+        },
+        select: { id: true },
+      });
+
+      createdRideId = ride.id;
+
+      if (autoAssignBikeId) {
+        await incrementBikeComponentHours(tx, {
+          userId,
+          bikeId: autoAssignBikeId,
+          hoursDelta: durationHours,
+        });
+      }
+    });
+
+    importedCount++;
+
+    // Fire-and-forget weather fetch so the ride gets enriched later without
+    // blocking the backfill loop.
+    if (createdRideId && startLat != null && startLng != null) {
+      enqueueWeatherJob({ rideId: createdRideId }).catch((err) =>
+        logger.warn({ rideId: createdRideId, err }, '[BackfillWorker] Failed to enqueue weather job (Suunto)')
+      );
+    }
+  }
+
+  // Update session's lastActivityReceivedAt if any rides were created, so the
+  // idle-session checker doesn't prematurely close the import.
+  if (runningSession && importedCount > 0) {
+    await prisma.importSession.update({
+      where: { id: runningSession.id },
+      data: { lastActivityReceivedAt: new Date() },
+    });
+  }
+
+  await prisma.backfillRequest.updateMany({
+    where: { userId, provider: 'suunto', year },
+    data: {
+      status: 'completed',
+      ridesFound: importedCount,
+      backfilledUpTo: endDate,
+      completedAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+
+  logger.info(
+    { userId, year, imported: importedCount, skipped: skippedCount, duplicatesDetected },
+    '[BackfillWorker] Suunto backfill complete'
+  );
+}
+
 /**
  * Process a Garmin callback URL (used for backfill webhook responses).
  * Fetches activities from the callback URL and upserts them.
@@ -379,7 +624,7 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
 
     const existingRide = await prisma.ride.findUnique({
       where: { garminActivityId: activity.summaryId },
-      select: { location: true },
+      select: { location: true, bikeId: true, durationSeconds: true },
     });
 
     const locationUpdate = shouldApplyAutoLocation(
@@ -390,39 +635,53 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
     const startLat = activity.startLatitudeInDegrees ?? activity.beginLatitude ?? null;
     const startLng = activity.startLongitudeInDegrees ?? activity.beginLongitude ?? null;
 
-    // Upsert the ride
-    const upsertedRide = await prisma.ride.upsert({
-      where: { garminActivityId: activity.summaryId },
-      create: {
+    // Upsert the ride + sync component hours together so callback-delivered
+    // rides match the behavior of webhook-delivered ones (see sync.worker.ts
+    // `upsertGarminActivity`). Missing this was why Garmin backfill-imported
+    // rides didn't accrue component wear.
+    const upsertedRide = await prisma.$transaction(async (tx) => {
+      const ride = await tx.ride.upsert({
+        where: { garminActivityId: activity.summaryId },
+        create: {
+          userId,
+          garminActivityId: activity.summaryId,
+          startTime,
+          durationSeconds: activity.durationInSeconds,
+          distanceMeters,
+          elevationGainMeters,
+          averageHr: activity.averageHeartRateInBeatsPerMinute ?? null,
+          rideType: activity.activityType,
+          notes: activity.activityName ?? null,
+          location: autoLocation?.title ?? null,
+          importSessionId: runningSession?.id ?? null,
+          startLat,
+          startLng,
+        },
+        update: {
+          startTime,
+          durationSeconds: activity.durationInSeconds,
+          distanceMeters,
+          elevationGainMeters,
+          averageHr: activity.averageHeartRateInBeatsPerMinute ?? null,
+          rideType: activity.activityType,
+          notes: activity.activityName ?? null,
+          ...(locationUpdate !== undefined ? { location: locationUpdate } : {}),
+          // Known limitation: coords are only written, never cleared on
+          // re-sync. See sync.worker.ts for full rationale.
+          ...(startLat != null ? { startLat } : {}),
+          ...(startLng != null ? { startLng } : {}),
+        },
+        select: { id: true, bikeId: true, durationSeconds: true },
+      });
+
+      await syncBikeComponentHours(
+        tx,
         userId,
-        garminActivityId: activity.summaryId,
-        startTime,
-        durationSeconds: activity.durationInSeconds,
-        distanceMeters,
-        elevationGainMeters,
-        averageHr: activity.averageHeartRateInBeatsPerMinute ?? null,
-        rideType: activity.activityType,
-        notes: activity.activityName ?? null,
-        location: autoLocation?.title ?? null,
-        importSessionId: runningSession?.id ?? null,
-        startLat,
-        startLng,
-      },
-      update: {
-        startTime,
-        durationSeconds: activity.durationInSeconds,
-        distanceMeters,
-        elevationGainMeters,
-        averageHr: activity.averageHeartRateInBeatsPerMinute ?? null,
-        rideType: activity.activityType,
-        notes: activity.activityName ?? null,
-        ...(locationUpdate !== undefined ? { location: locationUpdate } : {}),
-        // Known limitation: coords are only written, never cleared on
-        // re-sync. See sync.worker.ts for full rationale.
-        ...(startLat != null ? { startLat } : {}),
-        ...(startLng != null ? { startLng } : {}),
-      },
-      select: { id: true },
+        { bikeId: existingRide?.bikeId ?? null, durationSeconds: existingRide?.durationSeconds ?? null },
+        { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds }
+      );
+
+      return ride;
     });
 
     if (startLat != null && startLng != null) {

--- a/apps/api/src/workers/sync.worker.test.ts
+++ b/apps/api/src/workers/sync.worker.test.ts
@@ -91,6 +91,22 @@ const mockGetValidGarminToken = getValidGarminToken as jest.MockedFunction<typeo
 const mockGetValidSuuntoToken = getValidSuuntoToken as jest.MockedFunction<typeof getValidSuuntoToken>;
 const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
 
+// The Suunto code path calls `suuntoApiHeaders()` which throws if
+// SUUNTO_SUBSCRIPTION_KEY is unset. Local dev machines usually have it via
+// .env, but CI / fresh clones don't — so set it explicitly here to keep the
+// test deterministic. Mirrors the pattern in suunto.backfill.test.ts.
+const originalSuuntoSubscriptionKey = process.env.SUUNTO_SUBSCRIPTION_KEY;
+beforeAll(() => {
+  process.env.SUUNTO_SUBSCRIPTION_KEY = 'test-subscription-key';
+});
+afterAll(() => {
+  if (originalSuuntoSubscriptionKey === undefined) {
+    delete process.env.SUUNTO_SUBSCRIPTION_KEY;
+  } else {
+    process.env.SUUNTO_SUBSCRIPTION_KEY = originalSuuntoSubscriptionKey;
+  }
+});
+
 describe('createSyncWorker', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/apps/api/src/workers/sync.worker.test.ts
+++ b/apps/api/src/workers/sync.worker.test.ts
@@ -45,6 +45,10 @@ jest.mock('../lib/whoop-token', () => ({
   getValidWhoopToken: jest.fn(),
 }));
 
+jest.mock('../lib/suunto-token', () => ({
+  getValidSuuntoToken: jest.fn(),
+}));
+
 jest.mock('../lib/queue/notification.queue', () => ({
   enqueueReceiptCheck: jest.fn().mockResolvedValue(undefined),
 }));
@@ -75,6 +79,7 @@ import { prisma } from '../lib/prisma';
 import { getValidStravaToken } from '../lib/strava-token';
 import { getValidGarminToken } from '../lib/garmin-token';
 import { getValidWhoopToken } from '../lib/whoop-token';
+import { getValidSuuntoToken } from '../lib/suunto-token';
 
 const MockedWorker = Worker as jest.MockedClass<typeof Worker>;
 const mockAcquireLock = acquireLock as jest.MockedFunction<typeof acquireLock>;
@@ -83,6 +88,7 @@ const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockGetValidStravaToken = getValidStravaToken as jest.MockedFunction<typeof getValidStravaToken>;
 const mockGetValidWhoopToken = getValidWhoopToken as jest.MockedFunction<typeof getValidWhoopToken>;
 const mockGetValidGarminToken = getValidGarminToken as jest.MockedFunction<typeof getValidGarminToken>;
+const mockGetValidSuuntoToken = getValidSuuntoToken as jest.MockedFunction<typeof getValidSuuntoToken>;
 const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
 
 describe('createSyncWorker', () => {
@@ -339,19 +345,34 @@ describe('processSyncJob (via worker processor)', () => {
       ).rejects.toThrow('No valid Garmin token available');
     });
 
-    it('should handle suunto provider gracefully', async () => {
+    it('should sync Suunto workouts', async () => {
       mockAcquireLock.mockResolvedValue({
         acquired: true,
         lockKey: 'lock:suunto:user123',
         lockValue: 'value123',
         redisAvailable: true,
       });
+      mockGetValidSuuntoToken.mockResolvedValue('valid-suunto-token');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(''),
+        json: () => Promise.resolve({ payload: [], metadata: {} }),
+      } as Response);
 
-      // Should not throw
       await processSyncJob({
         name: 'syncLatest',
         data: { userId: 'user123', provider: 'suunto' },
       });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('cloudapi.suunto.com/v3/workouts'),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer valid-suunto-token',
+          }),
+        })
+      );
+      expect(mockReleaseLock).toHaveBeenCalled();
     });
 
     it('should sync WHOOP workouts', async () => {

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -918,8 +918,20 @@ async function syncSuuntoLatest(userId: string): Promise<void> {
 
   logger.debug({ count: cyclingWorkouts.length }, '[SyncWorker] Processing cycling workouts');
 
+  // Hoist the active-bikes query out of the loop so we don't repeat it for
+  // every workout. The result feeds upsertSuuntoActivity's auto-assign logic
+  // for new rides — bike membership doesn't realistically change mid-sync,
+  // and even if it did, snapshotting at the start of the run is the right
+  // semantic (don't auto-assign to a bike the user just deleted).
+  const userBikes = cyclingWorkouts.length > 0
+    ? await prisma.bike.findMany({
+        where: { userId, status: 'ACTIVE' },
+        select: { id: true },
+      })
+    : [];
+
   for (const workout of cyclingWorkouts) {
-    await upsertSuuntoActivity(userId, workout);
+    await upsertSuuntoActivity(userId, workout, userBikes);
   }
 
   logger.info({ userId, count: cyclingWorkouts.length }, '[SyncWorker] Suunto sync complete');
@@ -965,7 +977,14 @@ async function syncSuuntoActivity(userId: string, workoutKey: string): Promise<v
   await upsertSuuntoActivity(userId, workout);
 }
 
-async function upsertSuuntoActivity(userId: string, workout: SuuntoWorkout): Promise<void> {
+async function upsertSuuntoActivity(
+  userId: string,
+  workout: SuuntoWorkout,
+  // Optional pre-fetched bike list: callers processing a batch (syncSuuntoLatest)
+  // pass it in to avoid re-querying per workout. Single-workout callers
+  // (syncSuuntoActivity) omit it — we only query on demand when isNewRide.
+  prefetchedUserBikes?: { id: string }[],
+): Promise<void> {
   const startTime = new Date(workout.startTime);
   const durationSeconds = workout.totalTime;
   const distanceMeters = workout.totalDistance ?? 0;
@@ -988,7 +1007,7 @@ async function upsertSuuntoActivity(userId: string, workout: SuuntoWorkout): Pro
   // assignments on re-sync, matching the Garmin pattern.
   let bikeId: string | null = null;
   if (isNewRide) {
-    const userBikes = await prisma.bike.findMany({
+    const userBikes = prefetchedUserBikes ?? await prisma.bike.findMany({
       where: { userId, status: 'ACTIVE' },
       select: { id: true },
     });

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -638,7 +638,25 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
       );
     });
   } catch (err) {
-    logger.error({ err, userId, rideId: ride.id }, '[SyncWorker] Failed to sync component hours for Garmin activity');
+    // Orphaned-hours warning: the ride upsert succeeded but its component
+    // hours weren't credited. A future re-sync can't auto-recover this —
+    // syncBikeComponentHours diffs prev vs next, and once the ride is in the
+    // DB both sides match, so the diff is zero. Log the bikeId + duration
+    // so an admin can credit the hours manually, and ship to Sentry so it's
+    // visible at trigger time rather than buried in log volume.
+    logger.error({
+      event: 'orphaned_component_hours',
+      provider: 'garmin',
+      err,
+      userId,
+      rideId: ride.id,
+      bikeId: ride.bikeId,
+      durationSeconds: ride.durationSeconds,
+    }, '[SyncWorker] Failed to sync component hours for Garmin activity — manual recovery required');
+    Sentry.captureException(err, {
+      tags: { worker: 'sync', provider: 'garmin', issue: 'orphaned_component_hours' },
+      extra: { userId, rideId: ride.id, bikeId: ride.bikeId, durationSeconds: ride.durationSeconds },
+    });
   }
 
   // Update session's lastActivityReceivedAt if there's a running session
@@ -1020,7 +1038,25 @@ async function upsertSuuntoActivity(userId: string, workout: SuuntoWorkout): Pro
       );
     });
   } catch (err) {
-    logger.error({ err, userId, rideId: ride.id }, '[SyncWorker] Failed to sync component hours for Suunto workout');
+    // Orphaned-hours warning: the ride upsert succeeded but its component
+    // hours weren't credited. A future re-sync can't auto-recover this —
+    // syncBikeComponentHours diffs prev vs next, and once the ride is in the
+    // DB both sides match, so the diff is zero. Log the bikeId + duration
+    // so an admin can credit the hours manually, and ship to Sentry so it's
+    // visible at trigger time rather than buried in log volume.
+    logger.error({
+      event: 'orphaned_component_hours',
+      provider: 'suunto',
+      err,
+      userId,
+      rideId: ride.id,
+      bikeId: ride.bikeId,
+      durationSeconds: ride.durationSeconds,
+    }, '[SyncWorker] Failed to sync component hours for Suunto workout — manual recovery required');
+    Sentry.captureException(err, {
+      tags: { worker: 'sync', provider: 'suunto', issue: 'orphaned_component_hours' },
+      extra: { userId, rideId: ride.id, bikeId: ride.bikeId, durationSeconds: ride.durationSeconds },
+    });
   }
 
   logger.debug({ suuntoWorkoutId: workout.workoutKey }, '[SyncWorker] Upserted Suunto workout');

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -7,8 +7,9 @@ import { prisma } from '../lib/prisma';
 import { getValidStravaToken } from '../lib/strava-token';
 import { getValidGarminToken } from '../lib/garmin-token';
 import { getValidWhoopToken } from '../lib/whoop-token';
+import { getValidSuuntoToken } from '../lib/suunto-token';
 import { deriveLocation, deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
-import { incrementBikeComponentHours, decrementBikeComponentHours } from '../lib/component-hours';
+import { syncBikeComponentHours } from '../lib/component-hours';
 import { logger } from '../lib/logger';
 import { fireRideNotifications } from '../services/notification.service';
 import { completeReferral } from '../services/referral.service';
@@ -24,6 +25,13 @@ import {
   type WhoopWorkout,
   type WhoopPaginatedResponse,
 } from '../types/whoop';
+import { isSuuntoCyclingActivity, getSuuntoRideType } from '../types/suunto';
+import {
+  SUUNTO_API_BASE,
+  suuntoApiHeaders,
+  type SuuntoWorkout,
+  type SuuntoWorkoutsResponse,
+} from '../lib/suunto-sync';
 
 // Retry delay when lock acquisition fails (30 seconds)
 const LOCK_RETRY_DELAY = 30 * 1000;
@@ -160,7 +168,7 @@ async function syncLatestActivities(userId: string, provider: SyncProvider): Pro
       await syncWhoopLatest(userId);
       break;
     case 'suunto':
-      logger.warn({ provider: 'suunto' }, '[SyncWorker] Suunto sync not yet implemented');
+      await syncSuuntoLatest(userId);
       break;
     default:
       throw new Error(`Unknown provider: ${provider}`);
@@ -188,7 +196,7 @@ async function syncSingleActivity(
       await syncWhoopActivity(userId, activityId);
       break;
     case 'suunto':
-      logger.warn({ provider: 'suunto' }, '[SyncWorker] Suunto sync not yet implemented');
+      await syncSuuntoActivity(userId, activityId);
       break;
     default:
       throw new Error(`Unknown provider: ${provider}`);
@@ -843,39 +851,199 @@ async function upsertWhoopActivity(userId: string, workout: WhoopWorkout): Promi
 }
 
 // ============================================================================
-// HELPER FUNCTIONS
+// SUUNTO SYNC
 // ============================================================================
 
-const secondsToHours = (seconds: number | null | undefined) =>
-  Math.max(0, seconds ?? 0) / 3600;
+async function syncSuuntoLatest(userId: string): Promise<void> {
+  const accessToken = await getValidSuuntoToken(userId);
 
-async function syncBikeComponentHours(
-  tx: Prisma.TransactionClient,
-  userId: string,
-  previous: { bikeId: string | null; durationSeconds: number | null | undefined },
-  next: { bikeId: string | null; durationSeconds: number | null | undefined }
-): Promise<void> {
-  const prevBikeId = previous.bikeId;
-  const nextBikeId = next.bikeId;
-  const prevHours = secondsToHours(previous.durationSeconds);
-  const nextHours = secondsToHours(next.durationSeconds);
-  const bikeChanged = prevBikeId !== nextBikeId;
-  const hoursDiff = nextHours - prevHours;
+  if (!accessToken) {
+    throw new Error('No valid Suunto token available');
+  }
 
-  if (prevBikeId) {
-    if (bikeChanged) {
-      await decrementBikeComponentHours(tx, { userId, bikeId: prevBikeId, hoursDelta: prevHours });
-    } else if (hoursDiff < 0) {
-      await decrementBikeComponentHours(tx, { userId, bikeId: prevBikeId, hoursDelta: Math.abs(hoursDiff) });
+  // Fetch workouts from the last 30 days. Suunto's `/v3/workouts` uses epoch ms
+  // for `since`/`until` and paginates via offset/limit (no cursor).
+  const thirtyDaysAgoMs = Date.now() - 30 * 24 * 60 * 60 * 1000;
+  const nowMs = Date.now();
+  const LIMIT = 100;
+  const MAX_PAGES = 10; // 1000 workouts in 30 days is already an absurd ceiling
+  const workouts: SuuntoWorkout[] = [];
+  let offset = 0;
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const url = new URL(`${SUUNTO_API_BASE}/workouts`);
+    url.searchParams.set('since', String(thirtyDaysAgoMs));
+    url.searchParams.set('until', String(nowMs));
+    url.searchParams.set('limit', String(LIMIT));
+    url.searchParams.set('offset', String(offset));
+
+    const response = await fetch(url.toString(), {
+      headers: suuntoApiHeaders(accessToken),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Suunto API error: ${response.status} ${text.slice(0, 200)}`);
+    }
+
+    const body = (await response.json()) as SuuntoWorkoutsResponse;
+    const records = body.payload ?? [];
+    workouts.push(...records);
+
+    if (records.length < LIMIT) break;
+    offset += LIMIT;
+  }
+
+  logger.debug({ count: workouts.length }, '[SyncWorker] Fetched Suunto workouts');
+
+  const cyclingWorkouts = workouts.filter((w) => isSuuntoCyclingActivity(w.activityId));
+
+  logger.debug({ count: cyclingWorkouts.length }, '[SyncWorker] Processing cycling workouts');
+
+  for (const workout of cyclingWorkouts) {
+    await upsertSuuntoActivity(userId, workout);
+  }
+
+  logger.info({ userId, count: cyclingWorkouts.length }, '[SyncWorker] Suunto sync complete');
+}
+
+async function syncSuuntoActivity(userId: string, workoutKey: string): Promise<void> {
+  const accessToken = await getValidSuuntoToken(userId);
+
+  if (!accessToken) {
+    throw new Error('No valid Suunto token available');
+  }
+
+  const response = await fetch(`${SUUNTO_API_BASE}/workouts/${workoutKey}`, {
+    headers: suuntoApiHeaders(accessToken),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Suunto API error: ${response.status} ${text.slice(0, 200)}`);
+  }
+
+  // Single-workout responses use the same envelope as the list endpoint but
+  // with a single-element payload. Unwrap defensively — if the API ever
+  // returns the bare workout object, accept that too.
+  const body = (await response.json()) as SuuntoWorkoutsResponse | SuuntoWorkout;
+  const workout: SuuntoWorkout | undefined = 'payload' in body
+    ? body.payload?.[0]
+    : body;
+
+  if (!workout) {
+    logger.warn({ workoutKey }, '[SyncWorker] Suunto workout response empty');
+    return;
+  }
+
+  if (!isSuuntoCyclingActivity(workout.activityId)) {
+    logger.debug(
+      { workoutKey, activityId: workout.activityId },
+      '[SyncWorker] Skipping non-cycling Suunto workout'
+    );
+    return;
+  }
+
+  await upsertSuuntoActivity(userId, workout);
+}
+
+async function upsertSuuntoActivity(userId: string, workout: SuuntoWorkout): Promise<void> {
+  const startTime = new Date(workout.startTime);
+  const durationSeconds = workout.totalTime;
+  const distanceMeters = workout.totalDistance ?? 0;
+  const elevationGainMeters = workout.totalAscent ?? 0;
+  const startLat = workout.startPosition?.y ?? null;
+  const startLng = workout.startPosition?.x ?? null;
+  const averageHr = workout.hrdata?.workoutAvgHR != null
+    ? Math.round(workout.hrdata.workoutAvgHR)
+    : null;
+  const rideType = getSuuntoRideType(workout.activityId);
+
+  const existing = await prisma.ride.findUnique({
+    where: { suuntoWorkoutId: workout.workoutKey },
+    select: { id: true, durationSeconds: true, bikeId: true },
+  });
+
+  const isNewRide = !existing;
+
+  // Auto-assign single active bike only on new rides — preserves manual
+  // assignments on re-sync, matching the Garmin pattern.
+  let bikeId: string | null = null;
+  if (isNewRide) {
+    const userBikes = await prisma.bike.findMany({
+      where: { userId, status: 'ACTIVE' },
+      select: { id: true },
+    });
+    if (userBikes.length === 1) {
+      bikeId = userBikes[0].id;
     }
   }
 
-  if (nextBikeId) {
-    if (bikeChanged) {
-      await incrementBikeComponentHours(tx, { userId, bikeId: nextBikeId, hoursDelta: nextHours });
-    } else if (hoursDiff > 0) {
-      await incrementBikeComponentHours(tx, { userId, bikeId: nextBikeId, hoursDelta: hoursDiff });
-    }
+  // Upsert ride first — this is the primary data, must not be lost if the
+  // component-hour sync fails.
+  const ride = await prisma.ride.upsert({
+    where: { suuntoWorkoutId: workout.workoutKey },
+    create: {
+      userId,
+      suuntoWorkoutId: workout.workoutKey,
+      startTime,
+      durationSeconds,
+      distanceMeters,
+      elevationGainMeters,
+      averageHr,
+      rideType,
+      bikeId,
+      startLat,
+      startLng,
+    },
+    update: {
+      startTime,
+      durationSeconds,
+      distanceMeters,
+      elevationGainMeters,
+      averageHr,
+      rideType,
+      ...(startLat != null ? { startLat } : {}),
+      ...(startLng != null ? { startLng } : {}),
+    },
+  });
+
+  // Component hours are secondary — a failure here should not roll back the
+  // ride because Suunto won't re-deliver it.
+  try {
+    await prisma.$transaction(async (tx) => {
+      await syncBikeComponentHours(
+        tx,
+        userId,
+        { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
+        { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds }
+      );
+    });
+  } catch (err) {
+    logger.error({ err, userId, rideId: ride.id }, '[SyncWorker] Failed to sync component hours for Suunto workout');
+  }
+
+  logger.debug({ suuntoWorkoutId: workout.workoutKey }, '[SyncWorker] Upserted Suunto workout');
+
+  // Fire-and-forget weather fetch
+  if (startLat != null && startLng != null) {
+    enqueueWeatherJob({ rideId: ride.id }).catch((err) =>
+      logger.warn({ rideId: ride.id, err }, '[SyncWorker] Failed to enqueue weather job (Suunto)')
+    );
+  }
+
+  // Fire-and-forget notifications
+  fireRideNotifications({
+    userId,
+    rideId: ride.id,
+    bikeId: ride.bikeId ?? null,
+    durationSeconds,
+    distanceMeters,
+    isNewRide,
+  }).catch(() => {}); // swallow - already logged internally
+
+  if (isNewRide) {
+    completeReferral(userId).catch(() => {}); // swallow - already logged internally
   }
 }
 

--- a/apps/web/src/components/ConnectGarminLink.tsx
+++ b/apps/web/src/components/ConnectGarminLink.tsx
@@ -1,36 +1,22 @@
-import { useState } from "react"
 import { Mountain } from "lucide-react"
 
 const apiBase =
   (import.meta.env.VITE_API_URL ?? "").replace(/\/$/, "") ||
   (import.meta.env.DEV ? "http://localhost:4000" : "")
 
+// Anchor rather than button+JS — `window.location.href = ...` never throws
+// so the prior try/catch was dead code and could leave the button stuck in
+// "Connecting...". Anchor navigates natively, supports right-click open in
+// new tab, works without JavaScript, and has no stuck state.
 export default function ConnectGarminLink() {
-  const [isConnecting, setIsConnecting] = useState(false)
-
-  const handleConnect = () => {
-    try {
-      setIsConnecting(true)
-      window.location.href = `${apiBase}/auth/garmin/start`
-    } catch (err) {
-      console.error('Failed to initiate Garmin OAuth:', err)
-      alert('Failed to connect to Garmin. Please try again.')
-      setIsConnecting(false)
-    }
-  }
-
   return (
-    <button
-      onClick={handleConnect}
-      disabled={isConnecting}
-      className={`flex items-center justify-center gap-3 w-full rounded-2xl border px-4 py-3 font-medium transition
-        ${isConnecting
-          ? 'border-app/70 bg-surface-2/50 text-muted cursor-wait opacity-50'
-          : 'border-[#11A9ED]/50 bg-[#11A9ED]/20 text-[#11A9ED] hover:bg-[#11A9ED]/30 hover:border-[#11A9ED]/70 hover:cursor-pointer'
-        }`}
+    <a
+      href={`${apiBase}/auth/garmin/start`}
+      className="flex items-center justify-center gap-3 w-full rounded-2xl border px-4 py-3 font-medium transition no-underline
+        border-[#11A9ED]/50 bg-[#11A9ED]/20 text-[#11A9ED] hover:bg-[#11A9ED]/30 hover:border-[#11A9ED]/70 hover:cursor-pointer"
     >
       <Mountain size={18} />
-      <span>{isConnecting ? 'Connecting...' : 'Connect Garmin'}</span>
-    </button>
+      <span>Connect Garmin</span>
+    </a>
   )
 }

--- a/apps/web/src/components/ConnectStravaLink.tsx
+++ b/apps/web/src/components/ConnectStravaLink.tsx
@@ -1,36 +1,22 @@
-import { useState } from "react"
 import { StravaIcon } from './icons/BrandIcons'
 
 const apiBase =
   (import.meta.env.VITE_API_URL ?? "").replace(/\/$/, "") ||
   (import.meta.env.DEV ? "http://localhost:4000" : "")
 
+// Anchor rather than button+JS — `window.location.href = ...` never throws
+// so the prior try/catch was dead code and could leave the button stuck in
+// "Connecting...". Anchor navigates natively, supports right-click open in
+// new tab, works without JavaScript, and has no stuck state.
 export default function ConnectStravaLink() {
-  const [isConnecting, setIsConnecting] = useState(false)
-
-  const handleConnect = () => {
-    try {
-      setIsConnecting(true)
-      window.location.href = `${apiBase}/auth/strava/start`
-    } catch (err) {
-      console.error('Failed to initiate Strava OAuth:', err)
-      alert('Failed to connect to Strava. Please try again.')
-      setIsConnecting(false)
-    }
-  }
-
   return (
-    <button
-      onClick={handleConnect}
-      disabled={isConnecting}
-      className={`flex items-center justify-center gap-3 w-full rounded-2xl border px-4 py-3 font-medium transition
-        ${isConnecting
-          ? 'border-app/70 bg-surface-2/50 text-muted cursor-wait opacity-50'
-          : 'border-[#FC4C02]/50 bg-[#FC4C02]/20 text-[#FC4C02] hover:bg-[#FC4C02]/30 hover:border-[#FC4C02]/70 hover:cursor-pointer'
-        }`}
+    <a
+      href={`${apiBase}/auth/strava/start`}
+      className="flex items-center justify-center gap-3 w-full rounded-2xl border px-4 py-3 font-medium transition no-underline
+        border-[#FC4C02]/50 bg-[#FC4C02]/20 text-[#FC4C02] hover:bg-[#FC4C02]/30 hover:border-[#FC4C02]/70 hover:cursor-pointer"
     >
       <StravaIcon size={18} />
-      <span>{isConnecting ? 'Connecting...' : 'Connect Strava'}</span>
-    </button>
+      <span>Connect Strava</span>
+    </a>
   )
 }

--- a/apps/web/src/components/ConnectSuuntoLink.tsx
+++ b/apps/web/src/components/ConnectSuuntoLink.tsx
@@ -1,36 +1,24 @@
-import { useState } from "react"
 import { SuuntoIcon } from './icons/BrandIcons'
 
 const apiBase =
   (import.meta.env.VITE_API_URL ?? "").replace(/\/$/, "") ||
   (import.meta.env.DEV ? "http://localhost:4000" : "")
 
+// Rendered as an anchor rather than a button+JS navigation. The previous
+// button-driven version used `window.location.href = ...` wrapped in a
+// try/catch, but assigning to `location.href` never throws, so the catch
+// was dead code — if navigation was blocked, the "Connecting..." state
+// would stick forever. An anchor: navigates natively, supports right-click
+// "open in new tab", works without JavaScript, and has no stuck state.
 export default function ConnectSuuntoLink() {
-  const [isConnecting, setIsConnecting] = useState(false)
-
-  const handleConnect = () => {
-    try {
-      setIsConnecting(true)
-      window.location.href = `${apiBase}/auth/suunto/start`
-    } catch (err) {
-      console.error('Failed to initiate Suunto OAuth:', err)
-      alert('Failed to connect to Suunto. Please try again.')
-      setIsConnecting(false)
-    }
-  }
-
   return (
-    <button
-      onClick={handleConnect}
-      disabled={isConnecting}
-      className={`flex items-center justify-center gap-3 w-full rounded-2xl border px-4 py-3 font-medium transition
-        ${isConnecting
-          ? 'border-app/70 bg-surface-2/50 text-muted cursor-wait opacity-50'
-          : 'border-[#0072CE]/50 bg-[#0072CE]/20 text-[#0072CE] hover:bg-[#0072CE]/30 hover:border-[#0072CE]/70 hover:cursor-pointer'
-        }`}
+    <a
+      href={`${apiBase}/auth/suunto/start`}
+      className="flex items-center justify-center gap-3 w-full rounded-2xl border px-4 py-3 font-medium transition no-underline
+        border-[#0072CE]/50 bg-[#0072CE]/20 text-[#0072CE] hover:bg-[#0072CE]/30 hover:border-[#0072CE]/70 hover:cursor-pointer"
     >
       <SuuntoIcon size={18} />
-      <span>{isConnecting ? 'Connecting...' : 'Connect Suunto'}</span>
-    </button>
+      <span>Connect Suunto</span>
+    </a>
   )
 }

--- a/apps/web/src/components/ConnectSuuntoLink.tsx
+++ b/apps/web/src/components/ConnectSuuntoLink.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react"
+import { SuuntoIcon } from './icons/BrandIcons'
+
+const apiBase =
+  (import.meta.env.VITE_API_URL ?? "").replace(/\/$/, "") ||
+  (import.meta.env.DEV ? "http://localhost:4000" : "")
+
+export default function ConnectSuuntoLink() {
+  const [isConnecting, setIsConnecting] = useState(false)
+
+  const handleConnect = () => {
+    try {
+      setIsConnecting(true)
+      window.location.href = `${apiBase}/auth/suunto/start`
+    } catch (err) {
+      console.error('Failed to initiate Suunto OAuth:', err)
+      alert('Failed to connect to Suunto. Please try again.')
+      setIsConnecting(false)
+    }
+  }
+
+  return (
+    <button
+      onClick={handleConnect}
+      disabled={isConnecting}
+      className={`flex items-center justify-center gap-3 w-full rounded-2xl border px-4 py-3 font-medium transition
+        ${isConnecting
+          ? 'border-app/70 bg-surface-2/50 text-muted cursor-wait opacity-50'
+          : 'border-[#0072CE]/50 bg-[#0072CE]/20 text-[#0072CE] hover:bg-[#0072CE]/30 hover:border-[#0072CE]/70 hover:cursor-pointer'
+        }`}
+    >
+      <SuuntoIcon size={18} />
+      <span>{isConnecting ? 'Connecting...' : 'Connect Suunto'}</span>
+    </button>
+  )
+}

--- a/apps/web/src/components/ConnectWhoopLink.tsx
+++ b/apps/web/src/components/ConnectWhoopLink.tsx
@@ -1,36 +1,22 @@
-import { useState } from "react"
 import { Activity } from "lucide-react"
 
 const apiBase =
   (import.meta.env.VITE_API_URL ?? "").replace(/\/$/, "") ||
   (import.meta.env.DEV ? "http://localhost:4000" : "")
 
+// Anchor rather than button+JS — `window.location.href = ...` never throws
+// so the prior try/catch was dead code and could leave the button stuck in
+// "Connecting...". Anchor navigates natively, supports right-click open in
+// new tab, works without JavaScript, and has no stuck state.
 export default function ConnectWhoopLink() {
-  const [isConnecting, setIsConnecting] = useState(false)
-
-  const handleConnect = () => {
-    try {
-      setIsConnecting(true)
-      window.location.href = `${apiBase}/auth/whoop/start`
-    } catch (err) {
-      console.error('Failed to initiate WHOOP OAuth:', err)
-      alert('Failed to connect to WHOOP. Please try again.')
-      setIsConnecting(false)
-    }
-  }
-
   return (
-    <button
-      onClick={handleConnect}
-      disabled={isConnecting}
-      className={`flex items-center justify-center gap-3 w-full rounded-2xl border px-4 py-3 font-medium transition
-        ${isConnecting
-          ? 'border-app/70 bg-surface-2/50 text-muted cursor-wait opacity-50'
-          : 'border-[#00FF87]/50 bg-[#00FF87]/10 text-[#00FF87] hover:bg-[#00FF87]/20 hover:border-[#00FF87]/70 hover:cursor-pointer'
-        }`}
+    <a
+      href={`${apiBase}/auth/whoop/start`}
+      className="flex items-center justify-center gap-3 w-full rounded-2xl border px-4 py-3 font-medium transition no-underline
+        border-[#00FF87]/50 bg-[#00FF87]/10 text-[#00FF87] hover:bg-[#00FF87]/20 hover:border-[#00FF87]/70 hover:cursor-pointer"
     >
       <Activity size={18} />
-      <span>{isConnecting ? 'Connecting...' : 'Connect WHOOP'}</span>
-    </button>
+      <span>Connect WHOOP</span>
+    </a>
   )
 }

--- a/apps/web/src/components/DataSourceSelector.tsx
+++ b/apps/web/src/components/DataSourceSelector.tsx
@@ -28,6 +28,12 @@ export default function DataSourceSelector({ currentSource, hasGarmin, hasStrava
         <p className="text-body-muted mt-1">
           Choose which provider to sync activities from. Only one can be active at a time.
         </p>
+        <p className="text-body-muted mt-2 text-sm">
+          Real-time ride uploads from the other connected providers are ignored while this is set.
+          This prevents duplicate imports when, for example, your watch auto-uploads to both
+          Strava and Garmin. You can switch at any time, or disconnect a provider entirely in
+          the section above.
+        </p>
       </div>
 
       <div className={`grid gap-4 ${gridCols}`}>

--- a/apps/web/src/components/DataSourceSelector.tsx
+++ b/apps/web/src/components/DataSourceSelector.tsx
@@ -1,21 +1,24 @@
 import { Mountain, Activity } from 'lucide-react';
-import { StravaIcon } from './icons/BrandIcons';
+import { StravaIcon, SuuntoIcon } from './icons/BrandIcons';
 
 type Props = {
-  currentSource: 'garmin' | 'strava' | 'whoop' | null;
+  currentSource: 'garmin' | 'strava' | 'whoop' | 'suunto' | null;
   hasGarmin: boolean;
   hasStrava: boolean;
   hasWhoop?: boolean;
-  onSelect: (provider: 'garmin' | 'strava' | 'whoop') => void;
+  hasSuunto?: boolean;
+  onSelect: (provider: 'garmin' | 'strava' | 'whoop' | 'suunto') => void;
 };
 
-export default function DataSourceSelector({ currentSource, hasGarmin, hasStrava, hasWhoop = false, onSelect }: Props) {
+export default function DataSourceSelector({ currentSource, hasGarmin, hasStrava, hasWhoop = false, hasSuunto = false, onSelect }: Props) {
   // Count connected providers
-  const connectedCount = [hasGarmin, hasStrava, hasWhoop].filter(Boolean).length;
+  const connectedCount = [hasGarmin, hasStrava, hasWhoop, hasSuunto].filter(Boolean).length;
 
   if (connectedCount < 2) {
     return null; // Only show if multiple providers are connected
   }
+
+  const gridCols = connectedCount >= 4 ? 'grid-cols-4' : connectedCount === 3 ? 'grid-cols-3' : 'grid-cols-2';
 
   return (
     <div className="space-y-4">
@@ -27,7 +30,7 @@ export default function DataSourceSelector({ currentSource, hasGarmin, hasStrava
         </p>
       </div>
 
-      <div className={`grid gap-4 ${connectedCount === 3 ? 'grid-cols-3' : 'grid-cols-2'}`}>
+      <div className={`grid gap-4 ${gridCols}`}>
         {/* Garmin Card */}
         {hasGarmin && (
           <button
@@ -104,6 +107,33 @@ export default function DataSourceSelector({ currentSource, hasGarmin, hasStrava
               <p className="font-semibold">WHOOP</p>
               <p className="text-xs text-muted mt-1">
                 Sync from WHOOP
+              </p>
+            </div>
+          </button>
+        )}
+
+        {/* Suunto Card */}
+        {hasSuunto && (
+          <button
+            onClick={() => onSelect('suunto')}
+            className={`relative flex flex-col items-center gap-3 p-6 rounded-2xl border-2 transition ${
+              currentSource === 'suunto'
+                ? 'border-[#0072CE] bg-[#0072CE]/20 ring-2 ring-[#0072CE]/50'
+                : 'border-app/50 bg-surface-2/50 hover:border-[#0072CE]/50 hover:bg-[#0072CE]/10'
+            }`}
+          >
+            {currentSource === 'suunto' && (
+              <div className="absolute top-3 right-3 flex items-center gap-1 text-xs font-semibold text-[#0072CE]">
+                <span>✓</span>
+                <span>Active</span>
+              </div>
+            )}
+
+            <SuuntoIcon size={32} className={currentSource === 'suunto' ? 'text-[#0072CE]' : 'text-muted'} />
+            <div className="text-center">
+              <p className="font-semibold">Suunto</p>
+              <p className="text-xs text-muted mt-1">
+                Sync from Suunto
               </p>
             </div>
           </button>

--- a/apps/web/src/components/DuplicateRidesModal.tsx
+++ b/apps/web/src/components/DuplicateRidesModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Modal, Button } from './ui';
 import { getAuthHeaders } from '@/lib/csrf';
 import { usePreferences } from '../hooks/usePreferences';
+import { getRideSource, SOURCE_LABELS, type RideSource } from '../utils/rideSource';
 
 type Ride = {
   id: string;
@@ -11,9 +12,36 @@ type Ride = {
   elevationGainMeters: number;
   garminActivityId: string | null;
   stravaActivityId: string | null;
+  whoopWorkoutId: string | null;
+  suuntoWorkoutId: string | null;
   rideType: string;
   notes: string | null;
   createdAt: string;
+};
+
+// Brand-colored styling per provider. Fallback to a neutral shade for any
+// source the catalog doesn't define a color for.
+const SOURCE_STYLES: Record<RideSource, { border: string; button: string }> = {
+  garmin: {
+    border: 'border border-[#00a0df]/30',
+    button: 'bg-[#00a0df]/20 border border-[#00a0df]/50 text-[#00a0df] hover:bg-[#00a0df]/30',
+  },
+  strava: {
+    border: 'border border-[#fc4c02]/30',
+    button: 'bg-[#fc4c02]/20 border border-[#fc4c02]/50 text-[#fc4c02] hover:bg-[#fc4c02]/30',
+  },
+  whoop: {
+    border: 'border border-[#00FF87]/30',
+    button: 'bg-[#00FF87]/20 border border-[#00FF87]/50 text-[#00FF87] hover:bg-[#00FF87]/30',
+  },
+  suunto: {
+    border: 'border border-[#0072CE]/30',
+    button: 'bg-[#0072CE]/20 border border-[#0072CE]/50 text-[#0072CE] hover:bg-[#0072CE]/30',
+  },
+  manual: {
+    border: 'border border-app/30',
+    button: 'bg-surface-2 border border-app/50 text-primary hover:bg-surface-1',
+  },
 };
 
 type DuplicateGroup = {
@@ -241,7 +269,9 @@ export default function DuplicateRidesModal({ open, onClose }: Props) {
         <div className="space-y-6">
           {duplicateGroups.map((group) => {
             const primaryRide = group as unknown as Ride;
-            const primaryIsGarmin = !!primaryRide.garminActivityId;
+            const primarySource = getRideSource(primaryRide);
+            const primaryLabel = SOURCE_LABELS[primarySource];
+            const primaryStyle = SOURCE_STYLES[primarySource];
 
             return (
               <div key={group.id} className="border border-app/50 rounded-2xl p-4 space-y-3">
@@ -250,12 +280,12 @@ export default function DuplicateRidesModal({ open, onClose }: Props) {
                 </p>
 
                 {/* Primary ride */}
-                <div className={`bg-surface-2 rounded-xl p-3 ${primaryIsGarmin ? 'border border-[#00a0df]/30' : 'border border-[#fc4c02]/30'}`}>
+                <div className={`bg-surface-2 rounded-xl p-3 ${primaryStyle.border}`}>
                   <div className="flex items-center justify-between">
                     <div className="flex-1 min-w-0">
                       <p className="font-semibold truncate">{primaryRide.notes || 'Ride'}</p>
                       <p className="text-xs text-muted">
-                        Source: {primaryIsGarmin ? 'Garmin' : 'Strava'}
+                        Source: {primaryLabel}
                       </p>
                     </div>
                     <div className="flex items-center gap-2">
@@ -264,14 +294,10 @@ export default function DuplicateRidesModal({ open, onClose }: Props) {
                         <button
                           key={`keep-primary-${dup.id}`}
                           onClick={() => handleMerge(group.id, dup.id)}
-                          aria-label={`Keep ${primaryIsGarmin ? 'Garmin' : 'Strava'} ride and delete duplicate`}
-                          className={`text-xs px-3 py-1.5 rounded-lg font-medium ${
-                            primaryIsGarmin
-                              ? 'bg-[#00a0df]/20 border border-[#00a0df]/50 text-[#00a0df] hover:bg-[#00a0df]/30'
-                              : 'bg-[#fc4c02]/20 border border-[#fc4c02]/50 text-[#fc4c02] hover:bg-[#fc4c02]/30'
-                          }`}
+                          aria-label={`Keep ${primaryLabel} ride and delete duplicate`}
+                          className={`text-xs px-3 py-1.5 rounded-lg font-medium ${primaryStyle.button}`}
                         >
-                          Keep {primaryIsGarmin ? 'Garmin' : 'Strava'}
+                          Keep {primaryLabel}
                         </button>
                       ))}
                     </div>
@@ -280,27 +306,25 @@ export default function DuplicateRidesModal({ open, onClose }: Props) {
 
                 {/* Duplicate rides */}
                 {group.duplicates.map((dup) => {
-                  const dupIsGarmin = !!dup.garminActivityId;
+                  const dupSource = getRideSource(dup);
+                  const dupLabel = SOURCE_LABELS[dupSource];
+                  const dupStyle = SOURCE_STYLES[dupSource];
 
                   return (
-                    <div key={dup.id} className={`bg-surface-2 rounded-xl p-3 ${dupIsGarmin ? 'border border-[#00a0df]/30' : 'border border-[#fc4c02]/30'}`}>
+                    <div key={dup.id} className={`bg-surface-2 rounded-xl p-3 ${dupStyle.border}`}>
                       <div className="flex items-center justify-between">
                         <div className="flex-1 min-w-0">
                           <p className="font-semibold truncate">{dup.notes || 'Ride'}</p>
                           <p className="text-xs text-muted">
-                            Source: {dupIsGarmin ? 'Garmin' : 'Strava'}
+                            Source: {dupLabel}
                           </p>
                         </div>
                         <button
                           onClick={() => handleMerge(dup.id, group.id)}
-                          aria-label={`Keep ${dupIsGarmin ? 'Garmin' : 'Strava'} ride and delete primary`}
-                          className={`text-xs px-3 py-1.5 rounded-lg font-medium ${
-                            dupIsGarmin
-                              ? 'bg-[#00a0df]/20 border border-[#00a0df]/50 text-[#00a0df] hover:bg-[#00a0df]/30'
-                              : 'bg-[#fc4c02]/20 border border-[#fc4c02]/50 text-[#fc4c02] hover:bg-[#fc4c02]/30'
-                          }`}
+                          aria-label={`Keep ${dupLabel} ride and delete primary`}
+                          className={`text-xs px-3 py-1.5 rounded-lg font-medium ${dupStyle.button}`}
                         >
-                          Keep {dupIsGarmin ? 'Garmin' : 'Strava'}
+                          Keep {dupLabel}
                         </button>
                       </div>
                     </div>

--- a/apps/web/src/components/SuuntoImportModal.tsx
+++ b/apps/web/src/components/SuuntoImportModal.tsx
@@ -33,15 +33,15 @@ const YEAR_OPTIONS = [
 ];
 
 export default function SuuntoImportModal({ open, onClose, onSuccess, onDuplicatesFound }: Props) {
+  // Uses POST /api/suunto/backfill/batch — returns immediately after enqueuing
+  // jobs into the backfill worker. Multi-year selection mirrors Garmin's modal.
+  // The previous version called the synchronous GET /api/suunto/backfill/fetch
+  // which blocked the browser until import completed (minutes for users with
+  // years of history) and only handled one year per request.
   const [step, setStep] = useState<'period' | 'processing' | 'complete'>('period');
-  const [year, setYear] = useState<string>('ytd');
+  const [selectedYears, setSelectedYears] = useState<Set<string>>(new Set(['ytd']));
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  const [importStats, setImportStats] = useState<{
-    imported: number;
-    skipped: number;
-    total: number;
-  } | null>(null);
   const [duplicatesFound, setDuplicatesFound] = useState(0);
   const [backfillHistory, setBackfillHistory] = useState<BackfillRequest[]>([]);
   const [historyLoading, setHistoryLoading] = useState(true);
@@ -78,13 +78,26 @@ export default function SuuntoImportModal({ open, onClose, onSuccess, onDuplicat
     return !backfilledYears.has(yearValue) && !inProgressYears.has(yearValue);
   };
 
-  const canImport = canSelectYear(year);
-
   const getYearStatus = (yearValue: string): 'backfilled' | 'in_progress' | 'available' => {
     if (inProgressYears.has(yearValue)) return 'in_progress';
     if (backfilledYears.has(yearValue)) return 'backfilled';
     return 'available';
   };
+
+  const toggleYearSelection = (yearValue: string) => {
+    if (!canSelectYear(yearValue)) return;
+    setSelectedYears((prev) => {
+      const next = new Set(prev);
+      if (next.has(yearValue)) {
+        next.delete(yearValue);
+      } else {
+        next.add(yearValue);
+      }
+      return next;
+    });
+  };
+
+  const selectableYearsCount = selectedYears.size;
 
   const fetchHistory = async () => {
     try {
@@ -109,18 +122,18 @@ export default function SuuntoImportModal({ open, onClose, onSuccess, onDuplicat
       fetchHistory();
     } else {
       setStep('period');
-      setYear('ytd');
+      setSelectedYears(new Set(['ytd']));
       setError(null);
       setSuccessMessage(null);
-      setImportStats(null);
       setDuplicatesFound(0);
       setHistoryLoading(true);
     }
   }, [open]);
 
-  const handleTriggerImport = async () => {
-    if (!canImport) {
-      setError('This year has already been imported');
+  const handleTriggerBackfill = async () => {
+    const yearsArray = Array.from(selectedYears);
+    if (yearsArray.length === 0) {
+      setError('Please select at least one year');
       return;
     }
 
@@ -129,33 +142,37 @@ export default function SuuntoImportModal({ open, onClose, onSuccess, onDuplicat
 
     try {
       const res = await fetch(
-        `${import.meta.env.VITE_API_URL}/api/suunto/backfill/fetch?year=${year}`,
+        `${import.meta.env.VITE_API_URL}/api/suunto/backfill/batch`,
         {
+          method: 'POST',
           credentials: 'include',
-          headers: getAuthHeaders(),
+          headers: {
+            ...getAuthHeaders(),
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ years: yearsArray }),
         }
       );
 
-      if (!res.ok) {
-        const errorData = await res.json();
+      const data = await res.json();
 
+      if (!res.ok) {
         if (res.status === 409) {
-          setSuccessMessage(errorData.message || 'This year has already been imported.');
+          setSuccessMessage(data.message || 'Selected years are already imported or in progress.');
           setStep('complete');
           await fetchHistory();
           return;
         }
 
-        throw new Error(errorData.error || 'Failed to import workouts');
+        throw new Error(data.message || data.error || 'Failed to trigger backfill');
       }
 
-      const data = await res.json();
-      setSuccessMessage(data.message || `Successfully imported rides from Suunto.`);
-      setImportStats({
-        imported: data.imported || 0,
-        skipped: data.skipped || 0,
-        total: data.cyclingWorkouts || 0,
-      });
+      const queuedCount = data.queued?.length || 0;
+      const skippedCount = data.skipped?.length || 0;
+      setSuccessMessage(
+        data.message ||
+        `Queued ${queuedCount} year${queuedCount !== 1 ? 's' : ''} for import.${skippedCount > 0 ? ` ${skippedCount} already imported.` : ''}`
+      );
       setStep('complete');
 
       try {
@@ -178,7 +195,7 @@ export default function SuuntoImportModal({ open, onClose, onSuccess, onDuplicat
 
       onSuccess();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to import workouts');
+      setError(err instanceof Error ? err.message : 'Failed to trigger backfill');
       setStep('period');
     }
   };
@@ -195,12 +212,12 @@ export default function SuuntoImportModal({ open, onClose, onSuccess, onDuplicat
         <div className="space-y-6">
           <div>
             <p className="text-sm text-muted mb-4">
-              Import your historical Suunto workouts by year.
-              Workouts will be fetched and imported immediately.
+              Import your historical Suunto workouts by year. Selected years will be queued
+              and processed in the background — you can close this modal once they're queued.
             </p>
 
             <label className="block text-sm font-medium text-muted mb-2">
-              Year to import
+              Years to import
             </label>
 
             {historyLoading ? (
@@ -215,7 +232,7 @@ export default function SuuntoImportModal({ open, onClose, onSuccess, onDuplicat
                   const isBackfilled = status === 'backfilled';
                   const isInProgress = status === 'in_progress';
                   const isDisabled = !canSelectYear(option.value);
-                  const isSelected = year === option.value;
+                  const isSelected = selectedYears.has(option.value);
 
                   return (
                     <label
@@ -229,12 +246,11 @@ export default function SuuntoImportModal({ open, onClose, onSuccess, onDuplicat
                       `}
                     >
                       <input
-                        type="radio"
-                        name="suunto-year"
+                        type="checkbox"
                         checked={isSelected}
                         disabled={isDisabled}
-                        onChange={() => !isDisabled && setYear(option.value)}
-                        className="w-4 h-4 text-accent border-gray-500 focus:ring-accent"
+                        onChange={() => toggleYearSelection(option.value)}
+                        className="w-4 h-4 text-accent border-gray-500 focus:ring-accent rounded"
                       />
                       <span className={`flex-1 text-sm ${isDisabled ? 'text-muted' : 'text-primary'}`}>
                         {option.label}
@@ -271,14 +287,12 @@ export default function SuuntoImportModal({ open, onClose, onSuccess, onDuplicat
             </Button>
             <Button
               variant="primary"
-              onClick={handleTriggerImport}
-              disabled={!canImport || historyLoading}
+              onClick={handleTriggerBackfill}
+              disabled={selectableYearsCount === 0 || historyLoading}
             >
-              {!canImport
-                ? inProgressYears.has(year)
-                  ? 'Import In Progress'
-                  : 'Already Imported'
-                : 'Import Rides'}
+              {selectableYearsCount === 0
+                ? 'Select years to import'
+                : `Import ${selectableYearsCount} ${selectableYearsCount === 1 ? 'Year' : 'Years'}`}
             </Button>
           </div>
         </div>
@@ -288,8 +302,7 @@ export default function SuuntoImportModal({ open, onClose, onSuccess, onDuplicat
         <div className="space-y-6">
           <div className="flex flex-col items-center justify-center py-8">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mb-4"></div>
-            <p className="text-muted">Importing workouts from Suunto...</p><br/>
-            <p className="text-muted text-center">Depending on how many workouts you have completed,<br/>this may take 1-2 minutes.</p>
+            <p className="text-muted">Queuing backfill request...</p>
           </div>
         </div>
       )}
@@ -298,22 +311,18 @@ export default function SuuntoImportModal({ open, onClose, onSuccess, onDuplicat
         <div className="space-y-6">
           <div className="alert-success-dark">
             <p>
-              {successMessage}
+              ✓ {successMessage}
             </p>
-            {importStats && (
-              <div className="text-sm mt-3 opacity-90 space-y-1">
-                <p className="font-medium">Import completed for {year === 'ytd' ? 'Year to Date' : year}</p>
-                <p>Imported: {importStats.imported} rides</p>
-                <p>Skipped (already exist): {importStats.skipped} rides</p>
-                <p>Total cycling workouts found: {importStats.total}</p>
-              </div>
-            )}
+            <p className="text-sm mt-2 opacity-90">
+              Your rides will appear in the Rides page as Suunto data is processed.
+              This may take a few minutes per year.
+            </p>
           </div>
 
           {duplicatesFound > 0 && (
             <div className="alert-warning-dark">
               <p>
-                Found {duplicatesFound} duplicate ride{duplicatesFound === 1 ? '' : 's'}
+                ⚠ Found {duplicatesFound} existing duplicate ride{duplicatesFound === 1 ? '' : 's'}
               </p>
               <p className="text-sm mt-1 opacity-90">
                 These rides may exist across multiple providers. Review them to keep only one copy.

--- a/apps/web/src/components/SuuntoImportModal.tsx
+++ b/apps/web/src/components/SuuntoImportModal.tsx
@@ -1,0 +1,344 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Check } from 'lucide-react';
+import { Modal, Button } from './ui';
+import { getAuthHeaders } from '@/lib/csrf';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  onDuplicatesFound?: (count: number) => void;
+};
+
+interface BackfillRequest {
+  id: string;
+  provider: 'strava' | 'garmin' | 'whoop' | 'suunto';
+  year: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  ridesFound: number | null;
+  backfilledUpTo: string | null;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+const CURRENT_YEAR = new Date().getFullYear();
+
+const YEAR_OPTIONS = [
+  { value: 'ytd', label: `Year to Date (${CURRENT_YEAR})` },
+  ...Array.from({ length: 5 }, (_, i) => ({
+    value: String(CURRENT_YEAR - 1 - i),
+    label: String(CURRENT_YEAR - 1 - i),
+  })),
+];
+
+export default function SuuntoImportModal({ open, onClose, onSuccess, onDuplicatesFound }: Props) {
+  const [step, setStep] = useState<'period' | 'processing' | 'complete'>('period');
+  const [year, setYear] = useState<string>('ytd');
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [importStats, setImportStats] = useState<{
+    imported: number;
+    skipped: number;
+    total: number;
+  } | null>(null);
+  const [duplicatesFound, setDuplicatesFound] = useState(0);
+  const [backfillHistory, setBackfillHistory] = useState<BackfillRequest[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(true);
+
+  const backfilledYears = useMemo(() => {
+    return new Set(
+      backfillHistory
+        .filter(
+          (req) =>
+            req.provider === 'suunto' &&
+            req.year !== 'ytd' &&
+            req.status !== 'failed'
+        )
+        .map((req) => req.year)
+    );
+  }, [backfillHistory]);
+
+  const inProgressYears = useMemo(() => {
+    return new Set(
+      backfillHistory
+        .filter(
+          (req) =>
+            req.provider === 'suunto' &&
+            (req.status === 'in_progress' || req.status === 'pending')
+        )
+        .map((req) => req.year)
+    );
+  }, [backfillHistory]);
+
+  const canSelectYear = (yearValue: string): boolean => {
+    if (yearValue === 'ytd') {
+      return !inProgressYears.has('ytd');
+    }
+    return !backfilledYears.has(yearValue) && !inProgressYears.has(yearValue);
+  };
+
+  const canImport = canSelectYear(year);
+
+  const getYearStatus = (yearValue: string): 'backfilled' | 'in_progress' | 'available' => {
+    if (inProgressYears.has(yearValue)) return 'in_progress';
+    if (backfilledYears.has(yearValue)) return 'backfilled';
+    return 'available';
+  };
+
+  const fetchHistory = async () => {
+    try {
+      const baseUrl = import.meta.env.VITE_API_URL;
+      const response = await fetch(`${baseUrl}/api/backfill/history`, {
+        credentials: 'include',
+        headers: getAuthHeaders(),
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setBackfillHistory(data.requests || []);
+      }
+    } catch {
+      // Silently fail - history is supplementary
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      fetchHistory();
+    } else {
+      setStep('period');
+      setYear('ytd');
+      setError(null);
+      setSuccessMessage(null);
+      setImportStats(null);
+      setDuplicatesFound(0);
+      setHistoryLoading(true);
+    }
+  }, [open]);
+
+  const handleTriggerImport = async () => {
+    if (!canImport) {
+      setError('This year has already been imported');
+      return;
+    }
+
+    setError(null);
+    setStep('processing');
+
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_API_URL}/api/suunto/backfill/fetch?year=${year}`,
+        {
+          credentials: 'include',
+          headers: getAuthHeaders(),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await res.json();
+
+        if (res.status === 409) {
+          setSuccessMessage(errorData.message || 'This year has already been imported.');
+          setStep('complete');
+          await fetchHistory();
+          return;
+        }
+
+        throw new Error(errorData.error || 'Failed to import workouts');
+      }
+
+      const data = await res.json();
+      setSuccessMessage(data.message || `Successfully imported rides from Suunto.`);
+      setImportStats({
+        imported: data.imported || 0,
+        skipped: data.skipped || 0,
+        total: data.cyclingWorkouts || 0,
+      });
+      setStep('complete');
+
+      try {
+        const scanRes = await fetch(`${import.meta.env.VITE_API_URL}/api/duplicates/scan`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: getAuthHeaders(),
+        });
+        if (scanRes.ok) {
+          const scanData = await scanRes.json();
+          if (scanData.duplicatesFound > 0) {
+            setDuplicatesFound(scanData.duplicatesFound);
+          }
+        }
+      } catch (scanErr) {
+        console.error('Failed to scan for duplicates:', scanErr);
+      }
+
+      await fetchHistory();
+
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to import workouts');
+      setStep('period');
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={open}
+      onClose={onClose}
+      title="Import Suunto Rides"
+      size="lg"
+      preventClose={step === 'processing'}
+    >
+      {step === 'period' && (
+        <div className="space-y-6">
+          <div>
+            <p className="text-sm text-muted mb-4">
+              Import your historical Suunto workouts by year.
+              Workouts will be fetched and imported immediately.
+            </p>
+
+            <label className="block text-sm font-medium text-muted mb-2">
+              Year to import
+            </label>
+
+            {historyLoading ? (
+              <div className="flex items-center gap-2 text-sm text-muted py-4">
+                <div className="w-4 h-4 border border-muted border-t-transparent rounded-full animate-spin" />
+                Loading...
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-2">
+                {YEAR_OPTIONS.map((option) => {
+                  const status = getYearStatus(option.value);
+                  const isBackfilled = status === 'backfilled';
+                  const isInProgress = status === 'in_progress';
+                  const isDisabled = !canSelectYear(option.value);
+                  const isSelected = year === option.value;
+
+                  return (
+                    <label
+                      key={option.value}
+                      className={`
+                        flex items-center gap-2 p-2.5 rounded-lg border cursor-pointer transition-colors
+                        ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}
+                        ${isSelected && !isDisabled
+                          ? 'border-accent bg-accent/10'
+                          : 'border-app hover:border-accent/50'}
+                      `}
+                    >
+                      <input
+                        type="radio"
+                        name="suunto-year"
+                        checked={isSelected}
+                        disabled={isDisabled}
+                        onChange={() => !isDisabled && setYear(option.value)}
+                        className="w-4 h-4 text-accent border-gray-500 focus:ring-accent"
+                      />
+                      <span className={`flex-1 text-sm ${isDisabled ? 'text-muted' : 'text-primary'}`}>
+                        {option.label}
+                      </span>
+                      {isBackfilled && (
+                        <span title="Already imported"><Check className="w-3 h-3 text-green-400" /></span>
+                      )}
+                      {isInProgress && (
+                        <div className="w-3 h-3 border border-yellow-400 border-t-transparent rounded-full animate-spin" title="In progress" />
+                      )}
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+
+            <p className="text-xs text-muted mt-2">
+              Year to Date can be run multiple times to fetch new workouts since your last import.
+            </p>
+            <p className="text-xs text-muted mt-1">
+              Note: Suunto's workout list doesn't include gear mapping, so rides will be auto-assigned to your bike if you only have one.
+            </p>
+          </div>
+
+          {error && (
+            <div className="alert-danger-dark">
+              <p className="text-sm">{error}</p>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-3">
+            <Button variant="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              onClick={handleTriggerImport}
+              disabled={!canImport || historyLoading}
+            >
+              {!canImport
+                ? inProgressYears.has(year)
+                  ? 'Import In Progress'
+                  : 'Already Imported'
+                : 'Import Rides'}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {step === 'processing' && (
+        <div className="space-y-6">
+          <div className="flex flex-col items-center justify-center py-8">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mb-4"></div>
+            <p className="text-muted">Importing workouts from Suunto...</p><br/>
+            <p className="text-muted text-center">Depending on how many workouts you have completed,<br/>this may take 1-2 minutes.</p>
+          </div>
+        </div>
+      )}
+
+      {step === 'complete' && (
+        <div className="space-y-6">
+          <div className="alert-success-dark">
+            <p>
+              {successMessage}
+            </p>
+            {importStats && (
+              <div className="text-sm mt-3 opacity-90 space-y-1">
+                <p className="font-medium">Import completed for {year === 'ytd' ? 'Year to Date' : year}</p>
+                <p>Imported: {importStats.imported} rides</p>
+                <p>Skipped (already exist): {importStats.skipped} rides</p>
+                <p>Total cycling workouts found: {importStats.total}</p>
+              </div>
+            )}
+          </div>
+
+          {duplicatesFound > 0 && (
+            <div className="alert-warning-dark">
+              <p>
+                Found {duplicatesFound} duplicate ride{duplicatesFound === 1 ? '' : 's'}
+              </p>
+              <p className="text-sm mt-1 opacity-90">
+                These rides may exist across multiple providers. Review them to keep only one copy.
+              </p>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-3">
+            {duplicatesFound > 0 && onDuplicatesFound && (
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  onClose();
+                  onDuplicatesFound(duplicatesFound);
+                }}
+              >
+                Review Duplicates
+              </Button>
+            )}
+            <Button variant="primary" onClick={onClose}>
+              Done
+            </Button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/apps/web/src/components/icons/BrandIcons.tsx
+++ b/apps/web/src/components/icons/BrandIcons.tsx
@@ -17,6 +17,21 @@ export function StravaIcon({ size = 24, ...props }: IconProps) {
   );
 }
 
+export function SuuntoIcon({ size = 24, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      {...props}
+    >
+      <path d="M12 2L4 12l8 10 8-10L12 2zm0 4l5 6-5 6-5-6 5-6z" />
+    </svg>
+  );
+}
+
 export function GoogleIcon({ size = 24, ...props }: IconProps) {
   return (
     <svg

--- a/apps/web/src/components/onboarding/ImportRidesForm.test.tsx
+++ b/apps/web/src/components/onboarding/ImportRidesForm.test.tsx
@@ -422,4 +422,91 @@ describe('ImportRidesForm', () => {
       });
     });
   });
+
+  describe('Suunto', () => {
+    it('auto-selects Suunto when it is the only connected provider', () => {
+      render(<ImportRidesForm connectedProviders={['suunto']} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
+
+      expect(screen.getByText(/Importing from/)).toBeInTheDocument();
+      expect(screen.getByText('Suunto')).toBeInTheDocument();
+    });
+
+    it('shows Suunto in the provider selector alongside Strava', () => {
+      render(<ImportRidesForm connectedProviders={['strava', 'suunto']} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
+
+      expect(screen.getByRole('radio', { name: /Strava/i })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /Suunto/i })).toBeInTheDocument();
+    });
+
+    it('shows 6 year options for Suunto (YTD + 5 previous)', async () => {
+      render(<ImportRidesForm connectedProviders={['suunto']} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading history...')).not.toBeInTheDocument();
+      });
+
+      const select = screen.getByRole('combobox');
+      const options = select.querySelectorAll('option');
+      expect(options.length).toBe(6);
+      expect(options[0]).toHaveTextContent('Year to Date');
+    });
+
+    it('shows Suunto-specific bike-assignment note', () => {
+      render(<ImportRidesForm connectedProviders={['suunto']} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
+
+      expect(screen.getByText(/Suunto doesn't provide gear mapping/)).toBeInTheDocument();
+    });
+
+    it('posts to /api/suunto/backfill/fetch and shows success counts', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ success: true, requests: [] }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            success: true,
+            imported: 12,
+            skipped: 3,
+            duplicatesDetected: 1,
+            totalWorkouts: 15,
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ success: true, requests: [] }),
+        });
+
+      render(<ImportRidesForm connectedProviders={['suunto']} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading history...')).not.toBeInTheDocument();
+      });
+
+      const importButton = screen.getByRole('button', { name: /Start Import/i });
+      fireEvent.click(importButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/12 rides imported/)).toBeInTheDocument();
+        expect(screen.getByText(/3 already existed/)).toBeInTheDocument();
+      });
+
+      const importCall = mockFetch.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('/api/suunto/backfill/fetch')
+      );
+      expect(importCall).toBeDefined();
+      expect(importCall![0]).toMatch(/year=ytd/);
+    });
+  });
 });

--- a/apps/web/src/components/onboarding/ImportRidesForm.tsx
+++ b/apps/web/src/components/onboarding/ImportRidesForm.tsx
@@ -3,7 +3,7 @@ import { History, ChevronDown, ChevronUp, Check } from 'lucide-react';
 import { getAuthHeaders } from '@/lib/csrf';
 
 interface ImportRidesFormProps {
-  connectedProviders: Array<'strava' | 'garmin'>;
+  connectedProviders: Array<'strava' | 'garmin' | 'suunto'>;
 }
 
 interface ImportStats {
@@ -15,7 +15,7 @@ interface ImportStats {
 
 interface BackfillRequest {
   id: string;
-  provider: 'strava' | 'garmin';
+  provider: 'strava' | 'garmin' | 'suunto';
   year: string;
   status: 'pending' | 'in_progress' | 'completed' | 'failed';
   ridesFound: number | null;
@@ -41,15 +41,25 @@ const GARMIN_YEAR_OPTIONS = [
   { value: 'ytd', label: 'Last 30 Days' },
 ];
 
+// Suunto allows historical backfills back to 2015 (same as Strava)
+const SUUNTO_YEAR_OPTIONS = [
+  { value: 'ytd', label: `Year to Date (${CURRENT_YEAR})` },
+  ...Array.from({ length: 5 }, (_, i) => ({
+    value: String(CURRENT_YEAR - 1 - i),
+    label: String(CURRENT_YEAR - 1 - i),
+  })),
+];
+
 const PROVIDER_LABELS: Record<string, string> = {
   strava: 'Strava',
   garmin: 'Garmin Connect',
+  suunto: 'Suunto',
 };
 
 export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
   const [expanded, setExpanded] = useState(false);
-  const [selectedProvider, setSelectedProvider] = useState<'strava' | 'garmin' | ''>('');
-  const [selectedYear, setSelectedYear] = useState<string>('ytd'); // For Strava (single select)
+  const [selectedProvider, setSelectedProvider] = useState<'strava' | 'garmin' | 'suunto' | ''>('');
+  const [selectedYear, setSelectedYear] = useState<string>('ytd'); // For Strava/Suunto (single select)
   const [selectedYears, setSelectedYears] = useState<Set<string>>(new Set(['ytd'])); // For Garmin (multi-select)
   const [importState, setImportState] = useState<'idle' | 'loading' | 'done'>('idle');
   const [importStats, setImportStats] = useState<ImportStats | null>(null);
@@ -192,9 +202,9 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
         setImportState('done');
         await refreshBackfillHistory();
       } else {
-        // Strava uses single-year endpoint
+        // Strava and Suunto both use a synchronous single-year endpoint
         const response = await fetch(
-          `${baseUrl}/api/strava/backfill/fetch?year=${selectedYear}`,
+          `${baseUrl}/api/${selectedProvider}/backfill/fetch?year=${selectedYear}`,
           {
             credentials: 'include',
             headers: getAuthHeaders(),
@@ -214,7 +224,7 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
 
         setImportStats({
           imported: data.imported || 0,
-          skipped: data.duplicates || 0,
+          skipped: data.skipped ?? data.duplicates ?? 0,
           isAsync: false,
         });
 
@@ -309,7 +319,7 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
                       name="provider"
                       value={provider}
                       checked={selectedProvider === provider}
-                      onChange={(e) => setSelectedProvider(e.target.value as 'strava' | 'garmin')}
+                      onChange={(e) => setSelectedProvider(e.target.value as 'strava' | 'garmin' | 'suunto')}
                       className="w-4 h-4 text-accent border-gray-500 focus:ring-accent"
                     />
                     <span className="text-primary">{PROVIDER_LABELS[provider]}</span>
@@ -372,14 +382,14 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
                 </p>
               </div>
             ) : (
-              // Strava: full year selection
+              // Strava and Suunto: full year selection
               <select
                 value={selectedYear}
                 onChange={(e) => setSelectedYear(e.target.value)}
                 className="w-full input-soft"
                 disabled={importState === 'loading'}
               >
-                {STRAVA_YEAR_OPTIONS.map((option) => (
+                {(selectedProvider === 'suunto' ? SUUNTO_YEAR_OPTIONS : STRAVA_YEAR_OPTIONS).map((option) => (
                   <option key={option.value} value={option.value}>
                     {option.label}
                   </option>
@@ -436,6 +446,10 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
               {selectedProvider === 'garmin' ? (
                 <>
                   <span className="font-medium text-primary">Note:</span> If you rode multiple bikes, you'll need to assign the correct bike to each ride after import. Unassigned rides won't contribute to component wear tracking.
+                </>
+              ) : selectedProvider === 'suunto' ? (
+                <>
+                  <span className="font-medium text-primary">Note:</span> Suunto doesn't provide gear mapping, so rides will be auto-assigned to your bike if you only have one. Otherwise you'll need to assign each ride after import.
                 </>
               ) : (
                 <>

--- a/apps/web/src/graphql/rides.ts
+++ b/apps/web/src/graphql/rides.ts
@@ -25,6 +25,7 @@ export const RIDES = gql`
       garminActivityId
       stravaActivityId
       whoopWorkoutId
+      suuntoWorkoutId
       startTime
       durationSeconds
       distanceMeters

--- a/apps/web/src/hooks/useBikeRides.ts
+++ b/apps/web/src/hooks/useBikeRides.ts
@@ -17,6 +17,7 @@ export interface BikeRide {
   stravaActivityId?: string | null;
   garminActivityId?: string | null;
   whoopWorkoutId?: string | null;
+  suuntoWorkoutId?: string | null;
 }
 
 interface UseBikeRidesResult {

--- a/apps/web/src/models/Ride.ts
+++ b/apps/web/src/models/Ride.ts
@@ -33,5 +33,6 @@ export interface Ride {
   stravaActivityId?: string | null;
   garminActivityId?: string | null;
   whoopWorkoutId?: string | null;
+  suuntoWorkoutId?: string | null;
   weather?: RideWeather | null;
 }

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useApolloClient, useQuery, gql } from '@apollo/client';
 import { Mountain, Settings, Check, ChevronDown, ChevronUp, Clock } from 'lucide-react';
-import { StravaIcon } from '../components/icons/BrandIcons';
+import { StravaIcon, SuuntoIcon } from '../components/icons/BrandIcons';
 import { ME_QUERY } from '../graphql/me';
 import { useCurrentUser } from '../hooks/useCurrentUser';
 import { Button } from '@/components/ui';
@@ -139,7 +139,7 @@ export default function Onboarding() {
 
   const accounts = accountsData?.me?.accounts || [];
   const hasConnectedDevice = accounts.some((acc: { provider: string }) =>
-    acc.provider === 'garmin' || acc.provider === 'strava'
+    acc.provider === 'garmin' || acc.provider === 'strava' || acc.provider === 'suunto'
   );
 
   // Load initial data from sessionStorage if available (for OAuth redirects)
@@ -428,6 +428,11 @@ export default function Onboarding() {
   const handleConnectStrava = () => {
     const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:4000';
     window.location.href = `${apiBase}/auth/strava/start`;
+  };
+
+  const handleConnectSuunto = () => {
+    const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:4000';
+    window.location.href = `${apiBase}/auth/suunto/start`;
   };
 
   const handleSkipDevices = async () => {
@@ -894,12 +899,44 @@ export default function Onboarding() {
                   </button>
                 )}
 
+                {/* Suunto Connection */}
+                {accounts.find((acc: { provider: string }) => acc.provider === 'suunto') ? (
+                  <div className="w-full rounded-2xl border border-[#0072CE]/50 bg-surface-2 px-4 py-4">
+                    <div className="flex items-center justify-between gap-4">
+                      <div className="flex items-center gap-3">
+                        <SuuntoIcon className="text-lg" style={{ color: '#0072CE' }} />
+                        <div className="text-left">
+                          <p className="font-semibold">Suunto</p>
+                          <p className="text-xs text-success">Connected ✓</p>
+                        </div>
+                      </div>
+                      <span className="text-xs text-success">Ready</span>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    onClick={handleConnectSuunto}
+                    className="w-full rounded-2xl border border-[#0072CE]/50 bg-[#0072CE]/10 hover:bg-[#0072CE]/20 px-4 py-4 transition text-left"
+                  >
+                    <div className="flex items-center justify-between gap-4">
+                      <div className="flex items-center gap-3">
+                        <SuuntoIcon className="text-lg" style={{ color: '#0072CE' }} />
+                        <div>
+                          <p className="font-semibold">Suunto</p>
+                          <p className="text-xs text-muted">Import activities automatically</p>
+                        </div>
+                      </div>
+                      <span className="text-xs" style={{ color: '#0072CE' }}>Connect</span>
+                    </div>
+                  </button>
+                )}
+
                 {/* Coming Soon */}
                 <div className="w-full rounded-2xl border border-app/30 bg-surface-2/50 px-4 py-4 opacity-60 cursor-not-allowed">
                   <div className="flex items-center justify-between gap-4">
                     <div className="text-left">
                       <p className="font-semibold text-muted">Coming Soon</p>
-                      <p className="text-xs text-muted">Suunto, Coros, Whoop</p>
+                      <p className="text-xs text-muted">Coros, Whoop</p>
                     </div>
                   </div>
                 </div>
@@ -929,9 +966,9 @@ export default function Onboarding() {
                   <ImportRidesForm
                     connectedProviders={accounts
                       .filter((a: { provider: string }) =>
-                        a.provider === 'strava' || a.provider === 'garmin'
+                        a.provider === 'strava' || a.provider === 'garmin' || a.provider === 'suunto'
                       )
-                      .map((a: { provider: string }) => a.provider as 'strava' | 'garmin')}
+                      .map((a: { provider: string }) => a.provider as 'strava' | 'garmin' | 'suunto')}
                   />
                 )}
 

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -75,7 +75,7 @@ export default function Settings() {
   const [suuntoImportModalOpen, setSuuntoImportModalOpen] = useState(false);
   const [duplicatesModalOpen, setDuplicatesModalOpen] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  const [activeDataSource, setActiveDataSource] = useState<'garmin' | 'strava' | 'whoop' | null>(null);
+  const [activeDataSource, setActiveDataSource] = useState<'garmin' | 'strava' | 'whoop' | 'suunto' | null>(null);
   const [stravaDeleteLoading, setStravaDeleteLoading] = useState(false);
   const [garminDeleteLoading, setGarminDeleteLoading] = useState(false);
   const [whoopDeleteLoading, setWhoopDeleteLoading] = useState(false);
@@ -278,7 +278,7 @@ export default function Settings() {
     }
   };
 
-  const handleDataSourceSelect = async (provider: 'garmin' | 'strava' | 'whoop') => {
+  const handleDataSourceSelect = async (provider: 'garmin' | 'strava' | 'whoop' | 'suunto') => {
     try {
       const res = await fetch(`${import.meta.env.VITE_API_URL}/api/data-source/preference`, {
         method: 'POST',
@@ -652,13 +652,14 @@ export default function Settings() {
         </div>
 
         {/* Data Source Selector - only show when multiple providers are connected */}
-        {([isGarminConnected, isStravaConnected, isWhoopConnected].filter(Boolean).length >= 2) && (
+        {([isGarminConnected, isStravaConnected, isWhoopConnected, isSuuntoConnected].filter(Boolean).length >= 2) && (
           <div className="panel">
             <DataSourceSelector
               currentSource={activeDataSource}
               hasGarmin={isGarminConnected}
               hasStrava={isStravaConnected}
               hasWhoop={isWhoopConnected}
+              hasSuunto={isSuuntoConnected}
               onSelect={handleDataSourceSelect}
             />
           </div>

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -2,17 +2,19 @@ import { useState, useEffect, useRef } from "react";
 import { useQuery, useMutation, gql } from "@apollo/client";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { Mountain, Activity } from "lucide-react";
-import { StravaIcon, GoogleIcon } from '../components/icons/BrandIcons';
+import { StravaIcon, GoogleIcon, SuuntoIcon } from '../components/icons/BrandIcons';
 import { formatDistanceToNow } from "date-fns";
 
 import DeleteAccountModal from "../components/DeleteAccountModal";
 import SetPasswordModal from "../components/SetPasswordModal";
 import ConnectGarminLink from "../components/ConnectGarminLink";
 import ConnectStravaLink from "../components/ConnectStravaLink";
+import ConnectSuuntoLink from "../components/ConnectSuuntoLink";
 import ConnectWhoopLink from "../components/ConnectWhoopLink";
 import GarminImportModal from "../components/GarminImportModal";
 import StravaImportModal from "../components/StravaImportModal";
 import WhoopImportModal from "../components/WhoopImportModal";
+import SuuntoImportModal from "../components/SuuntoImportModal";
 import StravaBikeMappingOverlay from "../components/StravaBikeMappingOverlay";
 import DataSourceSelector from "../components/DataSourceSelector";
 import DuplicateRidesModal from "../components/DuplicateRidesModal";
@@ -70,6 +72,7 @@ export default function Settings() {
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [stravaImportModalOpen, setStravaImportModalOpen] = useState(false);
   const [whoopImportModalOpen, setWhoopImportModalOpen] = useState(false);
+  const [suuntoImportModalOpen, setSuuntoImportModalOpen] = useState(false);
   const [duplicatesModalOpen, setDuplicatesModalOpen] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [activeDataSource, setActiveDataSource] = useState<'garmin' | 'strava' | 'whoop' | null>(null);
@@ -125,6 +128,13 @@ export default function Settings() {
       setTimeout(() => setSuccessMessage(null), 8000);
       setSearchParams({});
     }
+
+    if (searchParams.get('suunto') === 'connected') {
+      refetchAccounts();
+      setSuccessMessage('Suunto connected successfully!');
+      setTimeout(() => setSuccessMessage(null), 8000);
+      setSearchParams({});
+    }
   }, [searchParams, setSearchParams, refetchAccounts]);
 
   // Sync activeDataSource from GraphQL data
@@ -170,9 +180,11 @@ export default function Settings() {
   const garminAccount = accounts.find((acc: { provider: string; connectedAt: string }) => acc.provider === "garmin");
   const stravaAccount = accounts.find((acc: { provider: string; connectedAt: string }) => acc.provider === "strava");
   const whoopAccount = accounts.find((acc: { provider: string; connectedAt: string }) => acc.provider === "whoop");
+  const suuntoAccount = accounts.find((acc: { provider: string; connectedAt: string }) => acc.provider === "suunto");
   const isGarminConnected = !!garminAccount;
   const isStravaConnected = !!stravaAccount;
   const isWhoopConnected = !!whoopAccount;
+  const isSuuntoConnected = !!suuntoAccount;
 
   const handleDisconnectGarmin = async () => {
     if (!confirm('Disconnect Garmin? Your synced rides will remain, but new activities will not sync.')) {
@@ -217,6 +229,29 @@ export default function Settings() {
     } catch (err) {
       console.error('Failed to disconnect Strava:', err);
       alert('Failed to disconnect Strava. Please try again.');
+    }
+  };
+
+  const handleDisconnectSuunto = async () => {
+    if (!confirm('Disconnect Suunto? Your synced rides will remain, but new workouts will not sync.')) {
+      return;
+    }
+
+    try {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/auth/suunto/disconnect`, {
+        method: 'DELETE',
+        credentials: 'include',
+        headers: getAuthHeaders(),
+      });
+
+      if (!res.ok) throw new Error('Failed to disconnect');
+
+      await refetchAccounts();
+      setSuccessMessage('Suunto disconnected successfully');
+      setTimeout(() => setSuccessMessage(null), 3000);
+    } catch (err) {
+      console.error('Failed to disconnect Suunto:', err);
+      alert('Failed to disconnect Suunto. Please try again.');
     }
   };
 
@@ -581,16 +616,38 @@ export default function Settings() {
               <ConnectWhoopLink />
             )}
 
-            {/* Suunto - Coming Soon */}
-            <div className="w-full rounded-2xl border border-app/70 bg-surface-2/50 px-4 py-3 opacity-50">
-              <div className="flex items-center justify-between gap-4">
-                <div>
-                  <p className="font-semibold">Suunto</p>
-                  <p className="text-sm text-muted">Coming soon</p>
+            {/* Suunto */}
+            {isSuuntoConnected ? (
+              <div className="w-full rounded-2xl border border-app/70 bg-surface-2 px-4 py-3">
+                <div className="flex items-center justify-between gap-4">
+                  <div className="flex items-center gap-3">
+                    <SuuntoIcon className="text-lg" style={{ color: '#0072CE' }} />
+                    <div>
+                      <p className="font-semibold">Suunto</p>
+                      <p className="text-xs text-muted">
+                        Connected {formatDistanceToNow(new Date(suuntoAccount.connectedAt))} ago
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => setSuuntoImportModalOpen(true)}
+                      className="rounded-xl px-3 py-1.5 text-xs font-medium text-[#0072CE]/80 bg-surface-2/50 border border-[#0072CE]/30 hover:bg-surface-2 hover:text-[#0072CE] hover:border-[#0072CE]/50 hover:cursor-pointer transition"
+                    >
+                      Sync Previous Rides
+                    </button>
+                    <button
+                      onClick={handleDisconnectSuunto}
+                      className="rounded-xl px-3 py-1.5 text-xs font-medium text-red-400/80 bg-surface-2/50 border border-red-400/30 hover:bg-surface-2 hover:text-red-400 hover:border-red-400/50 hover:cursor-pointer transition"
+                    >
+                      Disconnect
+                    </button>
+                  </div>
                 </div>
-                <span className="text-xs text-muted">Not available</span>
               </div>
-            </div>
+            ) : (
+              <ConnectSuuntoLink />
+            )}
           </div>
         </div>
 
@@ -970,6 +1027,18 @@ export default function Settings() {
         onClose={() => setWhoopImportModalOpen(false)}
         onSuccess={() => {
           setSuccessMessage('Rides imported from WHOOP successfully!');
+          setTimeout(() => setSuccessMessage(null), 8000);
+        }}
+        onDuplicatesFound={() => {
+          setDuplicatesModalOpen(true);
+        }}
+      />
+
+      <SuuntoImportModal
+        open={suuntoImportModalOpen}
+        onClose={() => setSuuntoImportModalOpen(false)}
+        onSuccess={() => {
+          setSuccessMessage('Rides imported from Suunto successfully!');
           setTimeout(() => setSuccessMessage(null), 8000);
         }}
         onDuplicatesFound={() => {

--- a/apps/web/src/utils/rideSource.test.ts
+++ b/apps/web/src/utils/rideSource.test.ts
@@ -70,6 +70,28 @@ describe('getRideSource', () => {
 
     expect(getRideSource(ride)).toBe('garmin');
   });
+
+  it('returns "suunto" when only suuntoWorkoutId is present', () => {
+    const ride: RideWithSource = {
+      stravaActivityId: null,
+      garminActivityId: null,
+      whoopWorkoutId: null,
+      suuntoWorkoutId: 'suunto-key-abc',
+    };
+
+    expect(getRideSource(ride)).toBe('suunto');
+  });
+
+  it('deprioritizes Suunto behind Strava/Garmin/WHOOP', () => {
+    const ride: RideWithSource = {
+      stravaActivityId: null,
+      garminActivityId: null,
+      whoopWorkoutId: 'whoop-uuid',
+      suuntoWorkoutId: 'suunto-key-abc',
+    };
+
+    expect(getRideSource(ride)).toBe('whoop');
+  });
 });
 
 describe('SOURCE_LABELS', () => {
@@ -79,6 +101,14 @@ describe('SOURCE_LABELS', () => {
 
   it('has correct label for garmin', () => {
     expect(SOURCE_LABELS.garmin).toBe('Garmin');
+  });
+
+  it('has correct label for whoop', () => {
+    expect(SOURCE_LABELS.whoop).toBe('WHOOP');
+  });
+
+  it('has correct label for suunto', () => {
+    expect(SOURCE_LABELS.suunto).toBe('Suunto');
   });
 
   it('has correct label for manual', () => {

--- a/apps/web/src/utils/rideSource.ts
+++ b/apps/web/src/utils/rideSource.ts
@@ -1,19 +1,21 @@
-export type RideSource = 'strava' | 'garmin' | 'whoop' | 'manual';
+export type RideSource = 'strava' | 'garmin' | 'whoop' | 'suunto' | 'manual';
 
 export interface RideWithSource {
   stravaActivityId?: string | null;
   garminActivityId?: string | null;
   whoopWorkoutId?: string | null;
+  suuntoWorkoutId?: string | null;
 }
 
 /**
  * Determines the source of a ride based on activity IDs.
- * Priority: Strava > Garmin > WHOOP > Manual
+ * Priority: Strava > Garmin > WHOOP > Suunto > Manual
  */
 export function getRideSource(ride: RideWithSource): RideSource {
   if (ride.stravaActivityId) return 'strava';
   if (ride.garminActivityId) return 'garmin';
   if (ride.whoopWorkoutId) return 'whoop';
+  if (ride.suuntoWorkoutId) return 'suunto';
   return 'manual';
 }
 
@@ -21,5 +23,6 @@ export const SOURCE_LABELS: Record<RideSource, string> = {
   strava: 'Strava',
   garmin: 'Garmin',
   whoop: 'WHOOP',
+  suunto: 'Suunto',
   manual: 'Manual',
 };

--- a/docs/suunto-todo.md
+++ b/docs/suunto-todo.md
@@ -1,0 +1,90 @@
+# Suunto integration — remaining work
+
+Gap inventory vs the Garmin integration, produced after the initial OAuth + webhook + Settings UI landed. Ordered by user-visible impact.
+
+## 1. Sync worker handlers — ✅ done
+
+Implemented `syncSuuntoLatest()`, `syncSuuntoActivity()`, and `upsertSuuntoActivity()` in [sync.worker.ts](../apps/api/src/workers/sync.worker.ts). The two switch statements (`syncLatestActivities` + `syncSingleActivity`) now route Suunto jobs to real handlers instead of warning.
+
+Details:
+- List sync: `GET /v3/workouts?since=&until=&limit=&offset=` paginated 30-day window, cycling filter via `isSuuntoCyclingActivity`.
+- Single sync: direct `GET /v3/workouts/{workoutKey}`, unwraps the `{ error, metadata, payload }` envelope defensively.
+- Upsert: auto-assigns the user's only active bike on new rides (preserved on re-sync), Garmin-style two-transaction safety so a component-hour failure never drops the ride, fires weather + notifications + referral completion.
+- All data-API calls send `Ocp-Apim-Subscription-Key` via a shared `suuntoApiHeaders()` helper.
+
+---
+
+## 2. Backfill batch queue — ✅ done
+
+Added `POST /suunto/backfill/batch` that enqueues one job per year via the shared backfill queue, mirroring the Garmin flow.
+
+Changes:
+- New shared helper module [lib/suunto-sync.ts](../apps/api/src/lib/suunto-sync.ts) holds the API base URL, `SuuntoWorkout` / `SuuntoWorkoutsResponse` types, and the `suuntoApiHeaders()` builder so all three call sites (sync worker, backfill worker, synchronous backfill route) agree.
+- Extended `BackfillProvider` to `'garmin' | 'suunto'` in [backfill.queue.ts](../apps/api/src/lib/queue/backfill.queue.ts).
+- [backfill.worker.ts](../apps/api/src/workers/backfill.worker.ts) now dispatches on provider and ships a `processSuuntoBackfill(userId, year)` that paginates `/v3/workouts`, filters cycling, runs cross-provider dedup via `findPotentialDuplicates`, auto-assigns the single active bike, tracks component hours, enqueues weather jobs, and updates `BackfillRequest` status.
+- [suunto.backfill.ts](../apps/api/src/routes/suunto.backfill.ts) now has two endpoints: the original synchronous `/fetch` (kept for single-year immediate-feedback flows) and the new `/batch` (queued, matches Garmin).
+- Fixed the **subscription-key bug** while here — the synchronous `/fetch` now uses `suuntoApiHeaders()` so every data-API call sends `Ocp-Apim-Subscription-Key`.
+
+---
+
+## 3. Component hour tracking in webhook — ✅ done
+
+Extracted the inline `syncBikeComponentHours` helper (duplicated between [webhooks.strava.ts](../apps/api/src/routes/webhooks.strava.ts) and [workers/sync.worker.ts](../apps/api/src/workers/sync.worker.ts)) into [lib/component-hours.ts](../apps/api/src/lib/component-hours.ts), then wired it into every ingestion path that was missing it.
+
+Changes:
+- **New shared helper**: `syncBikeComponentHours(tx, userId, previous, next)` exported from `lib/component-hours.ts`. Handles bike changes + duration diffs with floor-at-zero decrement semantics.
+- **Suunto webhook** ([webhooks.suunto.ts](../apps/api/src/routes/webhooks.suunto.ts)): now reads the existing ride before upsert, auto-assigns the single active bike on new rides (matching sync worker + backfill behavior), wraps upsert + hour sync in one transaction so a failure rolls both back.
+- **Garmin backfill callback** ([backfill.worker.ts](../apps/api/src/workers/backfill.worker.ts) `processGarminCallback`): was the actual Garmin gap — the webhook just enqueues to sync worker (which already synced hours), but the callback-delivered backfill rides silently skipped hour tracking. Now reads existing bikeId + duration and wraps upsert in a transaction with the helper.
+- **Dedup cleanup**: removed the two inline copies of the helper from `webhooks.strava.ts` and `sync.worker.ts` now that they import from the shared lib.
+
+**Note on Garmin webhook**: the Explore agent's earlier report flagged it as missing hour tracking, but actually the webhook only enqueues a sync job — the sync worker's `upsertGarminActivity` already calls `syncBikeComponentHours`. The real gap was the backfill callback, now fixed.
+
+---
+
+## 4. Bike/gear auto-mapping — moderate (optional)
+
+**Problem**
+Suunto webhook payload includes `gear: { manufacturer, name, productType }` but [webhooks.suunto.ts](../apps/api/src/routes/webhooks.suunto.ts) ignores it. Strava has a `StravaGearMapping` table + overlay UI; Garmin has nothing.
+
+**Consequence**
+Riders with multiple bikes must manually assign every Suunto workout to the right bike, even though Suunto is telling us which watch uploaded it (not a bike, but could be a useful correlation).
+
+*Note*: Suunto's `gear` field is the **watch** (e.g., "Suunto Vertical"), not the bike. So this isn't a direct bike-mapping opportunity the way Strava's gear_id is. Probably not worth building.
+
+**Approach**
+Skip unless the gear field turns out to be rider-configurable for bikes.
+
+---
+
+## 5. Mock endpoint for dev testing — tiny
+
+**Problem**
+[mock.garmin.ts](../apps/api/src/routes/mock.garmin.ts) exists for admin/dev fixtures. No Suunto equivalent.
+
+**Approach**
+Copy the pattern if we want repeatable local testing without hitting Suunto's API.
+
+---
+
+## 6. Activation email — ✅ done
+
+Added a Suunto-integration-live broadcast email matching the existing Strava pattern (admin-sendable via the email UI, not auto-fired on connect).
+
+Changes:
+- New template [apps/api/src/templates/emails/suunto-enabled.tsx](../apps/api/src/templates/emails/suunto-enabled.tsx) — mirrors the Strava version with Suunto-specific copy: direct watch sync (no Strava middleman), auto-bike-assign behavior, backfill pointer, duplicate-detection note for multi-provider users.
+- `EmailType` enum in [schema.prisma](../apps/api/prisma/schema.prisma) extended with `suunto_integration_live`. Requires a migration (`npm run prisma:mig add_suunto_integration_live_email_type`).
+- Registered in [templates/emails/index.ts](../apps/api/src/templates/emails/index.ts) so it appears in the admin email UI.
+
+**Reused the existing infrastructure** — same tokens/dark-mode/layout primitives as strava-enabled.tsx. Swap the hero image if you want something more Suunto-specific; `RyanAbenaki.jpg` is fine as a placeholder.
+
+---
+
+## Bugs fixed in passing
+
+- ✅ **Backfill missing subscription key**: fixed as part of #2 — all Suunto data-API calls now flow through the shared `suuntoApiHeaders()` helper.
+
+## Known non-gaps (for the record)
+
+- **`isActiveSource` in webhook**: Suunto webhook checks it, Garmin doesn't — *Suunto is ahead here*.
+- **Dedup in webhook path**: neither Garmin, Strava, nor Suunto dedup in the webhook path (only in backfill). By design.
+- **GraphQL resolvers**: provider-agnostic already; no Suunto-specific resolvers needed.

--- a/libs/graphql/src/generated/index.ts
+++ b/libs/graphql/src/generated/index.ts
@@ -40,6 +40,7 @@ export enum AcquisitionCondition {
 
 export type AddBikeInput = {
   acquisitionCondition?: InputMaybe<AcquisitionCondition>;
+  acquisitionDate?: InputMaybe<Scalars['String']['input']>;
   batteryWh?: InputMaybe<Scalars['Int']['input']>;
   buildKind?: InputMaybe<Scalars['String']['input']>;
   category?: InputMaybe<Scalars['String']['input']>;
@@ -81,6 +82,7 @@ export type AddBikeNoteInput = {
 export type AddComponentInput = {
   brand?: InputMaybe<Scalars['String']['input']>;
   hoursUsed?: InputMaybe<Scalars['Float']['input']>;
+  installedAt?: InputMaybe<Scalars['String']['input']>;
   isStock?: InputMaybe<Scalars['Boolean']['input']>;
   location?: InputMaybe<ComponentLocation>;
   model?: InputMaybe<Scalars['String']['input']>;
@@ -102,6 +104,13 @@ export type AddRideInput = {
   trailSystem?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type BackfillWeatherResult = {
+  __typename?: 'BackfillWeatherResult';
+  enqueuedCount: Scalars['Int']['output'];
+  remainingAfterBatch: Scalars['Int']['output'];
+  ridesWithoutCoords: Scalars['Int']['output'];
+};
+
 export enum BaselineConfidence {
   High = 'HIGH',
   Low = 'LOW',
@@ -117,6 +126,7 @@ export enum BaselineMethod {
 export type Bike = {
   __typename?: 'Bike';
   acquisitionCondition?: Maybe<AcquisitionCondition>;
+  acquisitionDate?: Maybe<Scalars['String']['output']>;
   batteryWh?: Maybe<Scalars['Int']['output']>;
   buildKind?: Maybe<Scalars['String']['output']>;
   category?: Maybe<Scalars['String']['output']>;
@@ -138,6 +148,7 @@ export type Bike = {
   motorTorqueNm?: Maybe<Scalars['Int']['output']>;
   nickname?: Maybe<Scalars['String']['output']>;
   notes?: Maybe<Scalars['String']['output']>;
+  notificationPreference?: Maybe<BikeNotificationPreference>;
   pivotBearings?: Maybe<Component>;
   predictions?: Maybe<BikePredictionSummary>;
   retiredAt?: Maybe<Scalars['String']['output']>;
@@ -182,6 +193,26 @@ export type BikeComponentInstall = {
   slotKey: Scalars['String']['output'];
 };
 
+export type BikeHistoryPayload = {
+  __typename?: 'BikeHistoryPayload';
+  bike: Bike;
+  installs: Array<ComponentInstallEvent>;
+  rides: Array<Ride>;
+  serviceEvents: Array<ServiceEvent>;
+  totals: BikeHistoryTotals;
+  truncated: Scalars['Boolean']['output'];
+};
+
+export type BikeHistoryTotals = {
+  __typename?: 'BikeHistoryTotals';
+  installEventCount: Scalars['Int']['output'];
+  rideCount: Scalars['Int']['output'];
+  serviceEventCount: Scalars['Int']['output'];
+  totalDistanceMeters: Scalars['Float']['output'];
+  totalDurationSeconds: Scalars['Int']['output'];
+  totalElevationGainMeters: Scalars['Float']['output'];
+};
+
 export type BikeNote = {
   __typename?: 'BikeNote';
   bikeId: Scalars['ID']['output'];
@@ -206,6 +237,14 @@ export type BikeNotesPage = {
   hasMore: Scalars['Boolean']['output'];
   items: Array<BikeNote>;
   totalCount: Scalars['Int']['output'];
+};
+
+export type BikeNotificationPreference = {
+  __typename?: 'BikeNotificationPreference';
+  bikeId: Scalars['ID']['output'];
+  serviceNotificationMode: ServiceNotificationMode;
+  serviceNotificationThreshold: Scalars['Int']['output'];
+  serviceNotificationsEnabled: Scalars['Boolean']['output'];
 };
 
 export type BikePredictionSummary = {
@@ -249,9 +288,15 @@ export type BikeSpecsSnapshot = {
 
 export enum BikeStatus {
   Active = 'ACTIVE',
+  Archived = 'ARCHIVED',
   Retired = 'RETIRED',
   Sold = 'SOLD'
 }
+
+export type BillingPortalResult = {
+  __typename?: 'BillingPortalResult';
+  url: Scalars['String']['output'];
+};
 
 export type BulkAssignResult = {
   __typename?: 'BulkAssignResult';
@@ -274,12 +319,39 @@ export type BulkUpdateBaselinesInput = {
   updates: Array<ComponentBaselineInput>;
 };
 
+/**
+ * Apply the same installedAt to multiple BikeComponentInstall rows in a
+ * single mutation. All rows must belong to the viewer — the batch is
+ * all-or-nothing to avoid leaking which ids they don't own.
+ */
+export type BulkUpdateBikeComponentInstallsInput = {
+  ids: Array<Scalars['ID']['input']>;
+  installedAt: Scalars['String']['input'];
+};
+
+export type BulkUpdateBikeComponentInstallsResult = {
+  __typename?: 'BulkUpdateBikeComponentInstallsResult';
+  serviceLogsMoved: Scalars['Int']['output'];
+  updatedCount: Scalars['Int']['output'];
+};
+
 export type CalibrationState = {
   __typename?: 'CalibrationState';
   bikes: Array<BikeCalibrationInfo>;
   overdueCount: Scalars['Int']['output'];
   showOverlay: Scalars['Boolean']['output'];
   totalComponentCount: Scalars['Int']['output'];
+};
+
+export enum CheckoutPlatform {
+  Mobile = 'MOBILE',
+  Web = 'WEB'
+}
+
+export type CheckoutSessionResult = {
+  __typename?: 'CheckoutSessionResult';
+  sessionId: Scalars['String']['output'];
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 export type Component = {
@@ -297,6 +369,7 @@ export type Component = {
   isSpare: Scalars['Boolean']['output'];
   isStock: Scalars['Boolean']['output'];
   lastServicedAt?: Maybe<Scalars['String']['output']>;
+  latestServiceLog?: Maybe<ServiceLog>;
   location: ComponentLocation;
   model: Scalars['String']['output'];
   notes?: Maybe<Scalars['String']['output']>;
@@ -323,6 +396,19 @@ export type ComponentFilterInput = {
   onlySpare?: InputMaybe<Scalars['Boolean']['input']>;
   types?: InputMaybe<Array<ComponentType>>;
 };
+
+export type ComponentInstallEvent = {
+  __typename?: 'ComponentInstallEvent';
+  component: Component;
+  eventType: ComponentInstallEventType;
+  id: Scalars['ID']['output'];
+  occurredAt: Scalars['String']['output'];
+};
+
+export enum ComponentInstallEventType {
+  Installed = 'INSTALLED',
+  Removed = 'REMOVED'
+}
 
 export enum ComponentLocation {
   Front = 'FRONT',
@@ -433,6 +519,7 @@ export type InstallComponentInput = {
   alsoReplacePair?: InputMaybe<Scalars['Boolean']['input']>;
   bikeId: Scalars['ID']['input'];
   existingComponentId?: InputMaybe<Scalars['ID']['input']>;
+  installedAt?: InputMaybe<Scalars['String']['input']>;
   newComponent?: InputMaybe<NewComponentInput>;
   noteText?: InputMaybe<Scalars['String']['input']>;
   pairNewComponent?: InputMaybe<NewComponentInput>;
@@ -467,13 +554,19 @@ export type Mutation = {
   addComponent: Component;
   addRide: Ride;
   assignBikeToRides: BulkAssignResult;
+  backfillWeatherForMyRides: BackfillWeatherResult;
+  bulkUpdateBikeComponentInstalls: BulkUpdateBikeComponentInstallsResult;
   bulkUpdateComponentBaselines: Array<Component>;
   completeCalibration: User;
+  createBillingPortalSession: BillingPortalResult;
+  createCheckoutSession: CheckoutSessionResult;
   createStravaGearMapping: StravaGearMapping;
   deleteBike: DeleteResult;
+  deleteBikeComponentInstall: Scalars['Boolean']['output'];
   deleteBikeNote: DeleteResult;
   deleteComponent: DeleteResult;
   deleteRide: DeleteRideResult;
+  deleteServiceLog: Scalars['Boolean']['output'];
   deleteStravaGearMapping: DeleteResult;
   dismissCalibration: User;
   installComponent: InstallComponentResult;
@@ -486,14 +579,20 @@ export type Mutation = {
   replaceComponent: ReplaceComponentResult;
   resetCalibration: User;
   retireBike: Bike;
+  selectBikeForDowngrade: Bike;
   snoozeComponent: Component;
   swapComponents: SwapComponentsResult;
   triggerProviderSync: TriggerSyncResult;
+  updateAnalyticsOptOut: User;
   updateBike: Bike;
+  updateBikeAcquisition: UpdateBikeAcquisitionResult;
+  updateBikeComponentInstall: BikeComponentInstall;
+  updateBikeNotificationPreference: BikeNotificationPreference;
   updateBikeServicePreferences: Array<BikeServicePreference>;
   updateBikesOrder: Array<Bike>;
   updateComponent: Component;
   updateRide: Ride;
+  updateServiceLog: ServiceLog;
   updateServicePreferences: Array<UserServicePreference>;
   updateUserPreferences: User;
 };
@@ -536,8 +635,24 @@ export type MutationAssignBikeToRidesArgs = {
 };
 
 
+export type MutationBulkUpdateBikeComponentInstallsArgs = {
+  input: BulkUpdateBikeComponentInstallsInput;
+};
+
+
 export type MutationBulkUpdateComponentBaselinesArgs = {
   input: BulkUpdateBaselinesInput;
+};
+
+
+export type MutationCreateBillingPortalSessionArgs = {
+  platform?: InputMaybe<CheckoutPlatform>;
+};
+
+
+export type MutationCreateCheckoutSessionArgs = {
+  plan: StripePlan;
+  platform?: InputMaybe<CheckoutPlatform>;
 };
 
 
@@ -547,6 +662,11 @@ export type MutationCreateStravaGearMappingArgs = {
 
 
 export type MutationDeleteBikeArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationDeleteBikeComponentInstallArgs = {
   id: Scalars['ID']['input'];
 };
 
@@ -562,6 +682,11 @@ export type MutationDeleteComponentArgs = {
 
 
 export type MutationDeleteRideArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationDeleteServiceLogArgs = {
   id: Scalars['ID']['input'];
 };
 
@@ -608,6 +733,11 @@ export type MutationRetireBikeArgs = {
 };
 
 
+export type MutationSelectBikeForDowngradeArgs = {
+  bikeId: Scalars['ID']['input'];
+};
+
+
 export type MutationSnoozeComponentArgs = {
   hours?: InputMaybe<Scalars['Float']['input']>;
   id: Scalars['ID']['input'];
@@ -624,9 +754,31 @@ export type MutationTriggerProviderSyncArgs = {
 };
 
 
+export type MutationUpdateAnalyticsOptOutArgs = {
+  optOut: Scalars['Boolean']['input'];
+};
+
+
 export type MutationUpdateBikeArgs = {
   id: Scalars['ID']['input'];
   input: UpdateBikeInput;
+};
+
+
+export type MutationUpdateBikeAcquisitionArgs = {
+  bikeId: Scalars['ID']['input'];
+  input: UpdateBikeAcquisitionInput;
+};
+
+
+export type MutationUpdateBikeComponentInstallArgs = {
+  id: Scalars['ID']['input'];
+  input: UpdateBikeComponentInstallInput;
+};
+
+
+export type MutationUpdateBikeNotificationPreferenceArgs = {
+  input: UpdateBikeNotificationPreferenceInput;
 };
 
 
@@ -649,6 +801,12 @@ export type MutationUpdateComponentArgs = {
 export type MutationUpdateRideArgs = {
   id: Scalars['ID']['input'];
   input: UpdateRideInput;
+};
+
+
+export type MutationUpdateServiceLogArgs = {
+  id: Scalars['ID']['input'];
+  input: UpdateServiceLogInput;
 };
 
 
@@ -688,12 +846,14 @@ export enum PredictionStatus {
 
 export type Query = {
   __typename?: 'Query';
+  bikeHistory: BikeHistoryPayload;
   bikeNotes: BikeNotesPage;
   bikes: Array<Bike>;
   calibrationState?: Maybe<CalibrationState>;
   components: Array<Component>;
   importNotificationState?: Maybe<ImportNotificationState>;
   me?: Maybe<User>;
+  referralStats: ReferralStats;
   rideTypes: Array<RideType>;
   rides: Array<Ride>;
   servicePreferenceDefaults: Array<ServicePreferenceDefault>;
@@ -701,6 +861,13 @@ export type Query = {
   unassignedRides: UnassignedRidesPage;
   unmappedStravaGears: Array<StravaGearInfo>;
   user?: Maybe<User>;
+};
+
+
+export type QueryBikeHistoryArgs = {
+  bikeId: Scalars['ID']['input'];
+  endDate?: InputMaybe<Scalars['String']['input']>;
+  startDate?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -739,9 +906,18 @@ export type QueryUserArgs = {
   id: Scalars['ID']['input'];
 };
 
+export type ReferralStats = {
+  __typename?: 'ReferralStats';
+  completedCount: Scalars['Int']['output'];
+  pendingCount: Scalars['Int']['output'];
+  referralCode: Scalars['String']['output'];
+  referralLink: Scalars['String']['output'];
+};
+
 export type ReplaceComponentInput = {
   alsoReplacePair?: InputMaybe<Scalars['Boolean']['input']>;
   componentId: Scalars['ID']['input'];
+  installedAt?: InputMaybe<Scalars['String']['input']>;
   newBrand: Scalars['String']['input'];
   newModel: Scalars['String']['input'];
   pairBrand?: InputMaybe<Scalars['String']['input']>;
@@ -770,9 +946,11 @@ export type Ride = {
   startTime: Scalars['String']['output'];
   stravaActivityId?: Maybe<Scalars['String']['output']>;
   stravaGearId?: Maybe<Scalars['String']['output']>;
+  suuntoWorkoutId?: Maybe<Scalars['String']['output']>;
   trailSystem?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['String']['output'];
   userId: Scalars['ID']['output'];
+  weather?: Maybe<RideWeather>;
   whoopWorkoutId?: Maybe<Scalars['String']['output']>;
 };
 
@@ -785,10 +963,35 @@ export enum RideType {
   Trainer = 'TRAINER'
 }
 
+export type RideWeather = {
+  __typename?: 'RideWeather';
+  condition: WeatherCondition;
+  feelsLikeC?: Maybe<Scalars['Float']['output']>;
+  fetchedAt: Scalars['String']['output'];
+  humidity?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+  lat: Scalars['Float']['output'];
+  lng: Scalars['Float']['output'];
+  precipitationMm: Scalars['Float']['output'];
+  source: Scalars['String']['output'];
+  tempC: Scalars['Float']['output'];
+  windSpeedKph: Scalars['Float']['output'];
+  wmoCode: Scalars['Int']['output'];
+};
+
 export type RidesFilterInput = {
   bikeId?: InputMaybe<Scalars['ID']['input']>;
   endDate?: InputMaybe<Scalars['String']['input']>;
   startDate?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ServiceEvent = {
+  __typename?: 'ServiceEvent';
+  component: Component;
+  hoursAtService: Scalars['Float']['output'];
+  id: Scalars['ID']['output'];
+  notes?: Maybe<Scalars['String']['output']>;
+  performedAt: Scalars['String']['output'];
 };
 
 export type ServiceLog = {
@@ -800,6 +1003,12 @@ export type ServiceLog = {
   notes?: Maybe<Scalars['String']['output']>;
   performedAt: Scalars['String']['output'];
 };
+
+export enum ServiceNotificationMode {
+  AtService = 'AT_SERVICE',
+  HoursBefore = 'HOURS_BEFORE',
+  RidesBefore = 'RIDES_BEFORE'
+}
 
 export type ServicePreferenceDefault = {
   __typename?: 'ServicePreferenceDefault';
@@ -884,9 +1093,27 @@ export type StravaGearMapping = {
   stravaGearName?: Maybe<Scalars['String']['output']>;
 };
 
+export enum StripePlan {
+  Annual = 'ANNUAL',
+  Monthly = 'MONTHLY'
+}
+
+export enum SubscriptionProvider {
+  Apple = 'APPLE',
+  Google = 'GOOGLE',
+  Stripe = 'STRIPE'
+}
+
+export enum SubscriptionTier {
+  FreeFull = 'FREE_FULL',
+  FreeLight = 'FREE_LIGHT',
+  Pro = 'PRO'
+}
+
 export type SwapComponentsInput = {
   bikeIdA: Scalars['ID']['input'];
   bikeIdB: Scalars['ID']['input'];
+  installedAt?: InputMaybe<Scalars['String']['input']>;
   noteText?: InputMaybe<Scalars['String']['input']>;
   slotKeyA: Scalars['String']['input'];
   slotKeyB: Scalars['String']['input'];
@@ -906,6 +1133,14 @@ export enum SyncProvider {
   Suunto = 'SUUNTO',
   Whoop = 'WHOOP'
 }
+
+export type TierLimits = {
+  __typename?: 'TierLimits';
+  allowedComponentTypes: Array<ComponentType>;
+  canAddBike: Scalars['Boolean']['output'];
+  currentBikeCount: Scalars['Int']['output'];
+  maxBikes?: Maybe<Scalars['Int']['output']>;
+};
 
 export type TriggerSyncResult = {
   __typename?: 'TriggerSyncResult';
@@ -939,7 +1174,51 @@ export type UnassignedRidesPage = {
   totalCount: Scalars['Int']['output'];
 };
 
+/**
+ * Retroactively fix a bike's acquisition date and, when requested, the
+ * install dates of every stock component + any install whose date was
+ * auto-stamped at bike creation. Built for users who added bikes before
+ * the acquisition-date feature existed and now see every stock part
+ * installed on the same day on BikeHistory.
+ */
+export type UpdateBikeAcquisitionInput = {
+  acquisitionDate: Scalars['String']['input'];
+  /**
+   * When true (default), move the installedAt on every BikeComponentInstall
+   * matching the "buggy auto-date" predicate to the new acquisitionDate,
+   * and move the corresponding synthetic baseline ServiceLog alongside.
+   */
+  cascadeInstalls?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type UpdateBikeAcquisitionResult = {
+  __typename?: 'UpdateBikeAcquisitionResult';
+  bike: Bike;
+  installsMoved: Scalars['Int']['output'];
+  serviceLogsMoved: Scalars['Int']['output'];
+};
+
+/**
+ * Patch fields on a BikeComponentInstall row.
+ *
+ * **Null handling is asymmetric**, mirroring the underlying Prisma schema:
+ *
+ * - `installedAt`: an ISO date string updates the value. `null` or omitted
+ *   is a no-op. You cannot clear this field — `installedAt` is required at
+ *   the database level.
+ * - `removedAt`: an ISO date string updates the value. Explicit `null`
+ *   **clears** the field (the component is no longer marked as removed).
+ *   Omitting the key is a no-op.
+ */
+export type UpdateBikeComponentInstallInput = {
+  /** ISO date string. Pass to update; null or omitted is ignored (cannot be cleared). */
+  installedAt?: InputMaybe<Scalars['String']['input']>;
+  /** ISO date string to set, or explicit null to clear. */
+  removedAt?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type UpdateBikeInput = {
+  acquisitionDate?: InputMaybe<Scalars['String']['input']>;
   batteryWh?: InputMaybe<Scalars['Int']['input']>;
   buildKind?: InputMaybe<Scalars['String']['input']>;
   category?: InputMaybe<Scalars['String']['input']>;
@@ -972,6 +1251,13 @@ export type UpdateBikeInput = {
   year?: InputMaybe<Scalars['Int']['input']>;
 };
 
+export type UpdateBikeNotificationPreferenceInput = {
+  bikeId: Scalars['ID']['input'];
+  serviceNotificationMode?: InputMaybe<ServiceNotificationMode>;
+  serviceNotificationThreshold?: InputMaybe<Scalars['Int']['input']>;
+  serviceNotificationsEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
 export type UpdateBikeServicePreferencesInput = {
   bikeId: Scalars['ID']['input'];
   preferences: Array<BikeServicePreferenceInput>;
@@ -1000,13 +1286,21 @@ export type UpdateRideInput = {
   trailSystem?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type UpdateServiceLogInput = {
+  hoursAtService?: InputMaybe<Scalars['Float']['input']>;
+  notes?: InputMaybe<Scalars['String']['input']>;
+  performedAt?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type UpdateServicePreferencesInput = {
   preferences: Array<ServicePreferenceInput>;
 };
 
 export type UpdateUserPreferencesInput = {
   distanceUnit?: InputMaybe<Scalars['String']['input']>;
+  expoPushToken?: InputMaybe<Scalars['String']['input']>;
   hoursDisplayPreference?: InputMaybe<Scalars['String']['input']>;
+  notifyOnRideUpload?: InputMaybe<Scalars['Boolean']['input']>;
   predictionMode?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1015,6 +1309,7 @@ export type User = {
   accounts: Array<ConnectedAccount>;
   activeDataSource?: Maybe<Scalars['String']['output']>;
   age?: Maybe<Scalars['Int']['output']>;
+  analyticsOptOut: Scalars['Boolean']['output'];
   avatarUrl?: Maybe<Scalars['String']['output']>;
   createdAt: Scalars['String']['output'];
   distanceUnit?: Maybe<Scalars['String']['output']>;
@@ -1027,13 +1322,26 @@ export type User = {
   location?: Maybe<Scalars['String']['output']>;
   mustChangePassword: Scalars['Boolean']['output'];
   name?: Maybe<Scalars['String']['output']>;
+  needsDowngradeSelection: Scalars['Boolean']['output'];
   needsReauthForSensitiveActions: Scalars['Boolean']['output'];
+  notifyOnRideUpload: Scalars['Boolean']['output'];
   onboardingCompleted: Scalars['Boolean']['output'];
   pairedComponentMigrationSeenAt?: Maybe<Scalars['String']['output']>;
   predictionMode?: Maybe<Scalars['String']['output']>;
+  referralCode?: Maybe<Scalars['String']['output']>;
   rides: Array<Ride>;
+  ridesMissingWeather: Scalars['Int']['output'];
   role: UserRole;
   servicePreferences: Array<UserServicePreference>;
+  subscriptionProvider?: Maybe<SubscriptionProvider>;
+  subscriptionTier: SubscriptionTier;
+  tierLimits: TierLimits;
+  weatherBreakdown: WeatherBreakdown;
+};
+
+
+export type UserWeatherBreakdownArgs = {
+  filter?: InputMaybe<RidesFilterInput>;
 };
 
 export enum UserRole {
@@ -1057,6 +1365,29 @@ export type WearDriver = {
   factor: Scalars['String']['output'];
   label: Scalars['String']['output'];
 };
+
+export type WeatherBreakdown = {
+  __typename?: 'WeatherBreakdown';
+  cloudy: Scalars['Int']['output'];
+  foggy: Scalars['Int']['output'];
+  pending: Scalars['Int']['output'];
+  rainy: Scalars['Int']['output'];
+  snowy: Scalars['Int']['output'];
+  sunny: Scalars['Int']['output'];
+  totalRides: Scalars['Int']['output'];
+  unknown: Scalars['Int']['output'];
+  windy: Scalars['Int']['output'];
+};
+
+export enum WeatherCondition {
+  Cloudy = 'CLOUDY',
+  Foggy = 'FOGGY',
+  Rainy = 'RAINY',
+  Snowy = 'SNOWY',
+  Sunny = 'SUNNY',
+  Unknown = 'UNKNOWN',
+  Windy = 'WINDY'
+}
 
 export type BikeFieldsFragment = { __typename?: 'Bike', id: string, nickname?: string | null, manufacturer: string, model: string, year?: number | null, travelForkMm?: number | null, travelShockMm?: number | null, notes?: string | null, createdAt: string, updatedAt: string, components: Array<{ __typename?: 'Component', id: string, type: ComponentType, brand: string, model: string, notes?: string | null, isStock: boolean, bikeId?: string | null, hoursUsed: number, serviceDueAtHours?: number | null }> };
 
@@ -1169,7 +1500,7 @@ export type RidesQueryVariables = Exact<{
 }>;
 
 
-export type RidesQuery = { __typename?: 'Query', rides: Array<{ __typename?: 'Ride', id: string, garminActivityId?: string | null, stravaActivityId?: string | null, whoopWorkoutId?: string | null, startTime: string, durationSeconds: number, distanceMeters: number, elevationGainMeters: number, averageHr?: number | null, rideType: string, bikeId?: string | null, notes?: string | null, trailSystem?: string | null, location?: string | null }> };
+export type RidesQuery = { __typename?: 'Query', rides: Array<{ __typename?: 'Ride', id: string, garminActivityId?: string | null, stravaActivityId?: string | null, whoopWorkoutId?: string | null, suuntoWorkoutId?: string | null, startTime: string, durationSeconds: number, distanceMeters: number, elevationGainMeters: number, averageHr?: number | null, rideType: string, bikeId?: string | null, notes?: string | null, trailSystem?: string | null, location?: string | null }> };
 
 export type UnmappedStravaGearsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1924,6 +2255,7 @@ export const RidesDocument = gql`
     garminActivityId
     stravaActivityId
     whoopWorkoutId
+    suuntoWorkoutId
     startTime
     durationSeconds
     distanceMeters

--- a/libs/graphql/src/operations/rides.graphql
+++ b/libs/graphql/src/operations/rides.graphql
@@ -4,6 +4,7 @@ query Rides($take: Int, $after: ID, $filter: RidesFilterInput) {
     garminActivityId
     stravaActivityId
     whoopWorkoutId
+    suuntoWorkoutId
     startTime
     durationSeconds
     distanceMeters


### PR DESCRIPTION
# Suunto integration

Adds Suunto as a first-class workout data provider alongside Strava, Garmin, and WHOOP. Covers two commits: `0cb2021` (initial integration — OAuth, webhooks, backfill, UI) and `6dae0eb` (parity — sync worker, batch queue, component hours, activation email).

Companion doc: [suunto-todo.md](./suunto-todo.md) tracks the gap analysis and what was closed in each pass.

## Why

Suunto users previously had to route their rides through Strava to get them into Loam Logger. That's extra friction for riders who don't otherwise use Strava, and it adds a dependency on a third party we don't control. With this PR, Suunto watches talk directly to Loam Logger.

## What's included

### OAuth + account linking
- `auth.suunto.ts` — full web + mobile OAuth flow mirroring the Strava pattern. Uses Suunto's `cloudapi-oauth.suunto.com` endpoints with HTTP Basic client auth per RFC7617.
- JWT access tokens are parsed for the `user` claim (Suunto's stable user identifier) and stored as `providerUserId`.
- Mobile flow uses the shared `OAuthAttempt` DB state-store; web flow uses an httpOnly `ll_suunto_state` cookie.
- Disconnect hits Suunto's `GET /oauth/deauthorize` endpoint, with graceful fallback to local-state cleanup on 401.
- Token refresh helper in `suunto-token.ts` with the same promise-caching + timeout logic as the Strava/Garmin/WHOOP equivalents.

### Schema
- `AuthProvider` enum: added `suunto`.
- `IntegrationProvider` enum: added `SUUNTO`.
- `User.suuntoUserId String? @unique` + `Ride.suuntoWorkoutId String? @unique`.
- `EmailType`: added `suunto_integration_live`.
- `BackfillProvider` union extended to `'garmin' | 'suunto'`.

### Webhook ingestion
- `POST /webhooks/suunto/workouts` — HMAC-SHA256 signature verification against `SUUNTO_NOTIFICATION_SECRET` using `timingSafeEqual`. Raw body parser mounted before `express.json()` so the HMAC has access to the original bytes (Stripe-style).
- Handles `WORKOUT_CREATED` directly — the webhook payload contains the full workout, so no follow-up fetch is needed.
- Other event types (routes, 24/7 metrics) are logged as ignored but don't error.
- Responds 200 within Suunto's 2s deadline; processing happens after the response.

### Historical sync
- **Synchronous single-year fetch** (`GET /suunto/backfill/fetch`) — paginates `GET /v3/workouts`, filters cycling via `isSuuntoCyclingActivity`, runs cross-provider dedup via `findPotentialDuplicates`, auto-assigns the single active bike, tracks component hours, upserts under the `BackfillRequest` checkpoint for YTD resume.
- **Queued multi-year batch** (`POST /suunto/backfill/batch`) — mirrors the Garmin batch endpoint. Enqueues one job per year via `enqueueBackfillJob`, creates a `running` `ImportSession`, returns immediately. The backfill worker's new `processSuuntoBackfill` handler does the actual work in the background.
- Both flows share a new `lib/suunto-sync.ts` helper (API base, types, `suuntoApiHeaders()`) so the subscription-key header is sent consistently — fixing a bug where the original synchronous path would have failed against Suunto's APIM gateway.

### On-demand sync worker
- `syncSuuntoLatest`, `syncSuuntoActivity`, `upsertSuuntoActivity` in `sync.worker.ts` — unblocks the `syncLatest`/`syncActivity` GraphQL mutations for Suunto. Uses the Garmin-style two-phase upsert (ride first, component hours in a separate transaction) so a hour-sync failure can't drop a ride.
- Previously these were `logger.warn` stubs.

### Component hour tracking
- Extracted the `syncBikeComponentHours` helper (previously duplicated inline in `webhooks.strava.ts` and `sync.worker.ts`) into `lib/component-hours.ts`.
- Wired it into the Suunto webhook path (reads existing ride, auto-assigns single bike on new rides, upsert + hour sync in one transaction).
- **Also fixed a pre-existing Garmin bug** in `backfill.worker.ts:processGarminCallback` — callback-delivered backfill rides weren't tracking component hours. The Garmin webhook path was correct because it delegated to the sync worker which already called the helper, but the direct callback-processing path silently skipped it.

### UI
- New `ConnectSuuntoLink` component + Suunto brand icon (`#0072CE`).
- Settings page shows Suunto alongside Garmin/Strava/WHOOP with connected state, disconnect button, and backfill modal.
- Onboarding step 6 includes a Suunto connect card.
- `DataSourceSelector` extended to include Suunto with a responsive grid that handles up to 4 connected providers.
- Backend `POST /api/data-source/preference` extended to accept `'whoop'` and `'suunto'` (previously only accepted `'garmin' | 'strava'` — WHOOP was already broken at this endpoint).

### Activation email
- New admin-broadcast template `suunto-enabled.tsx` mirroring the existing Strava announcement.
- Registered in `templates/emails/index.ts` so it shows up in the admin email UI.

## Env vars added

Already in `apps/api/.env`:

```
SUUNTO_CLIENT_ID=...
SUUNTO_CLIENT_SECRET=...
SUUNTO_NOTIFICATION_TOKEN=...
SUUNTO_NOTIFICATION_SECRET=...
SUUNTO_SUBSCRIPTION_KEY=...
SUUNTO_REDIRECT_URI=https://api.loamlogger.app/auth/suunto/callback
```

Production secrets store (Railway) needs the same set.

## Migrations

Two additive migrations, all nullable columns and new enum values — no data loss, no constraint changes against existing rows.

```bash
cd apps/api
npm run prisma:mig add_suunto_provider            # commit 0cb2021
npm run prisma:mig add_suunto_integration_live_email_type   # commit 6dae0eb (if not already run)
```

Production uses `npm run prisma:migrate:deploy` which applies committed migrations without prompts.

## Suunto developer portal config

For the OAuth app in the Suunto partner portal:

| Field | Value |
|---|---|
| Redirect URI | `https://api.loamlogger.app/auth/suunto/callback` |
| Workout notification URL | `https://api.loamlogger.app/webhooks/suunto/workouts` |
| Notification access secret | Matches `SUUNTO_NOTIFICATION_SECRET` in the API env (used for HMAC verification) |
| Notification sending | Enabled once the webhook is deployed |
| Legacy form URL / route / 247 URLs | Leave blank — not handled |

## Test plan

- [ ] `npm run prisma:mig add_suunto_provider` runs cleanly locally
- [ ] `npm run prisma:mig add_suunto_integration_live_email_type` runs cleanly locally
- [ ] `npm run typecheck` in both `apps/api` and `apps/web` — Suunto files clean (pre-existing BullMQ `Redis → ConnectionOptions` errors in queue files remain; unrelated)
- [ ] `npm run test` in `apps/api` — `suunto.backfill.test.ts`, `duplicates.test.ts`, and `types/suunto.test.ts` all pass
- [ ] OAuth round-trip: click "Connect Suunto" in Settings → complete consent on Suunto → land back on `/settings?suunto=connected` with `UserIntegration.provider='SUUNTO'` row present and encrypted tokens populated
- [ ] Mobile OAuth round-trip: `POST /auth/suunto/start` from the mobile WebView → deep-link back → `OAuthAttempt.usedAt` set
- [ ] Disconnect: Disconnect button clears `UserIntegration.revokedAt`, removes `OauthToken` + `UserAccount`, calls Suunto's deauthorize endpoint
- [ ] First live workout upload from a test Suunto account → `/webhooks/suunto/workouts` verifies HMAC, upserts a `Ride` keyed on `suuntoWorkoutId`, component hours increment on the auto-assigned bike
- [ ] Tamper with the body in a test request → returns 403 (HMAC mismatch)
- [ ] "Sync Previous Rides" from Settings → GraphQL `syncLatest` mutation → sync worker's `syncSuuntoLatest` runs, pulls last 30 days
- [ ] Multi-year batch: `POST /suunto/backfill/batch` with 3 years → returns immediately, three `BackfillRequest` rows go `pending → in_progress → completed`, `ImportSession` closes
- [ ] Data source selector: connect Suunto + Strava → selector appears with both + Suunto card → select Suunto → `User.activeDataSource='suunto'` persists
- [ ] Email: admin UI shows "Suunto Integration Live" template; test send to self renders correctly in light + dark mode clients

## Out of scope (documented in [suunto-todo.md](./suunto-todo.md))

- **Bike/gear mapping** — Suunto's `gear` field is the watch, not the bike, so there's no equivalent to `StravaGearMapping`.
- **Mock endpoint for dev** — Garmin has one; Suunto doesn't. Low value.
- **Per-user auto-fired "you connected Suunto" email** — the existing `strava-enabled.tsx` is a broadcast, not per-connect. No provider has a per-connect email today, so Suunto doesn't either.
