### PR TITLE
bugfix: calibration not showing all components

### DIFF
--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -1265,18 +1265,28 @@ export const resolvers = {
 
         totalComponents += predictions.components.length;
 
-        // Filter to OVERDUE and DUE_NOW components
+        // Bike-inclusion gate: only include bikes that have at least one
+        // OVERDUE / DUE_NOW component so the overlay still scopes itself to
+        // bikes that genuinely need attention. `totalOverdue` keeps using
+        // this strict filter — it drives `showOverlay` and the subtitle
+        // count, neither of which should fire on healthy components.
         const needsAttention = predictions.components.filter(
           (c) => c.status === 'OVERDUE' || c.status === 'DUE_NOW'
         );
 
         if (needsAttention.length > 0) {
           totalOverdue += needsAttention.length;
+          // Return ALL components on the included bike (not just needs-
+          // attention) so users can record historical service for a
+          // component currently in DUE_SOON / ALL_GOOD — e.g. brake pads
+          // they swapped last month that aren't due now but should still
+          // be on record. Each component carries its own `status`, so the
+          // frontend can sort and badge appropriately.
           bikesNeedingCalibration.push({
             bikeId: bike.id,
             bikeName: bike.nickname || `${bike.year || ''} ${bike.manufacturer} ${bike.model}`.trim(),
             thumbnailUrl: bike.thumbnailUrl,
-            components: needsAttention,
+            components: predictions.components,
           });
         }
       }

--- a/apps/web/src/components/CalibrationOverlay.test.tsx
+++ b/apps/web/src/components/CalibrationOverlay.test.tsx
@@ -273,7 +273,7 @@ describe('CalibrationOverlay', () => {
       render(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
 
       // The component details should be visible (bulk action section)
-      expect(screen.getByText('Mark serviced in:')).toBeInTheDocument();
+      expect(screen.getByText('Mark all overdue serviced in:')).toBeInTheDocument();
     });
 
     it('toggles bike section on click', () => {
@@ -283,19 +283,19 @@ describe('CalibrationOverlay', () => {
       render(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
 
       // Initially expanded
-      expect(screen.getByText('Mark serviced in:')).toBeInTheDocument();
+      expect(screen.getByText('Mark all overdue serviced in:')).toBeInTheDocument();
 
       // Click to collapse
       fireEvent.click(screen.getByText('Trail Bike'));
 
       // Content should be hidden
-      expect(screen.queryByText('Mark serviced in:')).not.toBeInTheDocument();
+      expect(screen.queryByText('Mark all overdue serviced in:')).not.toBeInTheDocument();
 
       // Click to expand again
       fireEvent.click(screen.getByText('Trail Bike'));
 
       // Content should be visible again
-      expect(screen.getByText('Mark serviced in:')).toBeInTheDocument();
+      expect(screen.getByText('Mark all overdue serviced in:')).toBeInTheDocument();
     });
   });
 
@@ -592,6 +592,43 @@ describe('CalibrationOverlay', () => {
       await waitFor(() => {
         expect(screen.getByText(/Log Service \(1\)/)).toBeInTheDocument();
       });
+    });
+
+    it('select-all is scoped to needs-attention rows, not healthy ones', async () => {
+      // OVERDUE sorts before ALL_GOOD, so checkbox order is:
+      // [0] header select-all, [1] comp-1 (OVERDUE), [2] comp-2 (ALL_GOOD).
+      const bike = createBike('bike-1', 'Trail Bike', [
+        createComponent('comp-1', { status: 'OVERDUE' }),
+        createComponent('comp-2', { status: 'ALL_GOOD', hoursRemaining: 40 }),
+      ]);
+      setupCalibrationState([bike]);
+
+      render(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
+
+      // Only the OVERDUE row is pre-selected on open — the ALL_GOOD one is
+      // not swept in. Subtitle counts needs-attention only.
+      expect(screen.getByText(/Log Service \(1\)/)).toBeInTheDocument();
+      expect(screen.getByTestId('subtitle')).toHaveTextContent(
+        '1 component needs attention'
+      );
+
+      // Header checkbox is checked (every needs-attention row is selected);
+      // toggling it off clears only the needs-attention selection.
+      expect(screen.getAllByRole('checkbox')[0]).toBeChecked();
+      fireEvent.click(screen.getAllByRole('checkbox')[0]);
+      await waitFor(() => {
+        expect(screen.getByText(/Log Service \(0\)/)).toBeInTheDocument();
+      });
+
+      // The healthy component is still selectable individually — servicing
+      // an "all good" component (a creak, a sloppy bleed) is a real case.
+      fireEvent.click(screen.getAllByRole('checkbox')[2]);
+      await waitFor(() => {
+        expect(screen.getByText(/Log Service \(1\)/)).toBeInTheDocument();
+      });
+      // Selecting the healthy row does not check the header checkbox — the
+      // header tracks needs-attention rows only.
+      expect(screen.getAllByRole('checkbox')[0]).not.toBeChecked();
     });
   });
 

--- a/apps/web/src/components/CalibrationOverlay.test.tsx
+++ b/apps/web/src/components/CalibrationOverlay.test.tsx
@@ -273,7 +273,7 @@ describe('CalibrationOverlay', () => {
       render(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
 
       // The component details should be visible (bulk action section)
-      expect(screen.getByText('Serviced in:')).toBeInTheDocument();
+      expect(screen.getByText('Mark serviced in:')).toBeInTheDocument();
     });
 
     it('toggles bike section on click', () => {
@@ -283,19 +283,19 @@ describe('CalibrationOverlay', () => {
       render(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
 
       // Initially expanded
-      expect(screen.getByText('Serviced in:')).toBeInTheDocument();
+      expect(screen.getByText('Mark serviced in:')).toBeInTheDocument();
 
       // Click to collapse
       fireEvent.click(screen.getByText('Trail Bike'));
 
       // Content should be hidden
-      expect(screen.queryByText('Serviced in:')).not.toBeInTheDocument();
+      expect(screen.queryByText('Mark serviced in:')).not.toBeInTheDocument();
 
       // Click to expand again
       fireEvent.click(screen.getByText('Trail Bike'));
 
       // Content should be visible again
-      expect(screen.getByText('Serviced in:')).toBeInTheDocument();
+      expect(screen.getByText('Mark serviced in:')).toBeInTheDocument();
     });
   });
 
@@ -310,11 +310,12 @@ describe('CalibrationOverlay', () => {
       const monthInput = document.querySelector('input[type="month"]');
       expect(monthInput).toBeInTheDocument();
 
-      // Should have Apply button
-      expect(screen.getByText(/Apply to All \(1\)/)).toBeInTheDocument();
+      // Should have the bulk Log Service button (needs-attention rows are
+      // pre-selected on open, so the count reflects the one component)
+      expect(screen.getByText(/Log Service \(1\)/)).toBeInTheDocument();
     });
 
-    it('marks components as calibrated on Apply and submits on Complete', async () => {
+    it('marks components as calibrated on bulk Log Service and submits on Complete', async () => {
       const bike = createBike('bike-1', 'Trail Bike', [
         createComponent('comp-1'),
         createComponent('comp-2'),
@@ -323,8 +324,8 @@ describe('CalibrationOverlay', () => {
 
       render(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
 
-      // Click Apply button
-      fireEvent.click(screen.getByText(/Apply to All \(2\)/));
+      // Click the bulk Log Service button (both rows pre-selected on open)
+      fireEvent.click(screen.getByText(/Log Service \(2\)/));
 
       // Progress should update (components marked locally)
       await waitFor(() => {
@@ -353,7 +354,7 @@ describe('CalibrationOverlay', () => {
 
       render(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
 
-      fireEvent.click(screen.getByText(/Apply to All \(1\)/));
+      fireEvent.click(screen.getByText(/Log Service \(1\)/));
 
       await waitFor(() => {
         expect(screen.getByText(/Marked 1 component as serviced/)).toBeInTheDocument();
@@ -371,11 +372,49 @@ describe('CalibrationOverlay', () => {
 
       expect(screen.getByText('0 of 2 calibrated')).toBeInTheDocument();
 
-      fireEvent.click(screen.getByText(/Apply to All \(2\)/));
+      fireEvent.click(screen.getByText(/Log Service \(2\)/));
 
       await waitFor(() => {
         expect(screen.getByText('2 of 2 calibrated')).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('state freeze across refetch', () => {
+    it('preserves in-progress calibration when calibrationState refetches mid-session', async () => {
+      const bike = createBike('bike-1', 'Trail Bike', [
+        createComponent('comp-1'),
+        createComponent('comp-2'),
+      ]);
+      setupCalibrationState([bike]);
+
+      const { rerender } = render(
+        <CalibrationOverlay isOpen={true} onClose={defaultOnClose} />
+      );
+
+      // Stage work: acknowledge one component.
+      const acknowledgeButtons = screen.getAllByRole('button', { name: 'Acknowledge' });
+      fireEvent.click(acknowledgeButtons[0]);
+      await waitFor(() => {
+        expect(screen.getByText('1 of 2 calibrated')).toBeInTheDocument();
+      });
+
+      // Simulate a `cache-and-network` background refetch: Apollo hands back
+      // a brand-new calibrationState object reference (same underlying data).
+      setupCalibrationState([
+        createBike('bike-1', 'Trail Bike', [
+          createComponent('comp-1'),
+          createComponent('comp-2'),
+        ]),
+      ]);
+      rerender(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
+
+      // The staged calibration must survive — the init effect is guarded so
+      // it does not re-run and wipe calibratedIds / pendingServiceLogs.
+      await waitFor(() => {
+        expect(screen.getByText('1 of 2 calibrated')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Calibrated')).toBeInTheDocument();
     });
   });
 
@@ -541,16 +580,17 @@ describe('CalibrationOverlay', () => {
 
       render(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
 
-      // All components are selected by default, so button shows Apply to All (2)
-      expect(screen.getByText(/Apply to All \(2\)/)).toBeInTheDocument();
+      // Needs-attention rows are pre-selected on open, so the bulk button
+      // starts at Log Service (2)
+      expect(screen.getByText(/Log Service \(2\)/)).toBeInTheDocument();
 
       // Deselect one component (component checkboxes are after the select-all)
       const checkboxes = screen.getAllByRole('checkbox');
       fireEvent.click(checkboxes[1]); // First component checkbox
 
-      // Button should now show Apply to Selected (1)
+      // Button should now show Log Service (1)
       await waitFor(() => {
-        expect(screen.getByText(/Apply to Selected \(1\)/)).toBeInTheDocument();
+        expect(screen.getByText(/Log Service \(1\)/)).toBeInTheDocument();
       });
     });
   });

--- a/apps/web/src/components/CalibrationOverlay.test.tsx
+++ b/apps/web/src/components/CalibrationOverlay.test.tsx
@@ -418,6 +418,46 @@ describe('CalibrationOverlay', () => {
     });
   });
 
+  describe('inline Log Service picker', () => {
+    it('disables Log Service on other rows while one inline picker is open', async () => {
+      const bike = createBike('bike-1', 'Trail Bike', [
+        createComponent('comp-1'),
+        createComponent('comp-2'),
+      ]);
+      setupCalibrationState([bike]);
+
+      render(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
+
+      // Per-row "Log Service" buttons (exact name — the bulk button reads
+      // "Log Service (2)" so it doesn't match).
+      const logServiceButtons = screen.getAllByRole('button', { name: 'Log Service' });
+      expect(logServiceButtons).toHaveLength(2);
+      expect(logServiceButtons[0]).not.toBeDisabled();
+      expect(logServiceButtons[1]).not.toBeDisabled();
+
+      // Open the inline picker on the first row.
+      fireEvent.click(logServiceButtons[0]);
+
+      // Row 1 is now in edit mode (Save/Cancel), so only row 2's per-row
+      // Log Service button remains — and it's disabled, so the open picker
+      // can't be silently replaced.
+      await waitFor(() => {
+        const remaining = screen.getAllByRole('button', { name: 'Log Service' });
+        expect(remaining).toHaveLength(1);
+        expect(remaining[0]).toBeDisabled();
+      });
+
+      // Cancelling the picker re-enables the other row.
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      await waitFor(() => {
+        const restored = screen.getAllByRole('button', { name: 'Log Service' });
+        expect(restored).toHaveLength(2);
+        expect(restored[0]).not.toBeDisabled();
+        expect(restored[1]).not.toBeDisabled();
+      });
+    });
+  });
+
   describe('individual component actions', () => {
     it('renders Acknowledge and Snooze buttons for each uncalibrated component', () => {
       const bike = createBike('bike-1', 'Trail Bike', [

--- a/apps/web/src/components/CalibrationOverlay.test.tsx
+++ b/apps/web/src/components/CalibrationOverlay.test.tsx
@@ -378,6 +378,62 @@ describe('CalibrationOverlay', () => {
         expect(screen.getByText('2 of 2 calibrated')).toBeInTheDocument();
       });
     });
+
+    it('auto-checks needs-attention rows when the bulk date changes and nothing is selected', async () => {
+      const bike = createBike('bike-1', 'Trail Bike', [
+        createComponent('comp-1'),
+        createComponent('comp-2'),
+      ]);
+      setupCalibrationState([bike]);
+
+      render(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
+
+      // Both needs-attention rows are pre-selected on open; clear them.
+      fireEvent.click(screen.getAllByRole('checkbox')[0]);
+      await waitFor(() => {
+        expect(screen.getByText(/Log Service \(0\)/)).toBeInTheDocument();
+      });
+
+      // Changing the bulk month with an empty selection auto-checks the
+      // needs-attention rows. fireEvent.change flushes synchronously.
+      const monthInput = document.querySelector('input[type="month"]') as HTMLInputElement;
+      fireEvent.change(monthInput, { target: { value: '2025-06' } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Log Service \(2\)/)).toBeInTheDocument();
+      });
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes[1]).toBeChecked();
+      expect(checkboxes[2]).toBeChecked();
+    });
+
+    it('leaves an existing selection untouched when the bulk date changes', () => {
+      const bike = createBike('bike-1', 'Trail Bike', [
+        createComponent('comp-1'),
+        createComponent('comp-2'),
+      ]);
+      setupCalibrationState([bike]);
+
+      render(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
+
+      // Deselect just comp-1, leaving comp-2 selected (a non-empty selection).
+      fireEvent.click(screen.getAllByRole('checkbox')[1]);
+      expect(screen.getByText(/Log Service \(1\)/)).toBeInTheDocument();
+      expect(screen.getAllByRole('checkbox')[1]).not.toBeChecked();
+      expect(screen.getAllByRole('checkbox')[2]).toBeChecked();
+
+      // Changing the bulk month must NOT re-check comp-1 — auto-check only
+      // fires when the selection is empty.
+      const monthInput = document.querySelector('input[type="month"]') as HTMLInputElement;
+      fireEvent.change(monthInput, { target: { value: '2025-06' } });
+
+      // The date change took effect (proves handleBulkDateChange ran)...
+      expect(monthInput.value).toBe('2025-06');
+      // ...but the existing selection is unchanged.
+      expect(screen.getByText(/Log Service \(1\)/)).toBeInTheDocument();
+      expect(screen.getAllByRole('checkbox')[1]).not.toBeChecked();
+      expect(screen.getAllByRole('checkbox')[2]).toBeChecked();
+    });
   });
 
   describe('state freeze across refetch', () => {
@@ -454,6 +510,52 @@ describe('CalibrationOverlay', () => {
         expect(restored).toHaveLength(2);
         expect(restored[0]).not.toBeDisabled();
         expect(restored[1]).not.toBeDisabled();
+      });
+    });
+
+    it('logs a per-row service: open picker, pick date, Save, then Complete submits it', async () => {
+      const bike = createBike('bike-1', 'Trail Bike', [
+        createComponent('comp-1'),
+        createComponent('comp-2'),
+      ]);
+      setupCalibrationState([bike]);
+
+      render(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
+
+      // Open the inline picker on the first row.
+      const logServiceButtons = screen.getAllByRole('button', { name: 'Log Service' });
+      fireEvent.click(logServiceButtons[0]);
+
+      // Pick a specific month in that row's inline date input. The inline
+      // input is the only one with an accessible name (the bulk one has none).
+      const monthInput = await screen.findByLabelText('Service date for FORK');
+      fireEvent.change(monthInput, { target: { value: '2025-03' } });
+
+      // Save stages the log and marks the component calibrated locally —
+      // only comp-1, not the still-untouched comp-2.
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      await waitFor(() => {
+        expect(screen.getByText('Calibrated')).toBeInTheDocument();
+        expect(screen.getByText('1 of 2 calibrated')).toBeInTheDocument();
+      });
+
+      // Complete Calibration flushes pendingServiceLogs via LOG_BULK_SERVICE
+      // — proof the staged entry carried the right componentId + performedAt.
+      fireEvent.click(screen.getByText('Complete Calibration'));
+
+      // performedAt is the 1st of the picked month; compute it the same way
+      // the component does so the assertion is timezone-independent.
+      const expectedPerformedAt = new Date(2025, 2, 1).toISOString();
+      await waitFor(() => {
+        expect(mockLogBulkService).toHaveBeenCalledTimes(1);
+        expect(mockLogBulkService).toHaveBeenCalledWith({
+          variables: {
+            input: {
+              componentIds: ['comp-1'],
+              performedAt: expectedPerformedAt,
+            },
+          },
+        });
       });
     });
   });

--- a/apps/web/src/components/CalibrationOverlay.test.tsx
+++ b/apps/web/src/components/CalibrationOverlay.test.tsx
@@ -273,7 +273,7 @@ describe('CalibrationOverlay', () => {
       render(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
 
       // The component details should be visible (bulk action section)
-      expect(screen.getByText('Mark all overdue serviced in:')).toBeInTheDocument();
+      expect(screen.getByText('All overdue, serviced in:')).toBeInTheDocument();
     });
 
     it('toggles bike section on click', () => {
@@ -283,19 +283,19 @@ describe('CalibrationOverlay', () => {
       render(<CalibrationOverlay isOpen={true} onClose={defaultOnClose} />);
 
       // Initially expanded
-      expect(screen.getByText('Mark all overdue serviced in:')).toBeInTheDocument();
+      expect(screen.getByText('All overdue, serviced in:')).toBeInTheDocument();
 
       // Click to collapse
       fireEvent.click(screen.getByText('Trail Bike'));
 
       // Content should be hidden
-      expect(screen.queryByText('Mark all overdue serviced in:')).not.toBeInTheDocument();
+      expect(screen.queryByText('All overdue, serviced in:')).not.toBeInTheDocument();
 
       // Click to expand again
       fireEvent.click(screen.getByText('Trail Bike'));
 
       // Content should be visible again
-      expect(screen.getByText('Mark all overdue serviced in:')).toBeInTheDocument();
+      expect(screen.getByText('All overdue, serviced in:')).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/components/CalibrationOverlay.tsx
+++ b/apps/web/src/components/CalibrationOverlay.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { BellOff, Bike, Check, ChevronDown, ChevronUp, TriangleAlert, CircleCheck } from 'lucide-react';
 import { Modal } from './ui/Modal';
 import { Button } from './ui/Button';
@@ -94,7 +94,17 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const calibrationState = data?.calibrationState;
-  const bikes = useMemo(() => calibrationState?.bikes ?? [], [calibrationState?.bikes]);
+  // `useCalibrationState` uses `cache-and-network`, so Apollo can hand us a
+  // fresh `calibrationState` reference mid-session — a background refetch,
+  // or a `refetchQueries: [CALIBRATION_STATE]` fired by a sibling mutation.
+  // We snapshot the bikes into state ONCE per modal-open (see the init
+  // effect below) and render/handle off that frozen copy, so an async
+  // refetch can't wipe the user's in-progress pendingServiceLogs /
+  // calibratedIds / inline-picker state out from under them.
+  const [bikes, setBikes] = useState<BikeCalibrationInfo[]>([]);
+  // Guards the init effect so it runs exactly once per modal-open, not on
+  // every `calibrationState` reference change.
+  const hasInitializedRef = useRef(false);
 
   // Calculate progress using initial total (stable across refetches).
   // Progress denominator is "needs-attention components at open" so the
@@ -106,51 +116,70 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
   );
   const remainingCount = Math.max(0, initialTotal - calibratedNeedsAttentionCount);
 
-  // Reset state when modal opens
+  // Snapshot + initialize state once per modal-open.
+  //
+  // Deliberately gated by `hasInitializedRef` rather than re-running on every
+  // `bikes` change: the query is `cache-and-network`, so a background refetch
+  // (or a sibling mutation's `refetchQueries`) lands a new `calibrationState`
+  // reference mid-session. Re-running this effect on that would reset
+  // `pendingServiceLogs`, `calibratedIds`, and the inline-picker state —
+  // silently discarding everything the user has staged before they hit
+  // "Complete Calibration." Snapshot once; ignore later refetches.
   useEffect(() => {
-    if (isOpen) {
-      setCalibratedIds(new Set());
-      setPendingServiceLogs(new Map());
-      setInlineDateComponentId(null);
-      setInlineDate(null);
-      setError(null);
-      setSuccessMessage(null);
-
-      // Initial total / pre-selection / bike-section badge all key off the
-      // needs-attention subset, NOT the full components array. The resolver
-      // returns every component on bikes that have at least one overdue
-      // item — without filtering here, the "5 components need attention"
-      // subtitle would balloon into the full bike inventory.
-      const attentionIds = new Set<string>();
-      bikes.forEach((bike) => {
-        bike.components.forEach((c) => {
-          if (isNeedsAttention(c.status)) attentionIds.add(c.componentId);
-        });
-      });
-      setNeedsAttentionIds(attentionIds);
-      setInitialTotal(attentionIds.size);
-
-      if (bikes.length > 0) {
-        setExpandedBikeId(bikes[0].bikeId);
-      }
-      const now = new Date();
-      const initialDates: Record<string, { month: number; year: number }> = {};
-      const initialSelected: Record<string, Set<string>> = {};
-      bikes.forEach((bike) => {
-        initialDates[bike.bikeId] = { month: now.getMonth(), year: now.getFullYear() };
-        // Pre-select needs-attention rows only — that's the most common
-        // intent ("I just serviced everything that's overdue"). Users can
-        // uncheck or extend selection manually.
-        initialSelected[bike.bikeId] = new Set(
-          bike.components
-            .filter((c) => isNeedsAttention(c.status))
-            .map((c) => c.componentId),
-        );
-      });
-      setBulkDates(initialDates);
-      setSelectedComponents(initialSelected);
+    if (!isOpen) {
+      // Modal closed — clear the guard so the next open re-snapshots fresh data.
+      hasInitializedRef.current = false;
+      return;
     }
-  }, [isOpen, bikes]);
+    if (hasInitializedRef.current) return;
+    // Wait for the query to resolve (from cache or network) before snapshotting.
+    if (!calibrationState) return;
+    hasInitializedRef.current = true;
+
+    const snapshot = calibrationState.bikes ?? [];
+    setBikes(snapshot);
+
+    setCalibratedIds(new Set());
+    setPendingServiceLogs(new Map());
+    setInlineDateComponentId(null);
+    setInlineDate(null);
+    setError(null);
+    setSuccessMessage(null);
+
+    // Initial total / pre-selection / bike-section badge all key off the
+    // needs-attention subset, NOT the full components array. The resolver
+    // returns every component on bikes that have at least one overdue
+    // item — without filtering here, the "5 components need attention"
+    // subtitle would balloon into the full bike inventory.
+    const attentionIds = new Set<string>();
+    snapshot.forEach((bike) => {
+      bike.components.forEach((c) => {
+        if (isNeedsAttention(c.status)) attentionIds.add(c.componentId);
+      });
+    });
+    setNeedsAttentionIds(attentionIds);
+    setInitialTotal(attentionIds.size);
+
+    if (snapshot.length > 0) {
+      setExpandedBikeId(snapshot[0].bikeId);
+    }
+    const now = new Date();
+    const initialDates: Record<string, { month: number; year: number }> = {};
+    const initialSelected: Record<string, Set<string>> = {};
+    snapshot.forEach((bike) => {
+      initialDates[bike.bikeId] = { month: now.getMonth(), year: now.getFullYear() };
+      // Pre-select needs-attention rows only — that's the most common
+      // intent ("I just serviced everything that's overdue"). Users can
+      // uncheck or extend selection manually.
+      initialSelected[bike.bikeId] = new Set(
+        bike.components
+          .filter((c) => isNeedsAttention(c.status))
+          .map((c) => c.componentId),
+      );
+    });
+    setBulkDates(initialDates);
+    setSelectedComponents(initialSelected);
+  }, [isOpen, calibrationState]);
 
   const toggleBikeExpanded = useCallback((bikeId: string) => {
     setExpandedBikeId((prev) => (prev === bikeId ? null : bikeId));

--- a/apps/web/src/components/CalibrationOverlay.tsx
+++ b/apps/web/src/components/CalibrationOverlay.tsx
@@ -41,6 +41,24 @@ function getMonthInputBounds(): { min: string; max: string } {
   };
 }
 
+// "Needs attention" matches the criterion the calibrationState resolver uses
+// to decide which bikes trigger the overlay. The resolver now returns all
+// components on those bikes (not just needs-attention ones), so this helper
+// is what the frontend uses to badge, sort, pre-select, and gate the
+// completion counter. Keep in sync with apps/api/src/graphql/resolvers.ts.
+function isNeedsAttention(status: string): boolean {
+  return status === 'OVERDUE' || status === 'DUE_NOW';
+}
+
+// Sort key used to render OVERDUE/DUE_NOW rows above DUE_SOON/ALL_GOOD ones
+// once the components array contains all statuses. Lower = earlier in list.
+const STATUS_PRIORITY: Record<string, number> = {
+  OVERDUE: 0,
+  DUE_NOW: 1,
+  DUE_SOON: 2,
+  ALL_GOOD: 3,
+};
+
 export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps) {
   const { data } = useCalibrationState();
   const [logBulkService] = useLogBulkService();
@@ -56,10 +74,20 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
   const [bulkDates, setBulkDates] = useState<Record<string, { month: number; year: number }>>({});
   // Track selected components per bike for bulk action
   const [selectedComponents, setSelectedComponents] = useState<Record<string, Set<string>>>({});
+  // Snapshot of components flagged "needs attention" at modal open. Drives the
+  // progress denominator and the bike-section badge so adding a historical
+  // service for an ALL_GOOD component doesn't inflate the "X need attention"
+  // count. Stable for the life of the modal (not refetched mid-session).
+  const [needsAttentionIds, setNeedsAttentionIds] = useState<Set<string>>(new Set());
   // Track initial total for progress (captured when modal opens, doesn't change on refetch)
   const [initialTotal, setInitialTotal] = useState(0);
   // Track pending service logs to batch submit on completion (componentId -> performedAt)
   const [pendingServiceLogs, setPendingServiceLogs] = useState<Map<string, string>>(new Map());
+  // Per-row inline Log Service flow. Only one row may have its inline date
+  // picker open at a time; second open replaces the first. `inlineDate` holds
+  // the month/year currently in the picker for that row.
+  const [inlineDateComponentId, setInlineDateComponentId] = useState<string | null>(null);
+  const [inlineDate, setInlineDate] = useState<{ month: number; year: number } | null>(null);
   // UI state
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -68,19 +96,40 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
   const calibrationState = data?.calibrationState;
   const bikes = useMemo(() => calibrationState?.bikes ?? [], [calibrationState?.bikes]);
 
-  // Calculate progress using initial total (stable across refetches)
-  const calibratedCount = calibratedIds.size;
-  const remainingCount = initialTotal - calibratedCount;
+  // Calculate progress using initial total (stable across refetches).
+  // Progress denominator is "needs-attention components at open" so the
+  // user logging an extra historical service on a healthy DUE_SOON
+  // component doesn't push remainingCount negative.
+  const calibratedNeedsAttentionCount = useMemo(
+    () => Array.from(calibratedIds).filter((id) => needsAttentionIds.has(id)).length,
+    [calibratedIds, needsAttentionIds],
+  );
+  const remainingCount = Math.max(0, initialTotal - calibratedNeedsAttentionCount);
 
   // Reset state when modal opens
   useEffect(() => {
     if (isOpen) {
       setCalibratedIds(new Set());
       setPendingServiceLogs(new Map());
+      setInlineDateComponentId(null);
+      setInlineDate(null);
       setError(null);
       setSuccessMessage(null);
-      const total = bikes.reduce((sum, bike) => sum + bike.components.length, 0);
-      setInitialTotal(total);
+
+      // Initial total / pre-selection / bike-section badge all key off the
+      // needs-attention subset, NOT the full components array. The resolver
+      // returns every component on bikes that have at least one overdue
+      // item — without filtering here, the "5 components need attention"
+      // subtitle would balloon into the full bike inventory.
+      const attentionIds = new Set<string>();
+      bikes.forEach((bike) => {
+        bike.components.forEach((c) => {
+          if (isNeedsAttention(c.status)) attentionIds.add(c.componentId);
+        });
+      });
+      setNeedsAttentionIds(attentionIds);
+      setInitialTotal(attentionIds.size);
+
       if (bikes.length > 0) {
         setExpandedBikeId(bikes[0].bikeId);
       }
@@ -89,7 +138,14 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
       const initialSelected: Record<string, Set<string>> = {};
       bikes.forEach((bike) => {
         initialDates[bike.bikeId] = { month: now.getMonth(), year: now.getFullYear() };
-        initialSelected[bike.bikeId] = new Set(bike.components.map((c) => c.componentId));
+        // Pre-select needs-attention rows only — that's the most common
+        // intent ("I just serviced everything that's overdue"). Users can
+        // uncheck or extend selection manually.
+        initialSelected[bike.bikeId] = new Set(
+          bike.components
+            .filter((c) => isNeedsAttention(c.status))
+            .map((c) => c.componentId),
+        );
       });
       setBulkDates(initialDates);
       setSelectedComponents(initialSelected);
@@ -192,6 +248,74 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
     setTimeout(() => setSuccessMessage(null), 3000);
   }, []);
 
+  // Per-row Log Service flow. Opens an inline month picker on a single
+  // component row. Confirming pushes the (componentId, performedAt) pair
+  // into pendingServiceLogs — the same Map the bulk flow uses — so a single
+  // LOG_BULK_SERVICE call on handleComplete persists everything together.
+  const handleOpenInlineLogService = useCallback((componentId: string) => {
+    setInlineDateComponentId(componentId);
+    const now = new Date();
+    setInlineDate({ month: now.getMonth(), year: now.getFullYear() });
+  }, []);
+
+  const handleCancelInlineLogService = useCallback(() => {
+    setInlineDateComponentId(null);
+    setInlineDate(null);
+  }, []);
+
+  const handleConfirmInlineLogService = useCallback((componentId: string) => {
+    if (!inlineDate) return;
+    const performedAt = new Date(inlineDate.year, inlineDate.month, 1).toISOString();
+
+    setPendingServiceLogs((prev) => {
+      const next = new Map(prev);
+      next.set(componentId, performedAt);
+      return next;
+    });
+    setCalibratedIds((prev) => new Set([...prev, componentId]));
+    // Clean up inline picker state and any lingering bulk-selection for
+    // this component so it doesn't double-count if the bulk button fires.
+    setInlineDateComponentId(null);
+    setInlineDate(null);
+    setSelectedComponents((prev) => {
+      const updated: Record<string, Set<string>> = {};
+      for (const [bikeId, ids] of Object.entries(prev)) {
+        if (ids.has(componentId)) {
+          const next = new Set(ids);
+          next.delete(componentId);
+          updated[bikeId] = next;
+        } else {
+          updated[bikeId] = ids;
+        }
+      }
+      return updated;
+    });
+
+    setSuccessMessage('Service logged');
+    setTimeout(() => setSuccessMessage(null), 3000);
+  }, [inlineDate]);
+
+  // When the user changes a bike's bulk date AND no rows are currently
+  // selected for that bike, auto-check the needs-attention rows. Removes
+  // the discoverability tax for the most common flow ("I just serviced
+  // the overdue stuff in <month>"). User can still uncheck individual
+  // rows after the auto-fill.
+  const handleBulkDateChange = useCallback((bikeId: string, month: number, year: number) => {
+    setBulkDates((prev) => ({ ...prev, [bikeId]: { month, year } }));
+    setSelectedComponents((prev) => {
+      const existing = prev[bikeId];
+      if (existing && existing.size > 0) return prev;
+      const bike = bikes.find((b) => b.bikeId === bikeId);
+      if (!bike) return prev;
+      const next = new Set(
+        bike.components
+          .filter((c) => isNeedsAttention(c.status) && !calibratedIds.has(c.componentId))
+          .map((c) => c.componentId),
+      );
+      return { ...prev, [bikeId]: next };
+    });
+  }, [bikes, calibratedIds]);
+
   const handleDismiss = useCallback(async () => {
     try {
       await dismissCalibration();
@@ -263,16 +387,19 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
       preventClose={isSubmitting}
     >
       <div className="calibration-overlay-content">
-        {/* Progress bar */}
+        {/* Progress bar — needs-attention-scoped so historical service logs
+            on healthy DUE_SOON/ALL_GOOD components don't push the bar past
+            100%. Those services still persist; they just don't count toward
+            "have you addressed everything that's overdue?" */}
         <div className="calibration-progress">
           <div className="calibration-progress-bar">
             <div
               className="calibration-progress-fill"
-              style={{ width: `${initialTotal > 0 ? (calibratedCount / initialTotal) * 100 : 0}%` }}
+              style={{ width: `${initialTotal > 0 ? (calibratedNeedsAttentionCount / initialTotal) * 100 : 0}%` }}
             />
           </div>
           <span className="calibration-progress-text">
-            {calibratedCount} of {initialTotal} calibrated
+            {calibratedNeedsAttentionCount} of {initialTotal} calibrated
           </span>
         </div>
 
@@ -287,6 +414,7 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
         {/* Button explanation */}
         <div className="calibration-info-secondary">
           <p>
+            <strong>Log Service</strong> — Record a date you serviced this component.<br />
             <strong>Acknowledge</strong> — Hours are accurate, no service performed yet.<br />
             <strong>Snooze</strong> — Visually inspected, extend interval by 50%.
           </p>
@@ -305,15 +433,16 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
               onToggleSelection={(componentId) => toggleComponentSelection(bike.bikeId, componentId)}
               onToggleAll={(selectAll) => toggleAllComponents(bike.bikeId, bike.components, selectAll)}
               bulkDate={bulkDates[bike.bikeId]}
-              onBulkDateChange={(month, year) => {
-                setBulkDates((prev) => ({
-                  ...prev,
-                  [bike.bikeId]: { month, year },
-                }));
-              }}
+              onBulkDateChange={(month, year) => handleBulkDateChange(bike.bikeId, month, year)}
               onBulkService={() => handleBulkServiceDate(bike.bikeId)}
               onSnoozeAlert={handleSnooze}
               onAcknowledge={handleAcknowledge}
+              inlineDateComponentId={inlineDateComponentId}
+              inlineDate={inlineDate}
+              onOpenInlineLogService={handleOpenInlineLogService}
+              onInlineDateChange={setInlineDate}
+              onConfirmInlineLogService={handleConfirmInlineLogService}
+              onCancelInlineLogService={handleCancelInlineLogService}
               isSubmitting={isSubmitting}
             />
           ))}
@@ -362,6 +491,12 @@ interface BikeSectionProps {
   onBulkService: () => void;
   onSnoozeAlert: (componentId: string) => void;
   onAcknowledge: (componentId: string) => void;
+  inlineDateComponentId: string | null;
+  inlineDate: { month: number; year: number } | null;
+  onOpenInlineLogService: (componentId: string) => void;
+  onInlineDateChange: (date: { month: number; year: number } | null) => void;
+  onConfirmInlineLogService: (componentId: string) => void;
+  onCancelInlineLogService: () => void;
   isSubmitting: boolean;
 }
 
@@ -378,19 +513,43 @@ function BikeSection({
   onBulkService,
   onSnoozeAlert,
   onAcknowledge,
+  inlineDateComponentId,
+  inlineDate,
+  onOpenInlineLogService,
+  onInlineDateChange,
+  onConfirmInlineLogService,
+  onCancelInlineLogService,
   isSubmitting,
 }: BikeSectionProps) {
   const uncalibratedComponents = bike.components.filter((c) => !calibratedIds.has(c.componentId));
-  const uncalibratedCount = uncalibratedComponents.length;
-  const allCalibrated = uncalibratedCount === 0;
+  // "Needs attention" is the gate the overlay scopes itself to. After the
+  // resolver change, `bike.components` includes DUE_SOON / ALL_GOOD too, so
+  // we have to derive the badge from status, not from the array length.
+  const needsAttentionCount = uncalibratedComponents.filter((c) => isNeedsAttention(c.status)).length;
+  const allNeedsAttentionAddressed = needsAttentionCount === 0;
+  // Distinct from `allNeedsAttentionAddressed`: this is true only when every
+  // component (healthy ones included) has been calibrated. Used to collapse
+  // the section's content entirely — nothing left to act on or confirm.
+  const allComponentsCalibrated = uncalibratedComponents.length === 0;
   const monthBounds = useMemo(() => getMonthInputBounds(), []);
+
+  // Sort components so OVERDUE/DUE_NOW render at the top, then DUE_SOON,
+  // then ALL_GOOD. Tie-break by componentId for stable ordering.
+  const sortedComponents = useMemo(() => {
+    return [...bike.components].sort((a, b) => {
+      const aPri = STATUS_PRIORITY[a.status] ?? 99;
+      const bPri = STATUS_PRIORITY[b.status] ?? 99;
+      if (aPri !== bPri) return aPri - bPri;
+      return a.componentId.localeCompare(b.componentId);
+    });
+  }, [bike.components]);
 
   // Count selected uncalibrated components
   const selectedCount = uncalibratedComponents.filter((c) => selectedIds.has(c.componentId)).length;
-  const allSelected = selectedCount === uncalibratedCount && uncalibratedCount > 0;
+  const allSelected = selectedCount === uncalibratedComponents.length && uncalibratedComponents.length > 0;
 
   return (
-    <div className={`calibration-bike ${allCalibrated ? 'calibration-bike-done' : ''}`}>
+    <div className={`calibration-bike ${allNeedsAttentionAddressed ? 'calibration-bike-done' : ''}`}>
       {/* Bike header */}
       <button
         type="button"
@@ -409,10 +568,10 @@ function BikeSection({
           <div className="calibration-bike-name">
             <span className="calibration-bike-title">{bike.bikeName}</span>
             <span className="calibration-bike-count">
-              {allCalibrated ? (
+              {allNeedsAttentionAddressed ? (
                 <><Check size={12} className="icon-success" /> All set</>
               ) : (
-                `${uncalibratedCount} need${uncalibratedCount === 1 ? 's' : ''} attention`
+                `${needsAttentionCount} need${needsAttentionCount === 1 ? 's' : ''} attention`
               )}
             </span>
           </div>
@@ -421,7 +580,7 @@ function BikeSection({
       </button>
 
       {/* Expanded content */}
-      {isExpanded && !allCalibrated && (
+      {isExpanded && !allComponentsCalibrated && (
         <div className="calibration-bike-content">
           {/* Bulk action */}
           <div className="calibration-bulk-action">
@@ -432,7 +591,7 @@ function BikeSection({
                 onChange={(e) => onToggleAll(e.target.checked)}
                 disabled={isSubmitting}
               />
-              <span>Serviced in:</span>
+              <span>Mark serviced in:</span>
             </label>
             <input
               type="month"
@@ -452,13 +611,13 @@ function BikeSection({
               onClick={onBulkService}
               disabled={isSubmitting || selectedCount === 0}
             >
-              Apply to {selectedCount === uncalibratedCount ? 'All' : 'Selected'} ({selectedCount})
+              Log Service ({selectedCount})
             </Button>
           </div>
 
           {/* Component list */}
           <div className="calibration-components">
-            {bike.components.map((component) => (
+            {sortedComponents.map((component) => (
               <ComponentRow
                 key={component.componentId}
                 component={component}
@@ -467,6 +626,13 @@ function BikeSection({
                 onToggleSelection={() => onToggleSelection(component.componentId)}
                 onSnoozeAlert={() => onSnoozeAlert(component.componentId)}
                 onAcknowledge={() => onAcknowledge(component.componentId)}
+                isInlineDateOpen={inlineDateComponentId === component.componentId}
+                inlineDate={inlineDate}
+                monthBounds={monthBounds}
+                onOpenInlineLogService={() => onOpenInlineLogService(component.componentId)}
+                onInlineDateChange={onInlineDateChange}
+                onConfirmInlineLogService={() => onConfirmInlineLogService(component.componentId)}
+                onCancelInlineLogService={onCancelInlineLogService}
                 isSubmitting={isSubmitting}
               />
             ))}
@@ -484,10 +650,32 @@ interface ComponentRowProps {
   onToggleSelection: () => void;
   onSnoozeAlert: () => void;
   onAcknowledge: () => void;
+  isInlineDateOpen: boolean;
+  inlineDate: { month: number; year: number } | null;
+  monthBounds: { min: string; max: string };
+  onOpenInlineLogService: () => void;
+  onInlineDateChange: (date: { month: number; year: number } | null) => void;
+  onConfirmInlineLogService: () => void;
+  onCancelInlineLogService: () => void;
   isSubmitting: boolean;
 }
 
-function ComponentRow({ component, isCalibrated, isSelected, onToggleSelection, onSnoozeAlert, onAcknowledge, isSubmitting }: ComponentRowProps) {
+function ComponentRow({
+  component,
+  isCalibrated,
+  isSelected,
+  onToggleSelection,
+  onSnoozeAlert,
+  onAcknowledge,
+  isInlineDateOpen,
+  inlineDate,
+  monthBounds,
+  onOpenInlineLogService,
+  onInlineDateChange,
+  onConfirmInlineLogService,
+  onCancelInlineLogService,
+  isSubmitting,
+}: ComponentRowProps) {
   const label = formatComponentLabel(component);
   const makeModel = [component.brand, component.model].filter(Boolean).join(' ') || 'Stock';
 
@@ -502,6 +690,55 @@ function ComponentRow({ component, isCalibrated, isSelected, onToggleSelection, 
           <span className="calibration-component-make">{makeModel}</span>
         </div>
         <span className="calibration-component-status">Calibrated</span>
+      </div>
+    );
+  }
+
+  // Inline Log Service flow: this row owns the inline date picker until
+  // the user confirms or cancels. The row's normal action buttons are
+  // swapped out for the picker + Save/Cancel so the user can't fire a
+  // second action mid-edit.
+  if (isInlineDateOpen) {
+    const now = new Date();
+    const monthValue = inlineDate
+      ? formatMonthValue(inlineDate.month, inlineDate.year)
+      : formatMonthValue(now.getMonth(), now.getFullYear());
+    return (
+      <div className="calibration-component">
+        <StatusDot status={component.status as PredictionStatus} />
+        <div className="calibration-component-info">
+          <span className="calibration-component-label">{label}</span>
+          <span className="calibration-component-make">{makeModel}</span>
+        </div>
+        <input
+          type="month"
+          className="form-input form-input-sm"
+          value={monthValue}
+          onChange={(e) => {
+            const { month, year } = parseMonthValue(e.target.value);
+            onInlineDateChange({ month, year });
+          }}
+          min={monthBounds.min}
+          max={monthBounds.max}
+          disabled={isSubmitting}
+          aria-label={`Service date for ${label}`}
+        />
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onConfirmInlineLogService}
+          disabled={isSubmitting || !inlineDate}
+        >
+          Save
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onCancelInlineLogService}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
       </div>
     );
   }
@@ -524,6 +761,15 @@ function ComponentRow({ component, isCalibrated, isSelected, onToggleSelection, 
       <span className="calibration-component-hours">
         {Math.round(component.hoursSinceService)}h since service
       </span>
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={onOpenInlineLogService}
+        disabled={isSubmitting}
+        title="Record a date you serviced this component"
+      >
+        Log Service
+      </Button>
       <Button
         variant="outline"
         size="sm"

--- a/apps/web/src/components/CalibrationOverlay.tsx
+++ b/apps/web/src/components/CalibrationOverlay.tsx
@@ -200,10 +200,25 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
 
   const toggleAllComponents = useCallback((bikeId: string, components: ComponentPrediction[], selectAll: boolean) => {
     setSelectedComponents((prev) => {
-      const uncalibrated = components.filter((c) => !calibratedIds.has(c.componentId));
-      const next = selectAll
-        ? new Set(uncalibrated.map((c) => c.componentId))
-        : new Set<string>();
+      const current = prev[bikeId] ?? new Set<string>();
+      // The header checkbox governs needs-attention (OVERDUE / DUE_NOW) rows
+      // ONLY — that's the bulk flow's primary intent and it matches the
+      // pre-selection on modal open. Healthy DUE_SOON / ALL_GOOD rows are
+      // left untouched: ticking the header can't accidentally sweep a
+      // healthy component into the batch, and unticking it can't silently
+      // drop a healthy component the user deliberately picked per-row.
+      // Healthy components stay fully serviceable via their own checkbox or
+      // the per-row Log Service button — a real use case (you might service
+      // an "all good" component because of a creak or a sloppy bleed).
+      const needsAttentionUncalibrated = components.filter(
+        (c) => !calibratedIds.has(c.componentId) && isNeedsAttention(c.status),
+      );
+      const next = new Set(current);
+      if (selectAll) {
+        needsAttentionUncalibrated.forEach((c) => next.add(c.componentId));
+      } else {
+        needsAttentionUncalibrated.forEach((c) => next.delete(c.componentId));
+      }
       return { ...prev, [bikeId]: next };
     });
   }, [calibratedIds]);
@@ -554,7 +569,8 @@ function BikeSection({
   // "Needs attention" is the gate the overlay scopes itself to. After the
   // resolver change, `bike.components` includes DUE_SOON / ALL_GOOD too, so
   // we have to derive the badge from status, not from the array length.
-  const needsAttentionCount = uncalibratedComponents.filter((c) => isNeedsAttention(c.status)).length;
+  const needsAttentionUncalibrated = uncalibratedComponents.filter((c) => isNeedsAttention(c.status));
+  const needsAttentionCount = needsAttentionUncalibrated.length;
   const allNeedsAttentionAddressed = needsAttentionCount === 0;
   // Distinct from `allNeedsAttentionAddressed`: this is true only when every
   // component (healthy ones included) has been calibrated. Used to collapse
@@ -573,9 +589,18 @@ function BikeSection({
     });
   }, [bike.components]);
 
-  // Count selected uncalibrated components
+  // `selectedCount` drives the bulk button and counts EVERY selected
+  // uncalibrated row — including healthy ones the user deliberately ticked
+  // per-row — because the button should log exactly what's selected.
   const selectedCount = uncalibratedComponents.filter((c) => selectedIds.has(c.componentId)).length;
-  const allSelected = selectedCount === uncalibratedComponents.length && uncalibratedComponents.length > 0;
+  // `allSelected` drives the header checkbox and is scoped to needs-attention
+  // rows only: the checkbox is a shortcut for "all the overdue stuff", not
+  // "literally everything", so it can't be used to bulk-batch healthy
+  // components by accident. (See toggleAllComponents for the matching toggle
+  // logic and the rationale.)
+  const allSelected =
+    needsAttentionCount > 0 &&
+    needsAttentionUncalibrated.every((c) => selectedIds.has(c.componentId));
 
   return (
     <div className={`calibration-bike ${allNeedsAttentionAddressed ? 'calibration-bike-done' : ''}`}>
@@ -611,7 +636,10 @@ function BikeSection({
       {/* Expanded content */}
       {isExpanded && !allComponentsCalibrated && (
         <div className="calibration-bike-content">
-          {/* Bulk action */}
+          {/* Bulk action. The checkbox label says "all overdue" explicitly
+              because the checkbox is scoped to needs-attention rows — see
+              allSelected / toggleAllComponents. Healthy components are not
+              swept in by this control; they're handled per-row. */}
           <div className="calibration-bulk-action">
             <label className="calibration-select-all">
               <input
@@ -620,7 +648,7 @@ function BikeSection({
                 onChange={(e) => onToggleAll(e.target.checked)}
                 disabled={isSubmitting}
               />
-              <span>Mark serviced in:</span>
+              <span>Mark all overdue serviced in:</span>
             </label>
             <input
               type="month"

--- a/apps/web/src/components/CalibrationOverlay.tsx
+++ b/apps/web/src/components/CalibrationOverlay.tsx
@@ -83,11 +83,14 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
   const [initialTotal, setInitialTotal] = useState(0);
   // Track pending service logs to batch submit on completion (componentId -> performedAt)
   const [pendingServiceLogs, setPendingServiceLogs] = useState<Map<string, string>>(new Map());
-  // Per-row inline Log Service flow. Only one row may have its inline date
-  // picker open at a time; second open replaces the first. `inlineDate` holds
-  // the month/year currently in the picker for that row.
-  const [inlineDateComponentId, setInlineDateComponentId] = useState<string | null>(null);
-  const [inlineDate, setInlineDate] = useState<{ month: number; year: number } | null>(null);
+  // Per-row inline Log Service flow. A single nullable object: the component
+  // id and the in-progress date are inseparable, so storing them together
+  // makes "they're always in sync" structural rather than convention. Only
+  // one row's picker is open at a time; opening another replaces this object.
+  const [inlinePicker, setInlinePicker] = useState<{
+    componentId: string;
+    date: { month: number; year: number };
+  } | null>(null);
   // UI state
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -141,8 +144,7 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
 
     setCalibratedIds(new Set());
     setPendingServiceLogs(new Map());
-    setInlineDateComponentId(null);
-    setInlineDate(null);
+    setInlinePicker(null);
     setError(null);
     setSuccessMessage(null);
 
@@ -293,22 +295,32 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
   }, []);
 
   const handleOpenInlineLogService = useCallback((componentId: string) => {
-    setInlineDateComponentId(componentId);
     const now = new Date();
-    setInlineDate({ month: now.getMonth(), year: now.getFullYear() });
+    setInlinePicker({
+      componentId,
+      date: { month: now.getMonth(), year: now.getFullYear() },
+    });
   }, []);
 
   const handleCancelInlineLogService = useCallback(() => {
-    setInlineDateComponentId(null);
-    setInlineDate(null);
+    setInlinePicker(null);
+  }, []);
+
+  const handleInlineDateChange = useCallback((date: { month: number; year: number }) => {
+    // No-op if the picker somehow isn't open — the date input only renders
+    // while it is, so `prev` is realistically always non-null here.
+    setInlinePicker((prev) => (prev ? { ...prev, date } : prev));
   }, []);
 
   // Stages the log in `pendingServiceLogs` — the same Map the bulk flow
   // writes to — so handleComplete's single LOG_BULK_SERVICE call persists
-  // per-row and bulk logs together.
-  const handleConfirmInlineLogService = useCallback((componentId: string) => {
-    if (!inlineDate) return;
-    const performedAt = new Date(inlineDate.year, inlineDate.month, 1).toISOString();
+  // per-row and bulk logs together. Both the component id and the date come
+  // from `inlinePicker`, so there's no separate componentId param to keep
+  // in sync with the open row.
+  const handleConfirmInlineLogService = useCallback(() => {
+    if (!inlinePicker) return;
+    const { componentId, date } = inlinePicker;
+    const performedAt = new Date(date.year, date.month, 1).toISOString();
 
     setPendingServiceLogs((prev) => {
       const next = new Map(prev);
@@ -318,8 +330,7 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
     setCalibratedIds((prev) => new Set([...prev, componentId]));
     // Clean up inline picker state and any lingering bulk-selection for
     // this component so it doesn't double-count if the bulk button fires.
-    setInlineDateComponentId(null);
-    setInlineDate(null);
+    setInlinePicker(null);
     setSelectedComponents((prev) => {
       const updated: Record<string, Set<string>> = {};
       for (const [bikeId, ids] of Object.entries(prev)) {
@@ -336,7 +347,7 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
 
     setSuccessMessage('Service logged');
     setTimeout(() => setSuccessMessage(null), 3000);
-  }, [inlineDate]);
+  }, [inlinePicker]);
 
   // When the user changes a bike's bulk date AND no rows are currently
   // selected for that bike, auto-check the needs-attention rows. Removes
@@ -491,10 +502,9 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
               onBulkService={() => handleBulkServiceDate(bike.bikeId)}
               onSnoozeAlert={handleSnooze}
               onAcknowledge={handleAcknowledge}
-              inlineDateComponentId={inlineDateComponentId}
-              inlineDate={inlineDate}
+              inlinePicker={inlinePicker}
               onOpenInlineLogService={handleOpenInlineLogService}
-              onInlineDateChange={setInlineDate}
+              onInlineDateChange={handleInlineDateChange}
               onConfirmInlineLogService={handleConfirmInlineLogService}
               onCancelInlineLogService={handleCancelInlineLogService}
               isSubmitting={isSubmitting}
@@ -545,11 +555,11 @@ interface BikeSectionProps {
   onBulkService: () => void;
   onSnoozeAlert: (componentId: string) => void;
   onAcknowledge: (componentId: string) => void;
-  inlineDateComponentId: string | null;
-  inlineDate: { month: number; year: number } | null;
+  /** The single open inline-picker (component id + in-progress date), or null. */
+  inlinePicker: { componentId: string; date: { month: number; year: number } } | null;
   onOpenInlineLogService: (componentId: string) => void;
-  onInlineDateChange: (date: { month: number; year: number } | null) => void;
-  onConfirmInlineLogService: (componentId: string) => void;
+  onInlineDateChange: (date: { month: number; year: number }) => void;
+  onConfirmInlineLogService: () => void;
   onCancelInlineLogService: () => void;
   isSubmitting: boolean;
 }
@@ -567,8 +577,7 @@ function BikeSection({
   onBulkService,
   onSnoozeAlert,
   onAcknowledge,
-  inlineDateComponentId,
-  inlineDate,
+  inlinePicker,
   onOpenInlineLogService,
   onInlineDateChange,
   onConfirmInlineLogService,
@@ -708,16 +717,22 @@ function BikeSection({
                 onToggleSelection={() => onToggleSelection(component.componentId)}
                 onSnoozeAlert={() => onSnoozeAlert(component.componentId)}
                 onAcknowledge={() => onAcknowledge(component.componentId)}
-                isInlineDateOpen={inlineDateComponentId === component.componentId}
-                isAnotherRowEditing={
-                  inlineDateComponentId !== null &&
-                  inlineDateComponentId !== component.componentId
+                // `inlineDate` is non-null exactly for the row whose picker
+                // is open — that's how ComponentRow knows it's the open row,
+                // no separate boolean needed.
+                inlineDate={
+                  inlinePicker?.componentId === component.componentId
+                    ? inlinePicker.date
+                    : null
                 }
-                inlineDate={inlineDate}
+                isAnotherRowEditing={
+                  inlinePicker !== null &&
+                  inlinePicker.componentId !== component.componentId
+                }
                 monthBounds={monthBounds}
                 onOpenInlineLogService={() => onOpenInlineLogService(component.componentId)}
                 onInlineDateChange={onInlineDateChange}
-                onConfirmInlineLogService={() => onConfirmInlineLogService(component.componentId)}
+                onConfirmInlineLogService={onConfirmInlineLogService}
                 onCancelInlineLogService={onCancelInlineLogService}
                 isSubmitting={isSubmitting}
               />
@@ -736,21 +751,26 @@ interface ComponentRowProps {
   onToggleSelection: () => void;
   onSnoozeAlert: () => void;
   onAcknowledge: () => void;
-  isInlineDateOpen: boolean;
+  /**
+   * The in-progress date when THIS row's inline picker is open, else null.
+   * Non-null is the single signal that this row is the open one — derived
+   * from the overlay's single `inlinePicker` object, so there's no separate
+   * "is open" boolean that could drift out of sync with the date.
+   */
+  inlineDate: { month: number; year: number } | null;
   /**
    * True when ANOTHER row's inline date picker is currently open. Used to
    * disable this row's "Log Service" button: only one inline picker can be
-   * open at a time (state is a single `inlineDateComponentId`), and opening
-   * a second one would silently replace the first — discarding whatever date
-   * the user had started entering there. Disabling the button makes the
-   * "finish or cancel the open one first" constraint visible instead of
-   * letting the discard happen silently.
+   * open at a time (the overlay holds a single `inlinePicker` object), and
+   * opening a second one would silently replace the first — discarding
+   * whatever date the user had started entering there. Disabling the button
+   * makes the "finish or cancel the open one first" constraint visible
+   * instead of letting the discard happen silently.
    */
   isAnotherRowEditing: boolean;
-  inlineDate: { month: number; year: number } | null;
   monthBounds: { min: string; max: string };
   onOpenInlineLogService: () => void;
-  onInlineDateChange: (date: { month: number; year: number } | null) => void;
+  onInlineDateChange: (date: { month: number; year: number }) => void;
   onConfirmInlineLogService: () => void;
   onCancelInlineLogService: () => void;
   isSubmitting: boolean;
@@ -763,9 +783,8 @@ function ComponentRow({
   onToggleSelection,
   onSnoozeAlert,
   onAcknowledge,
-  isInlineDateOpen,
-  isAnotherRowEditing,
   inlineDate,
+  isAnotherRowEditing,
   monthBounds,
   onOpenInlineLogService,
   onInlineDateChange,
@@ -791,18 +810,12 @@ function ComponentRow({
     );
   }
 
-  // Inline Log Service flow: this row owns the inline date picker until
-  // the user confirms or cancels. The row's normal action buttons are
-  // swapped out for the picker + Save/Cancel so the user can't fire a
-  // second action mid-edit.
-  //
-  // `isInlineDateOpen` and `inlineDate` are a coupled pair — the parent
-  // sets/clears `inlineDateComponentId` and `inlineDate` together — so
-  // checking both here lets TypeScript narrow `inlineDate` to non-null
-  // (no `!` assertion, no unreachable fallback). If the invariant is ever
-  // violated, the row falls through to the normal render: a safe
-  // degradation rather than a crash.
-  if (isInlineDateOpen && inlineDate) {
+  // Inline Log Service flow: a non-null `inlineDate` means this row owns
+  // the inline date picker. Its normal action buttons are swapped out for
+  // the picker + Save/Cancel so the user can't fire a second action
+  // mid-edit. The nullable prop is the only "is this row open" signal —
+  // no separate boolean to drift out of sync.
+  if (inlineDate) {
     const monthValue = formatMonthValue(inlineDate.month, inlineDate.year);
     return (
       <div className="calibration-component">

--- a/apps/web/src/components/CalibrationOverlay.tsx
+++ b/apps/web/src/components/CalibrationOverlay.tsx
@@ -346,17 +346,28 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
   // rows after the auto-fill.
   const handleBulkDateChange = useCallback((bikeId: string, month: number, year: number) => {
     setBulkDates((prev) => ({ ...prev, [bikeId]: { month, year } }));
+
+    // Compute the auto-check candidate set from closure state (`bikes`,
+    // `calibratedIds`) up front, so the functional updater below only
+    // reads `prev` — the genuinely-fresh selection map. Reading
+    // `calibratedIds` *inside* the updater would mix a closure snapshot
+    // with `prev`'s fresh value, a stale-closure footgun even though the
+    // useCallback dep list keeps it mostly honest.
+    const bike = bikes.find((b) => b.bikeId === bikeId);
+    const autoCheckIds = bike
+      ? new Set(
+          bike.components
+            .filter((c) => isNeedsAttention(c.status) && !calibratedIds.has(c.componentId))
+            .map((c) => c.componentId),
+        )
+      : null;
+
     setSelectedComponents((prev) => {
       const existing = prev[bikeId];
+      // Only auto-check when the user has nothing selected for this bike.
       if (existing && existing.size > 0) return prev;
-      const bike = bikes.find((b) => b.bikeId === bikeId);
-      if (!bike) return prev;
-      const next = new Set(
-        bike.components
-          .filter((c) => isNeedsAttention(c.status) && !calibratedIds.has(c.componentId))
-          .map((c) => c.componentId),
-      );
-      return { ...prev, [bikeId]: next };
+      if (!autoCheckIds) return prev;
+      return { ...prev, [bikeId]: autoCheckIds };
     });
   }, [bikes, calibratedIds]);
 

--- a/apps/web/src/components/CalibrationOverlay.tsx
+++ b/apps/web/src/components/CalibrationOverlay.tsx
@@ -684,6 +684,10 @@ function BikeSection({
                 onSnoozeAlert={() => onSnoozeAlert(component.componentId)}
                 onAcknowledge={() => onAcknowledge(component.componentId)}
                 isInlineDateOpen={inlineDateComponentId === component.componentId}
+                isAnotherRowEditing={
+                  inlineDateComponentId !== null &&
+                  inlineDateComponentId !== component.componentId
+                }
                 inlineDate={inlineDate}
                 monthBounds={monthBounds}
                 onOpenInlineLogService={() => onOpenInlineLogService(component.componentId)}
@@ -708,6 +712,16 @@ interface ComponentRowProps {
   onSnoozeAlert: () => void;
   onAcknowledge: () => void;
   isInlineDateOpen: boolean;
+  /**
+   * True when ANOTHER row's inline date picker is currently open. Used to
+   * disable this row's "Log Service" button: only one inline picker can be
+   * open at a time (state is a single `inlineDateComponentId`), and opening
+   * a second one would silently replace the first — discarding whatever date
+   * the user had started entering there. Disabling the button makes the
+   * "finish or cancel the open one first" constraint visible instead of
+   * letting the discard happen silently.
+   */
+  isAnotherRowEditing: boolean;
   inlineDate: { month: number; year: number } | null;
   monthBounds: { min: string; max: string };
   onOpenInlineLogService: () => void;
@@ -725,6 +739,7 @@ function ComponentRow({
   onSnoozeAlert,
   onAcknowledge,
   isInlineDateOpen,
+  isAnotherRowEditing,
   inlineDate,
   monthBounds,
   onOpenInlineLogService,
@@ -822,8 +837,12 @@ function ComponentRow({
         variant="primary"
         size="sm"
         onClick={onOpenInlineLogService}
-        disabled={isSubmitting}
-        title="Record a date you serviced this component"
+        disabled={isSubmitting || isAnotherRowEditing}
+        title={
+          isAnotherRowEditing
+            ? 'Finish or cancel the date you started on another component first'
+            : 'Record a date you serviced this component'
+        }
       >
         Log Service
       </Button>

--- a/apps/web/src/components/CalibrationOverlay.tsx
+++ b/apps/web/src/components/CalibrationOverlay.tsx
@@ -663,7 +663,10 @@ function BikeSection({
           {/* Bulk action. The checkbox label says "all overdue" explicitly
               because the checkbox is scoped to needs-attention rows — see
               allSelected / toggleAllComponents. Healthy components are not
-              swept in by this control; they're handled per-row. */}
+              swept in by this control; they're handled per-row. Kept short
+              ("All overdue, serviced in:") so it doesn't crowd the row on
+              small viewports; it also wraps rather than overflows there
+              (see .calibration-select-all in the mobile media query). */}
           <div className="calibration-bulk-action">
             <label className="calibration-select-all">
               <input
@@ -672,7 +675,7 @@ function BikeSection({
                 onChange={(e) => onToggleAll(e.target.checked)}
                 disabled={isSubmitting}
               />
-              <span>Mark all overdue serviced in:</span>
+              <span>All overdue, serviced in:</span>
             </label>
             <input
               type="month"

--- a/apps/web/src/components/CalibrationOverlay.tsx
+++ b/apps/web/src/components/CalibrationOverlay.tsx
@@ -292,10 +292,6 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
     setTimeout(() => setSuccessMessage(null), 3000);
   }, []);
 
-  // Per-row Log Service flow. Opens an inline month picker on a single
-  // component row. Confirming pushes the (componentId, performedAt) pair
-  // into pendingServiceLogs — the same Map the bulk flow uses — so a single
-  // LOG_BULK_SERVICE call on handleComplete persists everything together.
   const handleOpenInlineLogService = useCallback((componentId: string) => {
     setInlineDateComponentId(componentId);
     const now = new Date();
@@ -307,6 +303,9 @@ export function CalibrationOverlay({ isOpen, onClose }: CalibrationOverlayProps)
     setInlineDate(null);
   }, []);
 
+  // Stages the log in `pendingServiceLogs` — the same Map the bulk flow
+  // writes to — so handleComplete's single LOG_BULK_SERVICE call persists
+  // per-row and bulk logs together.
   const handleConfirmInlineLogService = useCallback((componentId: string) => {
     if (!inlineDate) return;
     const performedAt = new Date(inlineDate.year, inlineDate.month, 1).toISOString();
@@ -589,13 +588,12 @@ function BikeSection({
   const allComponentsCalibrated = uncalibratedComponents.length === 0;
   const monthBounds = useMemo(() => getMonthInputBounds(), []);
 
-  // Sort components so OVERDUE/DUE_NOW render at the top, then DUE_SOON,
-  // then ALL_GOOD. Tie-break by componentId for stable ordering.
   const sortedComponents = useMemo(() => {
     return [...bike.components].sort((a, b) => {
       const aPri = STATUS_PRIORITY[a.status] ?? 99;
       const bPri = STATUS_PRIORITY[b.status] ?? 99;
       if (aPri !== bPri) return aPri - bPri;
+      // Stable tie-break so same-status rows don't reshuffle between renders.
       return a.componentId.localeCompare(b.componentId);
     });
   }, [bike.components]);
@@ -797,11 +795,15 @@ function ComponentRow({
   // the user confirms or cancels. The row's normal action buttons are
   // swapped out for the picker + Save/Cancel so the user can't fire a
   // second action mid-edit.
-  if (isInlineDateOpen) {
-    const now = new Date();
-    const monthValue = inlineDate
-      ? formatMonthValue(inlineDate.month, inlineDate.year)
-      : formatMonthValue(now.getMonth(), now.getFullYear());
+  //
+  // `isInlineDateOpen` and `inlineDate` are a coupled pair — the parent
+  // sets/clears `inlineDateComponentId` and `inlineDate` together — so
+  // checking both here lets TypeScript narrow `inlineDate` to non-null
+  // (no `!` assertion, no unreachable fallback). If the invariant is ever
+  // violated, the row falls through to the normal render: a safe
+  // degradation rather than a crash.
+  if (isInlineDateOpen && inlineDate) {
+    const monthValue = formatMonthValue(inlineDate.month, inlineDate.year);
     return (
       <div className="calibration-component">
         <StatusDot status={component.status as PredictionStatus} />

--- a/apps/web/src/components/CalibrationOverlay.tsx
+++ b/apps/web/src/components/CalibrationOverlay.tsx
@@ -603,7 +603,13 @@ function BikeSection({
     needsAttentionUncalibrated.every((c) => selectedIds.has(c.componentId));
 
   return (
-    <div className={`calibration-bike ${allNeedsAttentionAddressed ? 'calibration-bike-done' : ''}`}>
+    // `calibration-bike-done` dims the whole section (opacity 0.7). Key it on
+    // `allComponentsCalibrated`, NOT `allNeedsAttentionAddressed`: in the
+    // mixed case (overdue items handled, healthy components still present)
+    // the body stays expanded with live Log Service / Acknowledge / Snooze
+    // buttons, and dimming those would make them read as disabled. Only dim
+    // once the section is genuinely finished and its body has collapsed.
+    <div className={`calibration-bike ${allComponentsCalibrated ? 'calibration-bike-done' : ''}`}>
       {/* Bike header */}
       <button
         type="button"
@@ -623,7 +629,14 @@ function BikeSection({
             <span className="calibration-bike-title">{bike.bikeName}</span>
             <span className="calibration-bike-count">
               {allNeedsAttentionAddressed ? (
-                <><Check size={12} className="icon-success" /> All set</>
+                <>
+                  <Check size={12} className="icon-success" />{' '}
+                  {/* "All set" only when there's literally nothing left.
+                      When healthy components remain uncalibrated the body
+                      is still showing optional Log Service buttons, so the
+                      badge must not claim the section is fully done. */}
+                  {allComponentsCalibrated ? 'All set' : 'Nothing due'}
+                </>
               ) : (
                 `${needsAttentionCount} need${needsAttentionCount === 1 ? 's' : ''} attention`
               )}

--- a/apps/web/src/styles/pages/dashboard.css
+++ b/apps/web/src/styles/pages/dashboard.css
@@ -5480,6 +5480,14 @@
     align-items: stretch;
   }
 
+  /* The bulk-action row stacks vertically here, so the select-all label
+     gets its own full-width line. Override the desktop `white-space: nowrap`
+     so a long label wraps gracefully instead of overflowing the modal on
+     narrow viewports. */
+  .calibration-select-all {
+    white-space: normal;
+  }
+
   .calibration-bulk-action .form-select-sm,
   .calibration-bulk-action .form-input-sm {
     width: 100%;


### PR DESCRIPTION
# bugfix: calibration not showing all components

## Summary

A founding rider reported (with a screenshot) that she could not enter services previously performed on her bike from the web **"Calibrate Your Components"** overlay. Investigation surfaced two separate issues — a backend filter that hid components, and a front-end UX dead-end where the obvious button (`Acknowledge`) silently records nothing. This PR fixes both so users can log historical service for **any** component, directly from the calibration overlay.

Commit: `93ae4d4` — `apps/api/src/graphql/resolvers.ts`, `apps/web/src/components/CalibrationOverlay.tsx`

## The problem

The calibration overlay opens after onboarding when a user has overdue components. The user's goal was to record real-world service history ("I replaced these brake pads last spring") so her maintenance predictions would be accurate. She couldn't:

1. **Components were missing.** The `calibrationState` resolver only returned components with `status === 'OVERDUE' || 'DUE_NOW'`. Anything she'd recently serviced (now `DUE_SOON` / `ALL_GOOD`) never appeared in the overlay, so there was no way to log historical service for it here.
2. **The visible action did nothing useful.** On each row, `Acknowledge` *looks* like "log this service" but it only marks the component calibrated locally — no service-log entry is written. The real "log service on date X" path was buried in a bulk-action row that required three non-obvious steps (pick a month, tick per-row checkboxes, click `Apply to Selected (N)`). With nothing ticked, that button reads `Apply to Selected (0)` and is disabled — a dead end.

This is the same family of issue as the recent mobile `LogServiceSheet` fix: service logging was being gated/hidden rather than offered.

## What changed

### Backend — `apps/api/src/graphql/resolvers.ts`

- **Dropped the components-array filter.** `calibrationState` now returns *all* components on a bike, not just `OVERDUE` / `DUE_NOW` ones.
- **Kept the bike-inclusion gate.** A bike still only appears in the overlay if it has at least one `OVERDUE` / `DUE_NOW` component, and `totalOverdue` still uses the strict filter — so `showOverlay` and the subtitle count are unchanged. The overlay still only auto-pops when something is genuinely overdue.
- No schema change; each component already carries its own `status` for the front end to sort/badge.

### Frontend — `apps/web/src/components/CalibrationOverlay.tsx`

**Per-row "Log Service" button (the direct fix for the screenshot).** Every component row gets a `Log Service` action alongside `Acknowledge` / `Snooze`. Clicking it swaps the row's buttons for an inline month picker + `Save` / `Cancel`. Confirming pushes `(componentId, performedAt)` into the existing `pendingServiceLogs` map — the *same* map the bulk flow uses — so the existing `LOG_BULK_SERVICE` batched submit on `Complete Calibration` persists everything. No new mutation, no new modal.

**Bulk-flow polish.**
- `Apply to Selected (N)` → `Log Service (N)`.
- `Serviced in:` → `Mark serviced in:`.
- Changing a bike's bulk date when nothing is selected now auto-checks the needs-attention rows (the common "I just serviced everything overdue in <month>" case).
- The explainer gained a `Log Service` line, listed first since it's the primary intent.

**Status-aware rendering.** Now that the components array includes healthy components:
- Rows sort `OVERDUE → DUE_NOW → DUE_SOON → ALL_GOOD` so attention-needing items stay at the top.
- The bike-header badge and modal subtitle derive their "X need attention" counts from component `status`, not array length — logging a historical service on a healthy component no longer inflates the count.
- The progress bar is needs-attention-scoped (`calibratedNeedsAttentionCount / initialTotal`), so an extra historical service on a healthy component can't push it past 100%.
- A new `allComponentsCalibrated` check preserves the original "collapse the section when fully done" behavior.

## Behavior changes

| Area | Before | After |
| --- | --- | --- |
| Components shown in overlay | OVERDUE / DUE_NOW only | All components on bikes that have ≥1 overdue item |
| Logging service for one component | Buried in bulk flow; `Acknowledge` records nothing | Per-row `Log Service` button → inline date picker → Save |
| Bulk button label | `Apply to Selected (N)` | `Log Service (N)` |
| Bulk date + empty selection | Nothing selected, button disabled | Needs-attention rows auto-checked |
| Row order | API order | Sorted by status priority |
| "X need attention" count | Array length | Derived from `OVERDUE` / `DUE_NOW` status |
| Overlay auto-open trigger | `totalOverdue > 0` | Unchanged |
| `Acknowledge` / `Snooze` semantics | — | Unchanged (explainer copy now clearer) |

## Testing

- `apps/web` typecheck: clean.
- `apps/api` typecheck: only pre-existing unrelated errors (`resolvers.ts:3823+`, `BikeNotificationPreference` / `TierUser` — predate this change).
- No automated tests cover `calibrationState` or `logBulkComponentService`, so **manual end-to-end testing is required before merge**:
  - **Per-row path** — open the overlay, click `Log Service` on a row, pick a month, `Save`; confirm the row collapses to the calibrated state, click `Complete Calibration`, verify `LOG_BULK_SERVICE` fires with the right `componentIds` + `performedAt` and a service-log row is written (bike detail / `bikeHistory`).
  - **Bulk path** — pick a month in `Mark serviced in:`, confirm needs-attention rows auto-check, click `Log Service (N)`, verify the same mutation fires.
  - **Filter expansion** — a bike with mixed statuses shows all its components, OVERDUE/DUE_NOW first; `Log Service` works on an `ALL_GOOD` component.
  - **Regressions** — `Acknowledge` still marks calibrated without writing a log; `Snooze` still extends interval 50%; `Remind Me Later` still dismisses; bikes with no overdue components still don't trigger the overlay.

## Risk / scope

- **No schema migration, no new mutation.** The per-row flow piggybacks on the existing `LOG_BULK_SERVICE` (it already accepts a single-element `componentIds` array).
- **Mobile unaffected.** The mobile `LogServiceSheet` was fixed separately and already supports all components.
- The dashboard `LogServiceModal` is untouched — it already accepted any component.
