### PR TITLE
feat: heatmaps reminder

### DIFF
--- a/apps/api/prisma/migrations/20260507200454_add_trail_stewardship_notice_seen/migration.sql
+++ b/apps/api/prisma/migrations/20260507200454_add_trail_stewardship_notice_seen/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+ALTER TYPE "EmailType" ADD VALUE 'suunto_integration_live';
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "trailStewardshipNoticeSeenAt" TIMESTAMP(3);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   calibrationCompletedAt DateTime?
   calibrationDismissedAt DateTime?
   pairedComponentMigrationSeenAt DateTime?
+  trailStewardshipNoticeSeenAt   DateTime?
 
   // When true, suppress all server-side PostHog events for this user
   // (captureServerEvent short-circuits). Client-side opt-out is handled

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -4137,6 +4137,24 @@ export const resolvers = {
       });
     },
 
+    markTrailStewardshipNoticeSeen: async (_: unknown, __: unknown, ctx: GraphQLContext) => {
+      const userId = requireUserId(ctx);
+
+      const rateLimit = await checkMutationRateLimit('markTrailStewardshipNoticeSeen', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(`Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`, {
+          extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
+        });
+      }
+
+      return prisma.user.update({
+        where: { id: userId },
+        data: {
+          trailStewardshipNoticeSeenAt: new Date(),
+        },
+      });
+    },
+
     replaceComponent: async (
       _: unknown,
       { input }: { input: ReplaceComponentInputGQL },
@@ -5412,6 +5430,8 @@ export const resolvers = {
     },
     pairedComponentMigrationSeenAt: (parent: { pairedComponentMigrationSeenAt?: Date | null }) =>
       parent.pairedComponentMigrationSeenAt?.toISOString() ?? null,
+    trailStewardshipNoticeSeenAt: (parent: { trailStewardshipNoticeSeenAt?: Date | null }) =>
+      parent.trailStewardshipNoticeSeenAt?.toISOString() ?? null,
     notifyOnRideUpload: (parent: { notifyOnRideUpload?: boolean }) => parent.notifyOnRideUpload ?? true,
     createdAt: (parent: { createdAt: Date }) => parent.createdAt.toISOString(),
     // Scoped to the viewer's User type so the shape matches other user-owned

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -940,6 +940,7 @@ export const typeDefs = gql`
     completeCalibration: User!
     resetCalibration: User!
     markPairedComponentMigrationSeen: User!
+    markTrailStewardshipNoticeSeen: User!
     replaceComponent(input: ReplaceComponentInput!): ReplaceComponentResult!
     installComponent(input: InstallComponentInput!): InstallComponentResult!
     swapComponents(input: SwapComponentsInput!): SwapComponentsResult!
@@ -1014,6 +1015,7 @@ export const typeDefs = gql`
     distanceUnit: String
     analyticsOptOut: Boolean!
     pairedComponentMigrationSeenAt: String
+    trailStewardshipNoticeSeenAt: String
     servicePreferences: [UserServicePreference!]!
     notifyOnRideUpload: Boolean!
     createdAt: String!

--- a/apps/web/src/graphql/me.ts
+++ b/apps/web/src/graphql/me.ts
@@ -29,6 +29,7 @@ export const ME_QUERY = gql`
       distanceUnit
       analyticsOptOut
       pairedComponentMigrationSeenAt
+      trailStewardshipNoticeSeenAt
       createdAt
     }
   }

--- a/apps/web/src/graphql/userPreferences.ts
+++ b/apps/web/src/graphql/userPreferences.ts
@@ -24,6 +24,19 @@ export function useMarkPairedComponentMigrationSeen() {
   return useMutation(MARK_PAIRED_COMPONENT_MIGRATION_SEEN_MUTATION)
 }
 
+export const MARK_TRAIL_STEWARDSHIP_NOTICE_SEEN_MUTATION = gql`
+  mutation MarkTrailStewardshipNoticeSeen {
+    markTrailStewardshipNoticeSeen {
+      id
+      trailStewardshipNoticeSeenAt
+    }
+  }
+`
+
+export function useMarkTrailStewardshipNoticeSeen() {
+  return useMutation(MARK_TRAIL_STEWARDSHIP_NOTICE_SEEN_MUTATION)
+}
+
 export const MIGRATE_PAIRED_COMPONENTS_MUTATION = gql`
   mutation MigratePairedComponents {
     migratePairedComponents {

--- a/apps/web/src/pages/Settings/SettingsSidebar.tsx
+++ b/apps/web/src/pages/Settings/SettingsSidebar.tsx
@@ -6,6 +6,7 @@ import {
   Wrench,
   Activity,
   Shield,
+  Mountain,
   AlertTriangle,
   type LucideIcon,
 } from 'lucide-react';
@@ -20,6 +21,7 @@ type SettingsSectionMeta = {
 const SETTINGS_SECTIONS: readonly SettingsSectionMeta[] = [
   { id: 'account', label: 'Account', icon: User },
   { id: 'data-sources', label: 'Data Sources', icon: LinkIcon },
+  { id: 'trail-stewardship', label: 'Trail Stewardship', icon: Mountain },
   { id: 'preferences', label: 'Preferences', icon: Sliders },
   { id: 'service-intervals', label: 'Service Intervals', icon: Wrench },
   { id: 'maintenance', label: 'Maintenance', icon: Activity },

--- a/apps/web/src/pages/Settings/components/TrailStewardshipModal.tsx
+++ b/apps/web/src/pages/Settings/components/TrailStewardshipModal.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Shield, ExternalLink } from 'lucide-react';
 import { Modal } from '../../../components/ui/Modal';
 import {
@@ -6,13 +7,7 @@ import {
   type StewardshipProviderId,
 } from '@loam/shared';
 import { useMarkTrailStewardshipNoticeSeen } from '../../../graphql/userPreferences';
-
-const BRAND_COLOR_VARS: Record<StewardshipProviderId, string> = {
-  strava: '--brand-strava',
-  garmin: '--brand-garmin',
-  suunto: '--brand-suunto',
-  whoop: '--brand-whoop',
-};
+import { STEWARDSHIP_BRAND_COLOR_VARS } from './trailStewardshipBrandColors';
 
 type Props = {
   isOpen: boolean;
@@ -29,17 +24,22 @@ type Props = {
  */
 export default function TrailStewardshipModal({ isOpen, provider, onClose }: Props) {
   const [markSeen] = useMarkTrailStewardshipNoticeSeen();
+  const [dismissing, setDismissing] = useState(false);
 
   const focused = provider
     ? TRAIL_STEWARDSHIP_PROVIDERS.find((p) => p.provider === provider)
     : null;
 
   const handleDismiss = async () => {
+    if (dismissing) return;
+    setDismissing(true);
     try {
       await markSeen();
     } catch {
       // Non-fatal. If the mutation fails the modal may show again on the next
       // connection; not worth blocking the user.
+    } finally {
+      setDismissing(false);
     }
     onClose();
   };
@@ -48,11 +48,17 @@ export default function TrailStewardshipModal({ isOpen, provider, onClose }: Pro
     <Modal
       isOpen={isOpen}
       onClose={handleDismiss}
+      preventClose={dismissing}
       title={STEWARDSHIP_HEADER.title}
       size="md"
       footer={
-        <button type="button" onClick={handleDismiss} className="btn-primary">
-          I've reviewed my settings
+        <button
+          type="button"
+          onClick={handleDismiss}
+          disabled={dismissing}
+          className="btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {dismissing ? 'Saving…' : "I've reviewed my settings"}
         </button>
       }
     >
@@ -67,7 +73,7 @@ export default function TrailStewardshipModal({ isOpen, provider, onClose }: Pro
             <div>
               <p
                 className="font-semibold text-sm"
-                style={{ color: `var(${BRAND_COLOR_VARS[focused.provider]})` }}
+                style={{ color: `var(${STEWARDSHIP_BRAND_COLOR_VARS[focused.provider]})` }}
               >
                 Just connected: {focused.name}
               </p>
@@ -78,7 +84,7 @@ export default function TrailStewardshipModal({ isOpen, provider, onClose }: Pro
               <p className="label-section mb-2">How to opt out</p>
               <ol className="space-y-2 text-sm">
                 {focused.steps.map((step, i) => (
-                  <li key={i} className="flex gap-3">
+                  <li key={step} className="flex gap-3">
                     <span className="font-semibold text-muted shrink-0 w-5">{i + 1}.</span>
                     <span>{step}</span>
                   </li>
@@ -92,8 +98,8 @@ export default function TrailStewardshipModal({ isOpen, provider, onClose }: Pro
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 rounded-xl border px-3 py-1.5 text-xs font-medium hover:bg-surface-3/40 transition"
               style={{
-                borderColor: `var(${BRAND_COLOR_VARS[focused.provider]})`,
-                color: `var(${BRAND_COLOR_VARS[focused.provider]})`,
+                borderColor: `var(${STEWARDSHIP_BRAND_COLOR_VARS[focused.provider]})`,
+                color: `var(${STEWARDSHIP_BRAND_COLOR_VARS[focused.provider]})`,
               }}
             >
               <ExternalLink className="h-3.5 w-3.5" />

--- a/apps/web/src/pages/Settings/components/TrailStewardshipModal.tsx
+++ b/apps/web/src/pages/Settings/components/TrailStewardshipModal.tsx
@@ -1,0 +1,111 @@
+import { Shield, ExternalLink } from 'lucide-react';
+import { Modal } from '../../../components/ui/Modal';
+import {
+  STEWARDSHIP_HEADER,
+  TRAIL_STEWARDSHIP_PROVIDERS,
+  type StewardshipProviderId,
+} from '@loam/shared';
+import { useMarkTrailStewardshipNoticeSeen } from '../../../graphql/userPreferences';
+
+const BRAND_COLOR_VARS: Record<StewardshipProviderId, string> = {
+  strava: '--brand-strava',
+  garmin: '--brand-garmin',
+  suunto: '--brand-suunto',
+  whoop: '--brand-whoop',
+};
+
+type Props = {
+  isOpen: boolean;
+  /** Provider that was just connected. Highlighted in the modal. */
+  provider: StewardshipProviderId | null;
+  onClose: () => void;
+};
+
+/**
+ * One-time modal shown after a user connects their first heatmap-publishing
+ * provider (Strava, Garmin, Suunto). Persists "seen" state server-side via
+ * markTrailStewardshipNoticeSeen so the modal doesn't reappear on subsequent
+ * connections, on any device.
+ */
+export default function TrailStewardshipModal({ isOpen, provider, onClose }: Props) {
+  const [markSeen] = useMarkTrailStewardshipNoticeSeen();
+
+  const focused = provider
+    ? TRAIL_STEWARDSHIP_PROVIDERS.find((p) => p.provider === provider)
+    : null;
+
+  const handleDismiss = async () => {
+    try {
+      await markSeen();
+    } catch {
+      // Non-fatal. If the mutation fails the modal may show again on the next
+      // connection; not worth blocking the user.
+    }
+    onClose();
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleDismiss}
+      title={STEWARDSHIP_HEADER.title}
+      size="md"
+      footer={
+        <button type="button" onClick={handleDismiss} className="btn-primary">
+          I've reviewed my settings
+        </button>
+      }
+    >
+      <div className="space-y-4">
+        <div className="flex items-start gap-3">
+          <Shield className="h-5 w-5 shrink-0 text-amber-400 mt-0.5" />
+          <p className="text-sm text-muted leading-relaxed">{STEWARDSHIP_HEADER.body}</p>
+        </div>
+
+        {focused && focused.hasPublicHeatmap && (
+          <div className="rounded-2xl border border-app/70 bg-surface-2 px-4 py-3 space-y-3">
+            <div>
+              <p
+                className="font-semibold text-sm"
+                style={{ color: `var(${BRAND_COLOR_VARS[focused.provider]})` }}
+              >
+                Just connected: {focused.name}
+              </p>
+              <p className="text-sm text-muted mt-1">{focused.summary}</p>
+            </div>
+
+            <div>
+              <p className="label-section mb-2">How to opt out</p>
+              <ol className="space-y-2 text-sm">
+                {focused.steps.map((step, i) => (
+                  <li key={i} className="flex gap-3">
+                    <span className="font-semibold text-muted shrink-0 w-5">{i + 1}.</span>
+                    <span>{step}</span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+
+            <a
+              href={focused.settingsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-xl border px-3 py-1.5 text-xs font-medium hover:bg-surface-3/40 transition"
+              style={{
+                borderColor: `var(${BRAND_COLOR_VARS[focused.provider]})`,
+                color: `var(${BRAND_COLOR_VARS[focused.provider]})`,
+              }}
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              Open {focused.name} privacy settings
+            </a>
+          </div>
+        )}
+
+        <p className="text-xs text-muted italic">
+          You can revisit these instructions any time from Settings, Trail Stewardship.
+        </p>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/pages/Settings/components/trailStewardshipBrandColors.ts
+++ b/apps/web/src/pages/Settings/components/trailStewardshipBrandColors.ts
@@ -1,0 +1,12 @@
+import type { StewardshipProviderId } from '@loam/shared';
+
+/**
+ * Brand color CSS variable per provider, matching the values used by
+ * `DataSourcesSection`. Single source of truth for the stewardship UI on web.
+ */
+export const STEWARDSHIP_BRAND_COLOR_VARS: Record<StewardshipProviderId, string> = {
+  strava: '--brand-strava',
+  garmin: '--brand-garmin',
+  suunto: '--brand-suunto',
+  whoop: '--brand-whoop',
+};

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -1,26 +1,38 @@
-import { useEffect, type ReactElement } from 'react';
+import { useEffect, useState, type ReactElement } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useApolloClient } from '@apollo/client';
 import { toast } from 'sonner';
 import SettingsShell from './SettingsShell';
 import AccountSection from './sections/AccountSection';
 import DataSourcesSection from './sections/DataSourcesSection';
+import TrailStewardshipSection from './sections/TrailStewardshipSection';
 import PreferencesSection from './sections/PreferencesSection';
 import ServiceIntervalsSection from './sections/ServiceIntervalsSection';
 import MaintenanceSection from './sections/MaintenanceSection';
 import PrivacySection from './sections/PrivacySection';
 import DangerZoneSection from './sections/DangerZoneSection';
+import TrailStewardshipModal from './components/TrailStewardshipModal';
 import type { SettingsSectionId } from './useSettingsSection';
-import { DATA_SOURCES, PROVIDER_LABELS } from './providers';
+import { DATA_SOURCES, PROVIDER_LABELS, type DataSource } from './providers';
+import { useViewer } from '../../graphql/me';
+import type { StewardshipProviderId } from '@loam/shared';
+
+// Heatmap-publishing providers. Connecting any of these for the first time
+// triggers the stewardship modal.
+const HEATMAP_PROVIDERS: ReadonlySet<DataSource> = new Set(['strava', 'garmin', 'suunto']);
 
 /**
  * Refetches ConnectedAccounts queries after an OAuth callback. Can't use a
  * hook here because this runs inside an effect in a separate component tree
  * slice; Apollo's `refetchQueries` on the client handles it.
+ *
+ * Also returns the provider that was just connected (if any) so the parent
+ * can decide whether to surface a follow-up UI like the stewardship modal.
  */
-function useOAuthCallback() {
+function useOAuthCallback(): { justConnected: DataSource | null } {
   const [searchParams, setSearchParams] = useSearchParams();
   const apollo = useApolloClient();
+  const [justConnected, setJustConnected] = useState<DataSource | null>(null);
 
   useEffect(() => {
     const connectedProvider = DATA_SOURCES.find(
@@ -42,6 +54,8 @@ function useOAuthCallback() {
       toast.success(`${label} connected`);
     }
 
+    setJustConnected(connectedProvider);
+
     // Strip only the OAuth keys. Crucially, preserve `section` and any other
     // params so deep links and the sidebar state survive the redirect.
     setSearchParams(
@@ -56,11 +70,14 @@ function useOAuthCallback() {
       { replace: true },
     );
   }, [searchParams, setSearchParams, apollo]);
+
+  return { justConnected };
 }
 
 const SECTION_COMPONENTS: Record<SettingsSectionId, () => ReactElement> = {
   account: AccountSection,
   'data-sources': DataSourcesSection,
+  'trail-stewardship': TrailStewardshipSection,
   preferences: PreferencesSection,
   'service-intervals': ServiceIntervalsSection,
   maintenance: MaintenanceSection,
@@ -69,14 +86,36 @@ const SECTION_COMPONENTS: Record<SettingsSectionId, () => ReactElement> = {
 };
 
 export default function Settings() {
-  useOAuthCallback();
+  const { justConnected } = useOAuthCallback();
+  const { viewer } = useViewer();
+
+  // Show the stewardship modal once, after a heatmap-publishing provider is
+  // connected for the first time. Server-backed flag keeps it cross-device.
+  const [stewardshipModalOpen, setStewardshipModalOpen] = useState(false);
+  const [stewardshipProvider, setStewardshipProvider] =
+    useState<StewardshipProviderId | null>(null);
+
+  useEffect(() => {
+    if (!justConnected) return;
+    if (!HEATMAP_PROVIDERS.has(justConnected)) return;
+    if (viewer?.trailStewardshipNoticeSeenAt) return;
+    setStewardshipProvider(justConnected as StewardshipProviderId);
+    setStewardshipModalOpen(true);
+  }, [justConnected, viewer?.trailStewardshipNoticeSeenAt]);
 
   return (
-    <SettingsShell>
-      {(section) => {
-        const Section = SECTION_COMPONENTS[section];
-        return <Section />;
-      }}
-    </SettingsShell>
+    <>
+      <SettingsShell>
+        {(section) => {
+          const Section = SECTION_COMPONENTS[section];
+          return <Section />;
+        }}
+      </SettingsShell>
+      <TrailStewardshipModal
+        isOpen={stewardshipModalOpen}
+        provider={stewardshipProvider}
+        onClose={() => setStewardshipModalOpen(false)}
+      />
+    </>
   );
 }

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -18,8 +18,18 @@ import { useViewer } from '../../graphql/me';
 import type { StewardshipProviderId } from '@loam/shared';
 
 // Heatmap-publishing providers. Connecting any of these for the first time
-// triggers the stewardship modal.
-const HEATMAP_PROVIDERS: ReadonlySet<DataSource> = new Set(['strava', 'garmin', 'suunto']);
+// triggers the stewardship modal. Typed as ReadonlySet<StewardshipProviderId>
+// so the `isHeatmapProvider` guard can narrow a DataSource into the
+// shared-library type without an `as` cast at the call site.
+const HEATMAP_PROVIDERS: ReadonlySet<StewardshipProviderId> = new Set([
+  'strava',
+  'garmin',
+  'suunto',
+]);
+
+function isHeatmapProvider(p: DataSource): p is DataSource & StewardshipProviderId {
+  return (HEATMAP_PROVIDERS as ReadonlySet<string>).has(p);
+}
 
 /**
  * Refetches ConnectedAccounts queries after an OAuth callback. Can't use a
@@ -97,9 +107,9 @@ export default function Settings() {
 
   useEffect(() => {
     if (!justConnected) return;
-    if (!HEATMAP_PROVIDERS.has(justConnected)) return;
+    if (!isHeatmapProvider(justConnected)) return;
     if (viewer?.trailStewardshipNoticeSeenAt) return;
-    setStewardshipProvider(justConnected as StewardshipProviderId);
+    setStewardshipProvider(justConnected);
     setStewardshipModalOpen(true);
   }, [justConnected, viewer?.trailStewardshipNoticeSeenAt]);
 

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -107,11 +107,12 @@ export default function Settings() {
 
   useEffect(() => {
     if (!justConnected) return;
+    if (!viewer) return;
     if (!isHeatmapProvider(justConnected)) return;
-    if (viewer?.trailStewardshipNoticeSeenAt) return;
+    if (viewer.trailStewardshipNoticeSeenAt) return;
     setStewardshipProvider(justConnected);
     setStewardshipModalOpen(true);
-  }, [justConnected, viewer?.trailStewardshipNoticeSeenAt]);
+  }, [justConnected, viewer]);
 
   return (
     <>

--- a/apps/web/src/pages/Settings/sections/TrailStewardshipSection.tsx
+++ b/apps/web/src/pages/Settings/sections/TrailStewardshipSection.tsx
@@ -1,0 +1,167 @@
+import { useState } from 'react';
+import { useQuery, gql } from '@apollo/client';
+import { Shield, AlertTriangle, CheckCircle2, ChevronDown, ChevronUp, ExternalLink } from 'lucide-react';
+import {
+  STEWARDSHIP_HEADER,
+  TRAIL_STEWARDSHIP_PROVIDERS,
+  type StewardshipProviderId,
+} from '@loam/shared';
+import SettingsSectionHeader from '../SettingsSectionHeader';
+
+// Brand color CSS variable per provider, matching DataSourcesSection.
+const BRAND_COLOR_VARS: Record<StewardshipProviderId, string> = {
+  strava: '--brand-strava',
+  garmin: '--brand-garmin',
+  suunto: '--brand-suunto',
+  whoop: '--brand-whoop',
+};
+
+const STEWARDSHIP_ACCOUNTS_QUERY = gql`
+  query StewardshipAccounts {
+    me {
+      id
+      accounts {
+        provider
+      }
+    }
+  }
+`;
+
+type AccountRow = { provider: string };
+
+/**
+ * "Don't blow up the spot" stewardship recommendations for each connected
+ * fitness provider on web. Mirrors the mobile section. Renders only the
+ * providers the user has connected; suppresses the alarming header copy
+ * when the only connection is WHOOP (which doesn't publish heat maps).
+ */
+export default function TrailStewardshipSection() {
+  const { data, loading } = useQuery<{ me: { accounts: AccountRow[] } }>(
+    STEWARDSHIP_ACCOUNTS_QUERY,
+    { fetchPolicy: 'cache-and-network' },
+  );
+
+  const [expanded, setExpanded] = useState<StewardshipProviderId | null>(null);
+
+  const connected = new Set((data?.me?.accounts ?? []).map((a) => a.provider));
+  const visibleProviders = TRAIL_STEWARDSHIP_PROVIDERS.filter((p) => connected.has(p.provider));
+  const anyHasHeatmap = visibleProviders.some((p) => p.hasPublicHeatmap);
+
+  return (
+    <div className="space-y-6">
+      <SettingsSectionHeader
+        eyebrow="Privacy"
+        title="Trail Stewardship"
+        description="Recommendations to keep your regular trails and home patterns off public heat maps."
+      />
+
+      {loading && !data ? (
+        <div className="space-y-3" aria-busy="true" aria-label="Loading providers">
+          <div className="skeleton skeleton-row" />
+          <div className="skeleton skeleton-row" />
+        </div>
+      ) : visibleProviders.length === 0 ? (
+        <div className="panel">
+          <p className="text-sm text-muted">
+            Connect a fitness provider in Data Sources to see stewardship recommendations.
+          </p>
+        </div>
+      ) : (
+        <>
+          {anyHasHeatmap && (
+            <div className="panel-spaced bg-amber-500/5 border-amber-500/30">
+              <div className="flex items-start gap-3">
+                <Shield className="h-5 w-5 shrink-0 text-amber-400 mt-0.5" />
+                <div>
+                  <p className="font-semibold text-amber-300">{STEWARDSHIP_HEADER.title}</p>
+                  <p className="text-sm text-muted mt-1 leading-relaxed">
+                    {STEWARDSHIP_HEADER.body}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-3">
+            {visibleProviders.map((provider) => {
+              const isExpanded = expanded === provider.provider;
+              const brandColor = `var(${BRAND_COLOR_VARS[provider.provider]})`;
+
+              if (!provider.hasPublicHeatmap) {
+                return (
+                  <div
+                    key={provider.provider}
+                    className="rounded-2xl border border-app/70 bg-surface-2 px-4 py-3"
+                  >
+                    <div className="flex items-center gap-3">
+                      <CheckCircle2 className="h-5 w-5 shrink-0 text-success" />
+                      <div>
+                        <p className="font-semibold" style={{ color: brandColor }}>
+                          {provider.name}
+                        </p>
+                        <p className="text-sm text-muted">{provider.summary}</p>
+                      </div>
+                    </div>
+                  </div>
+                );
+              }
+
+              return (
+                <div
+                  key={provider.provider}
+                  className="rounded-2xl border border-app/70 bg-surface-2 overflow-hidden"
+                >
+                  <button
+                    type="button"
+                    onClick={() => setExpanded(isExpanded ? null : provider.provider)}
+                    className="w-full px-4 py-3 flex items-center gap-3 text-left hover:bg-surface-3/40 transition"
+                    aria-expanded={isExpanded}
+                  >
+                    <AlertTriangle className="h-5 w-5 shrink-0 text-amber-400" />
+                    <div className="flex-1">
+                      <p className="font-semibold" style={{ color: brandColor }}>
+                        {provider.name}
+                      </p>
+                      <p className="text-sm text-muted">{provider.summary}</p>
+                    </div>
+                    {isExpanded ? (
+                      <ChevronUp className="h-4 w-4 shrink-0 text-muted" />
+                    ) : (
+                      <ChevronDown className="h-4 w-4 shrink-0 text-muted" />
+                    )}
+                  </button>
+
+                  {isExpanded && (
+                    <div className="border-t border-app/50 px-4 py-3 space-y-3">
+                      <p className="label-section">How to opt out</p>
+                      <ol className="space-y-2 text-sm">
+                        {provider.steps.map((step, i) => (
+                          <li key={i} className="flex gap-3">
+                            <span className="font-semibold text-muted shrink-0 w-5">
+                              {i + 1}.
+                            </span>
+                            <span>{step}</span>
+                          </li>
+                        ))}
+                      </ol>
+                      <a
+                        href={provider.settingsUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-2 rounded-xl border px-3 py-1.5 text-xs font-medium hover:bg-surface-3/40 transition"
+                        style={{ borderColor: brandColor, color: brandColor }}
+                      >
+                        <ExternalLink className="h-3.5 w-3.5" />
+                        Open {provider.name} privacy settings
+                      </a>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/Settings/sections/TrailStewardshipSection.tsx
+++ b/apps/web/src/pages/Settings/sections/TrailStewardshipSection.tsx
@@ -7,14 +7,7 @@ import {
   type StewardshipProviderId,
 } from '@loam/shared';
 import SettingsSectionHeader from '../SettingsSectionHeader';
-
-// Brand color CSS variable per provider, matching DataSourcesSection.
-const BRAND_COLOR_VARS: Record<StewardshipProviderId, string> = {
-  strava: '--brand-strava',
-  garmin: '--brand-garmin',
-  suunto: '--brand-suunto',
-  whoop: '--brand-whoop',
-};
+import { STEWARDSHIP_BRAND_COLOR_VARS } from '../components/trailStewardshipBrandColors';
 
 const STEWARDSHIP_ACCOUNTS_QUERY = gql`
   query StewardshipAccounts {
@@ -85,7 +78,7 @@ export default function TrailStewardshipSection() {
           <div className="space-y-3">
             {visibleProviders.map((provider) => {
               const isExpanded = expanded === provider.provider;
-              const brandColor = `var(${BRAND_COLOR_VARS[provider.provider]})`;
+              const brandColor = `var(${STEWARDSHIP_BRAND_COLOR_VARS[provider.provider]})`;
 
               if (!provider.hasPublicHeatmap) {
                 return (
@@ -106,6 +99,7 @@ export default function TrailStewardshipSection() {
                 );
               }
 
+              const panelId = `stewardship-panel-${provider.provider}`;
               return (
                 <div
                   key={provider.provider}
@@ -116,6 +110,7 @@ export default function TrailStewardshipSection() {
                     onClick={() => setExpanded(isExpanded ? null : provider.provider)}
                     className="w-full px-4 py-3 flex items-center gap-3 text-left hover:bg-surface-3/40 transition"
                     aria-expanded={isExpanded}
+                    aria-controls={panelId}
                   >
                     <AlertTriangle className="h-5 w-5 shrink-0 text-amber-400" />
                     <div className="flex-1">
@@ -132,11 +127,11 @@ export default function TrailStewardshipSection() {
                   </button>
 
                   {isExpanded && (
-                    <div className="border-t border-app/50 px-4 py-3 space-y-3">
+                    <div id={panelId} className="border-t border-app/50 px-4 py-3 space-y-3">
                       <p className="label-section">How to opt out</p>
                       <ol className="space-y-2 text-sm">
                         {provider.steps.map((step, i) => (
-                          <li key={i} className="flex gap-3">
+                          <li key={step} className="flex gap-3">
                             <span className="font-semibold text-muted shrink-0 w-5">
                               {i + 1}.
                             </span>

--- a/apps/web/src/pages/Settings/useSettingsSection.ts
+++ b/apps/web/src/pages/Settings/useSettingsSection.ts
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 export type SettingsSectionId =
   | 'account'
   | 'data-sources'
+  | 'trail-stewardship'
   | 'preferences'
   | 'service-intervals'
   | 'maintenance'
@@ -13,6 +14,7 @@ export type SettingsSectionId =
 const KNOWN_SECTIONS: readonly SettingsSectionId[] = [
   'account',
   'data-sources',
+  'trail-stewardship',
   'preferences',
   'service-intervals',
   'maintenance',

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -20,3 +20,4 @@ export * from './tiers';
 
 // Legal
 export * from './legal/terms';
+export * from './legal/trail-stewardship';

--- a/libs/shared/src/legal/trail-stewardship.ts
+++ b/libs/shared/src/legal/trail-stewardship.ts
@@ -27,7 +27,7 @@ export const STEWARDSHIP_HEADER = {
   body: "Strava, Garmin, and Suunto can publish your rides on global heat maps, exposing your regular trails, your home patterns, and any unsanctioned lines you ride. Here's how to opt out, per provider. Two minutes per service. Your call.",
 };
 
-export const TRAIL_STEWARDSHIP_PROVIDERS: StewardshipProvider[] = [
+export const TRAIL_STEWARDSHIP_PROVIDERS: readonly StewardshipProvider[] = [
   {
     provider: 'strava',
     name: 'Strava',

--- a/libs/shared/src/legal/trail-stewardship.ts
+++ b/libs/shared/src/legal/trail-stewardship.ts
@@ -1,0 +1,84 @@
+// Cross-platform "Don't blow up the spot" content used by mobile and web
+// Trail Stewardship sections. Source of truth for provider-specific
+// instructions — keep step lists current as providers change their UIs.
+
+export type StewardshipProviderId = 'strava' | 'garmin' | 'suunto' | 'whoop';
+
+export interface StewardshipProvider {
+  /** Stable identifier matching the IntegrationProvider values used elsewhere. */
+  provider: StewardshipProviderId;
+  /** Display name. */
+  name: string;
+  /**
+   * Whether the provider feeds a publicly viewable heat map or aggregated
+   * route dataset. WHOOP does not, so its row is informational only.
+   */
+  hasPublicHeatmap: boolean;
+  /** One-line summary of what is publicly exposed. */
+  summary: string;
+  /** Step-by-step opt-out instructions, in order. */
+  steps: string[];
+  /** Deep link to the provider's privacy / settings page. */
+  settingsUrl: string;
+}
+
+export const STEWARDSHIP_HEADER = {
+  title: "Don't blow up the spot.",
+  body: "Strava, Garmin, and Suunto can publish your rides on global heat maps, exposing your regular trails, your home patterns, and any unsanctioned lines you ride. Here's how to opt out, per provider. Two minutes per service. Your call.",
+};
+
+export const TRAIL_STEWARDSHIP_PROVIDERS: StewardshipProvider[] = [
+  {
+    provider: 'strava',
+    name: 'Strava',
+    hasPublicHeatmap: true,
+    summary: 'Strava feeds the Global Heatmap and Metro datasets, both publicly viewable.',
+    steps: [
+      'Open Strava and go to You > Settings > Privacy Controls',
+      'Set Activities default to "Followers" or "Only You"',
+      'Set Map Visibility to "Hide entire map", or define a Privacy Zone around your home',
+      'Under Aggregated Data Usage, uncheck "Include my activities in aggregated data"',
+      'Under Metro and Heatmap, opt out of contribution',
+    ],
+    settingsUrl: 'https://www.strava.com/settings/privacy',
+  },
+  {
+    provider: 'garmin',
+    name: 'Garmin',
+    hasPublicHeatmap: true,
+    summary: 'Garmin Connect aggregates activity data for its public heatmaps and Insights features.',
+    steps: [
+      'Open Garmin Connect (web) and go to Account Settings > Account Information > Display Preferences',
+      'Set the default activity privacy to "Private" or "My Connections"',
+      'Go to Account Settings > Privacy and disable "Insights" and any aggregated-data sharing toggles',
+      'Optionally remove location data from already-uploaded activities individually',
+    ],
+    settingsUrl: 'https://www.garmin.com/account/privacy/',
+  },
+  {
+    provider: 'suunto',
+    name: 'Suunto',
+    hasPublicHeatmap: true,
+    summary: 'Suunto publishes a global Heatmap built from app users\' workouts.',
+    steps: [
+      'Open the Suunto app and go to Profile > Settings > Privacy',
+      'Set the default workout visibility to "Private" or "Friends"',
+      'Disable "Heatmap" or "Public Heatmap" contribution',
+      'Review previously uploaded workouts and adjust visibility individually if needed',
+    ],
+    settingsUrl: 'https://www.suunto.com/Support/faq-articles/suunto-app/how-do-i-edit-the-privacy-settings-of-my-suunto-app-account/',
+  },
+  {
+    provider: 'whoop',
+    name: 'WHOOP',
+    hasPublicHeatmap: false,
+    summary: "WHOOP doesn't aggregate or publish your routes. No action needed.",
+    steps: [],
+    settingsUrl: 'https://www.whoop.com/membership/privacy/',
+  },
+];
+
+/** Lookup by provider id. */
+export function getStewardshipProvider(id: StewardshipProviderId): StewardshipProvider | undefined {
+  return TRAIL_STEWARDSHIP_PROVIDERS.find((p) => p.provider === id);
+}


### PR DESCRIPTION
# Trail Stewardship: "Don't Blow Up The Spot"

## Summary

Adds a stewardship recommendation flow that helps users opt out of public heatmap contributions on their connected fitness providers. MTB culture has a phrase for this: "don't blow up the spot." Strava, Garmin, and Suunto all publish heat maps that expose where users ride regularly, including unsanctioned trails. This is a personal safety risk (revealing home patterns) and a stewardship concern (exposing unsanctioned lines that builders and land managers haven't sanctioned).

This PR introduces:
- **A new "Trail Stewardship" settings section** with provider-specific opt-out instructions and deep links to each privacy page
- **A one-time post-connect modal** shown after a user connects Strava, Garmin, or Suunto for the first time
- **Server-backed seen flag** (`User.trailStewardshipNoticeSeenAt`) so the modal doesn't reappear across devices
- **WHOOP-aware copy** that suppresses the warning treatment for users who only connect WHOOP (no public heatmap exposure)

The companion mobile changes ship in a separate PR on `loam-logger-mobile`.

## Voice & Approach

Direct, no preachiness, MTB-native vernacular. Acknowledges user choice ("Two minutes per service. Your call."). The shared content file lets us update opt-out steps in one place when providers change their UIs.

## Changes

### Database
- `User.trailStewardshipNoticeSeenAt: DateTime?` added to the Prisma schema. Will require a migration (`prisma migrate dev --name add_trail_stewardship_notice_seen` or `db push` against staging/production).

### GraphQL
- New mutation: `markTrailStewardshipNoticeSeen` (rate limited, sets the timestamp on the current user)
- New field on `User`: `trailStewardshipNoticeSeenAt: String`
- Resolver formats the date as ISO 8601, matching the pattern used by `pairedComponentMigrationSeenAt`
- `Me` query and `userPreferences` mutation hooks updated on the web client

### Shared library (`libs/shared`)
- New `legal/trail-stewardship.ts` exports `TRAIL_STEWARDSHIP_PROVIDERS` (provider configs with summary, step-by-step opt-out instructions, and privacy URLs) plus a `STEWARDSHIP_HEADER` for consistent copy. Cross-platform consumable so mobile and web stay in sync.

### Web Settings
- New sidebar entry "Trail Stewardship" (Mountain icon) between "Data Sources" and "Preferences"
- New `TrailStewardshipSection` renders only the providers the user has connected. WHOOP shows a positive "no action needed" row; the others expand to step lists with "Open privacy settings" links
- New `TrailStewardshipModal` fires once after first OAuth connection of a heatmap-publishing provider. `useOAuthCallback` hook now returns the `justConnected` provider so the parent can drive the modal. Server-backed flag prevents re-firing across devices.

## Files

| Action | Path |
|--------|------|
| Add | `libs/shared/src/legal/trail-stewardship.ts` |
| Modify | `libs/shared/src/index.ts` |
| Modify | `apps/api/prisma/schema.prisma` |
| Modify | `apps/api/src/graphql/schema.ts` |
| Modify | `apps/api/src/graphql/resolvers.ts` |
| Modify | `apps/web/src/graphql/me.ts` |
| Modify | `apps/web/src/graphql/userPreferences.ts` |
| Add | `apps/web/src/pages/Settings/sections/TrailStewardshipSection.tsx` |
| Add | `apps/web/src/pages/Settings/components/TrailStewardshipModal.tsx` |
| Modify | `apps/web/src/pages/Settings/SettingsSidebar.tsx` |
| Modify | `apps/web/src/pages/Settings/useSettingsSection.ts` |
| Modify | `apps/web/src/pages/Settings/index.tsx` |

## Test plan

- [ ] Run `prisma migrate dev` (or `db push` to staging) before merging so the new column lands
- [ ] With no providers connected, the section shows a "Connect a fitness provider" hint and no warning banner
- [ ] With only WHOOP connected, the section renders WHOOP's "no action needed" row and suppresses the amber header
- [ ] With Strava connected, expand the Strava row and confirm the steps render and "Open privacy settings" opens the correct URL in a new tab
- [ ] Connect Strava (or Garmin/Suunto) for the first time and confirm the modal opens automatically after the OAuth round-trip
- [ ] Dismiss the modal with "I've reviewed my settings" and confirm `trailStewardshipNoticeSeenAt` is set on the User row
- [ ] Disconnect and reconnect the same provider — the modal does not reappear
- [ ] Sign in on a different device and confirm the modal still does not reappear (cross-device persistence)
- [ ] Manually verify each provider's step list against their current privacy settings UI (these UIs change occasionally)

## Notes

- WHOOP's row is intentionally informational and marked `hasPublicHeatmap: false`. WHOOP doesn't aggregate or publish routes.
- The new section is intentionally distinct from the existing "Privacy" section, which is scoped to Loam Logger's own analytics opt-out (PostHog). Trail Stewardship is about provider-side exposure and warrants its own home so it's discoverable.
- Provider step lists live in `libs/shared` so they can be updated in one place; mobile mirrors the same content (separate PR).
