### PR TITLE
feat: preserve dueNowCount for free users in prediction degrade

### DIFF
--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -4503,7 +4503,9 @@ describe('GraphQL Resolvers', () => {
       const result = await resolver({ id: 'bike-1', userId: 'user-123' } as never, {}, ctx as never);
 
       expect(result.overallStatus).toBeNull();
-      expect(result.dueNowCount).toBeNull();
+      // dueNowCount is preserved for free users so the dashboard tile can
+      // render the binary READY / NOT READY signal.
+      expect(result.dueNowCount).toBe(0);
       expect(result.dueSoonCount).toBeNull();
       expect(result.priorityComponent).toBeNull();
       const comp = result.components[0];

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -5487,7 +5487,9 @@ export const resolvers = {
           isFoundingRider: user.isFoundingRider,
         });
         // Rides-remaining predictions are Pro-only: free users get the raw
-        // usage counters with the predictive fields nulled out.
+        // usage counters with the predictive fields nulled out. The one
+        // exception is dueNowCount, which is preserved for all tiers so the
+        // free dashboard tile can render a binary READY / NOT READY signal.
         return canSeePredictions(user) ? summary : degradeSummaryForFreeTier(summary);
       } catch (error) {
         logError('Resolver Prediction generation', error);

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -272,8 +272,10 @@ export const typeDefs = gql`
   }
 
   # Predictive fields (status, hoursRemaining, ridesRemainingEstimate,
-  # confidence, overallStatus, due counts) are Pro-only and null for free
-  # users. Raw usage fields (currentHours, serviceIntervalHours,
+  # confidence, overallStatus, dueSoonCount) are Pro-only and null for free
+  # users. dueNowCount is served to all tiers so free users get a binary
+  # READY / NOT READY signal on the dashboard tile without the Pro-only
+  # due-soon lookahead. Raw usage fields (currentHours, serviceIntervalHours,
   # hoursSinceService, ridesSinceService) are served to all tiers.
   type ComponentPrediction {
     componentId: ID!

--- a/apps/api/src/services/prediction/degrade.ts
+++ b/apps/api/src/services/prediction/degrade.ts
@@ -19,22 +19,23 @@ export type DegradedComponentPrediction = Omit<
 
 export type DegradedBikePredictionSummary = Omit<
   BikePredictionSummary,
-  'components' | 'priorityComponent' | 'overallStatus' | 'dueNowCount' | 'dueSoonCount'
+  'components' | 'priorityComponent' | 'overallStatus' | 'dueSoonCount'
 > & {
   components: DegradedComponentPrediction[];
   priorityComponent: null;
   overallStatus: null;
-  dueNowCount: null;
   dueSoonCount: null;
 };
 
 /**
  * Strip the Pro-only predictive fields from a bike prediction summary.
  *
- * "Rides left until service due" is a Pro feature: free users keep the raw
- * usage counters but get no remaining-life estimates, due statuses, or wear
- * explanations. Applied at the serving boundary (GraphQL resolver) so the
- * engine, cache, and notification paths keep working with full summaries.
+ * Free users keep the raw usage counters and a binary READY / NOT READY
+ * signal (`dueNowCount`) so the dashboard tile can render without leaking
+ * the Pro-only due-soon lookahead. Remaining-life estimates, per-component
+ * due statuses, and wear explanations stay Pro-only. Applied at the serving
+ * boundary (GraphQL resolver) so the engine, cache, and notification paths
+ * keep working with full summaries.
  */
 export function degradeSummaryForFreeTier(
   summary: BikePredictionSummary
@@ -52,7 +53,6 @@ export function degradeSummaryForFreeTier(
     })),
     priorityComponent: null,
     overallStatus: null,
-    dueNowCount: null,
     dueSoonCount: null,
   };
 }


### PR DESCRIPTION
## Summary

- `degradeSummaryForFreeTier` no longer nulls `dueNowCount` — free users need a binary READY / NOT READY signal for the mobile dashboard tile.
- `dueSoonCount` and per-component predictive fields (`status`, `hoursRemaining`, `ridesRemainingEstimate`, `confidence`, `why`, `drivers`, `priorityComponent`, `overallStatus`) remain Pro-only, so the free-tier boundary is unchanged for the actual due-soon lookahead.
- Test updated: `resolvers.test.ts` "nulls predictive fields but keeps raw usage" now asserts `dueNowCount === 0` instead of `null`.

Paired mobile PR: ryanlecours/loam-logger-mobile#37 — consumes `dueNowCount` to render "Ready to Ride" vs "Not Ready / SERVICE DUE".

## Test plan

- [ ] Run the existing `Query.bikePredictions tier gating` describe block in `resolvers.test.ts` — both "serves full predictions to Pro users" and "nulls predictive fields but keeps raw usage for free users" should pass.
- [ ] Manually query `bikePredictions` as a free user against a bike with a due-now component → `dueNowCount` should be `>=1`, `dueSoonCount` should be `null`.
- [ ] Same query as a Pro user → both counts populated (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)