### PR TITLE
chore(legal): terms 1.4.0 — machine-generated content + Anthropic sub-processor

### DIFF
--- a/apps/web/src/legal/terms.ts
+++ b/apps/web/src/legal/terms.ts
@@ -12,11 +12,11 @@
 
 // Re-export from shared to ensure frontend and backend use the same version
 export { CURRENT_TERMS_VERSION as TERMS_VERSION } from '@loam/shared';
-export const TERMS_LAST_UPDATED = "January 2026";
+export const TERMS_LAST_UPDATED = "July 2026";
 
 export const TERMS_TEXT = `# Terms and Conditions of Use
 
-**Last Updated:** January 2026
+**Last Updated:** July 2026
 
 These Terms and Conditions ("Terms") govern your access to and use of Loam Logger, including the Loam Logger website, web application, mobile applications, and any related services, tools, features, content, or software (collectively, the "Service"). The Service is owned and operated by Loam Logger ("Loam Logger," "we," "us," or "our").
 
@@ -171,6 +171,20 @@ Loam Logger is not responsible for:
 - Decisions made based on third-party data
 
 Use of third-party services is at your own risk and subject to their respective terms.
+
+### 9.1 Machine-Generated Content
+
+Certain features of the Service produce **machine-generated content**, including natural-language maintenance summaries. To generate this content, the Service transmits non-identifying data about your bicycle and its components — such as component types, service intervals, hours since last service, and computed status — to a third-party AI processing provider (currently Anthropic, PBC, operator of the Claude API).
+
+The following applies to all machine-generated content:
+
+- Output is produced by statistical language models and may be **inaccurate, incomplete, out of date, or nonsensical**, even when the underlying data is correct.
+- Machine-generated summaries are **not** professional advice, diagnostic output, or a safety indicator, and are subject to every disclaimer already stated in these Terms (see Sections 2–7).
+- The Service does not send your name, email address, ride GPS coordinates, payment information, or account credentials to the AI provider. Data sent is limited to what is needed to describe your bicycle's maintenance state.
+- The AI provider processes the data solely to return output to the Service. Under the AI provider's current terms, submitted data is not used to train their models. Data may be retained by the AI provider for a limited period for abuse and safety review.
+- The AI provider is a **sub-processor** of the Service. Their terms and privacy practices are available on their website.
+
+You acknowledge that machine-generated content is an assistive feature and agree not to rely on it as the sole basis for any maintenance, repair, safety, or purchasing decision.
 
 ---
 

--- a/apps/web/src/legal/terms.ts
+++ b/apps/web/src/legal/terms.ts
@@ -172,9 +172,9 @@ Loam Logger is not responsible for:
 
 Use of third-party services is at your own risk and subject to their respective terms.
 
-### 9.1 Machine-Generated Content
+### 9.1 Machine-Generated Content Using AI
 
-Certain features of the Service produce **machine-generated content**, including natural-language maintenance summaries. To generate this content, the Service transmits non-identifying data about your bicycle and its components — such as component types, service intervals, hours since last service, and computed status — to a third-party AI processing provider (currently Anthropic, PBC, operator of the Claude API).
+Certain features of the Service produce **machine-generated content using artificial intelligence (AI)**, including natural-language maintenance summaries. To generate this content, the Service transmits non-identifying data about your bicycle and its components — such as component types, service intervals, hours since last service, and computed status — to a third-party AI processing provider (currently Anthropic, PBC, operator of the Claude API).
 
 The following applies to all machine-generated content:
 

--- a/libs/shared/src/legal/terms.ts
+++ b/libs/shared/src/legal/terms.ts
@@ -3,4 +3,4 @@
 // Both the API and web app must use this value to ensure consistency.
 // When updating terms, increment the version here and it will apply everywhere.
 
-export const CURRENT_TERMS_VERSION = '1.3.0';
+export const CURRENT_TERMS_VERSION = '1.4.0';


### PR DESCRIPTION
## Summary
Adds subsection 9.1 (Machine-Generated Content) to the Terms of Service to cover the upcoming advisor summary widget ([#235](https://github.com/ryanlecours/loam-logger/pull/235)), which sends bike/component data to Anthropic to generate maintenance summaries.

Language covers:
- Machine-generated output may be inaccurate; not professional advice; every existing "estimates only" disclaimer (§§ 2-7) applies
- What is / isn't sent to Anthropic — no name, email, GPS, or payment info; only what's needed to describe the bike's maintenance state
- Sub-processor role of Anthropic, retention and no-training posture per current Anthropic terms
- Users must not rely on machine-generated summaries as the sole basis for maintenance, repair, or safety decisions

## Version bump
- `TERMS_VERSION` 1.3.0 → **1.4.0** (minor: new content section, no removals)
- `TERMS_LAST_UPDATED` January 2026 → **July 2026**
- Existing users will be prompted to re-accept on next login once the frontend carrying this file deploys.

## Sequencing
Ideally lands **before** or **concurrently with** the advisor widget mobile PR so the terms cover the feature by the time riders can use it. Merging this PR alone won't force re-acceptance until the next web deploy carries the new `TERMS_VERSION`.

## Follow-ups (outside code, my checklist for you)
- [ ] Update marketing-site privacy policy to name Anthropic as a sub-processor
- [ ] Sign Anthropic's DPA in the Anthropic Console (Settings → Legal → Data Processing Addendum)
- [ ] "Machine-generated" affordance in the mobile advisor widget will land with the widget PR

## Test plan
- [x] Diff is 2 files (both `terms.ts` locations, kept in sync)
- [x] No code paths reference the removed language (nothing removed)
- [ ] Reviewer / legal counsel: word-level check of §9.1 for accuracy of what data goes to Anthropic (currently: no PII, no GPS, only bike + component + service data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)