### PR TITLE
fix: adding user to signup response

### DIFF
--- a/apps/api/src/auth/mobile-signup.route.test.ts
+++ b/apps/api/src/auth/mobile-signup.route.test.ts
@@ -1,0 +1,186 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+const mockGenerateAccessToken = jest.fn().mockReturnValue('mock-access-token');
+const mockGenerateRefreshToken = jest.fn().mockReturnValue('mock-refresh-token');
+const mockCheckAuthRateLimit = jest.fn().mockResolvedValue({ allowed: true });
+const mockCreateNewUser = jest.fn();
+const mockVerifyEmailAvailable = jest.fn();
+const mockLoggerWarn = jest.fn();
+const mockLoggerInfo = jest.fn();
+const mockLoggerError = jest.fn();
+const mockLoggerDebug = jest.fn();
+const mockSentryCaptureException = jest.fn();
+
+jest.mock('@sentry/node', () => ({
+  captureException: (...args: unknown[]) => mockSentryCaptureException(...args),
+}));
+
+jest.mock('./appleTokenVerifier', () => ({
+  verifyAppleIdentityToken: jest.fn(),
+}));
+
+jest.mock('./ensureUserFromApple', () => ({
+  ensureUserFromApple: jest.fn(),
+}));
+
+jest.mock('./ensureUserFromGoogle', () => ({
+  ensureUserFromGoogle: jest.fn(),
+}));
+
+jest.mock('google-auth-library', () => ({
+  OAuth2Client: jest.fn().mockImplementation(() => ({
+    verifyIdToken: jest.fn(),
+  })),
+}));
+
+jest.mock('./token', () => ({
+  generateAccessToken: (...args: unknown[]) => mockGenerateAccessToken(...args),
+  generateRefreshToken: (...args: unknown[]) => mockGenerateRefreshToken(...args),
+  verifyToken: jest.fn(),
+}));
+
+jest.mock('./recent-auth', () => ({
+  updateLastAuthAt: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('./password.utils', () => ({
+  validatePassword: jest.fn().mockReturnValue({ isValid: true }),
+  hashPassword: jest.fn().mockResolvedValue('hashed-pw'),
+  verifyPassword: jest.fn(),
+}));
+
+jest.mock('../lib/rate-limit', () => ({
+  checkAuthRateLimit: (...args: unknown[]) => mockCheckAuthRateLimit(...args),
+  checkMutationRateLimit: jest.fn().mockResolvedValue({ allowed: true }),
+}));
+
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    // getSessionTokenVersion (via issueMobileTokens) reads this; undefined → version 0.
+    user: { findUnique: jest.fn() },
+  },
+}));
+
+jest.mock('../lib/logger', () => {
+  const auditLogger = { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() };
+  return {
+    logger: {
+      error: (...args: unknown[]) => mockLoggerError(...args),
+      info: (...args: unknown[]) => mockLoggerInfo(...args),
+      warn: (...args: unknown[]) => mockLoggerWarn(...args),
+      debug: (...args: unknown[]) => mockLoggerDebug(...args),
+    },
+    createLogger: () => auditLogger,
+  };
+});
+
+jest.mock('../services/password-notification.service', () => ({
+  sendPasswordAddedNotification: jest.fn(),
+  sendPasswordChangedNotification: jest.fn(),
+}));
+
+jest.mock('../config/env', () => ({
+  config: { bypassWaitlistFlow: true, appleBundleId: 'com.loamlabs.loamlogger' },
+}));
+
+jest.mock('../services/signup.service', () => ({
+  createNewUser: (...args: unknown[]) => mockCreateNewUser(...args),
+  verifyEmailAvailable: (...args: unknown[]) => mockVerifyEmailAvailable(...args),
+}));
+
+import router from './mobile.route';
+
+interface RouteLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: RequestHandler }>;
+  };
+}
+
+function getHandler(path: string, method: string): RequestHandler | undefined {
+  const routerStack = (router as unknown as { stack: RouteLayer[] }).stack;
+  const layer = routerStack.find(
+    (l) => l.route?.path === path && l.route?.methods?.[method]
+  );
+  const handlers = layer?.route?.stack;
+  return handlers?.[handlers.length - 1]?.handle;
+}
+
+async function invokeHandler(
+  h: RequestHandler | undefined,
+  req: Request,
+  res: Response
+): Promise<void> {
+  if (!h) throw new Error('Handler not found');
+  await h(req, res, jest.fn() as NextFunction);
+}
+
+function createMockResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+  };
+}
+
+describe('POST /mobile/signup', () => {
+  let handler: RequestHandler | undefined;
+
+  beforeAll(() => {
+    handler = getHandler('/mobile/signup', 'post');
+    if (!handler) throw new Error('Handler not found for /mobile/signup');
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckAuthRateLimit.mockResolvedValue({ allowed: true });
+  });
+
+  it('should return 201 with tokens AND a user object on success', async () => {
+    // Regression guard: the signup response previously omitted `user`, which made
+    // the mobile client store `undefined` in SecureStore and crash. All mobile auth
+    // routes must return `user: { id, email, name, avatarUrl }`.
+    mockVerifyEmailAvailable.mockResolvedValue({ available: true, email: 'test@example.com' });
+    mockCreateNewUser.mockResolvedValue({ user: { id: 'u1', email: 'test@example.com' } });
+
+    const req = {
+      body: { email: 'test@example.com', password: 'StrongPassw0rd!', name: 'Test User' },
+      ip: '127.0.0.1',
+      headers: {},
+    } as unknown as Request;
+    const res = createMockResponse();
+
+    await invokeHandler(handler, req, res as unknown as Response);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      ok: true,
+      accessToken: 'mock-access-token',
+      refreshToken: 'mock-refresh-token',
+      user: {
+        id: 'u1',
+        email: 'test@example.com',
+        name: 'Test User',
+        avatarUrl: null,
+      },
+    });
+  });
+
+  it('should return 409 when the email is already registered', async () => {
+    mockVerifyEmailAvailable.mockResolvedValue({ available: false });
+
+    const req = {
+      body: { email: 'taken@example.com', password: 'StrongPassw0rd!', name: 'Test User' },
+      ip: '127.0.0.1',
+      headers: {},
+    } as unknown as Request;
+    const res = createMockResponse();
+
+    await invokeHandler(handler, req, res as unknown as Response);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(mockCreateNewUser).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/auth/mobile.route.ts
+++ b/apps/api/src/auth/mobile.route.ts
@@ -116,6 +116,12 @@ router.post('/mobile/signup', express.json(), async (req, res) => {
       ok: true,
       accessToken,
       refreshToken,
+      user: {
+        id: user.id,
+        email: user.email,
+        name: trimmedName,
+        avatarUrl: null,
+      },
     });
   } catch (e) {
     logger.error({ err: e, route: 'mobile/signup' }, '[MobileAuth] Signup failed');


### PR DESCRIPTION
# Fix: `/auth/mobile/signup` now returns `user` in its response

## Summary

The mobile signup endpoint (`POST /auth/mobile/signup`) returned only
`{ ok, accessToken, refreshToken }` — it omitted the `user` object that every other
mobile auth route already returns. This PR adds `user: { id, email, name, avatarUrl }`
to the signup response so all four mobile auth endpoints share a single, consistent
response shape.

## Motivation

The mobile client persists the auth response into `SecureStore` after signup, calling
`storeTokens(data.accessToken, data.refreshToken, data.user)`. Because the signup
response had no `user`, `data.user` was `undefined`, and the client crashed with:

> **Signup Failed** — Invalid value provided to SecureStore. Values must be strings;
> consider JSON-encoding your values if they are serializable.

The account was still created — the server returns `201` *before* the client attempts
to store the response — so users ended up with a working account but a scary error
dialog on every signup.

The root cause is the response-shape inconsistency: `login`, `google`, and `apple`
all return `user`, but `signup` did not. Aligning signup with the others is the
correct, minimal fix.

## Changes

**`apps/api/src/auth/mobile.route.ts`** — the `/mobile/signup` handler now returns:

```ts
return res.status(201).json({
  ok: true,
  accessToken,
  refreshToken,
  user: {
    id: user.id,
    email: user.email,
    name: trimmedName,   // already computed during input validation
    avatarUrl: null,     // a brand-new email/password signup has no avatar
  },
});
```

- `user.id` / `user.email` come from `createNewUser(...)`.
- `name` reuses the already-validated `trimmedName` local.
- `avatarUrl` is `null` — email/password signups never carry an avatar (only OAuth
  providers supply one).

No change to `signup.service.ts` was required.

**`apps/api/src/auth/mobile-signup.route.test.ts`** (new) — adds a regression test
asserting the signup response body contains `user: { id, email, name, avatarUrl }`,
plus a `409`-on-duplicate-email case. Mirrors the mocking setup already used in
`mobile-apple.route.test.ts`.

## Response shape (before → after)

```diff
  {
    "ok": true,
    "accessToken": "…",
-   "refreshToken": "…"
+   "refreshToken": "…",
+   "user": {
+     "id": "…",
+     "email": "…",
+     "name": "Test User",
+     "avatarUrl": null
+   }
  }
```

Now identical in shape to `/auth/mobile/login`, `/auth/mobile/google`, and
`/auth/mobile/apple`.

## Compatibility

Additive and backward-compatible — this only *adds* a field. Existing clients that
ignore `user` are unaffected; the current mobile client, which reads it, stops
crashing on signup.

## Testing

- **New/updated tests:** `npx jest src/auth/mobile-signup.route.test.ts` — passes
  (signup success returns tokens **and** `user`; duplicate email returns `409`).
- **Regression suite:** `npx jest src/auth/mobile-apple.route.test.ts` — still passes.
- **Typecheck:** no new errors introduced in `mobile.route.ts` (pre-existing,
  unrelated typecheck errors in worker/Redis files remain untouched).

## Rollout note

This is a server-side fix; deploy the backend for devices hitting production to stop
seeing the signup error.
