### PR TITLE
fix: pr revisions

### DIFF
--- a/apps/api/src/auth/appleTokenVerifier.ts
+++ b/apps/api/src/auth/appleTokenVerifier.ts
@@ -35,19 +35,44 @@ export type AppleTokenPayload = {
  * the audience/issuer checks enforced by jose. This matches our Google handler
  * which also operates without nonces.
  */
+/**
+ * Discriminator metadata attached to thrown errors so the route handler can
+ * log a specific reason (jose error code or class name) and the failing claim
+ * (e.g. 'aud') without re-parsing message text.
+ */
+export type AppleVerifyErrorDetail = { reason: string; claim?: unknown };
+
+function tagAppleError(err: unknown): unknown {
+  if (!(err instanceof Error)) return err;
+  const reason =
+    'code' in err && err.code != null
+      ? String((err as { code: unknown }).code)
+      : err.name || 'UNKNOWN';
+  const claim = 'claim' in err ? (err as { claim: unknown }).claim : undefined;
+  (err as Error & { _apple?: AppleVerifyErrorDetail })._apple = { reason, claim };
+  return err;
+}
+
 export async function verifyAppleIdentityToken(
   identityToken: string,
   bundleId: string,
 ): Promise<AppleTokenPayload> {
-  const { payload } = await jwtVerify(identityToken, appleJWKS, {
-    issuer: APPLE_ISSUER,
-    audience: bundleId,
-    algorithms: ['RS256'],
-  });
+  let payload;
+  try {
+    ({ payload } = await jwtVerify(identityToken, appleJWKS, {
+      issuer: APPLE_ISSUER,
+      audience: bundleId,
+      algorithms: ['RS256'],
+    }));
+  } catch (err) {
+    throw tagAppleError(err);
+  }
 
   const sub = payload.sub;
   if (!sub) {
-    throw new Error('Apple identity token missing sub claim');
+    const err = new Error('Apple identity token missing sub claim');
+    (err as Error & { _apple?: AppleVerifyErrorDetail })._apple = { reason: 'MISSING_SUB' };
+    throw err;
   }
 
   return {

--- a/apps/api/src/auth/ensureUserFromApple.test.ts
+++ b/apps/api/src/auth/ensureUserFromApple.test.ts
@@ -81,7 +81,7 @@ describe('ensureUserFromApple', () => {
 
     const result = await ensureUserFromApple(baseClaims);
 
-    expect(result).toEqual(createdUser);
+    expect(result).toEqual({ user: createdUser, wasCreated: true });
     expect(mockUserCreate).toHaveBeenCalledWith({
       data: expect.objectContaining({
         email: 'test@test.com',
@@ -151,7 +151,7 @@ describe('ensureUserFromApple', () => {
 
     const result = await ensureUserFromApple(baseClaims);
 
-    expect(result).toEqual(existingUser);
+    expect(result).toEqual({ user: existingUser, wasCreated: false });
     expect(mockUserCreate).not.toHaveBeenCalled();
   });
 
@@ -166,7 +166,7 @@ describe('ensureUserFromApple', () => {
 
     const result = await ensureUserFromApple(baseClaims);
 
-    expect(result).toEqual(existingUser);
+    expect(result).toEqual({ user: existingUser, wasCreated: false });
     expect(mockUserAccountCreate).toHaveBeenCalledWith({
       data: { userId: 'email-user', provider: 'apple', providerUserId: 'apple-001.abc123' },
     });
@@ -186,7 +186,8 @@ describe('ensureUserFromApple', () => {
       where: { id: 'nameless' },
       data: { name: 'Test User' },
     });
-    expect(result.name).toBe('Test User');
+    expect(result.user.name).toBe('Test User');
+    expect(result.wasCreated).toBe(false);
   });
 
   it('should throw when no email and no existing account', async () => {

--- a/apps/api/src/auth/ensureUserFromApple.ts
+++ b/apps/api/src/auth/ensureUserFromApple.ts
@@ -1,11 +1,14 @@
-import { Prisma } from '@prisma/client';
+import { Prisma, type User } from '@prisma/client';
 import { normalizeEmail } from './utils';
 import { AUTH_ERROR, type AppleClaims } from './types';
 import { prisma } from '../lib/prisma';
 import { config } from '../config/env';
+import { logger } from '../lib/logger';
 import { resolveReferrer, createUserWithReferralCode } from '../services/referral.service';
 
-export function ensureUserFromApple(claims: AppleClaims, ref?: string) {
+export type AppleUserResult = { user: User; wasCreated: boolean };
+
+export function ensureUserFromApple(claims: AppleClaims, ref?: string): Promise<AppleUserResult> {
   return ensureUserFromAppleInner(claims, ref, 0);
 }
 
@@ -13,7 +16,7 @@ async function ensureUserFromAppleInner(
   claims: AppleClaims,
   ref: string | undefined,
   retries: number,
-) {
+): Promise<AppleUserResult> {
   const { sub } = claims;
   // Trusted email from the identity token — safe for account lookup/linking
   const trustedEmail = normalizeEmail(claims.email);
@@ -79,7 +82,7 @@ async function ensureUserFromAppleInner(
     return null;
   });
 
-  if (existing) return existing;
+  if (existing) return { user: existing, wasCreated: false };
 
   // Phase 2: New user — fall back to untrusted client email if token had none.
   // When clientEmail is used, claims.email_verified will be false (the token had
@@ -96,9 +99,9 @@ async function ensureUserFromAppleInner(
   const referrerId = ref ? await resolveReferrer(ref) : null;
 
   try {
-    return await createUserWithReferralCode(async (referralCode) => {
+    const newUser = await createUserWithReferralCode(async (referralCode) => {
       return prisma.$transaction(async (tx) => {
-        const newUser = await tx.user.create({
+        const created = await tx.user.create({
           data: {
             email: emailForCreation,
             name: claims.name ?? null,
@@ -111,18 +114,19 @@ async function ensureUserFromAppleInner(
         });
 
         await tx.userAccount.create({
-          data: { userId: newUser.id, provider: 'apple', providerUserId: sub },
+          data: { userId: created.id, provider: 'apple', providerUserId: sub },
         });
 
         if (referrerId) {
           await tx.referral.create({
-            data: { referrerUserId: referrerId, referredUserId: newUser.id },
+            data: { referrerUserId: referrerId, referredUserId: created.id },
           });
         }
 
-        return newUser;
+        return created;
       });
     });
+    return { user: newUser, wasCreated: true };
   } catch (err) {
     // A concurrent request created this user between Phase 1 and Phase 2.
     // Re-run the full function — Phase 1 will now find the existing user.
@@ -132,6 +136,7 @@ async function ensureUserFromAppleInner(
       (err.meta?.target as string[] | undefined)?.includes('email');
 
     if (isEmailCollision) {
+      logger.warn({ sub, retries }, 'Apple sign-in email-collision retry');
       if (retries >= 2) throw err;
       return ensureUserFromAppleInner(claims, ref, retries + 1);
     }

--- a/apps/api/src/auth/ensureUserFromGoogle.test.ts
+++ b/apps/api/src/auth/ensureUserFromGoogle.test.ts
@@ -87,7 +87,7 @@ describe('ensureUserFromGoogle', () => {
 
     const result = await ensureUserFromGoogle(baseClaims);
 
-    expect(result).toEqual(createdUser);
+    expect(result).toEqual({ user: createdUser, wasCreated: true });
     expect(mockUserCreate).toHaveBeenCalledWith({
       data: expect.objectContaining({
         email: 'test@test.com',
@@ -149,7 +149,7 @@ describe('ensureUserFromGoogle', () => {
 
     const result = await ensureUserFromGoogle(baseClaims);
 
-    expect(result).toEqual(existingUser);
+    expect(result).toEqual({ user: existingUser, wasCreated: false });
     expect(mockUserCreate).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/auth/ensureUserFromGoogle.ts
+++ b/apps/api/src/auth/ensureUserFromGoogle.ts
@@ -1,15 +1,17 @@
-import { Prisma } from '@prisma/client';
+import { Prisma, type User } from '@prisma/client';
 import { normalizeEmail, computeExpiry } from './utils';
 import { AUTH_ERROR, type GoogleClaims, type GoogleTokens } from './types';
 import { prisma } from '../lib/prisma';
 import { config } from '../config/env';
 import { resolveReferrer, createUserWithReferralCode } from '../services/referral.service';
 
+export type GoogleUserResult = { user: User; wasCreated: boolean };
+
 export function ensureUserFromGoogle(
   claims: GoogleClaims,
   tokens?: GoogleTokens,
   ref?: string,
-) {
+): Promise<GoogleUserResult> {
   return ensureUserFromGoogleInner(claims, tokens, ref, 0);
 }
 
@@ -18,7 +20,7 @@ async function ensureUserFromGoogleInner(
   tokens: GoogleTokens | undefined,
   ref: string | undefined,
   retries: number,
-) {
+): Promise<GoogleUserResult> {
   const sub = claims.sub;
   if (!sub) throw new Error('Google sub is required');
 
@@ -90,7 +92,7 @@ async function ensureUserFromGoogleInner(
     return null;
   });
 
-  if (existing) return existing;
+  if (existing) return { user: existing, wasCreated: false };
 
   // Phase 2: New user — create with referral code retry handling
   if (!config.bypassWaitlistFlow) {
@@ -100,9 +102,9 @@ async function ensureUserFromGoogleInner(
   const referrerId = ref ? await resolveReferrer(ref) : null;
 
   try {
-    return await createUserWithReferralCode(async (referralCode) => {
+    const newUser = await createUserWithReferralCode(async (referralCode) => {
       return prisma.$transaction(async (tx) => {
-        const newUser = await tx.user.create({
+        const created = await tx.user.create({
         data: {
           email,
           name: claims.name ?? null,
@@ -115,19 +117,19 @@ async function ensureUserFromGoogleInner(
       });
 
       await tx.userAccount.create({
-        data: { userId: newUser.id, provider: 'google', providerUserId: sub },
+        data: { userId: created.id, provider: 'google', providerUserId: sub },
       });
 
       if (referrerId) {
         await tx.referral.create({
-          data: { referrerUserId: referrerId, referredUserId: newUser.id },
+          data: { referrerUserId: referrerId, referredUserId: created.id },
         });
       }
 
       if (tokens?.access_token || tokens?.refresh_token) {
         await tx.oauthToken.create({
           data: {
-            userId: newUser.id,
+            userId: created.id,
             provider: 'google',
             accessToken: tokens.access_token ?? '',
             refreshToken: tokens.refresh_token ?? null,
@@ -136,9 +138,10 @@ async function ensureUserFromGoogleInner(
         });
       }
 
-      return newUser;
+      return created;
     });
   });
+    return { user: newUser, wasCreated: true };
   } catch (err) {
     // A concurrent request created this user between Phase 1 and Phase 2.
     // Re-run the full function — Phase 1 will now find the existing user.

--- a/apps/api/src/auth/google.route.ts
+++ b/apps/api/src/auth/google.route.ts
@@ -35,7 +35,7 @@ router.post('/google/code', express.json(), async (req, res) => {
     const p = ticket.getPayload();
     if (!p?.sub) return res.status(401).send('Invalid Google token');
 
-    const user = await ensureUserFromGoogle(
+    const { user } = await ensureUserFromGoogle(
       {
         sub: p.sub,
         email: p.email ?? undefined,

--- a/apps/api/src/auth/mobile-apple.route.test.ts
+++ b/apps/api/src/auth/mobile-apple.route.test.ts
@@ -6,6 +6,15 @@ const mockGenerateAccessToken = jest.fn().mockReturnValue('mock-access-token');
 const mockGenerateRefreshToken = jest.fn().mockReturnValue('mock-refresh-token');
 const mockUpdateLastAuthAt = jest.fn().mockResolvedValue(undefined);
 const mockCheckAuthRateLimit = jest.fn().mockResolvedValue({ allowed: true });
+const mockLoggerWarn = jest.fn();
+const mockLoggerInfo = jest.fn();
+const mockLoggerError = jest.fn();
+const mockLoggerDebug = jest.fn();
+const mockSentryCaptureException = jest.fn();
+
+jest.mock('@sentry/node', () => ({
+  captureException: (...args: unknown[]) => mockSentryCaptureException(...args),
+}));
 
 jest.mock('./appleTokenVerifier', () => ({
   verifyAppleIdentityToken: (...args: unknown[]) => mockVerifyAppleIdentityToken(...args),
@@ -46,9 +55,18 @@ jest.mock('../lib/prisma', () => ({
   },
 }));
 
-jest.mock('../lib/logger', () => ({
-  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
-}));
+jest.mock('../lib/logger', () => {
+  const auditLogger = { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() };
+  return {
+    logger: {
+      error: (...args: unknown[]) => mockLoggerError(...args),
+      info: (...args: unknown[]) => mockLoggerInfo(...args),
+      warn: (...args: unknown[]) => mockLoggerWarn(...args),
+      debug: (...args: unknown[]) => mockLoggerDebug(...args),
+    },
+    createLogger: () => auditLogger,
+  };
+});
 
 jest.mock('../services/password-notification.service', () => ({
   sendPasswordAddedNotification: jest.fn(),
@@ -112,6 +130,11 @@ describe('POST /mobile/apple', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCheckAuthRateLimit.mockResolvedValue({ allowed: true });
+    mockLoggerWarn.mockClear();
+    mockLoggerInfo.mockClear();
+    mockLoggerError.mockClear();
+    mockLoggerDebug.mockClear();
+    mockSentryCaptureException.mockClear();
   });
 
   it('should return 400 when identityToken is missing', async () => {
@@ -121,7 +144,7 @@ describe('POST /mobile/apple', () => {
     await invokeHandler(handler, req, res as unknown as Response);
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.send).toHaveBeenCalledWith('Missing identityToken');
+    expect(res.json).toHaveBeenCalledWith({ error: 'Missing identityToken', code: 'MISSING_TOKEN' });
   });
 
   it('should return 429 when rate limited', async () => {
@@ -134,19 +157,19 @@ describe('POST /mobile/apple', () => {
     expect(res.status).toHaveBeenCalledWith(429);
   });
 
-  it('should assemble fullName from givenName and familyName', async () => {
+  it('should assemble name from firstName and lastName', async () => {
     const mockUser = { id: 'u1', email: 'jane@example.com', name: 'Jane Doe', avatarUrl: null };
     mockVerifyAppleIdentityToken.mockResolvedValue({
       sub: 'apple-001',
       email: 'jane@example.com',
       email_verified: 'true',
     });
-    mockEnsureUserFromApple.mockResolvedValue(mockUser);
+    mockEnsureUserFromApple.mockResolvedValue({ user: mockUser, wasCreated: false });
 
     const req = {
       body: {
         identityToken: 'valid-token',
-        fullName: { givenName: 'Jane', familyName: 'Doe' },
+        user: { name: { firstName: 'Jane', lastName: 'Doe' } },
       },
       ip: '127.0.0.1',
       headers: {},
@@ -161,19 +184,19 @@ describe('POST /mobile/apple', () => {
     );
   });
 
-  it('should handle givenName only', async () => {
+  it('should handle firstName only', async () => {
     const mockUser = { id: 'u1', email: 'j@example.com', name: 'Jane', avatarUrl: null };
     mockVerifyAppleIdentityToken.mockResolvedValue({
       sub: 'apple-001',
       email: 'j@example.com',
       email_verified: 'false',
     });
-    mockEnsureUserFromApple.mockResolvedValue(mockUser);
+    mockEnsureUserFromApple.mockResolvedValue({ user: mockUser, wasCreated: false });
 
     const req = {
       body: {
         identityToken: 'valid-token',
-        fullName: { givenName: 'Jane', familyName: null },
+        user: { name: { firstName: 'Jane' } },
       },
       ip: '127.0.0.1',
       headers: {},
@@ -195,7 +218,7 @@ describe('POST /mobile/apple', () => {
       email: 'a@b.com',
       email_verified: 'true',
     });
-    mockEnsureUserFromApple.mockResolvedValue(mockUser);
+    mockEnsureUserFromApple.mockResolvedValue({ user: mockUser, wasCreated: false });
 
     const req = {
       body: { identityToken: 'valid-token' },
@@ -219,10 +242,10 @@ describe('POST /mobile/apple', () => {
       email: 'token@apple.com',
       email_verified: 'true',
     });
-    mockEnsureUserFromApple.mockResolvedValue(mockUser);
+    mockEnsureUserFromApple.mockResolvedValue({ user: mockUser, wasCreated: false });
 
     const req = {
-      body: { identityToken: 'valid-token', email: 'client@user.com' },
+      body: { identityToken: 'valid-token', user: { email: 'client@user.com' } },
       ip: '127.0.0.1',
       headers: {},
     } as unknown as Request;
@@ -245,10 +268,10 @@ describe('POST /mobile/apple', () => {
       sub: 'apple-001',
       email_verified: 'false',
     });
-    mockEnsureUserFromApple.mockResolvedValue(mockUser);
+    mockEnsureUserFromApple.mockResolvedValue({ user: mockUser, wasCreated: false });
 
     const req = {
-      body: { identityToken: 'valid-token', email: 'client@user.com' },
+      body: { identityToken: 'valid-token', user: { email: 'client@user.com' } },
       ip: '127.0.0.1',
       headers: {},
     } as unknown as Request;
@@ -272,7 +295,7 @@ describe('POST /mobile/apple', () => {
       email: 'a@b.com',
       email_verified: 'true',
     });
-    mockEnsureUserFromApple.mockResolvedValue(mockUser);
+    mockEnsureUserFromApple.mockResolvedValue({ user: mockUser, wasCreated: false });
 
     const req = {
       body: { identityToken: 'valid-token', ref: 'abc123' },
@@ -296,7 +319,7 @@ describe('POST /mobile/apple', () => {
       email: 'jane@example.com',
       email_verified: 'true',
     });
-    mockEnsureUserFromApple.mockResolvedValue(mockUser);
+    mockEnsureUserFromApple.mockResolvedValue({ user: mockUser, wasCreated: false });
 
     const req = {
       body: { identityToken: 'valid-token' },
@@ -321,7 +344,7 @@ describe('POST /mobile/apple', () => {
     expect(mockUpdateLastAuthAt).toHaveBeenCalledWith('u1');
   });
 
-  it('should return 403 for CLOSED_BETA error', async () => {
+  it('should return 403 for CLOSED_BETA error and log it with sub', async () => {
     mockVerifyAppleIdentityToken.mockResolvedValue({
       sub: 'apple-001',
       email: 'new@user.com',
@@ -339,7 +362,37 @@ describe('POST /mobile/apple', () => {
     await invokeHandler(handler, req, res as unknown as Response);
 
     expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.send).toHaveBeenCalledWith('CLOSED_BETA');
+    expect(res.json).toHaveBeenCalledWith({ error: 'CLOSED_BETA', code: 'CLOSED_BETA' });
+    // Anchor assertion: gate hits are logged at info level with the apple sub
+    // and the closed-beta discriminator so Railway can filter to them.
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'CLOSED_BETA', sub: 'apple-001' }),
+      expect.any(String)
+    );
+  });
+
+  it('should return 401 when Apple token verification fails and log the reason', async () => {
+    const verifyErr = new Error('audience mismatch') as Error & { _apple?: { reason: string; claim?: unknown } };
+    verifyErr._apple = { reason: 'ERR_JWT_CLAIM_VALIDATION_FAILED', claim: 'aud' };
+    mockVerifyAppleIdentityToken.mockRejectedValue(verifyErr);
+
+    const req = {
+      body: { identityToken: 'forged-token' },
+      ip: '127.0.0.1',
+      headers: {},
+    } as unknown as Request;
+    const res = createMockResponse();
+
+    await invokeHandler(handler, req, res as unknown as Response);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    // Anchor assertion: token-verify failures emit a warn-level log with the
+    // jose error discriminator so the failure mode is debuggable from Railway alone.
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'ERR_JWT_CLAIM_VALIDATION_FAILED', claim: 'aud' }),
+      expect.stringMatching(/token verification failed/i)
+    );
+    expect(mockSentryCaptureException).toHaveBeenCalled();
   });
 
   it('should return 403 for ALREADY_ON_WAITLIST error', async () => {
@@ -360,6 +413,6 @@ describe('POST /mobile/apple', () => {
     await invokeHandler(handler, req, res as unknown as Response);
 
     expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.send).toHaveBeenCalledWith('ALREADY_ON_WAITLIST');
+    expect(res.json).toHaveBeenCalledWith({ error: 'ALREADY_ON_WAITLIST', code: 'ALREADY_ON_WAITLIST' });
   });
 });

--- a/apps/api/src/auth/mobile-apple.route.test.ts
+++ b/apps/api/src/auth/mobile-apple.route.test.ts
@@ -128,13 +128,10 @@ describe('POST /mobile/apple', () => {
   });
 
   beforeEach(() => {
+    // clearAllMocks already resets every jest.fn() in the registry, including
+    // the logger / Sentry mocks. Only restore the rate-limit default after.
     jest.clearAllMocks();
     mockCheckAuthRateLimit.mockResolvedValue({ allowed: true });
-    mockLoggerWarn.mockClear();
-    mockLoggerInfo.mockClear();
-    mockLoggerError.mockClear();
-    mockLoggerDebug.mockClear();
-    mockSentryCaptureException.mockClear();
   });
 
   it('should return 400 when identityToken is missing', async () => {

--- a/apps/api/src/auth/mobile-password.route.test.ts
+++ b/apps/api/src/auth/mobile-password.route.test.ts
@@ -31,10 +31,16 @@ jest.mock('../lib/logger', () => ({
     error: jest.fn(),
     info: jest.fn(),
     warn: jest.fn(),
+    debug: jest.fn(),
   },
+  createLogger: () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() }),
 }));
 
 // Mock other dependencies that mobile.route.ts imports
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+}));
+
 jest.mock('google-auth-library', () => ({
   OAuth2Client: jest.fn().mockImplementation(() => ({
     verifyIdToken: jest.fn(),

--- a/apps/api/src/auth/mobile.route.ts
+++ b/apps/api/src/auth/mobile.route.ts
@@ -1,8 +1,9 @@
 import express from 'express';
+import * as Sentry from '@sentry/node';
 import { OAuth2Client } from 'google-auth-library';
 import { ensureUserFromGoogle } from './ensureUserFromGoogle';
 import { ensureUserFromApple } from './ensureUserFromApple';
-import { verifyAppleIdentityToken } from './appleTokenVerifier';
+import { verifyAppleIdentityToken, type AppleVerifyErrorDetail } from './appleTokenVerifier';
 import { normalizeEmail, getClientIp } from './utils';
 import { validateEmailFormat } from './email.utils';
 import { verifyPassword, validatePassword, hashPassword } from './password.utils';
@@ -12,11 +13,15 @@ import { updateLastAuthAt } from './recent-auth';
 import { prisma } from '../lib/prisma';
 import { checkAuthRateLimit, checkMutationRateLimit } from '../lib/rate-limit';
 import { sendPasswordAddedNotification, sendPasswordChangedNotification } from '../services/password-notification.service';
-import { logger } from '../lib/logger';
+import { logger, createLogger } from '../lib/logger';
 import { sendUnauthorized, sendBadRequest, sendForbidden, sendConflict, sendInternalError, sendTooManyRequests } from '../lib/api-response';
 import { config } from '../config/env';
 import { AUTH_ERROR } from './types';
 import { createNewUser, verifyEmailAvailable } from '../services/signup.service';
+
+// Filter Railway logs with `module:"auth-audit"` to see only successful sign-ins and
+// account creations — the audit stream. Failure-side logs use the regular `logger`.
+const auditLogger = createLogger('auth-audit');
 
 const router = express.Router();
 
@@ -49,6 +54,7 @@ router.post('/mobile/signup', express.json(), async (req, res) => {
     const clientIp = getClientIp(req);
     const rateLimit = await checkAuthRateLimit('signup', clientIp);
     if (!rateLimit.allowed) {
+      logger.warn({ clientIp, operation: 'signup', retryAfter: rateLimit.retryAfter, route: 'mobile/signup' }, 'Mobile signup rate-limited');
       return sendTooManyRequests(res, 'Too many signup attempts. Please try again later.', rateLimit.retryAfter);
     }
 
@@ -61,15 +67,18 @@ router.post('/mobile/signup', express.json(), async (req, res) => {
 
     // Validate email
     if (!rawEmail) {
+      logger.warn({ field: 'email', route: 'mobile/signup' }, 'Signup 400: email required');
       return sendBadRequest(res, 'Email is required');
     }
 
     const email = normalizeEmail(rawEmail);
     if (!email) {
+      logger.warn({ field: 'email', route: 'mobile/signup' }, 'Signup 400: invalid email');
       return sendBadRequest(res, 'Invalid email');
     }
 
     if (!validateEmailFormat(email)) {
+      logger.warn({ field: 'email', route: 'mobile/signup' }, 'Signup 400: invalid email format');
       return sendBadRequest(res, 'Invalid email format');
     }
 
@@ -77,12 +86,14 @@ router.post('/mobile/signup', express.json(), async (req, res) => {
     const check = await verifyEmailAvailable(email);
     if (!check.available) {
       if (check.role === 'WAITLIST') {
+        logger.info({ code: 'ALREADY_ON_WAITLIST', route: 'mobile/signup' }, 'Signup blocked: already on waitlist');
         return sendForbidden(
           res,
           'You are already on the waitlist. We will email you when your account is activated.',
           'ALREADY_ON_WAITLIST'
         );
       }
+      logger.info({ code: 'EMAIL_EXISTS', route: 'mobile/signup' }, 'Signup 409: account exists');
       return sendConflict(res, 'An account with this email already exists. Please log in.');
     }
     const verifiedEmail = check.email;
@@ -93,6 +104,7 @@ router.post('/mobile/signup', express.json(), async (req, res) => {
     if (password) {
       const validation = validatePassword(password);
       if (!validation.isValid) {
+        logger.warn({ field: 'password', route: 'mobile/signup' }, 'Signup 400: password validation failed');
         return sendBadRequest(res, validation.error || 'Password does not meet requirements');
       }
       passwordHash = await hashPassword(password);
@@ -100,17 +112,21 @@ router.post('/mobile/signup', express.json(), async (req, res) => {
 
     const trimmedName = name?.trim() || null;
     if (trimmedName && trimmedName.length > 100) {
+      logger.warn({ field: 'name', nameLength: trimmedName.length, route: 'mobile/signup' }, 'Signup 400: name too long');
       return sendBadRequest(res, 'Name must be 100 characters or fewer');
     }
 
     if (config.bypassWaitlistFlow) {
       if (!passwordHash) {
+        logger.warn({ field: 'password', route: 'mobile/signup' }, 'Signup 400: password required when bypass is on');
         return sendBadRequest(res, 'Password is required');
       }
 
       const { user } = await createNewUser({ email: verifiedEmail, name: trimmedName, passwordHash, ref });
 
       const { accessToken, refreshToken } = await issueMobileTokens({ id: user.id, email: user.email });
+
+      auditLogger.info({ userId: user.id, provider: 'email', wasCreated: true, hasRef: !!ref }, 'Mobile account created');
 
       return res.status(201).json({
         ok: true,
@@ -121,7 +137,8 @@ router.post('/mobile/signup', express.json(), async (req, res) => {
     }
 
     // Waitlist flow
-    await createNewUser({ email: verifiedEmail, name: trimmedName, passwordHash, ref });
+    const { user } = await createNewUser({ email: verifiedEmail, name: trimmedName, passwordHash, ref });
+    auditLogger.info({ userId: user.id, provider: 'email', role: 'WAITLIST', hasRef: !!ref }, 'Mobile waitlist signup');
 
     return res.status(200).json({
       ok: true,
@@ -129,7 +146,8 @@ router.post('/mobile/signup', express.json(), async (req, res) => {
       message: 'You have been added to the waitlist. We will email you when your account is activated.',
     });
   } catch (e) {
-    logger.error({ err: e }, '[MobileAuth] Signup failed');
+    logger.error({ err: e, route: 'mobile/signup' }, '[MobileAuth] Signup failed');
+    Sentry.captureException(e, { tags: { route: 'mobile/signup' } });
     return sendInternalError(res, 'Signup failed');
   }
 });
@@ -140,27 +158,39 @@ router.post('/mobile/signup', express.json(), async (req, res) => {
  * Returns access token and refresh token for mobile app
  */
 router.post('/mobile/google', express.json(), async (req, res) => {
+  let googleSub: string | undefined;
   try {
     const clientIp = getClientIp(req);
     const rateLimit = await checkAuthRateLimit('oauth-login', clientIp);
     if (!rateLimit.allowed) {
+      logger.warn({ clientIp, operation: 'oauth-login', retryAfter: rateLimit.retryAfter, route: 'mobile/google' }, 'Mobile auth rate-limited');
       return sendTooManyRequests(res, 'Too many login attempts. Please try again later.', rateLimit.retryAfter);
     }
 
     const { idToken } = req.body as { idToken?: string };
     if (!idToken) {
-      return res.status(400).send('Missing idToken');
+      logger.warn({ field: 'idToken', route: 'mobile/google' }, 'Google sign-in 400: missing idToken');
+      return sendBadRequest(res, 'Missing idToken', 'MISSING_TOKEN');
     }
 
-    // Verify the Google ID token
-    const ticket = await googleClient.verifyIdToken({
-      idToken,
-      audience: [GOOGLE_CLIENT_ID!, GOOGLE_IOS_CLIENT_ID!].filter(Boolean),
-    });
-    const payload = ticket.getPayload();
-    if (!payload?.sub) {
-      return res.status(401).send('Invalid Google token');
+    // Verify the Google ID token. googleClient.verifyIdToken throws on bad sig / wrong aud / exp.
+    let payload;
+    try {
+      const ticket = await googleClient.verifyIdToken({
+        idToken,
+        audience: [GOOGLE_CLIENT_ID!, GOOGLE_IOS_CLIENT_ID!].filter(Boolean),
+      });
+      payload = ticket.getPayload();
+    } catch (err) {
+      logger.warn({ err, route: 'mobile/google' }, 'Google token verification failed');
+      Sentry.captureException(err, { tags: { route: 'mobile/google', stage: 'token-verify' } });
+      return sendUnauthorized(res, 'Invalid Google token');
     }
+    if (!payload?.sub) {
+      logger.warn({ route: 'mobile/google' }, 'Google token missing sub claim');
+      return sendUnauthorized(res, 'Invalid Google token');
+    }
+    googleSub = payload.sub;
 
     // Create or update user
     const user = await ensureUserFromGoogle({
@@ -179,6 +209,8 @@ router.post('/mobile/google', express.json(), async (req, res) => {
     // Generate tokens for mobile
     const { accessToken, refreshToken } = await issueMobileTokens({ id: user.id, email: user.email });
 
+    auditLogger.info({ userId: user.id, sub: payload.sub, provider: 'google' }, 'Mobile sign-in succeeded');
+
     res.status(200).json({
       accessToken,
       refreshToken,
@@ -193,14 +225,17 @@ router.post('/mobile/google', express.json(), async (req, res) => {
     const errorMessage = e instanceof Error ? e.message : String(e);
 
     if (errorMessage === AUTH_ERROR.CLOSED_BETA) {
-      return res.status(403).send(AUTH_ERROR.CLOSED_BETA);
+      logger.info({ sub: googleSub, code: 'CLOSED_BETA', route: 'mobile/google' }, 'Google sign-in blocked: closed beta');
+      return sendForbidden(res, AUTH_ERROR.CLOSED_BETA, 'CLOSED_BETA');
     }
     if (errorMessage === AUTH_ERROR.ALREADY_ON_WAITLIST) {
-      return res.status(403).send(AUTH_ERROR.ALREADY_ON_WAITLIST);
+      logger.info({ sub: googleSub, code: 'ALREADY_ON_WAITLIST', route: 'mobile/google' }, 'Google sign-in blocked: waitlist');
+      return sendForbidden(res, AUTH_ERROR.ALREADY_ON_WAITLIST, 'ALREADY_ON_WAITLIST');
     }
 
-    logger.error({ err: e }, '[MobileAuth] Google login failed');
-    res.status(500).send('Authentication failed');
+    logger.error({ err: e, sub: googleSub, route: 'mobile/google' }, '[MobileAuth] Google login failed');
+    Sentry.captureException(e, { tags: { route: 'mobile/google', stage: 'ensure-user' }, contexts: { google_signin: { sub: googleSub ?? 'unknown' } } });
+    sendInternalError(res, 'Authentication failed');
   }
 });
 
@@ -213,46 +248,75 @@ router.post('/mobile/google', express.json(), async (req, res) => {
  * The mobile client must capture and forward these alongside the identity token.
  */
 router.post('/mobile/apple', express.json(), async (req, res) => {
+  // Track the verified Apple sub across the function so catch-block logs can include it.
+  let appleSub: string | undefined;
   try {
     const clientIp = getClientIp(req);
     const rateLimit = await checkAuthRateLimit('oauth-login', clientIp);
     if (!rateLimit.allowed) {
+      logger.warn({ clientIp, operation: 'oauth-login', retryAfter: rateLimit.retryAfter, route: 'mobile/apple' }, 'Mobile auth rate-limited');
       return sendTooManyRequests(res, 'Too many login attempts. Please try again later.', rateLimit.retryAfter);
     }
 
-    const { identityToken, fullName, email: clientEmail, ref } = req.body as {
+    // Mobile client sends `{ user: { email, name: { firstName, lastName } } }` — Apple only
+    // populates these on the FIRST sign-in per Apple ID, so they may be undefined.
+    const { identityToken, user: clientUser, ref } = req.body as {
       identityToken?: string;
-      fullName?: { givenName?: string | null; familyName?: string | null } | null;
-      email?: string;
+      user?: {
+        email?: string;
+        name?: { firstName?: string; lastName?: string } | null;
+      } | null;
       ref?: string;
     };
+    const clientEmail = clientUser?.email;
 
     if (!identityToken) {
-      return res.status(400).send('Missing identityToken');
+      logger.warn({ field: 'identityToken', route: 'mobile/apple' }, 'Apple sign-in 400: missing identityToken');
+      return sendBadRequest(res, 'Missing identityToken', 'MISSING_TOKEN');
     }
     if (clientEmail && !validateEmailFormat(clientEmail)) {
-      return res.status(400).send('Invalid email');
+      logger.warn({ field: 'email', route: 'mobile/apple' }, 'Apple sign-in 400: invalid client email');
+      return sendBadRequest(res, 'Invalid email', 'INVALID_EMAIL');
     }
     if (ref && ref.length > 20) {
-      return res.status(400).send('Invalid ref');
+      logger.warn({ field: 'ref', refLength: ref.length, route: 'mobile/apple' }, 'Apple sign-in 400: invalid ref');
+      return sendBadRequest(res, 'Invalid ref', 'INVALID_REF');
     }
     if (!config.appleBundleId) {
-      logger.error('[MobileAuth] APPLE_BUNDLE_ID not configured');
-      return res.status(500).send('Authentication failed');
+      logger.error({ route: 'mobile/apple' }, '[MobileAuth] APPLE_BUNDLE_ID not configured');
+      return sendInternalError(res, 'Authentication failed');
     }
 
-    // Verify Apple identity token signature and claims
-    const applePayload = await verifyAppleIdentityToken(identityToken, config.appleBundleId);
+    // Verify Apple identity token signature and claims. jose errors are tagged with
+    // `_apple = { reason, claim }` by the verifier so we can log a specific reason
+    // (e.g. JWTClaimsValidationFailed on 'aud') without re-parsing message text.
+    let applePayload;
+    try {
+      applePayload = await verifyAppleIdentityToken(identityToken, config.appleBundleId);
+    } catch (err) {
+      const detail = (err as Error & { _apple?: AppleVerifyErrorDetail })._apple;
+      logger.warn(
+        { err, reason: detail?.reason, claim: detail?.claim, expectedAudience: config.appleBundleId, route: 'mobile/apple' },
+        'Apple token verification failed'
+      );
+      Sentry.captureException(err, {
+        tags: { route: 'mobile/apple', stage: 'token-verify' },
+        contexts: { apple_signin: { reason: detail?.reason ?? 'UNKNOWN', claim: String(detail?.claim ?? '') } },
+      });
+      return sendUnauthorized(res, 'Invalid Apple identity token');
+    }
+    appleSub = applePayload.sub;
+    logger.debug({ sub: applePayload.sub, hasEmail: !!applePayload.email, emailVerified: applePayload.email_verified }, 'Apple token verified');
 
     // Apple sends email_verified as the string "true"/"false", not a boolean
     const emailVerified = applePayload.email_verified === 'true';
-    const givenName = fullName?.givenName?.slice(0, 50) || null;
-    const familyName = fullName?.familyName?.slice(0, 50) || null;
+    const givenName = clientUser?.name?.firstName?.slice(0, 50) || null;
+    const familyName = clientUser?.name?.lastName?.slice(0, 50) || null;
     const name = [givenName, familyName].filter(Boolean).join(' ') || null;
 
     // Token email is trusted (verified by Apple) — used for account lookup/linking.
     // Client email is untrusted — only used for new user creation as a fallback.
-    const user = await ensureUserFromApple({
+    const { user, wasCreated } = await ensureUserFromApple({
       sub: applePayload.sub,
       email: applePayload.email,
       clientEmail: clientEmail || undefined,
@@ -268,6 +332,11 @@ router.post('/mobile/apple', express.json(), async (req, res) => {
     // Generate tokens for mobile
     const { accessToken, refreshToken } = await issueMobileTokens({ id: user.id, email: user.email });
 
+    auditLogger.info(
+      { userId: user.id, sub: applePayload.sub, provider: 'apple', wasCreated },
+      wasCreated ? 'Mobile account created' : 'Mobile sign-in succeeded'
+    );
+
     res.status(200).json({
       accessToken,
       refreshToken,
@@ -282,14 +351,20 @@ router.post('/mobile/apple', express.json(), async (req, res) => {
     const errorMessage = e instanceof Error ? e.message : String(e);
 
     if (errorMessage === AUTH_ERROR.CLOSED_BETA) {
-      return res.status(403).send(AUTH_ERROR.CLOSED_BETA);
+      logger.info({ sub: appleSub, code: 'CLOSED_BETA', route: 'mobile/apple' }, 'Apple sign-in blocked: closed beta');
+      return sendForbidden(res, AUTH_ERROR.CLOSED_BETA, 'CLOSED_BETA');
     }
     if (errorMessage === AUTH_ERROR.ALREADY_ON_WAITLIST) {
-      return res.status(403).send(AUTH_ERROR.ALREADY_ON_WAITLIST);
+      logger.info({ sub: appleSub, code: 'ALREADY_ON_WAITLIST', route: 'mobile/apple' }, 'Apple sign-in blocked: waitlist');
+      return sendForbidden(res, AUTH_ERROR.ALREADY_ON_WAITLIST, 'ALREADY_ON_WAITLIST');
     }
 
-    logger.error({ err: e }, '[MobileAuth] Apple login failed');
-    res.status(500).send('Authentication failed');
+    logger.error({ err: e, sub: appleSub, route: 'mobile/apple' }, '[MobileAuth] Apple login failed');
+    Sentry.captureException(e, {
+      tags: { route: 'mobile/apple', stage: 'ensure-user' },
+      contexts: { apple_signin: { sub: appleSub ?? 'unknown' } },
+    });
+    sendInternalError(res, 'Authentication failed');
   }
 });
 
@@ -299,6 +374,8 @@ router.post('/mobile/apple', express.json(), async (req, res) => {
  * Returns access token and refresh token for mobile app
  */
 router.post('/mobile/login', express.json(), async (req, res) => {
+  // NOTE: this route currently has no rate-limit check — out of scope for this change,
+  // but worth adding to match /mobile/google and /mobile/apple. Tracked separately.
   try {
     const { email: rawEmail, password } = req.body as {
       email?: string;
@@ -307,12 +384,14 @@ router.post('/mobile/login', express.json(), async (req, res) => {
 
     // Validate input
     if (!rawEmail || !password) {
-      return res.status(400).send('Email and password are required');
+      logger.warn({ field: !rawEmail ? 'email' : 'password', route: 'mobile/login' }, 'Email login 400: missing credentials');
+      return sendBadRequest(res, 'Email and password are required', 'MISSING_CREDENTIALS');
     }
 
     const email = normalizeEmail(rawEmail);
     if (!email) {
-      return res.status(400).send('Invalid email');
+      logger.warn({ field: 'email', route: 'mobile/login' }, 'Email login 400: invalid email');
+      return sendBadRequest(res, 'Invalid email', 'INVALID_EMAIL');
     }
 
     // Find user by email
@@ -321,23 +400,27 @@ router.post('/mobile/login', express.json(), async (req, res) => {
     });
 
     if (!user) {
-      return res.status(401).send('Invalid email or password');
+      logger.info({ reason: 'no-such-user', route: 'mobile/login' }, 'Email login 401');
+      return sendUnauthorized(res, 'Invalid email or password');
     }
 
     // Check if user has a password (created via email/password signup)
     if (!user.passwordHash) {
-      return res.status(401).send('This account uses OAuth login only');
+      logger.info({ userId: user.id, reason: 'oauth-only', route: 'mobile/login' }, 'Email login 401: account is OAuth-only');
+      return sendUnauthorized(res, 'This account uses OAuth login only');
     }
 
     // Verify password
     const isValid = await verifyPassword(password, user.passwordHash);
     if (!isValid) {
-      return res.status(401).send('Invalid email or password');
+      logger.info({ userId: user.id, reason: 'bad-password', route: 'mobile/login' }, 'Email login 401: bad password');
+      return sendUnauthorized(res, 'Invalid email or password');
     }
 
     // Block WAITLIST users - they cannot login until activated
     if (user.role === 'WAITLIST') {
-      return res.status(403).send(AUTH_ERROR.ALREADY_ON_WAITLIST);
+      logger.info({ userId: user.id, code: 'ALREADY_ON_WAITLIST', route: 'mobile/login' }, 'Email login blocked: waitlist');
+      return sendForbidden(res, AUTH_ERROR.ALREADY_ON_WAITLIST, 'ALREADY_ON_WAITLIST');
     }
 
     // Update last auth timestamp for recent-auth gating (non-blocking)
@@ -347,6 +430,8 @@ router.post('/mobile/login', express.json(), async (req, res) => {
 
     // Generate tokens for mobile
     const { accessToken, refreshToken } = await issueMobileTokens({ id: user.id, email: user.email });
+
+    auditLogger.info({ userId: user.id, provider: 'email' }, 'Mobile sign-in succeeded');
 
     res.status(200).json({
       accessToken,
@@ -359,8 +444,9 @@ router.post('/mobile/login', express.json(), async (req, res) => {
       },
     });
   } catch (e) {
-    logger.error({ err: e }, '[MobileAuth] Email login failed');
-    res.status(500).send('Login failed');
+    logger.error({ err: e, route: 'mobile/login' }, '[MobileAuth] Email login failed');
+    Sentry.captureException(e, { tags: { route: 'mobile/login' } });
+    sendInternalError(res, 'Login failed');
   }
 });
 
@@ -375,13 +461,16 @@ router.post('/mobile/refresh', express.json(), async (req, res) => {
   try {
     const { refreshToken } = req.body as { refreshToken?: string };
     if (!refreshToken) {
-      return res.status(400).send('Missing refreshToken');
+      logger.warn({ field: 'refreshToken', route: 'mobile/refresh' }, 'Refresh 400: missing refreshToken');
+      return sendBadRequest(res, 'Missing refreshToken', 'MISSING_TOKEN');
     }
 
     // Verify refresh token
     const payload = verifyToken(refreshToken);
     if (!payload) {
-      return res.status(401).send('Invalid or expired refresh token');
+      // Stale / malformed token is the common case here — info, not warn.
+      logger.info({ reason: 'invalid-or-expired', route: 'mobile/refresh' }, 'Refresh 401: token invalid or expired');
+      return sendUnauthorized(res, 'Invalid or expired refresh token');
     }
 
     // Verify user still exists
@@ -391,12 +480,15 @@ router.post('/mobile/refresh', express.json(), async (req, res) => {
     });
 
     if (!user) {
-      return res.status(401).send('User not found');
+      // Token signature was valid but the user row is gone — likely deletion or DB drift.
+      logger.error({ uid: payload.uid, route: 'mobile/refresh' }, 'Refresh 401: user not found for valid token');
+      return sendUnauthorized(res, 'User not found');
     }
 
     // Reject refresh tokens issued before a session invalidation (e.g. password reset)
     if ((payload.v ?? 0) !== user.sessionTokenVersion) {
-      return res.status(401).send('Refresh token has been revoked');
+      logger.info({ userId: user.id, tokenVersion: payload.v, currentVersion: user.sessionTokenVersion, route: 'mobile/refresh' }, 'Refresh 401: token revoked by version bump');
+      return sendUnauthorized(res, 'Refresh token has been revoked');
     }
 
     // Generate new access token stamped with the current token version
@@ -408,8 +500,9 @@ router.post('/mobile/refresh', express.json(), async (req, res) => {
 
     res.status(200).json({ accessToken });
   } catch (e) {
-    logger.error({ err: e }, '[MobileAuth] Token refresh failed');
-    res.status(500).send('Token refresh failed');
+    logger.error({ err: e, route: 'mobile/refresh' }, '[MobileAuth] Token refresh failed');
+    Sentry.captureException(e, { tags: { route: 'mobile/refresh' } });
+    sendInternalError(res, 'Token refresh failed');
   }
 });
 

--- a/apps/api/src/auth/mobile.route.ts
+++ b/apps/api/src/auth/mobile.route.ts
@@ -193,7 +193,7 @@ router.post('/mobile/google', express.json(), async (req, res) => {
     googleSub = payload.sub;
 
     // Create or update user
-    const user = await ensureUserFromGoogle({
+    const { user, wasCreated } = await ensureUserFromGoogle({
       sub: payload.sub,
       email: payload.email ?? undefined,
       email_verified: payload.email_verified,
@@ -209,7 +209,10 @@ router.post('/mobile/google', express.json(), async (req, res) => {
     // Generate tokens for mobile
     const { accessToken, refreshToken } = await issueMobileTokens({ id: user.id, email: user.email });
 
-    auditLogger.info({ userId: user.id, sub: payload.sub, provider: 'google' }, 'Mobile sign-in succeeded');
+    auditLogger.info(
+      { userId: user.id, sub: payload.sub, provider: 'google', wasCreated },
+      wasCreated ? 'Mobile account created' : 'Mobile sign-in succeeded'
+    );
 
     res.status(200).json({
       accessToken,
@@ -235,7 +238,7 @@ router.post('/mobile/google', express.json(), async (req, res) => {
 
     logger.error({ err: e, sub: googleSub, route: 'mobile/google' }, '[MobileAuth] Google login failed');
     Sentry.captureException(e, { tags: { route: 'mobile/google', stage: 'ensure-user' }, contexts: { google_signin: { sub: googleSub ?? 'unknown' } } });
-    sendInternalError(res, 'Authentication failed');
+    return sendInternalError(res, 'Authentication failed');
   }
 });
 
@@ -364,7 +367,7 @@ router.post('/mobile/apple', express.json(), async (req, res) => {
       tags: { route: 'mobile/apple', stage: 'ensure-user' },
       contexts: { apple_signin: { sub: appleSub ?? 'unknown' } },
     });
-    sendInternalError(res, 'Authentication failed');
+    return sendInternalError(res, 'Authentication failed');
   }
 });
 
@@ -446,7 +449,7 @@ router.post('/mobile/login', express.json(), async (req, res) => {
   } catch (e) {
     logger.error({ err: e, route: 'mobile/login' }, '[MobileAuth] Email login failed');
     Sentry.captureException(e, { tags: { route: 'mobile/login' } });
-    sendInternalError(res, 'Login failed');
+    return sendInternalError(res, 'Login failed');
   }
 });
 
@@ -502,7 +505,7 @@ router.post('/mobile/refresh', express.json(), async (req, res) => {
   } catch (e) {
     logger.error({ err: e, route: 'mobile/refresh' }, '[MobileAuth] Token refresh failed');
     Sentry.captureException(e, { tags: { route: 'mobile/refresh' } });
-    sendInternalError(res, 'Token refresh failed');
+    return sendInternalError(res, 'Token refresh failed');
   }
 });
 

--- a/apps/api/src/lib/logger.ts
+++ b/apps/api/src/lib/logger.ts
@@ -44,6 +44,9 @@ const REDACT_PATHS = [
   'userEmail',
   'phoneNumber',
   'phone',
+  'clientIp',
+  'ip',
+  'remoteAddress',
   // GPS coordinates (protect location privacy)
   'startLatitude',
   'startLongitude',


### PR DESCRIPTION
# bugfix: calibration not showing all components

## Summary

A founding rider reported (with a screenshot) that she could not enter services previously performed on her bike from the web **"Calibrate Your Components"** overlay. Investigation surfaced two separate issues — a backend filter that hid components, and a front-end UX dead-end where the obvious button (`Acknowledge`) silently records nothing. This PR fixes both so users can log historical service for **any** component, directly from the calibration overlay.

Commit: `93ae4d4` — `apps/api/src/graphql/resolvers.ts`, `apps/web/src/components/CalibrationOverlay.tsx`

## The problem

The calibration overlay opens after onboarding when a user has overdue components. The user's goal was to record real-world service history ("I replaced these brake pads last spring") so her maintenance predictions would be accurate. She couldn't:

1. **Components were missing.** The `calibrationState` resolver only returned components with `status === 'OVERDUE' || 'DUE_NOW'`. Anything she'd recently serviced (now `DUE_SOON` / `ALL_GOOD`) never appeared in the overlay, so there was no way to log historical service for it here.
2. **The visible action did nothing useful.** On each row, `Acknowledge` *looks* like "log this service" but it only marks the component calibrated locally — no service-log entry is written. The real "log service on date X" path was buried in a bulk-action row that required three non-obvious steps (pick a month, tick per-row checkboxes, click `Apply to Selected (N)`). With nothing ticked, that button reads `Apply to Selected (0)` and is disabled — a dead end.

This is the same family of issue as the recent mobile `LogServiceSheet` fix: service logging was being gated/hidden rather than offered.

## What changed

### Backend — `apps/api/src/graphql/resolvers.ts`

- **Dropped the components-array filter.** `calibrationState` now returns *all* components on a bike, not just `OVERDUE` / `DUE_NOW` ones.
- **Kept the bike-inclusion gate.** A bike still only appears in the overlay if it has at least one `OVERDUE` / `DUE_NOW` component, and `totalOverdue` still uses the strict filter — so `showOverlay` and the subtitle count are unchanged. The overlay still only auto-pops when something is genuinely overdue.
- No schema change; each component already carries its own `status` for the front end to sort/badge.

### Frontend — `apps/web/src/components/CalibrationOverlay.tsx`

**Per-row "Log Service" button (the direct fix for the screenshot).** Every component row gets a `Log Service` action alongside `Acknowledge` / `Snooze`. Clicking it swaps the row's buttons for an inline month picker + `Save` / `Cancel`. Confirming pushes `(componentId, performedAt)` into the existing `pendingServiceLogs` map — the *same* map the bulk flow uses — so the existing `LOG_BULK_SERVICE` batched submit on `Complete Calibration` persists everything. No new mutation, no new modal.

**Bulk-flow polish.**
- `Apply to Selected (N)` → `Log Service (N)`.
- `Serviced in:` → `Mark serviced in:`.
- Changing a bike's bulk date when nothing is selected now auto-checks the needs-attention rows (the common "I just serviced everything overdue in <month>" case).
- The explainer gained a `Log Service` line, listed first since it's the primary intent.

**Status-aware rendering.** Now that the components array includes healthy components:
- Rows sort `OVERDUE → DUE_NOW → DUE_SOON → ALL_GOOD` so attention-needing items stay at the top.
- The bike-header badge and modal subtitle derive their "X need attention" counts from component `status`, not array length — logging a historical service on a healthy component no longer inflates the count.
- The progress bar is needs-attention-scoped (`calibratedNeedsAttentionCount / initialTotal`), so an extra historical service on a healthy component can't push it past 100%.
- A new `allComponentsCalibrated` check preserves the original "collapse the section when fully done" behavior.

## Behavior changes

| Area | Before | After |
| --- | --- | --- |
| Components shown in overlay | OVERDUE / DUE_NOW only | All components on bikes that have ≥1 overdue item |
| Logging service for one component | Buried in bulk flow; `Acknowledge` records nothing | Per-row `Log Service` button → inline date picker → Save |
| Bulk button label | `Apply to Selected (N)` | `Log Service (N)` |
| Bulk date + empty selection | Nothing selected, button disabled | Needs-attention rows auto-checked |
| Row order | API order | Sorted by status priority |
| "X need attention" count | Array length | Derived from `OVERDUE` / `DUE_NOW` status |
| Overlay auto-open trigger | `totalOverdue > 0` | Unchanged |
| `Acknowledge` / `Snooze` semantics | — | Unchanged (explainer copy now clearer) |

## Testing

- `apps/web` typecheck: clean.
- `apps/api` typecheck: only pre-existing unrelated errors (`resolvers.ts:3823+`, `BikeNotificationPreference` / `TierUser` — predate this change).
- No automated tests cover `calibrationState` or `logBulkComponentService`, so **manual end-to-end testing is required before merge**:
  - **Per-row path** — open the overlay, click `Log Service` on a row, pick a month, `Save`; confirm the row collapses to the calibrated state, click `Complete Calibration`, verify `LOG_BULK_SERVICE` fires with the right `componentIds` + `performedAt` and a service-log row is written (bike detail / `bikeHistory`).
  - **Bulk path** — pick a month in `Mark serviced in:`, confirm needs-attention rows auto-check, click `Log Service (N)`, verify the same mutation fires.
  - **Filter expansion** — a bike with mixed statuses shows all its components, OVERDUE/DUE_NOW first; `Log Service` works on an `ALL_GOOD` component.
  - **Regressions** — `Acknowledge` still marks calibrated without writing a log; `Snooze` still extends interval 50%; `Remind Me Later` still dismisses; bikes with no overdue components still don't trigger the overlay.

## Risk / scope

- **No schema migration, no new mutation.** The per-row flow piggybacks on the existing `LOG_BULK_SERVICE` (it already accepts a single-element `componentIds` array).
- **Mobile unaffected.** The mobile `LogServiceSheet` was fixed separately and already supports all components.
- The dashboard `LogServiceModal` is untouched — it already accepted any component.

---

# Mobile auth: error format + diagnostics — `fix: pr revisions` (b8d9b61)

App Store reviewers couldn't sign in via Apple. The on-device alert was "Login Failed: Network error" but the actual failure was being thrown silently on the backend with no log line to grep for. This commit reshapes the `/auth/mobile/*` responses so the mobile client can route the error correctly, fixes the silent Apple-name-drop bug that's been there since launch, and adds structured logging at every failure branch so the next time Apple says "it errored," the cause is one Railway query away.

## ⚠ Breaking API changes

Two changes to the public `/auth/mobile/*` contract. The Loam mobile client in `loam-logger-mobile` already speaks both formats (the corresponding mobile PR ships defensive parsing + the new request shape), so the official client is unaffected. Any third-party or older mobile build pinned to the old contract will break — details below.

### 1. Error response body: plain text → JSON `{ error, code }`

Every `/auth/mobile/*` error path now goes through the shared `sendBadRequest` / `sendUnauthorized` / `sendForbidden` / `sendConflict` / `sendInternalError` / `sendTooManyRequests` helpers (see [apps/api/src/lib/api-response.ts](apps/api/src/lib/api-response.ts)). Old responses used `res.status(403).send(AUTH_ERROR.CLOSED_BETA)` — `Content-Type: text/html`, body literally `"CLOSED_BETA"`. New responses use `res.status(403).json({ error: 'CLOSED_BETA', code: 'CLOSED_BETA' })` — `Content-Type: application/json`.

Applies in this commit to: `/mobile/signup`, `/mobile/google`, `/mobile/apple`, `/mobile/login`, `/mobile/refresh`. (`/mobile/password/add` and `/mobile/password/change` were already converted to the same helpers in an earlier commit on this branch — they're on the new format too, just not changed here.)

**Migration for any client doing `if (await response.text() === 'CLOSED_BETA')`:**

```ts
// Before
if ((await response.text()) === 'CLOSED_BETA') { /* show waitlist screen */ }

// After
const { code } = await response.json() as { code?: string };
if (code === 'CLOSED_BETA') { /* show waitlist screen */ }
```

Stable error codes returned today: `MISSING_TOKEN`, `MISSING_CREDENTIALS`, `INVALID_EMAIL`, `INVALID_REF`, `BAD_REQUEST`, `UNAUTHORIZED`, `FORBIDDEN`, `CLOSED_BETA`, `ALREADY_ON_WAITLIST`, `EMAIL_EXISTS`, `INTERNAL_ERROR`, `TOO_MANY_REQUESTS`.

### 2. Apple sign-in request body shape: `fullName` → `user.name`

`/auth/mobile/apple` previously destructured `{ identityToken, fullName: { givenName, familyName }, email, ref }` (line 223 pre-change). The Loam mobile client had been sending `{ identityToken, user: { email, name: { firstName, lastName } } }` for some time. Result: every Apple first-time sign-in succeeded (Apple's identity token carries `sub` + email), but the destructured `fullName` and `email` were always `undefined`, so the user's display name was **never** persisted — and Apple only sends name on the *first* sign-in per Apple ID, so the data was unrecoverable on retry.

The server now reads `{ identityToken, user, ref }` and extracts `givenName`/`familyName` from `user.name.firstName`/`user.name.lastName`. This matches what the mobile client has been sending all along — it is the fix.

**Migration for any client still sending the old shape:**

```jsonc
// Before (silently loses name)
{ "identityToken": "...", "fullName": { "givenName": "Jane", "familyName": "Doe" }, "email": "jane@example.com" }

// After
{ "identityToken": "...", "user": { "email": "jane@example.com", "name": { "firstName": "Jane", "lastName": "Doe" } } }
```

Failure mode for non-migrated clients: **silent** — the request still 200s, but `fullName` is `undefined` server-side and the user row's `name` stays null. No error surfaces.

## Additive changes (non-breaking)

These are also in [b8d9b61](../../commit/b8d9b61) and don't affect the API contract, but the mobile team will see them surface in Railway logs / Sentry:

### Structured logging at every auth branch

Previously the only log line on Apple sign-in failure was a generic `logger.error({ err: e }, '[MobileAuth] Apple login failed')` — no `sub`, no JWT error discriminator, no audience expected-vs-actual. The new log statements cover:

- **Rate-limit hits** ([mobile.route.ts](apps/api/src/auth/mobile.route.ts)): `logger.warn({ clientIp, operation, retryAfter, route }, 'Mobile auth rate-limited')` on `/mobile/apple`, `/mobile/google`, `/mobile/signup`.
- **Validation 400s**: `logger.warn({ field, route }, '...')` for every 400 (missing identityToken, invalid email, invalid ref, missing password, name too long).
- **Apple JWT verify failures**: now wrapped in a discriminating try/catch — `logger.warn({ err, reason, claim, expectedAudience, route }, 'Apple token verification failed')`. The `reason` comes from the new `_apple` discriminator on jose errors (`ERR_JWT_CLAIM_VALIDATION_FAILED`, `JWSSignatureVerificationFailed`, `MISSING_SUB`, etc.) attached by [appleTokenVerifier.ts](apps/api/src/auth/appleTokenVerifier.ts)'s new `tagAppleError` helper. The route now returns a distinct **401** for verify failures (previously masked as 500).
- **Gate hits**: `CLOSED_BETA` and `ALREADY_ON_WAITLIST` now log at `info` level with the apple/google `sub` so reviewers' failed sign-ins are pin-pointable.
- **Successful sign-ins**: new `auditLogger = createLogger('auth-audit')` for `auditLogger.info({ userId, sub, provider, wasCreated }, 'Mobile sign-in succeeded' | 'Mobile account created')`. Filter Railway with `module:"auth-audit"` for the audit stream.
- **Email-collision retry** in [ensureUserFromApple.ts](apps/api/src/auth/ensureUserFromApple.ts) — previously a silent retry that hid race conditions; now `logger.warn({ sub, retries }, 'Apple sign-in email-collision retry')`.

### `ensureUserFromApple` return type widened

Changed from returning `User` directly to returning `{ user: User; wasCreated: boolean }` so the route's audit log can distinguish account creation from re-login. Internal-only — no public API impact.

### Server-side Sentry capture on unexpected failures

`Sentry.captureException(e, { tags: { route, stage }, contexts: { apple_signin: { sub, reason, claim } } })` on each `/mobile/*` catch-block and on token-verify failures. Server already had Sentry initialized via [instrument.ts](apps/api/src/instrument.ts); this just wires it into the auth paths.

## Coordinated mobile changes

The Loam mobile client in [`loam-logger-mobile`](../loam-logger-mobile) ships matching changes on `feat/app-store-gap-closure`:

- `parseErrorResponse` reads the body as text first, then attempts `JSON.parse` — works against both the old plain-text and new JSON formats.
- Routing checks the new structured `code` field first, falls back to substring matching on the message (back-compat for the brief deploy window where the mobile build precedes the server deploy).
- Surfaces the server's `x-request-id` header in the on-device alert ("Reference: <uuid>") so any failure is pin-pointable to one Railway log line.

The mobile client was already sending the new Apple body shape, so no migration is needed there — this server change merely starts honoring it.

## Tests

- `apps/api/src/auth/mobile-apple.route.test.ts` — 11 existing cases updated for the new request body shape (`fullName` → `user.name`) and new JSON error format. Two new anchor-case assertions added: (a) `logger.warn` is called with `reason` + matching message on token-verify failure, (b) `logger.info` is called with `{ code: 'CLOSED_BETA', sub }` on the gate path. Plus a new test verifying the route returns 401 (not 500) on verify failure.
- `apps/api/src/auth/ensureUserFromApple.test.ts` — return-shape assertions updated to `{ user, wasCreated }`.
- `apps/api/src/auth/mobile-password.route.test.ts` — logger mock extended with `createLogger`, `@sentry/node` mocked (since mobile.route.ts now imports it).
- Full auth suite: **187/187 pass** (was 186 — +1 from the new anchor case). Full backend suite: **1474/1474 pass**.

## Risk / scope

- **Breaking for non-Loam clients only.** The Loam mobile client already speaks the new shape and parses both response formats. There is no other production consumer.
- **Server-side Apple verify path now returns 401 instead of 500** on a malformed/expired token. The mobile client treats 401 the same way it treated 500 in this scope (generic "Invalid Apple identity token" alert).
- **No DB migration, no schema change, no new env vars.**
- **Pino logger and Sentry were already wired in production**; this commit just adds call sites. Log volume will increase modestly — mostly `info`-level audit lines on successful sign-ins (one per login) and `warn`-level lines on rejected attempts. No PII added in log payloads: the redact paths in [logger.ts](apps/api/src/lib/logger.ts) cover `email`, `token`, `password`, etc., and `clientIp` / `ip` / `remoteAddress` were added to that list in this commit so the new rate-limit `warn` lines don't leak raw IPs to Railway.
