### PR TITLE
fix(api): remove unauthenticated user(id) query; require age at onboarding

### DIFF
--- a/apps/api/src/graphql/__tests__/schema.test.ts
+++ b/apps/api/src/graphql/__tests__/schema.test.ts
@@ -1,0 +1,27 @@
+import { buildASTSchema, validate, parse } from 'graphql';
+import { typeDefs } from '../schema';
+
+// Schema-shape guards built straight from the SDL the server serves (no
+// resolvers / DB needed). These lock in the removal of the unauthenticated
+// Query.user(id) field — a broken-object-level-authorization hole that
+// returned any user's email + subscription + rides — so it can't silently
+// come back.
+describe('GraphQL schema — Query.user removal', () => {
+  const schema = buildASTSchema(typeDefs);
+
+  it('does not expose a Query.user field', () => {
+    const queryFields = schema.getQueryType()?.getFields() ?? {};
+    expect(queryFields.user).toBeUndefined();
+  });
+
+  it('still exposes Query.me (the intended self-lookup)', () => {
+    const queryFields = schema.getQueryType()?.getFields() ?? {};
+    expect(queryFields.me).toBeDefined();
+  });
+
+  it('rejects a query selecting user(id) at validation time', () => {
+    const errors = validate(schema, parse('{ user(id: "any") { id email } }'));
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.map((e) => e.message).join('\n')).toMatch(/Cannot query field "user"/);
+  });
+});

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -49,8 +49,6 @@ import { FRONTEND_URL } from '../config/env';
 
 type ComponentType = ComponentTypeLiteral;
 
-type UserArgs = { id: string };
-
 type AddRideInput = {
   startTime: string;
   durationSeconds: number;
@@ -882,12 +880,6 @@ const pickComponent = (
 
 export const resolvers = {
   Query: {
-    user: (args: UserArgs) =>
-      prisma.user.findUnique({
-        where: { id: args.id },
-        include: { rides: true },
-      }),
-
     // Single-ride lookup keyed on (id, userId) so a foreign-user id resolves
     // to null instead of leaking another user's ride. Returning null on miss
     // (rather than throwing) lets the mobile ride-detail screen render its

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -1141,7 +1141,6 @@ export const typeDefs = gql`
 
   type Query {
     me: User
-    user(id: ID!): User
     ride(id: ID!): Ride
     rides(take: Int = 1000, after: ID, filter: RidesFilterInput): [Ride!]!
     rideTypes: [RideType!]!

--- a/apps/api/src/routes/onboarding.test.ts
+++ b/apps/api/src/routes/onboarding.test.ts
@@ -93,6 +93,9 @@ describe('POST /onboarding/complete', () => {
         bikeYear: 2024,
         bikeTravelFork: 160,
         bikeTravelShock: 150,
+        // Age is required by the onboarding handler (16+ gate); include a
+        // valid default so bike/component-focused tests reach the happy path.
+        age: 30,
       },
     };
 
@@ -268,7 +271,7 @@ describe('POST /onboarding/complete', () => {
       });
     });
 
-    it('should set age and location to null when not provided', async () => {
+    it('should return 400 when age is not provided (age is required)', async () => {
       mockReq.body = {
         bikeMake: 'Santa Cruz',
         bikeModel: 'Bronson',
@@ -276,10 +279,27 @@ describe('POST /onboarding/complete', () => {
 
       await invokeHandler(handler, mockReq as Request, mockRes as Response);
 
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(jsonResponse).toMatchObject({
+        error: 'Please enter a valid age',
+        code: 'BAD_REQUEST',
+      });
+      expect(mockUserUpdateMany).not.toHaveBeenCalled();
+    });
+
+    it('should set location to null when not provided (age given)', async () => {
+      mockReq.body = {
+        bikeMake: 'Santa Cruz',
+        bikeModel: 'Bronson',
+        age: 30,
+      };
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
       expect(mockUserUpdateMany).toHaveBeenCalledWith({
         where: { id: 'user-123', onboardingCompleted: false },
         data: {
-          age: null,
+          age: 30,
           location: null,
           onboardingCompleted: true,
         },
@@ -292,6 +312,7 @@ describe('POST /onboarding/complete', () => {
       mockReq.body = {
         bikeMake: 'Santa Cruz',
         bikeModel: 'Bronson',
+        age: 30,
         bikeYear: 2024,
         bikeTravelFork: 160,
         bikeTravelShock: 150,
@@ -315,6 +336,7 @@ describe('POST /onboarding/complete', () => {
       mockReq.body = {
         bikeMake: 'Santa Cruz',
         bikeModel: 'Bronson',
+        age: 30,
         spokesId: 'spokes-123',
         spokesUrl: 'https://99spokes.com/bike',
         thumbnailUrl: 'https://example.com/thumb.jpg',
@@ -351,6 +373,7 @@ describe('POST /onboarding/complete', () => {
       mockReq.body = {
         bikeMake: 'Specialized',
         bikeModel: 'Levo',
+        age: 30,
         isEbike: true,
         motorMaker: 'Specialized',
         motorModel: '2.2',
@@ -377,6 +400,7 @@ describe('POST /onboarding/complete', () => {
       mockReq.body = {
         bikeMake: 'Santa Cruz',
         bikeModel: 'Bronson',
+        age: 30,
         isEbike: false,
         motorMaker: 'Bosch', // Should be ignored
         motorPowerW: 250, // Should be ignored
@@ -402,6 +426,7 @@ describe('POST /onboarding/complete', () => {
       mockReq.body = {
         bikeMake: 'Santa Cruz',
         bikeModel: 'Bronson',
+        age: 30,
         bikeTravelFork: 160,
         bikeTravelShock: 150,
       };
@@ -427,6 +452,7 @@ describe('POST /onboarding/complete', () => {
       mockReq.body = {
         bikeMake: 'Santa Cruz',
         bikeModel: 'Chameleon',
+        age: 30,
         bikeTravelFork: 130,
         bikeTravelShock: 0, // Hardtail
       };
@@ -450,6 +476,7 @@ describe('POST /onboarding/complete', () => {
       mockReq.body = {
         bikeMake: 'Surly',
         bikeModel: 'Karate Monkey',
+        age: 30,
         bikeTravelFork: 0,
         bikeTravelShock: 0,
       };
@@ -473,6 +500,7 @@ describe('POST /onboarding/complete', () => {
       mockReq.body = {
         bikeMake: 'Santa Cruz',
         bikeModel: 'Bronson',
+        age: 30,
         acquisitionCondition: 'USED',
       };
 
@@ -490,6 +518,7 @@ describe('POST /onboarding/complete', () => {
       mockReq.body = {
         bikeMake: 'Santa Cruz',
         bikeModel: 'Bronson',
+        age: 30,
       };
 
       await invokeHandler(handler, mockReq as Request, mockRes as Response);
@@ -511,6 +540,7 @@ describe('POST /onboarding/complete', () => {
       mockReq.body = {
         bikeMake: 'Santa Cruz',
         bikeModel: 'Bronson',
+        age: 30,
         spokesComponents,
       };
 
@@ -534,6 +564,7 @@ describe('POST /onboarding/complete', () => {
       mockReq.body = {
         bikeMake: 'Santa Cruz',
         bikeModel: 'Bronson',
+        age: 30,
         components,
       };
 

--- a/apps/api/src/routes/onboarding.ts
+++ b/apps/api/src/routes/onboarding.ts
@@ -112,7 +112,12 @@ router.post('/complete', express.json(), async (req: Request, res) => {
       return sendBadRequest(res, 'Bike make and model are required');
     }
 
-    if (age && (age < 16 || age > 150)) {
+    // Age is required at onboarding: the 16+ minimum is a hard gate (Terms
+    // §; App Store age declaration), so a missing/invalid age is rejected
+    // rather than silently stored as null. Both the mobile and web onboarding
+    // flows collect age as a mandatory step, so this only rejects crafted or
+    // out-of-date clients.
+    if (typeof age !== 'number' || !Number.isInteger(age) || age < 16 || age > 150) {
       return sendBadRequest(res, 'Please enter a valid age');
     }
 
@@ -135,7 +140,7 @@ router.post('/complete', express.json(), async (req: Request, res) => {
       const { count } = await tx.user.updateMany({
         where: { id: userId, onboardingCompleted: false },
         data: {
-          age: age || null,
+          age, // validated 16–150 above
           location: location || null,
           onboardingCompleted: true,
         },


### PR DESCRIPTION
Access-control hardening surfaced while auditing cross-user data surfaces for the App Store age/social declarations.

## 1. 🔴 Broken object-level authorization (IDOR) — `Query.user(id)`
The `user(id: ID!): User` query took an **arbitrary** user id, had **no auth or ownership check** (the resolver didn't even receive `ctx`), and returned the full `User` — `email`, `role`, `subscriptionTier`, `subscriptionProvider`, and **every `ride` including GPS/location** — for any id.

- **No client referenced it** (dead product surface), but it was live on `/graphql`, so anyone reaching the endpoint could enumerate/guess ids and read arbitrary users' email + subscription + ride history.
- **Fix:** removed the schema field, the resolver, and the now-dead `UserArgs` type. `me` already serves the authenticated user's own record, so there's no functional loss.

## 2. Age gate — server-side defense-in-depth
The onboarding endpoint validated age **only when present** (`if (age && (age < 16 || age > 150))`) and stored `null` otherwise, so a request that omitted `age` bypassed the 16+ minimum.

- Both shipped clients collect age as a mandatory, non-skippable onboarding step, so real users were already gated — this closes the gap for crafted/out-of-date clients.
- **Fix:** the endpoint now rejects a missing/invalid age (requires an integer 16–150). `location` stays optional.

## Tests
- Removed query: confirmed zero references (schema/resolvers/clients).
- Onboarding tests updated for the now-required age (added a valid age to bike/component-creation fixtures; split the old "age null when omitted" test into "age required → 400" + "location optional").
- **Full api suite: 1446 pass**, `tsc` clean, lint clean.

Independent of the advisor work — branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)