### PR TITLE
Lift detection: stream ingestion, shadow-mode detection, admin validation (increments 1-3)

### DIFF
--- a/apps/api/prisma/migrations/20260718000000_add_ride_stream/migration.sql
+++ b/apps/api/prisma/migrations/20260718000000_add_ride_stream/migration.sql
@@ -1,0 +1,18 @@
+-- Raw per-point activity streams (Strava first). One row per ride; parallel
+-- index-aligned arrays in "data". Retained so lift detection can re-run
+-- without re-hitting provider APIs. Deleted explicitly on Strava disconnect
+-- (rides survive); ride deletion cascades.
+CREATE TABLE "RideStream" (
+    "id" TEXT NOT NULL,
+    "rideId" TEXT NOT NULL,
+    "source" TEXT NOT NULL,
+    "pointCount" INTEGER NOT NULL,
+    "data" JSONB NOT NULL,
+    "fetchedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RideStream_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "RideStream_rideId_key" ON "RideStream"("rideId");
+
+ALTER TABLE "RideStream" ADD CONSTRAINT "RideStream_rideId_fkey" FOREIGN KEY ("rideId") REFERENCES "Ride"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260718000001_add_lift_detection/migration.sql
+++ b/apps/api/prisma/migrations/20260718000001_add_lift_detection/migration.sql
@@ -1,0 +1,50 @@
+-- Lift detection, shadow mode (docs/plans/lift-detection-plan.md §2).
+-- Detected segments index into the immutable RideStream arrays; Ride gains
+-- nullable lift-delta columns (NULL = never analyzed, 0 = analyzed, no lift).
+-- Raw provider metrics are never mutated.
+
+CREATE TYPE "RideSegmentKind" AS ENUM ('LIFT');
+
+CREATE TABLE "RideSegment" (
+    "id" TEXT NOT NULL,
+    "rideId" TEXT NOT NULL,
+    "kind" "RideSegmentKind" NOT NULL,
+    "startIndex" INTEGER NOT NULL,
+    "endIndex" INTEGER NOT NULL,
+    "startTime" TIMESTAMP(3) NOT NULL,
+    "endTime" TIMESTAMP(3) NOT NULL,
+    "confidence" DOUBLE PRECISION NOT NULL,
+    "geometryScore" DOUBLE PRECISION,
+    "kinematicScore" DOUBLE PRECISION NOT NULL,
+    "liftName" TEXT,
+    "liftOsmId" TEXT,
+    "durationSeconds" INTEGER NOT NULL,
+    "elevationGainMeters" DOUBLE PRECISION NOT NULL,
+    "distanceMeters" DOUBLE PRECISION NOT NULL,
+    "detectorVersion" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RideSegment_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "RideSegment_rideId_idx" ON "RideSegment"("rideId");
+
+ALTER TABLE "RideSegment" ADD CONSTRAINT "RideSegment_rideId_fkey" FOREIGN KEY ("rideId") REFERENCES "Ride"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE TABLE "OverpassCache" (
+    "id" TEXT NOT NULL,
+    "cellKey" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "isEmpty" BOOLEAN NOT NULL DEFAULT false,
+    "fetchedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OverpassCache_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "OverpassCache_cellKey_key" ON "OverpassCache"("cellKey");
+
+ALTER TABLE "Ride"
+  ADD COLUMN "liftDurationSeconds" INTEGER,
+  ADD COLUMN "liftElevationGainMeters" DOUBLE PRECISION,
+  ADD COLUMN "liftDistanceMeters" DOUBLE PRECISION,
+  ADD COLUMN "liftDetectorVersion" INTEGER;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -128,6 +128,14 @@ model Ride {
   importSessionId   String?
   startLat          Float?
   startLng          Float?
+  // Lift-detection deltas (docs/plans/lift-detection-plan.md §2.4). Sums over
+  // this ride's LIFT segments; effective metrics = raw − delta. NULL means
+  // "never analyzed", 0 means "analyzed, no lift found". Raw provider columns
+  // above are never adjusted in place.
+  liftDurationSeconds     Int?
+  liftElevationGainMeters Float?
+  liftDistanceMeters      Float?
+  liftDetectorVersion     Int?
   bike              Bike?           @relation(fields: [bikeId], references: [id])
   duplicateOf       Ride?           @relation("DuplicateRides", fields: [duplicateOfId], references: [id], onDelete: SetNull)
   duplicates        Ride[]          @relation("DuplicateRides")
@@ -135,6 +143,7 @@ model Ride {
   importSession     ImportSession?  @relation(fields: [importSessionId], references: [id], onDelete: SetNull)
   weather           RideWeather?
   stream            RideStream?
+  segments          RideSegment[]
 
   @@index([importSessionId, bikeId])
   // NOTE: a partial index on (userId) WHERE startLat IS NOT NULL AND startLng IS NOT NULL
@@ -188,6 +197,50 @@ model RideStream {
   data       Json
   fetchedAt  DateTime @default(now())
   ride       Ride     @relation(fields: [rideId], references: [id], onDelete: Cascade)
+}
+
+enum RideSegmentKind {
+  LIFT
+}
+
+// A detected sub-interval of a ride (chairlift/gondola for now). Start/end
+// index into the RideStream parallel arrays rather than duplicating geometry:
+// the stream is immutable, so indices never dangle, and re-detection just
+// replaces these rows. Times and metric deltas are denormalized so metric
+// adjustment and display never need to load the stream blob.
+model RideSegment {
+  id                  String          @id @default(uuid())
+  rideId              String
+  kind                RideSegmentKind
+  startIndex          Int
+  endIndex            Int // inclusive
+  startTime           DateTime
+  endTime             DateTime
+  confidence          Float // combined score, 0..1
+  geometryScore       Float? // null = Overpass was unavailable at detection time
+  kinematicScore      Float
+  liftName            String? // OSM name of matched aerialway, if any
+  liftOsmId           String?
+  durationSeconds     Int
+  elevationGainMeters Float
+  distanceMeters      Float
+  detectorVersion     Int
+  createdAt           DateTime        @default(now())
+  ride                Ride            @relation(fields: [rideId], references: [id], onDelete: Cascade)
+
+  @@index([rideId])
+}
+
+// Cached Overpass aerialway lookups, keyed by 0.05° grid cell so repeat visits
+// to the same park are cache hits (WeatherCache/GeoCache precedent). Lifts
+// essentially never move; entries are treated as fresh for ~180 days and
+// refreshed lazily. isEmpty rows negative-cache the common no-lifts case.
+model OverpassCache {
+  id        String   @id @default(uuid())
+  cellKey   String   @unique
+  payload   Json // normalized LiftLine[]: [{ id, name?, kind, coordinates: [{lat,lng},...] }]
+  isEmpty   Boolean  @default(false)
+  fetchedAt DateTime @default(now())
 }
 
 model WeatherCache {

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -134,6 +134,7 @@ model Ride {
   user              User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   importSession     ImportSession?  @relation(fields: [importSessionId], references: [id], onDelete: SetNull)
   weather           RideWeather?
+  stream            RideStream?
 
   @@index([importSessionId, bikeId])
   // NOTE: a partial index on (userId) WHERE startLat IS NOT NULL AND startLng IS NOT NULL
@@ -170,6 +171,23 @@ model RideWeather {
   ride             Ride             @relation(fields: [rideId], references: [id], onDelete: Cascade)
 
   @@index([condition])
+}
+
+// Raw per-point activity streams (Strava first; `source` scopes the format).
+// One row per ride, parallel index-aligned arrays in `data`:
+// { time: number[], latlng: [number,number][], altitude?: number[],
+//   velocity?: number[], cadence?: number[], heartrate?: number[], moving?: boolean[] }
+// Never mutated after fetch — lift detection reads it; derived data lives elsewhere.
+// Deleted on Strava disconnect/deauth while rides survive, so those paths must
+// delete rows explicitly; ride deletion cascades.
+model RideStream {
+  id         String   @id @default(uuid())
+  rideId     String   @unique
+  source     String
+  pointCount Int
+  data       Json
+  fetchedAt  DateTime @default(now())
+  ride       Ride     @relation(fields: [rideId], references: [id], onDelete: Cascade)
 }
 
 model WeatherCache {

--- a/apps/api/src/lib/lift-detection/detector.test.ts
+++ b/apps/api/src/lib/lift-detection/detector.test.ts
@@ -1,0 +1,199 @@
+import {
+  DEFAULT_OPTIONS,
+  KINEMATIC_ONLY_OPTIONS,
+  pointsFromStream,
+  detectLiftSegments,
+  computeAdjustedMetrics,
+  type RidePoint,
+  type LiftLine,
+} from './detector';
+
+// ---------------------------------------------------------------------------
+// Synthetic fixtures. Point spacing is 5 s. A "lift" is a dead-straight,
+// constant-speed (4 m/s), zero-cadence ascent at ~1400 m/h VAM — every Layer B
+// signal saturated. Real-ride fixtures replace these in the validation phase.
+// ---------------------------------------------------------------------------
+
+const STEP_SEC = 5;
+const LAT_PER_STEP = 0.00018; // ~20 m at 4 m/s over 5 s
+
+type FixtureOpts = {
+  startT?: number;
+  startLat?: number;
+  startEle?: number;
+  count?: number;
+};
+
+function liftAscent(opts: FixtureOpts = {}): RidePoint[] {
+  const { startT = 0, startLat = 45.0, startEle = 1000, count = 97 } = opts;
+  const points: RidePoint[] = [];
+  for (let i = 0; i < count; i++) {
+    points.push({
+      t: startT + i * STEP_SEC,
+      lat: startLat + i * LAT_PER_STEP,
+      lng: -122.0,
+      ele: startEle + i * 1.94, // ~1400 m/h VAM
+      speed: 4,
+      cadence: 0,
+    });
+  }
+  return points;
+}
+
+// Pedaled switchback climb: modest VAM, active cadence, zigzag path,
+// varying speed. Should never classify as a lift.
+function pedaledClimb(opts: FixtureOpts = {}): RidePoint[] {
+  const { startT = 0, startLat = 45.0, startEle = 1000, count = 97 } = opts;
+  const points: RidePoint[] = [];
+  let lng = -122.0;
+  for (let i = 0; i < count; i++) {
+    const zigDirection = Math.floor(i / 10) % 2 === 0 ? 1 : -1;
+    lng += zigDirection * 0.0002;
+    points.push({
+      t: startT + i * STEP_SEC,
+      lat: startLat + i * 0.00005,
+      lng,
+      ele: startEle + i * 0.7, // ~500 m/h VAM
+      speed: 2 + (i % 5) * 0.4,
+      cadence: 80,
+    });
+  }
+  return points;
+}
+
+function liftLineAlong(points: RidePoint[], name = 'Summit Express'): LiftLine {
+  return {
+    id: 'way-1',
+    name,
+    kind: 'chair_lift',
+    coordinates: [
+      { lat: points[0].lat, lng: points[0].lng },
+      { lat: points[points.length - 1].lat, lng: points[points.length - 1].lng },
+    ],
+  };
+}
+
+describe('pointsFromStream', () => {
+  it('maps parallel arrays to points', () => {
+    const points = pointsFromStream({
+      time: [0, 5],
+      latlng: [[45, -122], [45.001, -122]],
+      altitude: [1000, 1010],
+      velocity: [4, 4.1],
+      cadence: [0, 2],
+    });
+
+    expect(points).toEqual([
+      { t: 0, lat: 45, lng: -122, ele: 1000, speed: 4, cadence: 0 },
+      { t: 5, lat: 45.001, lng: -122, ele: 1010, speed: 4.1, cadence: 2 },
+    ]);
+  });
+
+  it('returns null when the altitude series is missing', () => {
+    expect(
+      pointsFromStream({ time: [0, 5], latlng: [[45, -122], [45.001, -122]] })
+    ).toBeNull();
+  });
+});
+
+describe('detectLiftSegments', () => {
+  it('detects a lift-like ascent kinematically (no geometry)', () => {
+    const segments = detectLiftSegments(liftAscent(), [], DEFAULT_OPTIONS);
+
+    expect(segments).toHaveLength(1);
+    const seg = segments[0];
+    expect(seg.kinematicScore).toBeGreaterThan(0.9);
+    expect(seg.confidence).toBeGreaterThanOrEqual(DEFAULT_OPTIONS.openThreshold);
+    expect(seg.geometryScore).toBe(0);
+    expect(seg.matchedLiftName).toBeUndefined();
+    expect(seg.durationSec).toBeGreaterThanOrEqual(DEFAULT_OPTIONS.minSegmentSec);
+    expect(seg.elevationGainMeters).toBeGreaterThan(100);
+  });
+
+  it('short-circuits to high confidence on a geometry match and names the lift', () => {
+    const points = liftAscent();
+    const segments = detectLiftSegments(points, [liftLineAlong(points)], DEFAULT_OPTIONS);
+
+    expect(segments).toHaveLength(1);
+    const seg = segments[0];
+    expect(seg.confidence).toBeGreaterThanOrEqual(0.85);
+    expect(seg.geometryScore).toBeGreaterThan(0.9);
+    expect(seg.matchedLiftName).toBe('Summit Express');
+    expect(seg.matchedLiftId).toBe('way-1');
+  });
+
+  it('does not classify a pedaled switchback climb as a lift', () => {
+    expect(detectLiftSegments(pedaledClimb(), [], DEFAULT_OPTIONS)).toHaveLength(0);
+  });
+
+  it('drops segments shorter than minSegmentSec', () => {
+    // 75 s of lift-like ascent: windows can open but the merged segment is
+    // under the 90 s survival floor.
+    const short = liftAscent({ count: 16 });
+    expect(detectLiftSegments(short, [], DEFAULT_OPTIONS)).toHaveLength(0);
+  });
+
+  it('separates two laps split by a descent into two segments', () => {
+    const lap1 = liftAscent();
+    const lastLift = lap1[lap1.length - 1];
+    const descent: RidePoint[] = [];
+    for (let i = 1; i <= 60; i++) {
+      descent.push({
+        t: lastLift.t + i * STEP_SEC,
+        lat: lastLift.lat - i * 0.0003, // fast, not straight enough to matter: descending
+        lng: -122.0 + (i % 2 === 0 ? 0.0004 : 0),
+        ele: lastLift.ele - i * 3,
+        speed: 8,
+        cadence: 30,
+      });
+    }
+    const lastDescent = descent[descent.length - 1];
+    const lap2 = liftAscent({
+      startT: lastDescent.t + STEP_SEC,
+      startLat: lastDescent.lat,
+      startEle: lastDescent.ele,
+    });
+
+    const segments = detectLiftSegments([...lap1, ...descent, ...lap2], [], DEFAULT_OPTIONS);
+    expect(segments).toHaveLength(2);
+  });
+
+  it('kinematic-only options demand a higher bar than default', () => {
+    expect(KINEMATIC_ONLY_OPTIONS.openThreshold).toBeGreaterThan(DEFAULT_OPTIONS.openThreshold);
+    expect(KINEMATIC_ONLY_OPTIONS.extendThreshold).toBeGreaterThan(
+      DEFAULT_OPTIONS.extendThreshold
+    );
+  });
+});
+
+describe('computeAdjustedMetrics', () => {
+  it('attributes lift steps to lift time and the rest to active riding', () => {
+    const lift = liftAscent(); // 96 steps × 5 s = 480 s, ~186 m gain
+    const last = lift[lift.length - 1];
+    const ride: RidePoint[] = [];
+    for (let i = 1; i <= 60; i++) {
+      ride.push({
+        t: last.t + i * STEP_SEC,
+        lat: last.lat + i * 0.0002,
+        lng: -122.0,
+        ele: last.ele - i * 2, // descending
+        speed: 7,
+        cadence: 20,
+      });
+    }
+    const points = [...lift, ...ride];
+
+    const metrics = computeAdjustedMetrics(points, [
+      { startIndex: 0, endIndex: lift.length - 1 },
+    ]);
+
+    expect(metrics.liftCount).toBe(1);
+    expect(metrics.liftTimeSec).toBe((lift.length - 1) * STEP_SEC);
+    expect(metrics.liftGainMeters).toBeCloseTo(1.94 * (lift.length - 1), 0);
+    // Active time = 59 steps within the 60 ride points + the boundary step.
+    expect(metrics.activeTimeSec).toBe(60 * STEP_SEC);
+    expect(metrics.elevationLossMeters).toBeCloseTo(120, 0);
+    // No pedaled climbing outside the lift: gain excluding lift stays ~0.
+    expect(metrics.elevationGainMeters).toBeLessThan(1);
+  });
+});

--- a/apps/api/src/lib/lift-detection/detector.ts
+++ b/apps/api/src/lib/lift-detection/detector.ts
@@ -1,0 +1,541 @@
+/**
+ * Chairlift / gondola segment detection over a persisted ride stream.
+ * Adapted from the reference liftDetection.ts (docs/plans/lift-detection-plan.md).
+ *
+ * Layered approach:
+ *   Layer A - geometry match against OpenStreetMap aerialway ways (high
+ *             precision, patchy coverage).
+ *   Layer B - kinematic classifier (full coverage, occasionally confuses
+ *             truck shuttles).
+ *
+ * Pure functions only — no I/O, no clock, no randomness — so everything here
+ * is testable against fixtures without network access. Nothing mutates the
+ * raw stream: the output is a list of typed segments that downstream metric
+ * and wear calculations subtract from.
+ */
+
+import type { NormalizedStreams } from '../strava-streams';
+
+/**
+ * Bump when scoring/thresholds change in a way that should invalidate prior
+ * results. Rides analyzed at an older version are re-detected from their
+ * persisted stream on the next job run — no provider re-fetch.
+ */
+export const DETECTOR_VERSION = 1;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RidePoint {
+  /** Seconds elapsed from activity start. */
+  t: number;
+  lat: number;
+  lng: number;
+  /** Meters. */
+  ele: number;
+  /** Meters per second. Derived from geometry when absent. */
+  speed?: number;
+  /** RPM. Undefined when the activity has no cadence stream. */
+  cadence?: number;
+}
+
+/** A single OSM aerialway way, simplified to an ordered coordinate list. */
+export interface LiftLine {
+  id: string;
+  name?: string;
+  /** aerialway value: chair_lift, gondola, t-bar, platter, magic_carpet, etc. */
+  kind: string;
+  coordinates: Array<{ lat: number; lng: number }>;
+}
+
+export interface DetectedLiftSegment {
+  startIndex: number;
+  /** Inclusive. */
+  endIndex: number;
+  /** Seconds from activity start. */
+  startTimeOffsetSec: number;
+  endTimeOffsetSec: number;
+  durationSec: number;
+  distanceMeters: number;
+  elevationGainMeters: number;
+  /** Combined Layer A + Layer B score, 0..1. */
+  confidence: number;
+  /** Layer B alone, 0..1. */
+  kinematicScore: number;
+  /** Fraction of segment points within the lift-line buffer, 0..1. */
+  geometryScore: number;
+  matchedLiftName?: string;
+  matchedLiftId?: string;
+}
+
+export interface DetectionOptions {
+  /** Length of the scanning window in seconds. */
+  windowSec: number;
+  /** Stride between window starts in seconds. */
+  strideSec: number;
+  /** Minimum duration for a segment to survive into the output. */
+  minSegmentSec: number;
+  /** Minimum vertical gain for a segment to survive into the output. */
+  minSegmentGainMeters: number;
+  /** Confidence required to open a segment. */
+  openThreshold: number;
+  /** Confidence required to keep extending an open segment (hysteresis). */
+  extendThreshold: number;
+  /** Buffer distance around an OSM lift line, in meters. */
+  liftBufferMeters: number;
+}
+
+// Threshold values are estimates pending validation against real park rides
+// (plan increments 3–4); bump DETECTOR_VERSION when they change.
+export const DEFAULT_OPTIONS: DetectionOptions = {
+  windowSec: 60,
+  strideSec: 15,
+  minSegmentSec: 90,
+  minSegmentGainMeters: 60,
+  openThreshold: 0.62,
+  extendThreshold: 0.45,
+  liftBufferMeters: 40,
+};
+
+/**
+ * Degraded mode for when Overpass is unavailable (plan §3.2): Layer B alone
+ * must clear a higher bar, since it is the layer that confuses truck shuttles.
+ */
+export const KINEMATIC_ONLY_OPTIONS: DetectionOptions = {
+  ...DEFAULT_OPTIONS,
+  openThreshold: 0.72,
+  extendThreshold: 0.55,
+};
+
+// ---------------------------------------------------------------------------
+// Stream normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a persisted RideStream payload into detector points. Returns null
+ * when the stream lacks an altitude series — elevation is the backbone of
+ * every signal, so such rides cannot be analyzed (leave them unanalyzed
+ * rather than recording a false "no lift found").
+ */
+export function pointsFromStream(streams: NormalizedStreams): RidePoint[] | null {
+  const { time, latlng, altitude, velocity, cadence } = streams;
+  if (!altitude?.length) return null;
+
+  const n = Math.min(time.length, latlng.length, altitude.length);
+  const points: RidePoint[] = [];
+  for (let i = 0; i < n; i++) {
+    points.push({
+      t: time[i],
+      lat: latlng[i][0],
+      lng: latlng[i][1],
+      ele: altitude[i],
+      speed: velocity?.[i],
+      cadence: cadence?.[i],
+    });
+  }
+  return points;
+}
+
+// ---------------------------------------------------------------------------
+// Geometry helpers
+// ---------------------------------------------------------------------------
+
+const EARTH_RADIUS_M = 6371008.8;
+
+function toRadians(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+export function haversineMeters(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number }
+): number {
+  const dLat = toRadians(b.lat - a.lat);
+  const dLng = toRadians(b.lng - a.lng);
+  const lat1 = toRadians(a.lat);
+  const lat2 = toRadians(b.lat);
+
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(h));
+}
+
+/**
+ * Local equirectangular projection, accurate enough over the few kilometers a
+ * single lift line spans and far cheaper than a full geodesic solution.
+ */
+function project(
+  p: { lat: number; lng: number },
+  originLat: number
+): { x: number; y: number } {
+  return {
+    x: toRadians(p.lng) * Math.cos(toRadians(originLat)) * EARTH_RADIUS_M,
+    y: toRadians(p.lat) * EARTH_RADIUS_M,
+  };
+}
+
+function distanceToSegment(
+  p: { x: number; y: number },
+  a: { x: number; y: number },
+  b: { x: number; y: number }
+): number {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const lengthSq = dx * dx + dy * dy;
+
+  if (lengthSq === 0) {
+    return Math.hypot(p.x - a.x, p.y - a.y);
+  }
+
+  let u = ((p.x - a.x) * dx + (p.y - a.y) * dy) / lengthSq;
+  u = Math.max(0, Math.min(1, u));
+
+  return Math.hypot(p.x - (a.x + u * dx), p.y - (a.y + u * dy));
+}
+
+export function distanceToLiftLineMeters(
+  point: { lat: number; lng: number },
+  line: LiftLine
+): number {
+  if (line.coordinates.length === 0) return Infinity;
+  if (line.coordinates.length === 1) {
+    return haversineMeters(point, line.coordinates[0]);
+  }
+
+  const originLat = point.lat;
+  const p = project(point, originLat);
+  let best = Infinity;
+
+  for (let i = 0; i < line.coordinates.length - 1; i++) {
+    const a = project(line.coordinates[i], originLat);
+    const b = project(line.coordinates[i + 1], originLat);
+    best = Math.min(best, distanceToSegment(p, a, b));
+  }
+
+  return best;
+}
+
+// ---------------------------------------------------------------------------
+// Layer B: kinematic scoring
+// ---------------------------------------------------------------------------
+
+/** Maps a value onto 0..1 with a linear ramp between low and high. */
+function ramp(value: number, low: number, high: number): number {
+  if (high === low) return value >= high ? 1 : 0;
+  return Math.max(0, Math.min(1, (value - low) / (high - low)));
+}
+
+interface WindowStats {
+  durationSec: number;
+  distanceMeters: number;
+  elevationGainMeters: number;
+  vamMetersPerHour: number;
+  straightness: number;
+  meanSpeed: number;
+  speedCv: number;
+  cadenceActiveFraction: number;
+  hasCadenceStream: boolean;
+  monotonicAscentFraction: number;
+  onLiftFraction: number;
+  matchedLiftName?: string;
+  matchedLiftId?: string;
+}
+
+function computeWindowStats(
+  points: RidePoint[],
+  start: number,
+  end: number,
+  liftLines: LiftLine[],
+  bufferMeters: number
+): WindowStats {
+  const first = points[start];
+  const last = points[end];
+  const durationSec = Math.max(1, last.t - first.t);
+
+  let pathLength = 0;
+  let ascendingSteps = 0;
+  let steps = 0;
+  const speeds: number[] = [];
+
+  for (let i = start; i < end; i++) {
+    const d = haversineMeters(points[i], points[i + 1]);
+    const dt = Math.max(1, points[i + 1].t - points[i].t);
+
+    pathLength += d;
+    steps++;
+    if (points[i + 1].ele >= points[i].ele) ascendingSteps++;
+
+    const s = points[i].speed;
+    speeds.push(typeof s === 'number' ? s : d / dt);
+  }
+
+  const netDistance = haversineMeters(first, last);
+  const meanSpeed = speeds.reduce((a, b) => a + b, 0) / Math.max(1, speeds.length);
+  const variance =
+    speeds.reduce((acc, s) => acc + (s - meanSpeed) ** 2, 0) /
+    Math.max(1, speeds.length);
+  const speedCv = meanSpeed > 0 ? Math.sqrt(variance) / meanSpeed : 1;
+
+  const cadences = points
+    .slice(start, end + 1)
+    .map((p) => p.cadence)
+    .filter((c): c is number => typeof c === 'number');
+  const hasCadenceStream = cadences.length > 0;
+  const cadenceActiveFraction = hasCadenceStream
+    ? cadences.filter((c) => c > 5).length / cadences.length
+    : 0;
+
+  // Layer A overlay.
+  let onLift = 0;
+  let matchedLiftName: string | undefined;
+  let matchedLiftId: string | undefined;
+  if (liftLines.length > 0) {
+    for (let i = start; i <= end; i++) {
+      for (const line of liftLines) {
+        if (distanceToLiftLineMeters(points[i], line) <= bufferMeters) {
+          onLift++;
+          if (matchedLiftId === undefined) {
+            matchedLiftId = line.id;
+            matchedLiftName = line.name ?? line.kind;
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  const elevationGainMeters = last.ele - first.ele;
+
+  return {
+    durationSec,
+    distanceMeters: pathLength,
+    elevationGainMeters,
+    vamMetersPerHour: (elevationGainMeters / durationSec) * 3600,
+    straightness: pathLength > 0 ? netDistance / pathLength : 0,
+    meanSpeed,
+    speedCv,
+    cadenceActiveFraction,
+    hasCadenceStream,
+    monotonicAscentFraction: steps > 0 ? ascendingSteps / steps : 0,
+    onLiftFraction: onLift / (end - start + 1) || 0,
+    matchedLiftName,
+    matchedLiftId,
+  };
+}
+
+/**
+ * Layer B alone: the kinematic signals, without any geometry contribution.
+ *
+ * Reasoning behind the thresholds:
+ *  - VAM: a strong rider tops out near 1500 m/h on a road bike and well below
+ *    that on a trail bike. Sustained ascent above 1200 m/h is mechanical.
+ *  - Straightness: lifts run tower to tower in a straight line. Fire roads and
+ *    shuttle roads switchback.
+ *  - Speed CV: a lift holds constant line speed. A rider or a truck does not.
+ *  - Cadence: zero cadence during sustained ascent is the single cleanest
+ *    signal, but it only exists when the activity has a cadence stream.
+ */
+function scoreKinematic(stats: WindowStats): number {
+  const signals: Array<{ weight: number; value: number }> = [
+    { weight: 3, value: ramp(stats.vamMetersPerHour, 800, 1200) },
+    { weight: 3, value: ramp(stats.straightness, 0.9, 0.975) },
+    { weight: 2, value: 1 - ramp(stats.speedCv, 0.12, 0.35) },
+    { weight: 2, value: ramp(stats.monotonicAscentFraction, 0.75, 0.95) },
+    {
+      weight: 2,
+      // Lift line speed sits between roughly 1.5 and 6.5 m/s.
+      value:
+        stats.meanSpeed >= 1.5 && stats.meanSpeed <= 6.5
+          ? 1
+          : 1 - ramp(Math.abs(stats.meanSpeed - 4), 2.5, 6),
+    },
+  ];
+
+  if (stats.hasCadenceStream) {
+    signals.push({ weight: 4, value: 1 - ramp(stats.cadenceActiveFraction, 0.05, 0.25) });
+  }
+
+  const totalWeight = signals.reduce((a, s) => a + s.weight, 0);
+  return signals.reduce((a, s) => a + s.weight * s.value, 0) / totalWeight;
+}
+
+/** Combines Layer A and Layer B into a single 0..1 confidence. */
+function combineScores(stats: WindowStats): { confidence: number; kinematicScore: number } {
+  const kinematicScore = scoreKinematic(stats);
+
+  // A confident geometry match short circuits most of the doubt.
+  if (stats.onLiftFraction >= 0.8 && stats.elevationGainMeters > 0) {
+    return {
+      confidence: Math.min(1, 0.85 + 0.15 * stats.onLiftFraction),
+      kinematicScore,
+    };
+  }
+
+  if (stats.onLiftFraction > 0) {
+    // Fold the partial geometry match in with the kinematic signals at the
+    // same weight the reference gives it (3 of 12/16 total).
+    const kinematicWeight = stats.hasCadenceStream ? 16 : 12;
+    const geometryWeight = 3;
+    return {
+      confidence:
+        (kinematicScore * kinematicWeight + stats.onLiftFraction * geometryWeight) /
+        (kinematicWeight + geometryWeight),
+      kinematicScore,
+    };
+  }
+
+  return { confidence: kinematicScore, kinematicScore };
+}
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+export function detectLiftSegments(
+  points: RidePoint[],
+  liftLines: LiftLine[] = [],
+  options: Partial<DetectionOptions> = {}
+): DetectedLiftSegment[] {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+  if (points.length < 10) return [];
+
+  const indexAtOrAfter = (time: number, from: number): number => {
+    let i = from;
+    while (i < points.length && points[i].t < time) i++;
+    return Math.min(i, points.length - 1);
+  };
+
+  interface Candidate {
+    start: number;
+    end: number;
+    confidence: number;
+  }
+
+  const candidates: Candidate[] = [];
+  const lastTime = points[points.length - 1].t;
+
+  for (let tStart = points[0].t; tStart + opts.windowSec <= lastTime; tStart += opts.strideSec) {
+    const start = indexAtOrAfter(tStart, 0);
+    const end = indexAtOrAfter(tStart + opts.windowSec, start);
+    if (end - start < 3) continue;
+
+    const stats = computeWindowStats(points, start, end, liftLines, opts.liftBufferMeters);
+    if (stats.elevationGainMeters <= 0) continue;
+
+    const { confidence } = combineScores(stats);
+    if (confidence >= opts.extendThreshold) {
+      candidates.push({ start, end, confidence });
+    }
+  }
+
+  // Merge overlapping candidates. A run is kept only if at least one of its
+  // windows cleared the higher open threshold, which is the hysteresis that
+  // stops segment boundaries from flapping.
+  const merged: Candidate[] = [];
+  for (const c of candidates) {
+    const prev = merged[merged.length - 1];
+    if (prev && c.start <= prev.end) {
+      prev.end = Math.max(prev.end, c.end);
+      prev.confidence = Math.max(prev.confidence, c.confidence);
+    } else {
+      merged.push({ ...c });
+    }
+  }
+
+  return merged
+    .filter((c) => c.confidence >= opts.openThreshold)
+    .map((c) => {
+      // Recompute over the merged span so scores and metric deltas describe
+      // the whole persisted segment, not just its best window.
+      const stats = computeWindowStats(points, c.start, c.end, liftLines, opts.liftBufferMeters);
+      const { kinematicScore } = combineScores(stats);
+      return {
+        startIndex: c.start,
+        endIndex: c.end,
+        startTimeOffsetSec: points[c.start].t,
+        endTimeOffsetSec: points[c.end].t,
+        durationSec: stats.durationSec,
+        distanceMeters: stats.distanceMeters,
+        elevationGainMeters: stats.elevationGainMeters,
+        confidence: c.confidence,
+        kinematicScore,
+        geometryScore: stats.onLiftFraction,
+        matchedLiftName: stats.matchedLiftName,
+        matchedLiftId: stats.matchedLiftId,
+      };
+    })
+    .filter(
+      (s) =>
+        s.durationSec >= opts.minSegmentSec &&
+        s.elevationGainMeters >= opts.minSegmentGainMeters
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Adjusted metrics (consumed in the metric-exclusion increment; kept here so
+// the exclusion semantics live next to the detector they depend on)
+// ---------------------------------------------------------------------------
+
+export interface AdjustedRideMetrics {
+  /** Distance excluding lift segments. */
+  distanceMeters: number;
+  /** Elevation gain excluding lift segments. This is the number to display. */
+  elevationGainMeters: number;
+  /** Descent is unaffected by lifts but recomputed here for symmetry. */
+  elevationLossMeters: number;
+  /** Time excluding lift segments, for drivetrain wear accrual. */
+  activeTimeSec: number;
+  /** Time spent riding lifts, retained for auditing and lap counts. */
+  liftTimeSec: number;
+  liftGainMeters: number;
+  liftCount: number;
+}
+
+export function computeAdjustedMetrics(
+  points: RidePoint[],
+  liftSegments: Array<Pick<DetectedLiftSegment, 'startIndex' | 'endIndex'>>
+): AdjustedRideMetrics {
+  const isLift = new Array<boolean>(points.length).fill(false);
+  for (const seg of liftSegments) {
+    for (let i = seg.startIndex; i <= seg.endIndex; i++) isLift[i] = true;
+  }
+
+  let distanceMeters = 0;
+  let elevationGainMeters = 0;
+  let elevationLossMeters = 0;
+  let activeTimeSec = 0;
+  let liftTimeSec = 0;
+  let liftGainMeters = 0;
+
+  for (let i = 0; i < points.length - 1; i++) {
+    const dt = Math.max(0, points[i + 1].t - points[i].t);
+    const dEle = points[i + 1].ele - points[i].ele;
+    const d = haversineMeters(points[i], points[i + 1]);
+
+    // A step counts as lift time only when both of its endpoints are inside a
+    // lift segment, so boundary steps are attributed to riding.
+    if (isLift[i] && isLift[i + 1]) {
+      liftTimeSec += dt;
+      if (dEle > 0) liftGainMeters += dEle;
+      continue;
+    }
+
+    distanceMeters += d;
+    activeTimeSec += dt;
+    if (dEle > 0) elevationGainMeters += dEle;
+    else elevationLossMeters += -dEle;
+  }
+
+  return {
+    distanceMeters,
+    elevationGainMeters,
+    elevationLossMeters,
+    activeTimeSec,
+    liftTimeSec,
+    liftGainMeters,
+    liftCount: liftSegments.length,
+  };
+}

--- a/apps/api/src/lib/lift-detection/index.ts
+++ b/apps/api/src/lib/lift-detection/index.ts
@@ -1,0 +1,20 @@
+export {
+  DETECTOR_VERSION,
+  DEFAULT_OPTIONS,
+  KINEMATIC_ONLY_OPTIONS,
+  pointsFromStream,
+  detectLiftSegments,
+  computeAdjustedMetrics,
+  haversineMeters,
+  distanceToLiftLineMeters,
+} from './detector';
+export type {
+  RidePoint,
+  LiftLine,
+  DetectedLiftSegment,
+  DetectionOptions,
+  AdjustedRideMetrics,
+} from './detector';
+
+export { getLiftLines, cellKeysForPoints, buildOverpassQuery, parseOverpassAerialways } from './overpass';
+export type { LiftLinesResult } from './overpass';

--- a/apps/api/src/lib/lift-detection/overpass.test.ts
+++ b/apps/api/src/lib/lift-detection/overpass.test.ts
@@ -1,0 +1,208 @@
+process.env.OVERPASS_MIN_INTERVAL_MS = '1'; // keep multi-fetch tests fast
+
+jest.mock('../prisma', () => ({
+  prisma: {
+    overpassCache: {
+      findMany: jest.fn(),
+      upsert: jest.fn(),
+    },
+  },
+}));
+
+import { getLiftLines, cellKeysForPoints, buildOverpassQuery, parseOverpassAerialways } from './overpass';
+import { prisma } from '../prisma';
+
+const mockFindMany = prisma.overpassCache.findMany as jest.Mock;
+const mockUpsert = prisma.overpassCache.upsert as jest.Mock;
+
+const LINE = {
+  id: '99',
+  name: 'Summit Express',
+  kind: 'chair_lift',
+  coordinates: [
+    { lat: 45.51, lng: -122.02 },
+    { lat: 45.52, lng: -122.01 },
+  ],
+};
+
+// All within the single 0.05° cell whose SW corner is (45.50, -122.05).
+const IN_CELL_POINTS = [
+  { lat: 45.51, lng: -122.02 },
+  { lat: 45.52, lng: -122.01 },
+];
+
+const overpassBody = (elements: unknown[]) =>
+  ({ ok: true, status: 200, json: async () => ({ elements }) } as Response);
+
+describe('cellKeysForPoints', () => {
+  it('maps a compact ride to its single covering cell', () => {
+    expect(cellKeysForPoints(IN_CELL_POINTS)).toEqual(['45.50,-122.05']);
+  });
+
+  it('covers a bbox spanning cell boundaries with every overlapped cell', () => {
+    const keys = cellKeysForPoints([
+      { lat: 45.49, lng: -122.02 },
+      { lat: 45.51, lng: -122.07 },
+    ]);
+    expect(keys.sort()).toEqual(
+      ['45.45,-122.10', '45.45,-122.05', '45.50,-122.10', '45.50,-122.05'].sort()
+    );
+  });
+});
+
+describe('buildOverpassQuery', () => {
+  it('queries aerialway ways inside the cell bounds with geometry output', () => {
+    const q = buildOverpassQuery('45.50,-122.05');
+    expect(q).toContain('way["aerialway"](45.5,-122.05,45.55,-122)');
+    expect(q).toContain('out geom;');
+  });
+});
+
+describe('parseOverpassAerialways', () => {
+  it('keeps only multi-point geometries and normalizes fields', () => {
+    const lines = parseOverpassAerialways({
+      elements: [
+        {
+          id: 99,
+          tags: { aerialway: 'chair_lift', name: 'Summit Express' },
+          geometry: [
+            { lat: 45.51, lon: -122.02 },
+            { lat: 45.52, lon: -122.01 },
+          ],
+        },
+        { id: 100, tags: { aerialway: 'gondola' }, geometry: [{ lat: 45.5, lon: -122.0 }] },
+        { id: 101, tags: { aerialway: 'gondola' } },
+      ],
+    });
+    expect(lines).toEqual([LINE]);
+  });
+});
+
+describe('getLiftLines', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  it('serves a fresh cache hit without touching Overpass', async () => {
+    mockFindMany.mockResolvedValueOnce([
+      { cellKey: '45.50,-122.05', payload: [LINE], isEmpty: false, fetchedAt: new Date() },
+    ]);
+
+    const result = await getLiftLines(IN_CELL_POINTS);
+
+    expect(result).toEqual({ geometryAvailable: true, liftLines: [LINE] });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('serves a fresh negative-cache hit (isEmpty) without fetching', async () => {
+    mockFindMany.mockResolvedValueOnce([
+      { cellKey: '45.50,-122.05', payload: [], isEmpty: true, fetchedAt: new Date() },
+    ]);
+
+    const result = await getLiftLines(IN_CELL_POINTS);
+
+    expect(result).toEqual({ geometryAvailable: true, liftLines: [] });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('fetches a missing cell, caches the parsed lines, and returns them', async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      overpassBody([
+        {
+          id: 99,
+          tags: { aerialway: 'chair_lift', name: 'Summit Express' },
+          geometry: [
+            { lat: 45.51, lon: -122.02 },
+            { lat: 45.52, lon: -122.01 },
+          ],
+        },
+      ])
+    );
+
+    const result = await getLiftLines(IN_CELL_POINTS);
+
+    expect(result.geometryAvailable).toBe(true);
+    expect(result.liftLines).toEqual([LINE]);
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.method).toBe('POST');
+    expect(decodeURIComponent(init.body)).toContain('way["aerialway"]');
+    expect(init.headers['User-Agent']).toContain('loam-logger');
+
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { cellKey: '45.50,-122.05' },
+        create: expect.objectContaining({ isEmpty: false, payload: [LINE] }),
+      })
+    );
+  });
+
+  it('negative-caches an empty Overpass result', async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+    (global.fetch as jest.Mock).mockResolvedValueOnce(overpassBody([]));
+
+    const result = await getLiftLines(IN_CELL_POINTS);
+
+    expect(result).toEqual({ geometryAvailable: true, liftLines: [] });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ isEmpty: true, payload: [] }),
+      })
+    );
+  });
+
+  it('refreshes a stale cache entry', async () => {
+    const stale = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000);
+    mockFindMany.mockResolvedValueOnce([
+      { cellKey: '45.50,-122.05', payload: [], isEmpty: true, fetchedAt: stale },
+    ]);
+    (global.fetch as jest.Mock).mockResolvedValueOnce(overpassBody([]));
+
+    await getLiftLines(IN_CELL_POINTS);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('degrades without throwing when Overpass fails, and stops after the first failure', async () => {
+    // Two cells missing from cache.
+    mockFindMany.mockResolvedValueOnce([]);
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await getLiftLines([
+      { lat: 45.49, lng: -122.02 },
+      { lat: 45.51, lng: -122.02 },
+    ]);
+
+    expect(result.geometryAvailable).toBe(false);
+    expect(result.liftLines).toEqual([]);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a stale entry for a cell whose refresh failed', async () => {
+    const stale = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000);
+    mockFindMany.mockResolvedValueOnce([
+      { cellKey: '45.50,-122.05', payload: [LINE], isEmpty: false, fetchedAt: stale },
+    ]);
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('504'));
+
+    const result = await getLiftLines(IN_CELL_POINTS);
+
+    expect(result.geometryAvailable).toBe(false);
+    expect(result.liftLines).toEqual([LINE]);
+  });
+
+  it('skips the geometry layer for oversized bounding boxes', async () => {
+    const result = await getLiftLines([
+      { lat: 44.0, lng: -122.0 },
+      { lat: 45.0, lng: -121.0 },
+    ]);
+
+    expect(result).toEqual({ geometryAvailable: false, liftLines: [] });
+    expect(mockFindMany).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/lib/lift-detection/overpass.ts
+++ b/apps/api/src/lib/lift-detection/overpass.ts
@@ -1,0 +1,214 @@
+/**
+ * OpenStreetMap aerialway lookup for Layer A, cached per grid cell in the
+ * OverpassCache table (WeatherCache/GeoCache precedent).
+ *
+ * Overpass is a free, rate-limited, community-run service, so this module is
+ * strictly best-effort: it never throws. When a live query fails, callers get
+ * `geometryAvailable: false` plus whatever cached lines exist, and detection
+ * degrades to kinematic-only (plan §3.2).
+ */
+
+import { prisma } from '../prisma';
+import { logger } from '../logger';
+import type { LiftLine, RidePoint } from './detector';
+
+const OVERPASS_API_BASE =
+  process.env.OVERPASS_API_BASE || 'https://overpass-api.de/api/interpreter';
+// Identify ourselves per Overpass usage policy.
+const USER_AGENT = 'loam-logger (component wear tracking; lift detection)';
+
+const CELL_SIZE_DEG = 0.05;
+// Lift geometry changes on a scale of years; refresh lazily past this age.
+const FRESH_MS = 180 * 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 10_000;
+// A park ride is spatially compact. A bbox spanning more cells than this is a
+// tour, not a park day; skip the geometry layer rather than hammer Overpass.
+const MAX_CELLS = 12;
+
+// Per-process courtesy throttle, same pattern (and caveats) as open-meteo.ts:
+// with one API replica this serializes all Overpass traffic app-wide.
+const MIN_INTERVAL_MS = Number(process.env.OVERPASS_MIN_INTERVAL_MS) || 1000;
+let lastRequest = 0;
+let mutex: Promise<void> = Promise.resolve();
+
+const acquireSlot = async (): Promise<void> => {
+  const myTurn = mutex;
+  let release!: () => void;
+  mutex = new Promise((resolve) => {
+    release = resolve;
+  });
+  await myTurn;
+  const elapsed = Date.now() - lastRequest;
+  if (elapsed < MIN_INTERVAL_MS) {
+    await new Promise((r) => setTimeout(r, MIN_INTERVAL_MS - elapsed));
+  }
+  lastRequest = Date.now();
+  release();
+};
+
+export interface LiftLinesResult {
+  /**
+   * True when every cell covering the ride was resolved from cache or a live
+   * query. False means Overpass was unavailable (or the ride was too large to
+   * query) and lift lines may be incomplete — detection should require the
+   * stricter kinematic-only thresholds and persist geometryScore = null.
+   */
+  geometryAvailable: boolean;
+  liftLines: LiftLine[];
+}
+
+/** Grid-cell keys (southwest corner, 2dp) covering the points' bounding box. */
+export function cellKeysForPoints(points: Array<Pick<RidePoint, 'lat' | 'lng'>>): string[] {
+  let south = Infinity;
+  let north = -Infinity;
+  let west = Infinity;
+  let east = -Infinity;
+  for (const p of points) {
+    if (p.lat < south) south = p.lat;
+    if (p.lat > north) north = p.lat;
+    if (p.lng < west) west = p.lng;
+    if (p.lng > east) east = p.lng;
+  }
+
+  const keys: string[] = [];
+  const latStart = Math.floor(south / CELL_SIZE_DEG);
+  const latEnd = Math.floor(north / CELL_SIZE_DEG);
+  const lngStart = Math.floor(west / CELL_SIZE_DEG);
+  const lngEnd = Math.floor(east / CELL_SIZE_DEG);
+  for (let latIdx = latStart; latIdx <= latEnd; latIdx++) {
+    for (let lngIdx = lngStart; lngIdx <= lngEnd; lngIdx++) {
+      keys.push(`${(latIdx * CELL_SIZE_DEG).toFixed(2)},${(lngIdx * CELL_SIZE_DEG).toFixed(2)}`);
+    }
+  }
+  return keys;
+}
+
+function cellBounds(cellKey: string): { south: number; west: number; north: number; east: number } {
+  const [south, west] = cellKey.split(',').map(Number);
+  return { south, west, north: south + CELL_SIZE_DEG, east: west + CELL_SIZE_DEG };
+}
+
+export function buildOverpassQuery(cellKey: string): string {
+  const { south, west, north, east } = cellBounds(cellKey);
+  return `[out:json][timeout:25];
+way["aerialway"](${south},${west},${north},${east});
+out geom;`;
+}
+
+/** Parses the `out geom` response into LiftLine records. */
+export function parseOverpassAerialways(response: {
+  elements?: Array<{
+    id: number;
+    tags?: Record<string, string>;
+    geometry?: Array<{ lat: number; lon: number }>;
+  }>;
+}): LiftLine[] {
+  return (response.elements ?? [])
+    .filter((el) => el.geometry && el.geometry.length > 1)
+    .map((el) => ({
+      id: String(el.id),
+      name: el.tags?.name,
+      kind: el.tags?.aerialway ?? 'unknown',
+      coordinates: el.geometry!.map((g) => ({ lat: g.lat, lng: g.lon })),
+    }));
+}
+
+async function fetchCell(cellKey: string): Promise<LiftLine[]> {
+  await acquireSlot();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(OVERPASS_API_BASE, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'User-Agent': USER_AGENT,
+      },
+      body: `data=${encodeURIComponent(buildOverpassQuery(cellKey))}`,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if ((err as { name?: string }).name === 'AbortError') {
+      throw new Error(`Overpass request timed out after ${FETCH_TIMEOUT_MS}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+  if (!res.ok) {
+    throw new Error(`Overpass request failed: ${res.status}`);
+  }
+  return parseOverpassAerialways(await res.json());
+}
+
+/**
+ * Lift lines near a ride, from cache where fresh, from Overpass otherwise.
+ * Never throws.
+ */
+export async function getLiftLines(
+  points: Array<Pick<RidePoint, 'lat' | 'lng'>>
+): Promise<LiftLinesResult> {
+  const cells = cellKeysForPoints(points);
+  if (cells.length === 0) {
+    return { geometryAvailable: false, liftLines: [] };
+  }
+  if (cells.length > MAX_CELLS) {
+    logger.info(
+      { cellCount: cells.length, max: MAX_CELLS },
+      '[Overpass] Ride bbox too large for geometry layer, running kinematic-only'
+    );
+    return { geometryAvailable: false, liftLines: [] };
+  }
+
+  const byId = new Map<string, LiftLine>();
+  let geometryAvailable = true;
+
+  let cached: Array<{ cellKey: string; payload: unknown; isEmpty: boolean; fetchedAt: Date }>;
+  try {
+    cached = await prisma.overpassCache.findMany({ where: { cellKey: { in: cells } } });
+  } catch (err) {
+    logger.warn({ err }, '[Overpass] Cache read failed');
+    cached = [];
+  }
+  const cachedByKey = new Map(cached.map((c) => [c.cellKey, c]));
+
+  for (const cellKey of cells) {
+    const entry = cachedByKey.get(cellKey);
+    const isFresh = entry && Date.now() - entry.fetchedAt.getTime() < FRESH_MS;
+    if (entry && isFresh) {
+      if (!entry.isEmpty) {
+        for (const line of entry.payload as LiftLine[]) byId.set(line.id, line);
+      }
+      continue;
+    }
+
+    // Once one live query fails, assume Overpass is down and stop trying —
+    // stale cache (if any) is better than hammering a struggling service.
+    if (!geometryAvailable) {
+      if (entry && !entry.isEmpty) {
+        for (const line of entry.payload as LiftLine[]) byId.set(line.id, line);
+      }
+      continue;
+    }
+
+    try {
+      const lines = await fetchCell(cellKey);
+      for (const line of lines) byId.set(line.id, line);
+      await prisma.overpassCache.upsert({
+        where: { cellKey },
+        create: { cellKey, payload: lines as object[], isEmpty: lines.length === 0 },
+        update: { payload: lines as object[], isEmpty: lines.length === 0, fetchedAt: new Date() },
+      });
+    } catch (err) {
+      logger.warn({ cellKey, err }, '[Overpass] Cell fetch failed, degrading to kinematic-only');
+      geometryAvailable = false;
+      // A stale entry for this cell still beats nothing.
+      if (entry && !entry.isEmpty) {
+        for (const line of entry.payload as LiftLine[]) byId.set(line.id, line);
+      }
+    }
+  }
+
+  return { geometryAvailable, liftLines: [...byId.values()] };
+}

--- a/apps/api/src/lib/queue/index.ts
+++ b/apps/api/src/lib/queue/index.ts
@@ -11,5 +11,8 @@ export type { NotificationJobName, NotificationJobData } from './notification.qu
 export { getWeatherQueue, closeWeatherQueue, enqueueWeatherJob, buildWeatherJobId } from './weather.queue';
 export type { WeatherJobName, WeatherJobData, EnqueueWeatherResult } from './weather.queue';
 
+export { getLiftQueue, closeLiftQueue, enqueueLiftDetectionJob, buildLiftJobId } from './lift.queue';
+export type { LiftJobName, LiftJobData, EnqueueLiftResult } from './lift.queue';
+
 // Connection
 export { getQueueConnection } from './connection';

--- a/apps/api/src/lib/queue/lift.queue.ts
+++ b/apps/api/src/lib/queue/lift.queue.ts
@@ -1,0 +1,66 @@
+import { Queue } from 'bullmq';
+import { getQueueConnection } from './connection';
+
+const SECONDS = 1000;
+const INITIAL_RETRY_DELAY_MS = 10 * SECONDS;
+const MAX_RETRY_ATTEMPTS = 4;
+const COMPLETED_JOBS_TO_KEEP = 50;
+const FAILED_JOBS_TO_KEEP = 100;
+// Below sync but alongside weather: enrichment, never latency-sensitive.
+const LOW_PRIORITY = 10;
+
+export type LiftJobName = 'detectLifts';
+
+export type LiftJobData = {
+  rideId: string;
+};
+
+let liftQueue: Queue<LiftJobData, void, LiftJobName> | null = null;
+
+export function getLiftQueue(): Queue<LiftJobData, void, LiftJobName> {
+  if (!liftQueue) {
+    liftQueue = new Queue<LiftJobData, void, LiftJobName>('lift', {
+      connection: getQueueConnection(),
+      defaultJobOptions: {
+        attempts: MAX_RETRY_ATTEMPTS,
+        backoff: { type: 'exponential', delay: INITIAL_RETRY_DELAY_MS },
+        priority: LOW_PRIORITY,
+        removeOnComplete: COMPLETED_JOBS_TO_KEEP,
+        removeOnFail: FAILED_JOBS_TO_KEEP,
+      },
+    });
+  }
+  return liftQueue;
+}
+
+export function buildLiftJobId(rideId: string): string {
+  return `detectLifts_${rideId}`;
+}
+
+export type EnqueueLiftResult =
+  | { status: 'queued'; jobId: string }
+  | { status: 'already_queued'; jobId: string };
+
+// Same idempotency posture as enqueueWeatherJob: the static jobId makes `add`
+// idempotent at the Redis level; the existence check only refines the return
+// status and is best-effort under concurrency.
+export async function enqueueLiftDetectionJob(data: LiftJobData): Promise<EnqueueLiftResult> {
+  const queue = getLiftQueue();
+  const jobId = buildLiftJobId(data.rideId);
+  const existing = await queue.getJob(jobId);
+  if (existing) {
+    const state = await existing.getState();
+    if (state !== 'completed' && state !== 'failed' && state !== 'unknown') {
+      return { status: 'already_queued', jobId };
+    }
+  }
+  await queue.add('detectLifts', data, { jobId });
+  return { status: 'queued', jobId };
+}
+
+export async function closeLiftQueue(): Promise<void> {
+  if (liftQueue) {
+    await liftQueue.close();
+    liftQueue = null;
+  }
+}

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -222,6 +222,8 @@ export const ADMIN_RATE_LIMITS = {
   bulkEmail: 60 * SECONDS,
   /** Waitlist import cooldown: 60 seconds per admin (prevents spam) */
   importWaitlist: 60 * SECONDS,
+  /** Lift analysis cooldown: 5 seconds per target ride (prevents duplicate enqueue spam) */
+  liftAnalyze: 5 * SECONDS,
 } as const;
 
 /**

--- a/apps/api/src/lib/strava-streams.test.ts
+++ b/apps/api/src/lib/strava-streams.test.ts
@@ -1,0 +1,87 @@
+import { fetchStravaStreams } from './strava-streams';
+
+const okResponse = (body: unknown) =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response);
+
+const errorResponse = (status: number, text = '') =>
+  ({
+    ok: false,
+    status,
+    text: async () => text,
+  } as Response);
+
+describe('fetchStravaStreams', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  it('requests the full stream key set with key_by_type and bearer auth', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(okResponse({}));
+
+    await fetchStravaStreams('token-1', '12345');
+
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toContain('/activities/12345/streams');
+    expect(url).toContain('keys=time,latlng,altitude,velocity_smooth,cadence,heartrate,moving');
+    expect(url).toContain('key_by_type=true');
+    expect(init.headers.Authorization).toBe('Bearer token-1');
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('returns no_streams on 404 (manual activity)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(errorResponse(404));
+
+    await expect(fetchStravaStreams('t', '1')).resolves.toEqual({ status: 'no_streams' });
+  });
+
+  it('returns no_streams when time or latlng is missing (indoor ride)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      okResponse({
+        time: { data: [0, 1, 2] },
+        // no latlng stream
+        heartrate: { data: [120, 121, 122] },
+      })
+    );
+
+    await expect(fetchStravaStreams('t', '1')).resolves.toEqual({ status: 'no_streams' });
+  });
+
+  it('throws on transient errors so the queue can retry', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(errorResponse(429, 'Rate Limit Exceeded'));
+
+    await expect(fetchStravaStreams('t', '1')).rejects.toThrow('Strava streams API error: 429');
+  });
+
+  it('normalizes streams: velocity_smooth renamed, optional keys only when present', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      okResponse({
+        time: { data: [0, 1, 2] },
+        latlng: { data: [[45.0, -122.0], [45.001, -122.0], [45.002, -122.0]] },
+        altitude: { data: [100, 105, 110] },
+        velocity_smooth: { data: [2.5, 2.6, 2.7] },
+        moving: { data: [true, true, true] },
+        // cadence/heartrate absent (no sensors)
+      })
+    );
+
+    const result = await fetchStravaStreams('t', '1');
+
+    expect(result).toEqual({
+      status: 'ok',
+      pointCount: 3,
+      data: {
+        time: [0, 1, 2],
+        latlng: [[45.0, -122.0], [45.001, -122.0], [45.002, -122.0]],
+        altitude: [100, 105, 110],
+        velocity: [2.5, 2.6, 2.7],
+        moving: [true, true, true],
+      },
+    });
+    expect((result as { data: object }).data).not.toHaveProperty('cadence');
+    expect((result as { data: object }).data).not.toHaveProperty('heartrate');
+  });
+});

--- a/apps/api/src/lib/strava-streams.ts
+++ b/apps/api/src/lib/strava-streams.ts
@@ -1,0 +1,98 @@
+import { logger } from './logger';
+
+// Full-resolution per-point streams for one activity. Cadence/heartrate/moving
+// cost nothing extra to request and are needed by lift detection (cadence
+// absence is a kinematic signal; `moving` lets deltas count only points Strava
+// considered moving).
+const STREAM_KEYS = 'time,latlng,altitude,velocity_smooth,cadence,heartrate,moving';
+const FETCH_TIMEOUT_MS = 15_000;
+
+type StravaStream = {
+  data: unknown[];
+  series_type?: string;
+  original_size?: number;
+  resolution?: string;
+};
+
+type StravaStreamsResponse = Record<string, StravaStream | undefined>;
+
+// Parallel index-aligned arrays; the persisted shape of RideStream.data.
+export type NormalizedStreams = {
+  time: number[]; // seconds since activity start
+  latlng: [number, number][];
+  altitude?: number[];
+  velocity?: number[]; // m/s (Strava velocity_smooth)
+  cadence?: number[];
+  heartrate?: number[];
+  moving?: boolean[];
+};
+
+export type StravaStreamsResult =
+  | { status: 'ok'; pointCount: number; data: NormalizedStreams }
+  // Activity has no usable streams (manual entry, no-GPS upload, 404).
+  // Terminal for this activity — do not retry.
+  | { status: 'no_streams' };
+
+/**
+ * Fetch raw streams for a Strava activity. Throws on transient failures
+ * (network, 5xx, 429, timeout) so the caller's queue can retry; returns
+ * `no_streams` for activities that will never have per-point data.
+ */
+export async function fetchStravaStreams(
+  accessToken: string,
+  stravaActivityId: string
+): Promise<StravaStreamsResult> {
+  const url =
+    `https://www.strava.com/api/v3/activities/${stravaActivityId}/streams` +
+    `?keys=${STREAM_KEYS}&key_by_type=true`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json',
+      },
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (response.status === 404) {
+    return { status: 'no_streams' };
+  }
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Strava streams API error: ${response.status} ${text}`);
+  }
+
+  const payload = (await response.json()) as StravaStreamsResponse;
+
+  const time = payload.time?.data as number[] | undefined;
+  const latlng = payload.latlng?.data as [number, number][] | undefined;
+
+  // Streams without a time base or GPS track can't be lift-analyzed and are
+  // not worth storing (indoor/trainer rides).
+  if (!time?.length || !latlng?.length) {
+    logger.debug({ stravaActivityId }, '[StravaStreams] No time/latlng stream, skipping');
+    return { status: 'no_streams' };
+  }
+
+  const data: NormalizedStreams = { time, latlng };
+  const altitude = payload.altitude?.data as number[] | undefined;
+  const velocity = payload.velocity_smooth?.data as number[] | undefined;
+  const cadence = payload.cadence?.data as number[] | undefined;
+  const heartrate = payload.heartrate?.data as number[] | undefined;
+  const moving = payload.moving?.data as boolean[] | undefined;
+  if (altitude?.length) data.altitude = altitude;
+  if (velocity?.length) data.velocity = velocity;
+  if (cadence?.length) data.cadence = cadence;
+  if (heartrate?.length) data.heartrate = heartrate;
+  if (moving?.length) data.moving = moving;
+
+  return { status: 'ok', pointCount: time.length, data };
+}

--- a/apps/api/src/routes/admin.lift.test.ts
+++ b/apps/api/src/routes/admin.lift.test.ts
@@ -1,0 +1,259 @@
+// Mock dependencies before imports
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    ride: { count: jest.fn(), findMany: jest.fn(), findUnique: jest.fn(), update: jest.fn() },
+    rideStream: { count: jest.fn() },
+  },
+}));
+
+jest.mock('../auth/adminMiddleware', () => ({
+  requireAdmin: jest.fn((_req, _res, next) => next()),
+}));
+
+jest.mock('../lib/rate-limit', () => ({
+  checkAdminRateLimit: jest.fn(),
+}));
+
+jest.mock('../lib/queue', () => ({
+  enqueueLiftDetectionJob: jest.fn(),
+}));
+
+jest.mock('../lib/logger', () => ({
+  logError: jest.fn(),
+  logger: { warn: jest.fn(), info: jest.fn(), debug: jest.fn(), error: jest.fn() },
+}));
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import adminLiftRouter from './admin.lift';
+import { prisma } from '../lib/prisma';
+import { checkAdminRateLimit } from '../lib/rate-limit';
+import { enqueueLiftDetectionJob } from '../lib/queue';
+
+const mockRideCount = prisma.ride.count as jest.Mock;
+const mockRideFindMany = prisma.ride.findMany as jest.Mock;
+const mockRideFindUnique = prisma.ride.findUnique as jest.Mock;
+const mockRideUpdate = prisma.ride.update as jest.Mock;
+const mockStreamCount = prisma.rideStream.count as jest.Mock;
+const mockRateLimit = checkAdminRateLimit as jest.Mock;
+const mockEnqueue = enqueueLiftDetectionJob as jest.Mock;
+
+const RIDE_ID = '11111111-2222-4333-8444-555555555555';
+
+describe('Admin lift validation routes', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/admin/lift', adminLiftRouter);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRateLimit.mockResolvedValue({ allowed: true, redisAvailable: true });
+  });
+
+  describe('GET /report', () => {
+    const analyzedRide = {
+      id: RIDE_ID,
+      startTime: new Date('2026-07-12T16:00:00Z'),
+      location: 'Whistler, BC',
+      rideType: 'MountainBikeRide',
+      durationSeconds: 14400,
+      distanceMeters: 42000,
+      elevationGainMeters: 2100,
+      liftDurationSeconds: 5400,
+      liftElevationGainMeters: 1800,
+      liftDistanceMeters: 9000,
+      liftDetectorVersion: 1,
+      user: { email: 'rider@example.com' },
+      segments: [
+        {
+          id: 'seg-1',
+          kind: 'LIFT',
+          startTime: new Date('2026-07-12T16:10:00Z'),
+          endTime: new Date('2026-07-12T16:22:00Z'),
+          durationSeconds: 720,
+          elevationGainMeters: 380,
+          distanceMeters: 1800,
+          confidence: 0.96,
+          kinematicScore: 0.91,
+          geometryScore: 0.99,
+          liftName: 'Fitzsimmons Express',
+          liftOsmId: '123',
+          detectorVersion: 1,
+        },
+      ],
+    };
+
+    it('returns summary counts and per-ride segment rows', async () => {
+      mockRideCount
+        .mockResolvedValueOnce(12) // analyzed
+        .mockResolvedValueOnce(3) // with lift
+        .mockResolvedValueOnce(2); // pending
+      mockStreamCount.mockResolvedValueOnce(15);
+      mockRideFindMany.mockResolvedValueOnce([analyzedRide]);
+
+      const res = await request(app).get('/api/admin/lift/report');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.summary).toEqual({
+        analyzedCount: 12,
+        withLiftCount: 3,
+        streamCount: 15,
+        pendingCount: 2,
+      });
+      expect(res.body.data.rides).toHaveLength(1);
+      const row = res.body.data.rides[0];
+      expect(row.rideId).toBe(RIDE_ID);
+      expect(row.userEmail).toBe('rider@example.com');
+      expect(row.segmentCount).toBe(1);
+      expect(row.liftDeltas).toEqual({
+        durationSeconds: 5400,
+        elevationGainMeters: 1800,
+        distanceMeters: 9000,
+      });
+      expect(row.segments[0]).toMatchObject({
+        liftName: 'Fitzsimmons Express',
+        confidence: 0.96,
+        geometryScore: 0.99,
+        startTime: '2026-07-12T16:10:00.000Z',
+      });
+    });
+
+    it('filters to analyzed rides only, honoring since and withSegmentsOnly', async () => {
+      mockRideCount.mockResolvedValue(0);
+      mockStreamCount.mockResolvedValue(0);
+      mockRideFindMany.mockResolvedValueOnce([]);
+
+      const res = await request(app).get(
+        '/api/admin/lift/report?since=2026-07-01&withSegmentsOnly=true&limit=10'
+      );
+
+      expect(res.status).toBe(200);
+      const findArgs = mockRideFindMany.mock.calls[0][0];
+      expect(findArgs.where.liftDetectorVersion).toEqual({ not: null });
+      expect(findArgs.where.startTime.gte).toEqual(new Date('2026-07-01'));
+      expect(findArgs.where.segments).toEqual({ some: {} });
+      expect(findArgs.take).toBe(10);
+    });
+
+    it('rejects an invalid since date', async () => {
+      const res = await request(app).get('/api/admin/lift/report?since=not-a-date');
+      expect(res.status).toBe(400);
+    });
+
+    it('caps limit at 200', async () => {
+      mockRideCount.mockResolvedValue(0);
+      mockStreamCount.mockResolvedValue(0);
+      mockRideFindMany.mockResolvedValueOnce([]);
+
+      await request(app).get('/api/admin/lift/report?limit=9999');
+
+      expect(mockRideFindMany.mock.calls[0][0].take).toBe(200);
+    });
+  });
+
+  describe('POST /analyze/:rideId', () => {
+    const eligibleRide = {
+      id: RIDE_ID,
+      stravaActivityId: '9876',
+      startLat: 50.1,
+      startLng: -122.9,
+      liftDetectorVersion: 1,
+    };
+
+    it('enqueues analysis for an eligible ride', async () => {
+      mockRideFindUnique.mockResolvedValueOnce(eligibleRide);
+      mockEnqueue.mockResolvedValueOnce({ status: 'queued', jobId: `detectLifts_${RIDE_ID}` });
+
+      const res = await request(app).post(`/api/admin/lift/analyze/${RIDE_ID}`).send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual({ status: 'queued', jobId: `detectLifts_${RIDE_ID}` });
+      expect(mockRideUpdate).not.toHaveBeenCalled();
+    });
+
+    it('clears the detector version first when force is set', async () => {
+      mockRideFindUnique.mockResolvedValueOnce(eligibleRide);
+      mockEnqueue.mockResolvedValueOnce({ status: 'queued', jobId: 'j' });
+
+      const res = await request(app)
+        .post(`/api/admin/lift/analyze/${RIDE_ID}`)
+        .send({ force: true });
+
+      expect(res.status).toBe(200);
+      expect(mockRideUpdate).toHaveBeenCalledWith({
+        where: { id: RIDE_ID },
+        data: { liftDetectorVersion: null },
+      });
+    });
+
+    it('rejects invalid ids, unknown rides, and non-Strava rides', async () => {
+      const bad = await request(app).post('/api/admin/lift/analyze/not-a-uuid').send({});
+      expect(bad.status).toBe(400);
+
+      mockRideFindUnique.mockResolvedValueOnce(null);
+      const missing = await request(app).post(`/api/admin/lift/analyze/${RIDE_ID}`).send({});
+      expect(missing.status).toBe(404);
+
+      mockRideFindUnique.mockResolvedValueOnce({ ...eligibleRide, stravaActivityId: null });
+      const manual = await request(app).post(`/api/admin/lift/analyze/${RIDE_ID}`).send({});
+      expect(manual.status).toBe(400);
+
+      expect(mockEnqueue).not.toHaveBeenCalled();
+    });
+
+    it('applies the per-ride cooldown', async () => {
+      mockRateLimit.mockResolvedValueOnce({ allowed: false, retryAfter: 5, redisAvailable: true });
+
+      const res = await request(app).post(`/api/admin/lift/analyze/${RIDE_ID}`).send({});
+
+      expect(res.status).toBe(429);
+      expect(mockRateLimit).toHaveBeenCalledWith('liftAnalyze', RIDE_ID);
+      expect(mockRideFindUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /fixture/:rideId', () => {
+    it('exports stream, segments, and summary metrics', async () => {
+      mockRideFindUnique.mockResolvedValueOnce({
+        id: RIDE_ID,
+        startTime: new Date('2026-07-12T16:00:00Z'),
+        location: 'Whistler, BC',
+        durationSeconds: 14400,
+        distanceMeters: 42000,
+        elevationGainMeters: 2100,
+        liftDetectorVersion: 1,
+        stream: { source: 'strava', pointCount: 2, data: { time: [0, 5] } },
+        segments: [{ startIndex: 0, endIndex: 1, confidence: 0.9 }],
+      });
+
+      const res = await request(app).get(`/api/admin/lift/fixture/${RIDE_ID}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.expectedLiftCount).toBeNull();
+      expect(res.body.data.stream.pointCount).toBe(2);
+      expect(res.body.data.detectedAtExport.segments).toHaveLength(1);
+      expect(res.body.data.ride.location).toBe('Whistler, BC');
+    });
+
+    it('404s when the ride has no persisted stream', async () => {
+      mockRideFindUnique.mockResolvedValueOnce({
+        id: RIDE_ID,
+        startTime: new Date(),
+        location: null,
+        durationSeconds: 1,
+        distanceMeters: 1,
+        elevationGainMeters: 1,
+        liftDetectorVersion: null,
+        stream: null,
+        segments: [],
+      });
+
+      const res = await request(app).get(`/api/admin/lift/fixture/${RIDE_ID}`);
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/apps/api/src/routes/admin.lift.ts
+++ b/apps/api/src/routes/admin.lift.ts
@@ -1,0 +1,279 @@
+import { Router } from 'express';
+import { prisma } from '../lib/prisma';
+import { requireAdmin } from '../auth/adminMiddleware';
+import {
+  sendSuccess,
+  sendBadRequest,
+  sendNotFound,
+  sendInternalError,
+  sendTooManyRequests,
+} from '../lib/api-response';
+import { checkAdminRateLimit } from '../lib/rate-limit';
+import { enqueueLiftDetectionJob } from '../lib/queue';
+import { logError } from '../lib/logger';
+
+// Lift-detection validation surface (docs/plans/lift-detection-plan.md §5,
+// increment 3). Read-only report over shadow-mode results, plus the admin/dev
+// form of the analyze trigger used to seed known historical park rides into
+// the validation set. Nothing here changes user-visible metrics.
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const DEFAULT_REPORT_LIMIT = 50;
+const MAX_REPORT_LIMIT = 200;
+
+const router = Router();
+
+router.use(requireAdmin);
+
+/**
+ * GET /api/admin/lift/report
+ * Shadow-mode detection results for validation: summary counts plus per-ride
+ * rows with segments, scores, and deltas.
+ *
+ * Query params:
+ *   limit            max rides returned (default 50, cap 200)
+ *   since            ISO date; only rides starting on/after it
+ *   withSegmentsOnly 'true' to list only rides where lifts were detected
+ */
+router.get('/report', async (req, res) => {
+  try {
+    const limitRaw = Number(req.query.limit);
+    const limit = Number.isFinite(limitRaw)
+      ? Math.min(Math.max(Math.trunc(limitRaw), 1), MAX_REPORT_LIMIT)
+      : DEFAULT_REPORT_LIMIT;
+
+    let since: Date | undefined;
+    if (req.query.since !== undefined) {
+      since = new Date(String(req.query.since));
+      if (Number.isNaN(since.getTime())) {
+        return sendBadRequest(res, 'Invalid since date');
+      }
+    }
+
+    const withSegmentsOnly = req.query.withSegmentsOnly === 'true';
+
+    const analyzedWhere = {
+      liftDetectorVersion: { not: null },
+      ...(since ? { startTime: { gte: since } } : {}),
+    };
+
+    const [analyzedCount, withLiftCount, streamCount, pendingCount, rides] = await Promise.all([
+      prisma.ride.count({ where: analyzedWhere }),
+      prisma.ride.count({ where: { ...analyzedWhere, liftDurationSeconds: { gt: 0 } } }),
+      prisma.rideStream.count(),
+      // Stream persisted but never analyzed (e.g. missing altitude, or a
+      // detector-version bump re-queued them).
+      prisma.ride.count({ where: { stream: { isNot: null }, liftDetectorVersion: null } }),
+      prisma.ride.findMany({
+        where: {
+          ...analyzedWhere,
+          ...(withSegmentsOnly ? { segments: { some: {} } } : {}),
+        },
+        orderBy: { startTime: 'desc' },
+        take: limit,
+        select: {
+          id: true,
+          startTime: true,
+          location: true,
+          rideType: true,
+          durationSeconds: true,
+          distanceMeters: true,
+          elevationGainMeters: true,
+          liftDurationSeconds: true,
+          liftElevationGainMeters: true,
+          liftDistanceMeters: true,
+          liftDetectorVersion: true,
+          user: { select: { email: true } },
+          segments: {
+            orderBy: { startTime: 'asc' },
+            select: {
+              id: true,
+              kind: true,
+              startTime: true,
+              endTime: true,
+              durationSeconds: true,
+              elevationGainMeters: true,
+              distanceMeters: true,
+              confidence: true,
+              kinematicScore: true,
+              geometryScore: true,
+              liftName: true,
+              liftOsmId: true,
+              detectorVersion: true,
+            },
+          },
+        },
+      }),
+    ]);
+
+    return sendSuccess(res, {
+      summary: {
+        analyzedCount,
+        withLiftCount,
+        streamCount,
+        pendingCount,
+      },
+      rides: rides.map((ride) => ({
+        rideId: ride.id,
+        userEmail: ride.user.email,
+        startTime: ride.startTime.toISOString(),
+        location: ride.location,
+        rideType: ride.rideType,
+        raw: {
+          durationSeconds: ride.durationSeconds,
+          distanceMeters: ride.distanceMeters,
+          elevationGainMeters: ride.elevationGainMeters,
+        },
+        liftDeltas: {
+          durationSeconds: ride.liftDurationSeconds,
+          elevationGainMeters: ride.liftElevationGainMeters,
+          distanceMeters: ride.liftDistanceMeters,
+        },
+        detectorVersion: ride.liftDetectorVersion,
+        // The validation check is lap count: segments.length vs laps the
+        // rider remembers doing.
+        segmentCount: ride.segments.length,
+        segments: ride.segments.map((seg) => ({
+          ...seg,
+          startTime: seg.startTime.toISOString(),
+          endTime: seg.endTime.toISOString(),
+        })),
+      })),
+    });
+  } catch (error) {
+    logError('Admin lift report', error);
+    return sendInternalError(res, 'Failed to build lift report');
+  }
+});
+
+/**
+ * POST /api/admin/lift/analyze/:rideId
+ * Enqueue lift analysis for one ride — the admin/dev form of the
+ * mark-bike-park-ride path, used to seed known park rides for validation.
+ * Body: { force?: boolean } — re-analyze even if already at the current
+ * detector version (clears the version so the worker reruns).
+ */
+router.post('/analyze/:rideId', async (req, res) => {
+  try {
+    const { rideId } = req.params;
+    if (!UUID_REGEX.test(rideId)) {
+      return sendBadRequest(res, 'Invalid ride id');
+    }
+
+    const rateLimit = await checkAdminRateLimit('liftAnalyze', rideId);
+    if (!rateLimit.allowed) {
+      return sendTooManyRequests(res, 'Analysis recently requested for this ride', rateLimit.retryAfter);
+    }
+
+    const ride = await prisma.ride.findUnique({
+      where: { id: rideId },
+      select: {
+        id: true,
+        stravaActivityId: true,
+        startLat: true,
+        startLng: true,
+        liftDetectorVersion: true,
+      },
+    });
+
+    if (!ride) {
+      return sendNotFound(res, 'Ride not found');
+    }
+    if (!ride.stravaActivityId) {
+      return sendBadRequest(res, 'Ride is not Strava-sourced; lift analysis is Strava-only for now');
+    }
+    if (ride.startLat == null || ride.startLng == null) {
+      return sendBadRequest(res, 'Ride has no start coordinates');
+    }
+
+    if (req.body?.force === true && ride.liftDetectorVersion != null) {
+      await prisma.ride.update({
+        where: { id: rideId },
+        data: { liftDetectorVersion: null },
+      });
+    }
+
+    const result = await enqueueLiftDetectionJob({ rideId });
+    return sendSuccess(res, result);
+  } catch (error) {
+    logError('Admin lift analyze', error);
+    return sendInternalError(res, 'Failed to enqueue lift analysis');
+  }
+});
+
+/**
+ * GET /api/admin/lift/fixture/:rideId
+ * Export one analyzed ride (stream + segments + summary metrics) as JSON,
+ * to be saved under apps/api/src/lib/lift-detection/__fixtures__/ as a
+ * ground-truth detection test case.
+ */
+router.get('/fixture/:rideId', async (req, res) => {
+  try {
+    const { rideId } = req.params;
+    if (!UUID_REGEX.test(rideId)) {
+      return sendBadRequest(res, 'Invalid ride id');
+    }
+
+    const ride = await prisma.ride.findUnique({
+      where: { id: rideId },
+      select: {
+        id: true,
+        startTime: true,
+        location: true,
+        durationSeconds: true,
+        distanceMeters: true,
+        elevationGainMeters: true,
+        liftDetectorVersion: true,
+        stream: { select: { source: true, pointCount: true, data: true } },
+        segments: {
+          orderBy: { startTime: 'asc' },
+          select: {
+            startIndex: true,
+            endIndex: true,
+            durationSeconds: true,
+            elevationGainMeters: true,
+            distanceMeters: true,
+            confidence: true,
+            kinematicScore: true,
+            geometryScore: true,
+            liftName: true,
+            liftOsmId: true,
+            detectorVersion: true,
+          },
+        },
+      },
+    });
+
+    if (!ride) {
+      return sendNotFound(res, 'Ride not found');
+    }
+    if (!ride.stream) {
+      return sendNotFound(res, 'Ride has no persisted stream');
+    }
+
+    return sendSuccess(res, {
+      // Fill in observed ground truth (actual lap count etc.) by hand when
+      // saving this as a fixture.
+      expectedLiftCount: null,
+      notes: '',
+      ride: {
+        startTime: ride.startTime.toISOString(),
+        location: ride.location,
+        durationSeconds: ride.durationSeconds,
+        distanceMeters: ride.distanceMeters,
+        elevationGainMeters: ride.elevationGainMeters,
+      },
+      stream: ride.stream,
+      detectedAtExport: {
+        detectorVersion: ride.liftDetectorVersion,
+        segments: ride.segments,
+      },
+    });
+  } catch (error) {
+    logError('Admin lift fixture', error);
+    return sendInternalError(res, 'Failed to export fixture');
+  }
+});
+
+export default router;

--- a/apps/api/src/routes/auth.strava.ts
+++ b/apps/api/src/routes/auth.strava.ts
@@ -435,6 +435,11 @@ async function handleStravaDisconnect(userId: string): Promise<boolean> {
   }
 
   await prisma.$transaction(async (tx) => {
+    // Raw stream blobs are Strava data and go on disconnect; the rides and
+    // their derived metrics survive.
+    await tx.rideStream.deleteMany({
+      where: { ride: { userId, stravaActivityId: { not: null } } },
+    });
     await tx.userIntegration.updateMany({
       where: { userId, provider: 'STRAVA' },
       data: { revokedAt: new Date() },

--- a/apps/api/src/routes/webhooks.strava.ts
+++ b/apps/api/src/routes/webhooks.strava.ts
@@ -6,7 +6,7 @@ import { deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
 import { syncBikeComponentHours } from '../lib/component-hours';
 import { logError } from '../lib/logger';
 import { fireRideNotifications } from '../services/notification.service';
-import { enqueueWeatherJob } from '../lib/queue';
+import { enqueueWeatherJob, enqueueLiftDetectionJob } from '../lib/queue';
 import { isActiveSource } from '../lib/active-source';
 
 type Empty = Record<string, never>;
@@ -150,8 +150,15 @@ r.post<Empty, void, { athlete_id: number }>(
         select: { activeDataSource: true },
       });
 
-      // Delete tokens and account record
+      // Delete tokens and account record. Raw stream blobs go too (Strava data
+      // must not be retained past deauthorization) while the rides themselves
+      // and their derived metrics survive.
       await prisma.$transaction([
+        prisma.rideStream.deleteMany({
+          where: {
+            ride: { userId: userAccount.userId, stravaActivityId: { not: null } },
+          },
+        }),
         prisma.oauthToken.deleteMany({
           where: {
             userId: userAccount.userId,
@@ -406,6 +413,10 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
         if (activity.start_latlng) {
           enqueueWeatherJob({ rideId: syncedRideId }).catch((err) =>
             logError(`Strava Webhook weather enqueue ${syncedRideId}`, err)
+          );
+          // Fire-and-forget stream fetch for lift detection
+          enqueueLiftDetectionJob({ rideId: syncedRideId }).catch((err) =>
+            logError(`Strava Webhook lift enqueue ${syncedRideId}`, err)
           );
         }
       }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -48,6 +48,7 @@ import mockGarmin from './routes/mock.garmin';
 import onboardingRouter from './routes/onboarding';
 import publicRouter from './routes/public';
 import adminRouter from './routes/admin';
+import adminLiftRouter from './routes/admin.lift';
 import spokesRouter from './routes/spokes';
 import emailUnsubscribeRouter from './routes/email.unsubscribe';
 import { googleRouter, emailRouter, deleteAccountRouter, passwordRouter, attachUser, verifyCsrf } from './auth/index';
@@ -276,6 +277,7 @@ const startServer = async () => {
   app.use('/api', publicRouter);
   app.use('/api', emailUnsubscribeRouter);
   app.use('/api/admin', adminRouter);
+  app.use('/api/admin/lift', adminLiftRouter);
   app.use('/api/spokes', spokesRouter);
 
   app.use(webhooksGarmin);

--- a/apps/api/src/workers/index.ts
+++ b/apps/api/src/workers/index.ts
@@ -2,8 +2,9 @@ import { createSyncWorker, closeSyncWorker } from './sync.worker';
 import { createBackfillWorker, closeBackfillWorker } from './backfill.worker';
 import { createNotificationWorker, closeNotificationWorker } from './notification.worker';
 import { createWeatherWorker, closeWeatherWorker } from './weather.worker';
+import { createLiftWorker, closeLiftWorker } from './lift.worker';
 import { closeRedisConnection } from '../lib/redis';
-import { closeSyncQueue, closeBackfillQueue, closeNotificationQueue, closeWeatherQueue } from '../lib/queue';
+import { closeSyncQueue, closeBackfillQueue, closeNotificationQueue, closeWeatherQueue, closeLiftQueue } from '../lib/queue';
 
 /**
  * Start all BullMQ workers.
@@ -16,6 +17,7 @@ export function startWorkers(): void {
   createBackfillWorker();
   createNotificationWorker();
   createWeatherWorker();
+  createLiftWorker();
 
   console.log('[Workers] All workers started');
 }
@@ -37,12 +39,13 @@ export async function stopWorkers(): Promise<void> {
       closeBackfillWorker(),
       closeNotificationWorker(),
       closeWeatherWorker(),
+      closeLiftWorker(),
     ]);
 
     // Log any worker shutdown failures
     workerResults.forEach((result, index) => {
       if (result.status === 'rejected') {
-        const workerNames = ['SyncWorker', 'BackfillWorker', 'NotificationWorker', 'WeatherWorker'];
+        const workerNames = ['SyncWorker', 'BackfillWorker', 'NotificationWorker', 'WeatherWorker', 'LiftWorker'];
         console.error(`[Workers] Failed to close ${workerNames[index]}:`, result.reason);
       }
     });
@@ -53,12 +56,13 @@ export async function stopWorkers(): Promise<void> {
       closeBackfillQueue(),
       closeNotificationQueue(),
       closeWeatherQueue(),
+      closeLiftQueue(),
     ]);
 
     // Log any queue shutdown failures
     queueResults.forEach((result, index) => {
       if (result.status === 'rejected') {
-        const queueNames = ['SyncQueue', 'BackfillQueue', 'NotificationQueue', 'WeatherQueue'];
+        const queueNames = ['SyncQueue', 'BackfillQueue', 'NotificationQueue', 'WeatherQueue', 'LiftQueue'];
         console.error(`[Workers] Failed to close ${queueNames[index]}:`, result.reason);
       }
     });

--- a/apps/api/src/workers/lift.worker.test.ts
+++ b/apps/api/src/workers/lift.worker.test.ts
@@ -5,10 +5,16 @@ jest.mock('bullmq', () => ({ Worker: jest.fn() }));
 jest.mock('../lib/queue/connection', () => ({ getQueueConnection: jest.fn() }));
 jest.mock('@sentry/node', () => ({ captureException: jest.fn() }));
 
+const mockTx = {
+  rideSegment: { deleteMany: jest.fn(), createMany: jest.fn() },
+  ride: { update: jest.fn() },
+};
+
 jest.mock('../lib/prisma', () => ({
   prisma: {
     ride: { findUnique: jest.fn() },
     rideStream: { upsert: jest.fn() },
+    $transaction: jest.fn(async (fn: (tx: unknown) => Promise<void>) => fn(mockTx)),
   },
 }));
 
@@ -20,30 +26,77 @@ jest.mock('../lib/strava-streams', () => ({
   fetchStravaStreams: jest.fn(),
 }));
 
+jest.mock('../lib/lift-detection', () => ({
+  DETECTOR_VERSION: 1,
+  DEFAULT_OPTIONS: { openThreshold: 0.62 },
+  KINEMATIC_ONLY_OPTIONS: { openThreshold: 0.72 },
+  pointsFromStream: jest.fn(),
+  detectLiftSegments: jest.fn(),
+  getLiftLines: jest.fn(),
+}));
+
 import { processLiftJob } from './lift.worker';
 import { prisma } from '../lib/prisma';
 import { getValidStravaToken } from '../lib/strava-token';
 import { fetchStravaStreams } from '../lib/strava-streams';
+import {
+  DEFAULT_OPTIONS,
+  KINEMATIC_ONLY_OPTIONS,
+  pointsFromStream,
+  detectLiftSegments,
+  getLiftLines,
+} from '../lib/lift-detection';
 
 const mockFindUnique = prisma.ride.findUnique as jest.Mock;
-const mockUpsert = prisma.rideStream.upsert as jest.Mock;
+const mockStreamUpsert = prisma.rideStream.upsert as jest.Mock;
+const mockTransaction = prisma.$transaction as jest.Mock;
 const mockGetToken = getValidStravaToken as jest.Mock;
 const mockFetchStreams = fetchStravaStreams as jest.Mock;
+const mockPointsFromStream = pointsFromStream as jest.Mock;
+const mockDetect = detectLiftSegments as jest.Mock;
+const mockGetLiftLines = getLiftLines as jest.Mock;
 
 const makeJob = (rideId = 'ride-1') => ({ data: { rideId }, id: 'job-1' } as never);
+
+const RIDE_START = new Date('2026-07-01T09:00:00Z');
+const STREAM_DATA = { time: [0, 5], latlng: [[45, -122], [45.001, -122]], altitude: [1000, 1010] };
+const POINTS = [
+  { t: 0, lat: 45, lng: -122, ele: 1000 },
+  { t: 5, lat: 45.001, lng: -122, ele: 1010 },
+];
+const SEGMENT = {
+  startIndex: 10,
+  endIndex: 90,
+  startTimeOffsetSec: 50,
+  endTimeOffsetSec: 450,
+  durationSec: 400,
+  distanceMeters: 1600,
+  elevationGainMeters: 155.5,
+  confidence: 0.97,
+  kinematicScore: 0.95,
+  geometryScore: 0.98,
+  matchedLiftName: 'Summit Express',
+  matchedLiftId: 'way-99',
+};
 
 const baseRide = {
   id: 'ride-1',
   userId: 'user-1',
+  startTime: RIDE_START,
   stravaActivityId: '9876',
-  startLat: 45.1,
-  startLng: -122.3,
+  startLat: 45.0,
+  startLng: -122.0,
+  liftDetectorVersion: null,
   stream: null,
 };
 
 describe('processLiftJob', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => fn(mockTx));
+    mockGetLiftLines.mockResolvedValue({ geometryAvailable: true, liftLines: [] });
+    mockPointsFromStream.mockReturnValue(POINTS);
+    mockDetect.mockReturnValue([]);
   });
 
   it('skips when the ride does not exist', async () => {
@@ -52,87 +105,199 @@ describe('processLiftJob', () => {
     await processLiftJob(makeJob());
 
     expect(mockGetToken).not.toHaveBeenCalled();
-    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockTransaction).not.toHaveBeenCalled();
   });
 
-  it('skips non-Strava rides', async () => {
+  it('skips non-Strava rides and rides without coordinates', async () => {
     mockFindUnique.mockResolvedValueOnce({ ...baseRide, stravaActivityId: null });
-
     await processLiftJob(makeJob());
 
-    expect(mockGetToken).not.toHaveBeenCalled();
-    expect(mockUpsert).not.toHaveBeenCalled();
-  });
-
-  it('skips rides without coordinates', async () => {
     mockFindUnique.mockResolvedValueOnce({ ...baseRide, startLat: null, startLng: null });
-
     await processLiftJob(makeJob());
 
     expect(mockGetToken).not.toHaveBeenCalled();
-    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockTransaction).not.toHaveBeenCalled();
   });
 
-  it('skips when a stream is already persisted', async () => {
-    mockFindUnique.mockResolvedValueOnce({ ...baseRide, stream: { id: 'stream-1' } });
+  it('skips rides already analyzed at the current detector version', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      ...baseRide,
+      liftDetectorVersion: 1,
+      stream: { id: 'stream-1', data: STREAM_DATA },
+    });
+
+    await processLiftJob(makeJob());
+
+    expect(mockDetect).not.toHaveBeenCalled();
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('re-detects from the persisted stream without calling Strava when the version is stale', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      ...baseRide,
+      liftDetectorVersion: null,
+      stream: { id: 'stream-1', data: STREAM_DATA },
+    });
 
     await processLiftJob(makeJob());
 
     expect(mockGetToken).not.toHaveBeenCalled();
     expect(mockFetchStreams).not.toHaveBeenCalled();
+    expect(mockPointsFromStream).toHaveBeenCalledWith(STREAM_DATA);
+    expect(mockDetect).toHaveBeenCalled();
+    expect(mockTransaction).toHaveBeenCalled();
   });
 
-  it('skips (without throwing) when no valid token — user disconnected', async () => {
+  it('fetches and persists the stream first when none exists', async () => {
+    mockFindUnique.mockResolvedValueOnce(baseRide);
+    mockGetToken.mockResolvedValueOnce('token-1');
+    mockFetchStreams.mockResolvedValueOnce({ status: 'ok', pointCount: 2, data: STREAM_DATA });
+
+    await processLiftJob(makeJob());
+
+    expect(mockFetchStreams).toHaveBeenCalledWith('token-1', '9876');
+    expect(mockStreamUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { rideId: 'ride-1' },
+        create: expect.objectContaining({ source: 'strava', pointCount: 2, data: STREAM_DATA }),
+      })
+    );
+    expect(mockPointsFromStream).toHaveBeenCalledWith(STREAM_DATA);
+    expect(mockTransaction).toHaveBeenCalled();
+  });
+
+  it('skips without throwing when no valid token — user disconnected', async () => {
     mockFindUnique.mockResolvedValueOnce(baseRide);
     mockGetToken.mockResolvedValueOnce(null);
 
     await processLiftJob(makeJob());
 
     expect(mockFetchStreams).not.toHaveBeenCalled();
-    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockTransaction).not.toHaveBeenCalled();
   });
 
-  it('skips persisting when the activity has no usable streams', async () => {
+  it('stops after no_streams without persisting anything', async () => {
     mockFindUnique.mockResolvedValueOnce(baseRide);
     mockGetToken.mockResolvedValueOnce('token-1');
     mockFetchStreams.mockResolvedValueOnce({ status: 'no_streams' });
 
     await processLiftJob(makeJob());
 
-    expect(mockFetchStreams).toHaveBeenCalledWith('token-1', '9876');
-    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockStreamUpsert).not.toHaveBeenCalled();
+    expect(mockTransaction).not.toHaveBeenCalled();
   });
 
-  it('persists the stream on success', async () => {
-    const data = {
-      time: [0, 1],
-      latlng: [[45.1, -122.3], [45.101, -122.3]],
-      altitude: [100, 101],
-    };
-    mockFindUnique.mockResolvedValueOnce(baseRide);
-    mockGetToken.mockResolvedValueOnce('token-1');
-    mockFetchStreams.mockResolvedValueOnce({ status: 'ok', pointCount: 2, data });
+  it('leaves rides with no altitude series unanalyzed (detector version stays null)', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      ...baseRide,
+      stream: { id: 'stream-1', data: STREAM_DATA },
+    });
+    mockPointsFromStream.mockReturnValueOnce(null);
 
     await processLiftJob(makeJob());
 
-    expect(mockUpsert).toHaveBeenCalledTimes(1);
-    const call = mockUpsert.mock.calls[0][0];
-    expect(call.where).toEqual({ rideId: 'ride-1' });
-    expect(call.create).toEqual({
-      rideId: 'ride-1',
-      source: 'strava',
-      pointCount: 2,
-      data,
-    });
-    expect(call.update).toMatchObject({ source: 'strava', pointCount: 2, data });
+    expect(mockDetect).not.toHaveBeenCalled();
+    expect(mockTransaction).not.toHaveBeenCalled();
   });
 
-  it('propagates fetch errors so BullMQ can retry the job', async () => {
+  it('persists segments with times anchored to ride start, and delta sums on the ride', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      ...baseRide,
+      stream: { id: 'stream-1', data: STREAM_DATA },
+    });
+    mockDetect.mockReturnValueOnce([SEGMENT]);
+
+    await processLiftJob(makeJob());
+
+    expect(mockTx.rideSegment.deleteMany).toHaveBeenCalledWith({ where: { rideId: 'ride-1' } });
+    expect(mockTx.rideSegment.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          rideId: 'ride-1',
+          kind: 'LIFT',
+          startIndex: 10,
+          endIndex: 90,
+          startTime: new Date(RIDE_START.getTime() + 50 * 1000),
+          endTime: new Date(RIDE_START.getTime() + 450 * 1000),
+          confidence: 0.97,
+          geometryScore: 0.98,
+          kinematicScore: 0.95,
+          liftName: 'Summit Express',
+          liftOsmId: 'way-99',
+          durationSeconds: 400,
+          elevationGainMeters: 155.5,
+          distanceMeters: 1600,
+          detectorVersion: 1,
+        }),
+      ],
+    });
+    expect(mockTx.ride.update).toHaveBeenCalledWith({
+      where: { id: 'ride-1' },
+      data: {
+        liftDurationSeconds: 400,
+        liftElevationGainMeters: 155.5,
+        liftDistanceMeters: 1600,
+        liftDetectorVersion: 1,
+      },
+    });
+  });
+
+  it('records "analyzed, no lift" as zero deltas at the current version', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      ...baseRide,
+      stream: { id: 'stream-1', data: STREAM_DATA },
+    });
+    mockDetect.mockReturnValueOnce([]);
+
+    await processLiftJob(makeJob());
+
+    expect(mockTx.rideSegment.deleteMany).toHaveBeenCalled();
+    expect(mockTx.rideSegment.createMany).not.toHaveBeenCalled();
+    expect(mockTx.ride.update).toHaveBeenCalledWith({
+      where: { id: 'ride-1' },
+      data: {
+        liftDurationSeconds: 0,
+        liftElevationGainMeters: 0,
+        liftDistanceMeters: 0,
+        liftDetectorVersion: 1,
+      },
+    });
+  });
+
+  it('uses stricter options and nulls geometryScore when Overpass is unavailable', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      ...baseRide,
+      stream: { id: 'stream-1', data: STREAM_DATA },
+    });
+    mockGetLiftLines.mockResolvedValueOnce({ geometryAvailable: false, liftLines: [] });
+    mockDetect.mockReturnValueOnce([SEGMENT]);
+
+    await processLiftJob(makeJob());
+
+    expect(mockDetect).toHaveBeenCalledWith(POINTS, [], KINEMATIC_ONLY_OPTIONS);
+    const created = mockTx.rideSegment.createMany.mock.calls[0][0].data[0];
+    expect(created.geometryScore).toBeNull();
+  });
+
+  it('passes lift lines and default options when geometry is available', async () => {
+    const lines = [{ id: 'way-99', kind: 'chair_lift', coordinates: [] }];
+    mockFindUnique.mockResolvedValueOnce({
+      ...baseRide,
+      stream: { id: 'stream-1', data: STREAM_DATA },
+    });
+    mockGetLiftLines.mockResolvedValueOnce({ geometryAvailable: true, liftLines: lines });
+
+    await processLiftJob(makeJob());
+
+    expect(mockDetect).toHaveBeenCalledWith(POINTS, lines, DEFAULT_OPTIONS);
+  });
+
+  it('propagates stream-fetch errors so BullMQ can retry the job', async () => {
     mockFindUnique.mockResolvedValueOnce(baseRide);
     mockGetToken.mockResolvedValueOnce('token-1');
     mockFetchStreams.mockRejectedValueOnce(new Error('Strava streams API error: 500'));
 
     await expect(processLiftJob(makeJob())).rejects.toThrow('Strava streams API error: 500');
-    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockTransaction).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/workers/lift.worker.test.ts
+++ b/apps/api/src/workers/lift.worker.test.ts
@@ -1,0 +1,138 @@
+// Stop side-effectful imports (Sentry init, BullMQ Redis connection) from
+// firing just because the worker module is loaded.
+jest.mock('../instrument', () => ({}));
+jest.mock('bullmq', () => ({ Worker: jest.fn() }));
+jest.mock('../lib/queue/connection', () => ({ getQueueConnection: jest.fn() }));
+jest.mock('@sentry/node', () => ({ captureException: jest.fn() }));
+
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    ride: { findUnique: jest.fn() },
+    rideStream: { upsert: jest.fn() },
+  },
+}));
+
+jest.mock('../lib/strava-token', () => ({
+  getValidStravaToken: jest.fn(),
+}));
+
+jest.mock('../lib/strava-streams', () => ({
+  fetchStravaStreams: jest.fn(),
+}));
+
+import { processLiftJob } from './lift.worker';
+import { prisma } from '../lib/prisma';
+import { getValidStravaToken } from '../lib/strava-token';
+import { fetchStravaStreams } from '../lib/strava-streams';
+
+const mockFindUnique = prisma.ride.findUnique as jest.Mock;
+const mockUpsert = prisma.rideStream.upsert as jest.Mock;
+const mockGetToken = getValidStravaToken as jest.Mock;
+const mockFetchStreams = fetchStravaStreams as jest.Mock;
+
+const makeJob = (rideId = 'ride-1') => ({ data: { rideId }, id: 'job-1' } as never);
+
+const baseRide = {
+  id: 'ride-1',
+  userId: 'user-1',
+  stravaActivityId: '9876',
+  startLat: 45.1,
+  startLng: -122.3,
+  stream: null,
+};
+
+describe('processLiftJob', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('skips when the ride does not exist', async () => {
+    mockFindUnique.mockResolvedValueOnce(null);
+
+    await processLiftJob(makeJob());
+
+    expect(mockGetToken).not.toHaveBeenCalled();
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('skips non-Strava rides', async () => {
+    mockFindUnique.mockResolvedValueOnce({ ...baseRide, stravaActivityId: null });
+
+    await processLiftJob(makeJob());
+
+    expect(mockGetToken).not.toHaveBeenCalled();
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('skips rides without coordinates', async () => {
+    mockFindUnique.mockResolvedValueOnce({ ...baseRide, startLat: null, startLng: null });
+
+    await processLiftJob(makeJob());
+
+    expect(mockGetToken).not.toHaveBeenCalled();
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('skips when a stream is already persisted', async () => {
+    mockFindUnique.mockResolvedValueOnce({ ...baseRide, stream: { id: 'stream-1' } });
+
+    await processLiftJob(makeJob());
+
+    expect(mockGetToken).not.toHaveBeenCalled();
+    expect(mockFetchStreams).not.toHaveBeenCalled();
+  });
+
+  it('skips (without throwing) when no valid token — user disconnected', async () => {
+    mockFindUnique.mockResolvedValueOnce(baseRide);
+    mockGetToken.mockResolvedValueOnce(null);
+
+    await processLiftJob(makeJob());
+
+    expect(mockFetchStreams).not.toHaveBeenCalled();
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('skips persisting when the activity has no usable streams', async () => {
+    mockFindUnique.mockResolvedValueOnce(baseRide);
+    mockGetToken.mockResolvedValueOnce('token-1');
+    mockFetchStreams.mockResolvedValueOnce({ status: 'no_streams' });
+
+    await processLiftJob(makeJob());
+
+    expect(mockFetchStreams).toHaveBeenCalledWith('token-1', '9876');
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('persists the stream on success', async () => {
+    const data = {
+      time: [0, 1],
+      latlng: [[45.1, -122.3], [45.101, -122.3]],
+      altitude: [100, 101],
+    };
+    mockFindUnique.mockResolvedValueOnce(baseRide);
+    mockGetToken.mockResolvedValueOnce('token-1');
+    mockFetchStreams.mockResolvedValueOnce({ status: 'ok', pointCount: 2, data });
+
+    await processLiftJob(makeJob());
+
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    const call = mockUpsert.mock.calls[0][0];
+    expect(call.where).toEqual({ rideId: 'ride-1' });
+    expect(call.create).toEqual({
+      rideId: 'ride-1',
+      source: 'strava',
+      pointCount: 2,
+      data,
+    });
+    expect(call.update).toMatchObject({ source: 'strava', pointCount: 2, data });
+  });
+
+  it('propagates fetch errors so BullMQ can retry the job', async () => {
+    mockFindUnique.mockResolvedValueOnce(baseRide);
+    mockGetToken.mockResolvedValueOnce('token-1');
+    mockFetchStreams.mockRejectedValueOnce(new Error('Strava streams API error: 500'));
+
+    await expect(processLiftJob(makeJob())).rejects.toThrow('Strava streams API error: 500');
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/workers/lift.worker.ts
+++ b/apps/api/src/workers/lift.worker.ts
@@ -1,0 +1,116 @@
+import '../instrument';
+import { Worker, Job } from 'bullmq';
+import * as Sentry from '@sentry/node';
+import { getQueueConnection } from '../lib/queue/connection';
+import { prisma } from '../lib/prisma';
+import { logger } from '../lib/logger';
+import type { LiftJobData, LiftJobName } from '../lib/queue';
+import { getValidStravaToken } from '../lib/strava-token';
+import { fetchStravaStreams } from '../lib/strava-streams';
+
+// Increment 1 of the lift-detection plan (docs/plans/lift-detection-plan.md):
+// fetch and persist the raw stream only. Detection (Overpass + kinematic
+// scoring, RideSegment persistence) lands in increment 2 as later steps of
+// this same job.
+export async function processLiftJob(
+  job: Job<LiftJobData, void, LiftJobName>
+): Promise<void> {
+  const { rideId } = job.data;
+
+  const ride = await prisma.ride.findUnique({
+    where: { id: rideId },
+    select: {
+      id: true,
+      userId: true,
+      stravaActivityId: true,
+      startLat: true,
+      startLng: true,
+      stream: { select: { id: true } },
+    },
+  });
+
+  if (!ride) {
+    logger.debug({ rideId }, '[LiftWorker] Ride not found, skipping');
+    return;
+  }
+  if (!ride.stravaActivityId) {
+    logger.debug({ rideId }, '[LiftWorker] Not a Strava ride, skipping');
+    return;
+  }
+  if (ride.startLat == null || ride.startLng == null) {
+    logger.debug({ rideId }, '[LiftWorker] Ride has no coords, skipping');
+    return;
+  }
+  if (ride.stream) {
+    logger.debug({ rideId }, '[LiftWorker] Stream already persisted, skipping');
+    return;
+  }
+
+  const accessToken = await getValidStravaToken(ride.userId);
+  if (!accessToken) {
+    // User disconnected between import and job run — retrying won't help.
+    logger.warn({ rideId, userId: ride.userId }, '[LiftWorker] No valid Strava token, skipping');
+    return;
+  }
+
+  // Transient failures throw here and surface to BullMQ for retry.
+  const result = await fetchStravaStreams(accessToken, ride.stravaActivityId);
+
+  if (result.status === 'no_streams') {
+    logger.debug({ rideId }, '[LiftWorker] Activity has no usable streams');
+    return;
+  }
+
+  await prisma.rideStream.upsert({
+    where: { rideId },
+    create: {
+      rideId,
+      source: 'strava',
+      pointCount: result.pointCount,
+      data: result.data,
+    },
+    update: {
+      source: 'strava',
+      pointCount: result.pointCount,
+      data: result.data,
+      fetchedAt: new Date(),
+    },
+  });
+
+  logger.debug({ rideId, pointCount: result.pointCount }, '[LiftWorker] Stream persisted');
+}
+
+let liftWorker: Worker<LiftJobData, void, LiftJobName> | null = null;
+
+export function createLiftWorker(): Worker<LiftJobData, void, LiftJobName> {
+  if (liftWorker) return liftWorker;
+
+  liftWorker = new Worker<LiftJobData, void, LiftJobName>('lift', processLiftJob, {
+    connection: getQueueConnection(),
+    // Streams are the largest payloads we pull from Strava; keep concurrency
+    // low so a burst of imports doesn't spike memory or the shared rate limit.
+    concurrency: 2,
+    drainDelay: 5000,
+  });
+
+  liftWorker.on('completed', (job) => {
+    logger.debug({ jobId: job.id }, '[LiftWorker] Completed');
+  });
+  liftWorker.on('failed', (job, err) => {
+    logger.warn({ jobId: job?.id, error: err.message }, '[LiftWorker] Job failed');
+    Sentry.captureException(err, { tags: { worker: 'lift' }, extra: { jobId: job?.id } });
+  });
+  liftWorker.on('error', (err) => {
+    logger.error({ error: err.message }, '[LiftWorker] Worker error');
+    Sentry.captureException(err, { tags: { worker: 'lift' } });
+  });
+
+  return liftWorker;
+}
+
+export async function closeLiftWorker(): Promise<void> {
+  if (liftWorker) {
+    await liftWorker.close();
+    liftWorker = null;
+  }
+}

--- a/apps/api/src/workers/lift.worker.ts
+++ b/apps/api/src/workers/lift.worker.ts
@@ -6,12 +6,20 @@ import { prisma } from '../lib/prisma';
 import { logger } from '../lib/logger';
 import type { LiftJobData, LiftJobName } from '../lib/queue';
 import { getValidStravaToken } from '../lib/strava-token';
-import { fetchStravaStreams } from '../lib/strava-streams';
+import { fetchStravaStreams, type NormalizedStreams } from '../lib/strava-streams';
+import {
+  DETECTOR_VERSION,
+  DEFAULT_OPTIONS,
+  KINEMATIC_ONLY_OPTIONS,
+  pointsFromStream,
+  detectLiftSegments,
+  getLiftLines,
+} from '../lib/lift-detection';
 
-// Increment 1 of the lift-detection plan (docs/plans/lift-detection-plan.md):
-// fetch and persist the raw stream only. Detection (Overpass + kinematic
-// scoring, RideSegment persistence) lands in increment 2 as later steps of
-// this same job.
+// Shadow mode (docs/plans/lift-detection-plan.md §5, increment 2): the full
+// pipeline runs — stream fetch, Overpass lookup, detection, segment + delta
+// persistence — but nothing user-visible reads the results yet. Metric
+// exclusion and component-hour effects arrive behind a flag in increment 5.
 export async function processLiftJob(
   job: Job<LiftJobData, void, LiftJobName>
 ): Promise<void> {
@@ -22,10 +30,12 @@ export async function processLiftJob(
     select: {
       id: true,
       userId: true,
+      startTime: true,
       stravaActivityId: true,
       startLat: true,
       startLng: true,
-      stream: { select: { id: true } },
+      liftDetectorVersion: true,
+      stream: { select: { id: true, data: true } },
     },
   });
 
@@ -41,43 +51,111 @@ export async function processLiftJob(
     logger.debug({ rideId }, '[LiftWorker] Ride has no coords, skipping');
     return;
   }
+  if (ride.stream && ride.liftDetectorVersion === DETECTOR_VERSION) {
+    logger.debug({ rideId }, '[LiftWorker] Already analyzed at current detector version, skipping');
+    return;
+  }
+
+  // Step 1: ensure the raw stream is persisted. An existing stream is reused
+  // (re-detection after a DETECTOR_VERSION bump costs no Strava call).
+  let streamData: NormalizedStreams;
   if (ride.stream) {
-    logger.debug({ rideId }, '[LiftWorker] Stream already persisted, skipping');
+    streamData = ride.stream.data as NormalizedStreams;
+  } else {
+    const accessToken = await getValidStravaToken(ride.userId);
+    if (!accessToken) {
+      // User disconnected between import and job run — retrying won't help.
+      logger.warn({ rideId, userId: ride.userId }, '[LiftWorker] No valid Strava token, skipping');
+      return;
+    }
+
+    // Transient failures throw here and surface to BullMQ for retry.
+    const result = await fetchStravaStreams(accessToken, ride.stravaActivityId);
+    if (result.status === 'no_streams') {
+      logger.debug({ rideId }, '[LiftWorker] Activity has no usable streams');
+      return;
+    }
+
+    await prisma.rideStream.upsert({
+      where: { rideId },
+      create: {
+        rideId,
+        source: 'strava',
+        pointCount: result.pointCount,
+        data: result.data,
+      },
+      update: {
+        source: 'strava',
+        pointCount: result.pointCount,
+        data: result.data,
+        fetchedAt: new Date(),
+      },
+    });
+    streamData = result.data;
+  }
+
+  const points = pointsFromStream(streamData);
+  if (!points) {
+    // No altitude series — cannot analyze. Leave liftDetectorVersion null
+    // ("never analyzed") rather than record a false "no lift found".
+    logger.debug({ rideId }, '[LiftWorker] Stream has no altitude, leaving unanalyzed');
     return;
   }
 
-  const accessToken = await getValidStravaToken(ride.userId);
-  if (!accessToken) {
-    // User disconnected between import and job run — retrying won't help.
-    logger.warn({ rideId, userId: ride.userId }, '[LiftWorker] No valid Strava token, skipping');
-    return;
-  }
+  // Step 2: lift geometry, best-effort (getLiftLines never throws).
+  const { geometryAvailable, liftLines } = await getLiftLines(points);
 
-  // Transient failures throw here and surface to BullMQ for retry.
-  const result = await fetchStravaStreams(accessToken, ride.stravaActivityId);
+  // Step 3: pure detection. Without geometry, Layer B alone must clear the
+  // stricter bar (plan §3.2).
+  const detected = detectLiftSegments(
+    points,
+    liftLines,
+    geometryAvailable ? DEFAULT_OPTIONS : KINEMATIC_ONLY_OPTIONS
+  );
 
-  if (result.status === 'no_streams') {
-    logger.debug({ rideId }, '[LiftWorker] Activity has no usable streams');
-    return;
-  }
-
-  await prisma.rideStream.upsert({
-    where: { rideId },
-    create: {
-      rideId,
-      source: 'strava',
-      pointCount: result.pointCount,
-      data: result.data,
-    },
-    update: {
-      source: 'strava',
-      pointCount: result.pointCount,
-      data: result.data,
-      fetchedAt: new Date(),
-    },
+  // Step 4: persist segments and Ride deltas atomically. Delete-then-insert
+  // makes re-detection idempotent.
+  const rideStartMs = ride.startTime.getTime();
+  await prisma.$transaction(async (tx) => {
+    await tx.rideSegment.deleteMany({ where: { rideId } });
+    if (detected.length > 0) {
+      await tx.rideSegment.createMany({
+        data: detected.map((seg) => ({
+          rideId,
+          kind: 'LIFT' as const,
+          startIndex: seg.startIndex,
+          endIndex: seg.endIndex,
+          startTime: new Date(rideStartMs + seg.startTimeOffsetSec * 1000),
+          endTime: new Date(rideStartMs + seg.endTimeOffsetSec * 1000),
+          confidence: seg.confidence,
+          // geometryScore records whether geometry informed the decision:
+          // null = Overpass unavailable, 0 = geometry available but no match.
+          geometryScore: geometryAvailable ? seg.geometryScore : null,
+          kinematicScore: seg.kinematicScore,
+          liftName: seg.matchedLiftName ?? null,
+          liftOsmId: seg.matchedLiftId ?? null,
+          durationSeconds: Math.round(seg.durationSec),
+          elevationGainMeters: seg.elevationGainMeters,
+          distanceMeters: seg.distanceMeters,
+          detectorVersion: DETECTOR_VERSION,
+        })),
+      });
+    }
+    await tx.ride.update({
+      where: { id: rideId },
+      data: {
+        liftDurationSeconds: Math.round(detected.reduce((a, s) => a + s.durationSec, 0)),
+        liftElevationGainMeters: detected.reduce((a, s) => a + s.elevationGainMeters, 0),
+        liftDistanceMeters: detected.reduce((a, s) => a + s.distanceMeters, 0),
+        liftDetectorVersion: DETECTOR_VERSION,
+      },
+    });
   });
 
-  logger.debug({ rideId, pointCount: result.pointCount }, '[LiftWorker] Stream persisted');
+  logger.debug(
+    { rideId, segments: detected.length, geometryAvailable },
+    '[LiftWorker] Detection complete'
+  );
 }
 
 let liftWorker: Worker<LiftJobData, void, LiftJobName> | null = null;

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -14,7 +14,7 @@ import { logger } from '../lib/logger';
 import { fireRideNotifications } from '../services/notification.service';
 import { config } from '../config/env';
 import type { SyncJobData, SyncJobName, SyncProvider } from '../lib/queue/sync.queue';
-import { enqueueWeatherJob } from '../lib/queue';
+import { enqueueWeatherJob, enqueueLiftDetectionJob } from '../lib/queue';
 import { captureServerEvent } from '../lib/posthog';
 import type { Prisma } from '@prisma/client';
 import {
@@ -394,6 +394,10 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
   if (syncedRideId && activity.start_latlng) {
     enqueueWeatherJob({ rideId: syncedRideId }).catch((err) =>
       logger.warn({ rideId: syncedRideId, err }, '[SyncWorker] Failed to enqueue weather job (Strava)')
+    );
+    // Fire-and-forget stream fetch for lift detection (Strava-only, needs GPS)
+    enqueueLiftDetectionJob({ rideId: syncedRideId }).catch((err) =>
+      logger.warn({ rideId: syncedRideId, err }, '[SyncWorker] Failed to enqueue lift job (Strava)')
     );
   }
 

--- a/docs/lift-detection-brief.md
+++ b/docs/lift-detection-brief.md
@@ -1,0 +1,195 @@
+# Loam Logger: Chairlift Segment Detection Integration Brief
+
+## Your task
+
+This is a two phase task. **Phase 1 is an audit. Phase 2 is a plan. Do not write
+implementation code in either phase.**
+
+Read the codebase first and ground every statement you make in real file paths and
+symbol names. If you cannot find something, say so explicitly rather than assuming
+it exists. When you are done with Phase 1, write the Phase 2 deliverable to
+`docs/plans/lift-detection-plan.md`.
+
+---
+
+## Feature summary
+
+Loam Logger imports rides from Strava and Garmin and uses them to track wear on
+mountain bike components. Rides taken at lift served bike parks currently
+overstate effort: the chairlift ascent is recorded as climbing, which inflates
+elevation gain, moving time, and any component wear model keyed off those numbers.
+
+The goal is to detect chairlift and gondola segments inside an imported ride and
+exclude them from ride metrics and wear accrual.
+
+Detection uses two layers combined into a single confidence score:
+
+- **Layer A, geometry match.** Query OpenStreetMap via Overpass for
+  `aerialway` ways inside the ride bounding box, buffer each line by roughly 40m,
+  and check what fraction of points fall inside. High precision, patchy coverage
+  at smaller parks. Also serves as bike park detection.
+- **Layer B, kinematic classifier.** Score sliding time windows on sustained VAM,
+  path straightness, speed variance, monotonic ascent, and cadence absence. Full
+  coverage, but occasionally confuses a truck shuttle lap.
+
+A reference implementation of both layers is provided separately as
+`liftDetection.ts`. Treat it as a starting point to be adapted, not as
+finished code. Its numeric thresholds are estimates that have not been validated
+against real ride data.
+
+---
+
+## Phase 1: Codebase audit
+
+Answer each of the following with concrete file paths. Keep it terse. This is
+reconnaissance, not prose.
+
+### Import pipeline
+
+1. Where does Strava activity import happen? Trace the full path from OAuth token
+   through to a persisted ride.
+2. Do we currently fetch the Strava streams endpoint, or only the activity
+   summary? If streams are fetched, which stream keys do we request, and are the
+   raw streams persisted or discarded after processing?
+3. Is import synchronous within a request, or queued or backgrounded? What is the
+   retry and idempotency story if a ride is reimported?
+4. How does the Garmin path differ? Note this for later even though Strava is the
+   first target.
+5. Is there a webhook or polling mechanism for new activities, and where does it
+   land?
+
+### Data model
+
+6. Show the current Prisma models for rides, activities, and anything holding
+   per point or per stream data.
+7. Where are ride level aggregate metrics stored: elevation gain, distance,
+   moving time, and anything else? Are they computed on read or written at
+   import time?
+8. Is PostGIS enabled on the database? If not, what would enabling it involve
+   given the current migration setup and hosting?
+9. Is there any existing concept of a segment, lap, or sub interval within a ride?
+
+### Metrics and wear
+
+10. Find the component wear model. Which ride metrics feed it, and per component
+    type if the model differentiates.
+11. Which of those inputs would change if lift segments were excluded? Be
+    specific about which component types are affected and which are not.
+12. Is wear computed incrementally per ride, or recomputed from the full ride
+    history? This determines whether a backfill is feasible.
+13. Are there any cached, denormalized, or materialized aggregates that would go
+    stale if ride metrics changed retroactively?
+
+### Surfaces
+
+14. Where do ride metrics surface in the React web app and the React Native app?
+    List the components and the GraphQL queries behind them.
+15. Where is the GraphQL schema defined, and what is the convention for adding
+    fields and types?
+16. Is there any existing map rendering of a ride track that could show segment
+    overlays? Note the OpenLayers setup if relevant.
+
+### Infrastructure
+
+17. How is outbound HTTP to third party APIs handled? Is there a shared client
+    with retry, timeout, and rate limit handling that an Overpass call should use?
+18. What caching primitives are available for storing Overpass results across
+    imports?
+19. What is the test setup, and are there any existing fixtures of real ride
+    data that could serve as detection test cases?
+
+---
+
+## Phase 2: Deliverable
+
+Write `docs/plans/lift-detection-plan.md` containing the following sections.
+
+### 1. Audit summary
+
+The Phase 1 findings, condensed. Lead with anything that materially changes the
+shape of the work, for example missing stream data, absence of PostGIS, or a wear
+model that cannot be recomputed.
+
+### 2. Proposed data model changes
+
+Prisma schema additions and the migrations required. At minimum a segment record
+carrying ride reference, type, start and end indices into the stream, confidence
+score, and matched lift name. Justify storing indices versus duplicated geometry.
+Address what happens to rides imported before this feature existed.
+
+### 3. Pipeline changes
+
+Where detection runs in the import flow, what happens when Overpass is
+unavailable or times out, and how detection failure degrades. Detection must never
+block or fail an import. State whether raw streams need to be persisted and what
+that costs in storage.
+
+### 4. Metric and wear changes
+
+Exactly which computed values change and where. Make the distinction explicit
+between metrics that should exclude lift time entirely and metrics where lift
+time was never a factor. Note that descent load on brakes, suspension, and tires
+is unaffected, while drivetrain wear should key off active pedaling time.
+
+### 5. Phasing
+
+Break the work into shippable increments, each independently valuable and
+independently revertible. Suggested shape, adjust if the audit argues otherwise:
+
+- Detection running in shadow mode, persisting segments but changing no
+  user visible number
+- A validation pass over known park rides
+- Threshold tuning based on that validation
+- Metric exclusion switched on behind a flag
+- Backfill of historical rides
+
+### 6. Validation plan
+
+How to confirm the detector is correct before it affects anyone's data. Identify
+which real rides can serve as ground truth and what the acceptance bar is. Lap
+count matching observed reality is the most practical check.
+
+### 7. Risks and open questions
+
+Anything you found that needs a decision from me.
+
+---
+
+## Decisions already made
+
+Do not relitigate these, but do flag it if the audit reveals one of them is
+impractical.
+
+- **Strava first.** Garmin comes later. Design the detector so the source
+  specific code is confined to stream normalization.
+- **Both detection layers.** Geometry match and kinematic classifier, combined
+  into one confidence score rather than run as independent booleans.
+- **Silent exclusion in the UI.** Adjusted totals are what the user sees, with no
+  callout or interstitial. However, the segment classification and its confidence
+  score are persisted so the decision is auditable and tunable later.
+- **Raw stream data is never mutated.** Detection produces typed segments;
+  derived metrics are computed from those.
+
+---
+
+## Constraints
+
+- The app is live with roughly 90 active users, including professional riders.
+  Nothing in this plan should risk corrupting existing ride history.
+- Any change to historical metrics must be reversible. Prefer recomputation from
+  retained raw data over in place mutation.
+- Overpass is a free, rate limited, community run service. Treat it as best
+  effort: cache aggressively, key the cache by rounded bounding box so repeat
+  visits to the same park are cache hits, and never make a user facing operation
+  depend on its availability.
+- Detection must be a pure function over points plus lift lines so it can be
+  tested against fixtures without network access.
+
+---
+
+## Out of scope
+
+- Garmin import path changes
+- Any user facing UI for reviewing or overriding segment classification
+- Shuttle lap detection, which is a related but distinct problem
+- Retroactive changes to subscription or entitlement logic

--- a/docs/plans/lift-detection-plan.md
+++ b/docs/plans/lift-detection-plan.md
@@ -1,0 +1,631 @@
+# Lift Detection: Integration Plan
+
+Status: proposal. Produced from a full codebase audit on 2026-07-18. No implementation
+code exists yet; the reference `liftDetection.ts` is not in the repo and is treated as
+a spec for the two detection layers.
+
+---
+
+## 1. Audit summary
+
+Three findings materially change the shape of the work; everything else confirms the
+brief's assumptions.
+
+### Finding 1 — No per-point data exists anywhere. Stream ingestion is a prerequisite, not an adaptation.
+
+No code calls Strava's `/activities/{id}/streams` endpoint (or any provider's
+per-point API). Every import path consumes only the activity **summary**:
+`distance`, `moving_time`, `total_elevation_gain`, `average_heartrate`,
+`start_latlng`, `gear_id`, `sport_type` (`apps/api/src/workers/sync.worker.ts:76-93`,
+`apps/api/src/routes/strava.backfill.ts:584-614`). The `Ride` model
+(`apps/api/prisma/schema.prisma:106-143`) stores scalar summaries plus a single
+`startLat`/`startLng`. There is no polyline, track, stream, or trackpoint storage of
+any kind, and no GPX/FIT/JSON ride fixtures in the repo.
+
+Consequence: Phase 0 of this plan is fetching and persisting Strava streams — new
+API calls and a new table. Nothing in the detector can run until this lands.
+(A decision recorded in §7 skips bulk re-fetching for historical rides entirely;
+historical rides are analyzed only when the user explicitly marks one, §3.4.)
+
+### Finding 2 — Wear is almost entirely duration-driven, which simplifies metric exclusion.
+
+Two parallel wear systems exist:
+
+- **`Component.hoursUsed`** (`schema.prisma:261`) — an incrementally mutated running
+  total. Every import path calls `syncBikeComponentHours`
+  (`apps/api/src/lib/component-hours.ts:56`), which credits
+  `durationSeconds / 3600` equally to **every** installed component on the bike.
+  Distance and elevation are ignored entirely.
+- **Prediction engine** (`apps/api/src/services/prediction/`) — recomputed from ride
+  history on demand (up to 2000 rides, `window.ts:150`), cached in Redis/memory for
+  30 min (`cache.ts`). Its per-type multi-metric model (`wear.ts:61`,
+  `config.ts:77`) uses distance/elevation/steepness — but only in PRO predictive
+  mode with ≥MEDIUM confidence (`engine.ts:196-237`). The default path is again
+  pure duration.
+
+Consequence: excluding lift time flows overwhelmingly through `durationSeconds`.
+The prediction engine needs **no backfill** — it recomputes from `Ride` rows; only
+cache invalidation (`invalidateBikePrediction`) is required. `hoursUsed` can be
+re-derived per component using the existing `recomputeComponentAfterServiceChange`
+pattern (`resolvers.ts:306`).
+
+### Finding 3 — No PostGIS, and it isn't needed.
+
+No `CREATE EXTENSION` in any of the 70 migrations; coordinates are plain `Float`
+columns. The API deploys to Railway via `nixpacks.toml`, with `prisma migrate deploy`
+at container boot. Since a decided constraint is that detection must be a **pure
+function** over points plus lift lines (testable without network or DB), the 40 m
+buffer check is haversine math in TypeScript. PostGIS would add hosting risk
+(Railway extension support verification, `Unsupported` Prisma types) for zero
+benefit at this scale. **This plan does not enable PostGIS.**
+
+### Condensed answers to the remaining audit questions
+
+**Import pipeline.** Strava OAuth lands tokens in `OauthToken` (plaintext) and
+`UserIntegration` (encrypted) via `apps/api/src/routes/auth.strava.ts`; refresh via
+`getValidStravaToken` (`apps/api/src/lib/strava-token.ts:120`). Three import entry
+points converge on `prisma.ride.upsert` keyed by the `@unique stravaActivityId`:
+
+1. BullMQ sync worker (`apps/api/src/workers/sync.worker.ts` —
+   `syncStravaLatest:214`, `syncStravaActivity:259`, `upsertStravaActivity:291`),
+   queue in `apps/api/src/lib/queue/sync.queue.ts` (attempts: 5, exponential
+   backoff, deterministic job IDs for dedup).
+2. Strava webhook (`apps/api/src/routes/webhooks.strava.ts` —
+   `processActivityEvent:190`, inline upsert at `:338`); one app-wide subscription
+   with hub.challenge verification.
+3. Historical backfill (`apps/api/src/routes/strava.backfill.ts:20`) — notably
+   **synchronous within the HTTP request**, unlike Garmin/Suunto which use the
+   backfill queue/worker.
+
+Idempotency is solid: unique external-ID columns + upserts + deterministic BullMQ
+job IDs. Known gap: component-hour crediting is a separate transaction from the ride
+upsert on some paths; failures orphan hours (logged as `orphaned_component_hours`,
+`sync.worker.ts:647`).
+
+Garmin differs: REST/JSON push-only via PING/PULL webhooks
+(`webhooks.garmin.ts:182`); no polling (forbidden by Garmin outside verification);
+backfill is async via `backfill.worker.ts:156` with activities delivered back
+through the webhook. No FIT parsing exists. Whoop and Suunto integrations also
+exist; cross-provider dedup via `isActiveSource`
+(`apps/api/src/lib/active-source.ts`) and `duplicate-detector.ts`.
+
+**Data model.** Single schema at `apps/api/prisma/schema.prisma`, 32 models.
+Aggregates (`distanceMeters`, `elevationGainMeters`, `durationSeconds`,
+`averageHr`) are written at import time, copied verbatim from provider summaries.
+User/bike totals are computed on read via Prisma `_sum` (`resolvers.ts:1640`,
+bikeHistory `~1410-1690`). **No segment, lap, or sub-interval concept exists.**
+Json-column caches for external APIs are an established pattern: `WeatherCache`
+(keyed lat/lng/hour, `apps/api/src/lib/weather/cache.ts`) and `GeoCache`
+(`apps/api/src/lib/location.ts`).
+
+**Wear.** Covered in Finding 2. Ride delete/edit does adjust hours back
+(`deleteRide` `resolvers.ts:1786`, `updateRide` `:1829`), but decrements floor at 0
+(`component-hours.ts:37`), so repeated incremental adjustment can drift — a reason
+to prefer recompute over diffing during backfill. Denormalized values that go stale
+on retroactive change: `Component.hoursUsed`, `ServiceLog.hoursAtService`
+snapshots, and the Redis `pred:*`/`advisor:*` caches. No leaderboards or yearly
+summary tables exist.
+
+**Surfaces.** Web metrics flow through the `RIDES` query
+(`apps/web/src/graphql/rides.ts`) and `BIKE_HISTORY`
+(`apps/web/src/graphql/bikeHistory.ts`), rendered by `RideStatsCard`,
+`RideStatsCompact`, `RideCard`, `BikeHistory.tsx`, `SharedBikeHistory.tsx`, and the
+PDF export. Client-side stats recompute live from the rides list
+(`useRideStats.ts`, `rideStats.ts`), so adjusted per-ride values propagate to all
+dashboard stats automatically. **There is no React Native app in this repo** (only
+backend mobile-auth routes and planning docs; the client is external) and **no map
+rendering or mapping library at all** — no OpenLayers setup exists. GraphQL is
+schema-first: one SDL tagged template (`apps/api/src/graphql/schema.ts`, ~1160
+lines) + one resolver object (`resolvers.ts`, ~5900 lines) + dataloaders.
+
+**Infrastructure.** No shared outbound HTTP client — ad-hoc `fetch` per
+integration; only Open-Meteo has a timeout (15 s AbortController + throttle,
+`apps/api/src/lib/weather/open-meteo.ts:109`). That file is the template for the
+Overpass client. Caching: Redis singleton with graceful degradation
+(`src/lib/redis.ts`), in-memory fallbacks, and the Prisma-table cache pattern
+above. Rate limiting is custom Redis-backed (`src/lib/rate-limit.ts`) including
+outbound quotas (Suunto token bucket) and distributed locks. Tests: Jest +
+co-located `*.test.ts`, `global.fetch = jest.fn()` for HTTP mocking, **zero ride
+stream fixtures**. Background work: BullMQ workers (`sync`, `backfill`,
+`notification`, `weather`) started from `server.ts:321` when `REDIS_URL` is set.
+**No feature-flag framework** — env-var gates are the convention
+(`GARMIN_VERIFICATION_MODE`).
+
+---
+
+## 2. Proposed data model changes
+
+Three new models and three nullable delta columns on `Ride`. Raw provider values
+are never overwritten (decided constraint), so everything below is additive and
+reversible.
+
+### 2.1 `RideStream` — persisted raw streams
+
+```prisma
+model RideStream {
+  id            String   @id @default(uuid())
+  rideId        String   @unique
+  ride          Ride     @relation(fields: [rideId], references: [id], onDelete: Cascade)
+  source        String   // "strava" — normalization is source-specific, storage is not
+  pointCount    Int
+  // Parallel arrays, one JSON payload: { time: number[], latlng: [number,number][],
+  // altitude: number[], velocity: number[], cadence?: number[], heartrate?: number[],
+  // moving?: boolean[] }
+  data          Json
+  fetchedAt     DateTime @default(now())
+}
+```
+
+- **Stream keys requested from Strava:** `time,latlng,altitude,velocity_smooth,cadence,heartrate,moving`
+  with `key_by_type=true`. Cadence and moving cost nothing extra to request and are
+  needed later (cadence-absence is a Layer B signal; drivetrain "active pedaling
+  time" needs cadence).
+- **Storage cost:** a 3-hour ride at 1 s sampling is ~10k points ≈ 300–600 KB of
+  JSON, and Postgres TOAST compresses Json columns transparently (lat/lng arrays
+  compress well). At ~90 users, even 10k total rides is on the order of a few GB
+  worst case — acceptable on Railway Postgres without a separate object store. If
+  this ever matters, swap `data Json` for `data Bytes` (gzip) behind the same
+  accessor; do not design for it now.
+- One row per ride, `@unique rideId`, cascade delete — deleting a ride (e.g. via
+  the Strava delete webhook) removes its stream automatically. Note the cascade
+  alone does not cover disconnect: per the decision in §7, rides survive
+  deauthorization while streams are deleted, so the deauth webhook and disconnect
+  path must delete `RideStream` rows explicitly.
+
+### 2.2 `RideSegment` — detected lift segments
+
+```prisma
+enum RideSegmentKind {
+  LIFT
+}
+
+model RideSegment {
+  id               String          @id @default(uuid())
+  rideId           String
+  ride             Ride            @relation(fields: [rideId], references: [id], onDelete: Cascade)
+  kind             RideSegmentKind
+  startIndex       Int             // index into RideStream.data arrays
+  endIndex         Int             // inclusive
+  startTime        DateTime        // denormalized for display/debugging without loading the stream
+  endTime          DateTime
+  confidence       Float           // combined score, 0..1
+  geometryScore    Float?          // null when Overpass was unavailable — auditable degradation
+  kinematicScore   Float
+  liftName         String?         // OSM name of matched aerialway, if any
+  liftOsmId        String?
+  // Deltas this segment removes from ride metrics, precomputed at detection time
+  durationSeconds  Int
+  elevationGainMeters Float
+  distanceMeters   Float
+  detectorVersion  Int             // bump when thresholds change; enables selective re-detection
+  createdAt        DateTime        @default(now())
+
+  @@index([rideId])
+}
+```
+
+**Indices versus duplicated geometry:** segments store `startIndex`/`endIndex` into
+the stream rather than copying coordinates because (a) the raw stream is immutable
+by decision, so indices can never dangle or diverge; (b) a segment row stays ~200
+bytes instead of tens of KB, and per-ride segment queries (the hot path for metric
+computation) never touch the blob; (c) re-running detection with new thresholds
+replaces segment rows without touching geometry. The denormalized
+`startTime`/`endTime` and metric deltas are derived once from the stream at
+detection time so that metric adjustment and UI display need only the segment rows.
+
+### 2.3 `OverpassCache` — cached lift geometry per area
+
+Follows the `WeatherCache`/`GeoCache` precedent exactly:
+
+```prisma
+model OverpassCache {
+  id        String   @id @default(uuid())
+  cellKey   String   @unique // bounding box rounded to a 0.05° grid cell, e.g. "45.55,-122.90"
+  payload   Json     // normalized aerialway ways: [{ osmId, name, aerialwayType, points: [[lat,lng],...] }]
+  isEmpty   Boolean  @default(false) // negative caching: most ride areas have no lifts
+  fetchedAt DateTime @default(now())
+}
+```
+
+Keyed by rounded grid cell (per the brief's constraint), not exact ride bbox, so
+repeat visits to the same park are cache hits. A ride bbox maps to 1–4 cells;
+query each cell, union the ways. Lifts essentially never move: treat entries as
+fresh for ~180 days, refresh lazily on read past that. `isEmpty` rows make the
+common case (no lifts anywhere near the ride) a single indexed read.
+
+### 2.4 `Ride` delta columns
+
+```prisma
+model Ride {
+  // ... existing fields unchanged ...
+  liftDurationSeconds     Int?    // sum of segment durations; null = detection never ran
+  liftElevationGainMeters Float?
+  liftDistanceMeters      Float?
+  liftDetectorVersion     Int?
+  stream                  RideStream?
+  segments                RideSegment[]
+}
+```
+
+Deltas, not adjusted values: the raw provider columns (`durationSeconds`,
+`elevationGainMeters`, `distanceMeters`) remain exactly what the provider sent,
+forever. Effective metrics are computed as `raw − lift` in one shared helper (see
+§4). `null` means "never analyzed" and is distinguishable from `0` ("analyzed,
+no lift found") — this is what makes backfill progress and reversal auditable.
+
+### 2.5 Migrations and pre-feature rides
+
+Four additive migrations (or one combined), all safe under the boot-time
+`prisma migrate deploy`: new tables plus nullable columns, no rewrites of existing
+rows, no downtime. Rides imported before the feature simply have `stream = null`
+and `liftDurationSeconds = null` and display raw metrics unchanged — indefinitely,
+by decision (§7): there is **no bulk backfill**. A historical ride gets analyzed
+only when its owner taps "Mark Bike Park Ride" (§3.4), which fetches its stream
+and runs detection on demand. Because `null` still means "never analyzed," a bulk
+sweep remains possible later without any schema change if the decision is
+revisited. Reversal is `UPDATE "Ride" SET "liftDurationSeconds" = NULL, ...` (or
+just disabling the flag, which stops the helper from subtracting) — no raw data
+was touched.
+
+---
+
+## 3. Pipeline changes
+
+### 3.1 Where detection runs
+
+A new BullMQ queue + worker pair, `lift.queue.ts` / `lift.worker.ts`, modeled on
+the existing weather queue (`apps/api/src/lib/queue/weather.queue.ts`,
+`apps/api/src/workers/weather.worker.ts`), registered in
+`src/workers/index.ts` and gated (like everything else) on `REDIS_URL`.
+
+Every Strava ride-persist site already calls `enqueueWeatherJob` after upsert;
+`enqueueLiftDetectionJob(rideId)` is added at the two **ongoing** call sites:
+
+- `upsertStravaActivity` (`sync.worker.ts:291`)
+- webhook `processActivityEvent` (`webhooks.strava.ts:190`)
+
+The historical-import route (`strava.backfill.ts:233`) deliberately does **not**
+enqueue detection: a new user connecting Strava can create hundreds of rides in
+one request, and per the no-backfill decision (§7) history is not auto-analyzed —
+this also protects the shared Strava rate limit. Historical rides enter the
+pipeline only via "Mark Bike Park Ride" (§3.4).
+
+Only rides with `stravaActivityId` and a start coordinate are enqueued. Manual
+rides, Whoop rides (no GPS), and Garmin/Suunto rides are skipped in v1.
+
+The job:
+
+1. **Fetch stream** (skip if `RideStream` exists and is fresh): one call to
+   `GET /api/v3/activities/{id}/streams` using `getValidStravaToken`, with an
+   AbortController timeout following the Open-Meteo pattern
+   (`open-meteo.ts:109`). Persist `RideStream`.
+2. **Load lift lines**: compute grid cells from the stream bbox, read
+   `OverpassCache`; on miss, one Overpass query with a 10 s timeout, a proper
+   `User-Agent`, and a Redis-backed courtesy throttle (≤1 concurrent request
+   app-wide, via the existing `acquireLock` primitives in `rate-limit.ts`).
+   Cache the result, including empty results.
+3. **Detect**: call the pure detector — `detectLiftSegments(points, liftLines) →
+   segments[]` — adapted from the reference `liftDetection.ts` into
+   `apps/api/src/lib/lift-detection/`. No I/O inside; fully fixture-testable.
+4. **Persist**: in one transaction, delete prior segments for the ride
+   (idempotent re-detection), insert new ones, set the `lift*` delta columns and
+   `liftDetectorVersion`.
+5. **Apply metric effects** only when the exclusion flag is on (§4): diff old vs
+   new effective duration through the existing `syncBikeComponentHours` machinery
+   and call `invalidateBikePrediction`.
+
+### 3.2 Failure and degradation
+
+Detection can never block or fail an import because it runs on a separate queue
+after the ride is already persisted — the same isolation the weather enrichment
+already has. Degradation ladder:
+
+- **Overpass down/timeout/rate-limited:** run Layer B alone. The combined
+  confidence is computed with the geometry term absent and a stricter kinematic
+  threshold (Layer B alone must clear a higher bar, since it is the layer that
+  confuses truck shuttles). `geometryScore = null` on the persisted segment
+  records that the decision was made without geometry — auditable and re-runnable
+  later. Optionally re-enqueue a low-priority re-detection with backoff so
+  geometry gets applied when Overpass recovers.
+- **Strava streams call fails:** BullMQ retries (attempts: 3–5, exponential —
+  same posture as the sync queue). After final failure the ride simply keeps
+  `liftDurationSeconds = null` and raw metrics. Nothing user-facing breaks.
+- **Redis absent** (`REDIS_URL` unset, e.g. local dev): queue never starts;
+  imports behave exactly as today.
+- **Detector throws:** caught in the worker, reported to Sentry (matching the
+  `orphaned_component_hours` pattern), ride left unanalyzed.
+
+### 3.3 Raw stream persistence — required, and cheap
+
+Streams must be persisted (not fetched-and-discarded) because: threshold tuning
+and `detectorVersion` bumps require re-running detection without re-hitting
+Strava's rate limit; the validation phase needs fixtures pulled from real rides;
+and the reversibility constraint ("prefer recomputation from retained raw data")
+is only satisfiable if the raw data is retained. Cost is a few GB at current
+scale (§2.1). Strava's rate limit (app-wide, on the order of hundreds of requests
+per 15 min / low thousands per day) comfortably covers ongoing imports (~1 extra
+request per new ride); with bulk backfill dropped, the only other stream traffic
+is user-triggered marks, which are throttled per user (§3.4).
+
+### 3.4 "Mark Bike Park Ride" — user-triggered analysis of a historical ride
+
+The only way a pre-feature ride gets analyzed. A button on a specific ride in the
+web app (natural homes: `RideCard` and/or `EditRideModal`,
+`apps/web/src/components/`) calls a new GraphQL mutation:
+
+```graphql
+markBikeParkRide(rideId: ID!): MarkBikeParkRideResult
+```
+
+added to the SDL in `apps/api/src/graphql/schema.ts` with its resolver in
+`resolvers.ts` following the existing conventions (ownership check via context
+`userId`, rate limit via `checkMutationRateLimit` with a new entry in
+`MUTATION_RATE_LIMITS`, `src/lib/rate-limit.ts`). The resolver validates the ride
+is the user's, is Strava-sourced with a start coordinate, and is not already
+analyzed or in flight — then enqueues the same `enqueueLiftDetectionJob(rideId)`
+the import path uses. The job itself (§3.1 steps 1–5) is identical; the mutation
+is just a second entry point.
+
+Throttling, per the decision (§7):
+
+- **One in flight per user.** Deterministic job ID per ride gives per-ride dedup
+  for free (BullMQ rejects duplicates, same pattern as `buildSyncJobId`); the
+  resolver additionally rejects with "analysis already running" if the user has
+  any pending/active lift job, so marks are strictly serial per user.
+- **Rate-limited per user** via the existing Redis sliding-window limiter — a
+  small budget (e.g. a handful per hour) since a legitimate user marks a few park
+  days, not their whole history. Exact numbers are tuning-phase.
+
+The mutation returns quickly (enqueued, not completed); the ride's numbers adjust
+when the job lands, same as the accepted post-import shift for new rides. Scope
+note: the brief ruled out user-facing UI *for reviewing or overriding segment
+classification*; this button triggers analysis and does not expose or override
+classification, so it is a deliberate, narrow carve-out — the silent-exclusion
+posture is unchanged.
+
+---
+
+## 4. Metric and wear changes
+
+### 4.1 One helper, everywhere
+
+A single function in `apps/api/src/lib/effective-metrics.ts`:
+
+```ts
+effectiveMetrics(ride): { durationSeconds, elevationGainMeters, distanceMeters }
+// = raw − lift deltas when the flag is on and deltas are non-null; raw otherwise
+```
+
+Consumed at exactly these points — this is the complete list of places a number
+changes:
+
+| Where | What changes | File |
+| --- | --- | --- |
+| GraphQL `Ride` field resolvers | `durationSeconds`, `elevationGainMeters`, `distanceMeters` resolve to effective values | `resolvers.ts` (add `Ride.*` field resolvers) |
+| `bikeHistory` / `sharedBikeHistory` totals | replace raw `_sum` aggregates with sums of `(raw − coalesce(lift, 0))` | `resolvers.ts:~1410-1690` |
+| User totals `_sum` | same | `resolvers.ts:1640` |
+| Component-hour crediting | `syncBikeComponentHours` and all its call sites receive effective duration | `component-hours.ts`, worker/webhook call sites |
+| Prediction engine ride window | `getAllRidesForBike` maps rides through the helper before `calculateRideWear`/`calculateTotalHours` | `services/prediction/window.ts`, `wear.ts` |
+| `deleteRide` / `updateRide` hour adjustments | diffs computed on effective duration | `resolvers.ts:1786, 1829` |
+
+Because the web app computes all dashboard stats client-side from the `RIDES`
+query (`useRideStats.ts`), adjusting the `Ride` field resolvers propagates to
+every web surface — and to the external mobile client — with **zero client
+changes**. This is what makes silent exclusion cheap.
+
+### 4.2 Which metrics change, and which never had lift in them
+
+**Exclude lift entirely:**
+
+- `durationSeconds` (Strava `moving_time` counts the chairlift as moving) →
+  effective duration drops by segment duration. This is the dominant effect: it
+  feeds `Component.hoursUsed`, simple-mode `hoursSinceService`, and the `wH` term
+  in predictive mode — i.e. **every trackable component type equally**, because
+  the stored counter does not differentiate by type.
+- `elevationGainMeters` → lift ascent removed. User-facing totals change for
+  everyone; wear changes **only in PRO predictive mode**, where elevation feeds
+  the climbing (`wC`) and steepness (`wV`) weights — brakes
+  (`BRAKE_PAD`/`BRAKE_ROTOR`/`BRAKES`), tires, and pivot bearings most;
+  `REAR_DERAILLEUR` (wC=0, wV=0) not at all.
+- `distanceMeters` → lift travel distance removed (small; lifts are short
+  horizontal distances). Affects totals and the predictive `wD`/`wV` terms.
+
+**Never had lift in them (no change):**
+
+- `averageHr` — provider-computed over the whole activity. Recomputing it from
+  the HR stream excluding lift windows is possible once streams exist, but it
+  feeds nothing in the wear model; out of scope for v1 (open question §7).
+- Weather enrichment, location/trailSystem geocoding — keyed off start point and
+  time only.
+- `weatherBreakdown` — counts conditions, not metrics.
+- Descent-phase load on brakes, suspension, and tires — the lift segment is by
+  definition not a descent, and the current model has no explicit descent term
+  anyway; the descent's duration, distance, and (zero) elevation gain are outside
+  the excluded windows and unchanged.
+
+**Directionally-correct-but-imperfect (accepted for v1):** drivetrain wear should
+ideally key off active pedaling time (cadence > 0), not merely non-lift moving
+time. Cadence is in the persisted stream, so this refinement is available later
+without re-fetching; v1 stops at lift exclusion. Noted in §7.
+
+### 4.3 Consistency rules for retroactive changes
+
+Whenever the deltas on an already-counted ride change (first detection,
+re-detection, a user marking a historical ride), the worker must, in order:
+compute the hour diff (old effective vs new effective duration) through the same
+diff logic `updateRide` uses; apply it via `syncBikeComponentHours`; and call
+`invalidateBikePrediction(userId, bikeId)`. With bulk backfill dropped,
+retroactive changes arrive one ride at a time, so incremental diffing is
+acceptable — the floor-at-0 drift risk in `decrementBikeComponentHours`
+(`component-hours.ts:37`) is bounded by the per-user mark throttle. If a bulk
+sweep is ever revived, switch to per-component **recompute** (the
+`recomputeComponentAfterServiceChange` aggregate pattern, `resolvers.ts:306`)
+instead of accumulated decrements. `ServiceLog.hoursAtService` snapshots are
+historical facts recorded at service time and are deliberately **not** rewritten.
+
+---
+
+## 5. Phasing
+
+Each increment ships and reverts independently. The brief's suggested shape holds
+with two deviations: an added prerequisite increment (forced by Finding 1), and
+the historical backfill replaced by user-triggered per-ride analysis (decision,
+§7).
+
+1. **Stream ingestion (prerequisite).** `RideStream` model + migration; stream
+   fetch added to the lift worker's step 1 only (no detection yet); enqueue on new
+   Strava imports. Independently valuable: unlocks any future per-point feature
+   (maps, descent metrics). Revert: stop enqueueing; drop table later.
+2. **Shadow-mode detection.** `RideSegment` + `OverpassCache` models; the pure
+   detector adapted from `liftDetection.ts` with fixture tests; the full worker
+   pipeline persisting segments and delta columns — but no consumer reads the
+   deltas. Zero user-visible change by construction. Revert: stop the worker.
+3. **Validation pass.** An admin-only report (script or admin route following
+   `src/routes/admin.ts` conventions) listing, per analyzed ride: detected segment
+   count, lift names, confidence scores, per-segment deltas. Run against known
+   park rides (§6). No schema or user-facing change. Revert: n/a (read-only).
+4. **Threshold tuning.** Adjust detector constants against the validation set;
+   bump `detectorVersion`; re-enqueue analyzed rides (streams already persisted, so
+   no Strava calls). Repeat 3–4 until the acceptance bar (§6) is met. Revert: n/a.
+5. **Metric exclusion behind a flag.** `LIFT_METRIC_EXCLUSION_ENABLED` env var —
+   the repo's established gating convention (`GARMIN_VERIFICATION_MODE`; no flag
+   framework exists). Lands the `effectiveMetrics` helper at the §4.1 call sites
+   and the hour-diff/cache-invalidation logic. Applies to newly-detected rides
+   only at this point. Revert: unset the env var — every number returns to raw
+   instantly because raw columns were never touched.
+6. **"Mark Bike Park Ride" (replaces bulk backfill).** The `markBikeParkRide`
+   mutation, per-user throttling, and the web button (§3.4). Historical rides are
+   analyzed only on explicit user request, one at a time. During increments 2–4
+   the mutation can ship early in admin-only form (or as a dev script hitting the
+   same enqueue) to seed validation fixtures from known park rides. Revert:
+   remove the button/mutation; already-marked rides revert with the flag like any
+   other. A bulk sweep stays possible later with no schema change, since
+   unanalyzed rides remain distinguishable (`liftDurationSeconds IS NULL`).
+
+---
+
+## 6. Validation plan
+
+**Ground truth.** The practical ground-truth set is rides by the maintainer and
+friendly users at known lift-served parks — as the brief notes, **lap count is the
+check**: a rider knows they did N lifts that day, and the detector must find N
+lift segments. With bulk backfill dropped, the validation set accrues two ways:
+new rides flowing through shadow mode (it is July — peak park season, so park
+rides arrive quickly), and hand-picked historical park rides analyzed via the
+mark-ride enqueue path (§3.4, admin/dev form) — a handful of Strava calls, not a
+sweep. Because streams are persisted, any analyzed ride can be
+exported as a JSON fixture into
+`apps/api/src/lib/lift-detection/__fixtures__/` (the repo currently has zero ride
+fixtures — these will be the first) and asserted against in ordinary Jest tests
+with no network, satisfying the pure-function constraint.
+
+**Fixture matrix** (minimum set before increment 5 ships):
+
+| Case | Expectation |
+| --- | --- |
+| Park day with chairlift, N known laps, park mapped in OSM | exactly N LIFT segments, geometry + kinematic both scoring |
+| Park day at a park with poor/absent OSM `aerialway` coverage | N segments from Layer B alone (this is the stricter-threshold path) |
+| Gondola (enclosed, possibly indoor GPS dropout) | segments still detected; graceful handling of gaps |
+| Ordinary trail ride, no lift | 0 segments |
+| Sustained fire-road or paved climb (steady VAM, straight) | 0 segments — the known Layer B confusion case |
+| Truck-shuttle day | explicitly documented outcome; false LIFT positives here are acceptable only if flagged, since shuttle detection is out of scope |
+
+**Acceptance bar to enable increment 5:**
+
+- Lap count exactly matches rider-reported reality on 100% of geometry-covered
+  park fixtures, and ≥90% on kinematic-only fixtures.
+- Zero false-positive segments across a random sample of ≥50 non-park rides from
+  the existing production ride table (run in shadow mode, so this costs nothing).
+- Excluded elevation per park day is sanity-checked against `N × known lift
+  vertical` within ~15%.
+
+Shadow mode (increment 2) makes this free: the detector runs on all real incoming
+rides for weeks while affecting nothing, and the increment 3 report is reviewed
+before any number changes.
+
+---
+
+## 7. Risks and open questions
+
+**Risks:**
+
+1. **Strava rate limit is app-wide and shared.** Stream fetches (+1 request per
+   import, plus user-triggered marks) draw from the same budget as live sync and
+   webhook processing. Dropping bulk backfill removed the worst pressure;
+   remaining mitigation is the per-user mark throttle (§3.4) and monitoring 429s.
+   Current limits should still be confirmed in the Strava dashboard before
+   increment 1.
+2. **Strava API agreement on stored data.** Storing streams of a user's own
+   activities is permitted, but data must be deleted on disconnect/deauthorization.
+   `RideStream` cascades from `Ride`; the existing deauth webhook
+   (`webhooks.strava.ts:124`) must be checked for whether it deletes rides or only
+   tokens — if rides survive disconnect today, streams will too, and that needs a
+   decision.
+3. **Summary/stream inconsistency.** `moving_time` is Strava's own computation;
+   our lift window duration is stream-derived. Subtracting one from the other can
+   over- or under-correct when Strava already discounted part of the lift as
+   "stopped" (slow chairs sometimes trip Strava's moving detection). The `moving`
+   stream is requested precisely so the delta can count only points Strava
+   considered moving. This is a tuning-phase concern; the validation elevation
+   check (§6) catches gross errors.
+4. **Incremental hour-adjustment drift.** Floor-at-0 decrements
+   (`component-hours.ts:37`) plus the pre-existing orphaned-hours gap
+   (`sync.worker.ts:647`) mean repeated retroactive diffs can drift. With no bulk
+   backfill, retroactive diffs are rare and throttled (§4.3), so the exposure is
+   small; a general "rebuild hours from ride log" admin command would be a
+   worthwhile side quest but is not required.
+5. **Overpass etiquette.** Single community endpoint, aggressive caching with
+   negative caching, one concurrent request, proper User-Agent. Worst case
+   (Overpass long-term unavailable) the system runs kinematic-only permanently —
+   degraded precision, not failure.
+
+**Decisions (resolved 2026-07-18):**
+
+1. **Post-import metric shift — accepted.** Detection is async, so a park ride's
+   numbers appear raw for seconds-to-minutes after import, then silently drop
+   when the worker finishes. Accepted as-is; delaying import visibility would
+   violate the never-block rule in spirit.
+2. **`averageHr` — leave raw.** The provider's whole-activity average stays;
+   recomputing from the HR stream excluding lift windows changes a displayed
+   number for no wear effect. Revisit only if users notice.
+3. **Drivetrain pedaling-time refinement — fast-follow.** Cadence-keyed
+   drivetrain wear ships as its own follow-up after metric exclusion is live,
+   with its own validation. Cadence is already in the persisted stream, so no
+   re-fetch is needed.
+4. **Strava disconnect — keep rides, delete streams.** On
+   deauthorization/disconnect, users keep ride history and component hours; raw
+   `RideStream` blobs (the bulky, ToS-sensitive part) are deleted. Already-applied
+   segments and delta columns stay. Implementation note: this means `RideStream`
+   deletion must be wired into the deauth webhook
+   (`webhooks.strava.ts:124`) and the disconnect path explicitly — cascade from
+   `Ride` alone does not cover it, since rides survive. Current deauth behavior
+   for rides still needs confirming during increment 1.
+5. **No bulk historical backfill.** Lift exclusion applies to rides imported
+   after the feature ships. Rationale: removes retroactive mass-mutation risk on
+   a live database, the hour-recompute machinery, and the rate-limit sweep; wear
+   due-status is anchored at last service (`hoursSinceService`), so pre-feature
+   inflation washes out of predictions within one service cycle per component.
+   Lifetime totals will mix unadjusted old park rides with adjusted new ones —
+   accepted as cosmetic at current scale. Consistent with this, the new-user
+   history import (`strava.backfill.ts`) does not enqueue stream fetches at all.
+   Nothing forecloses a later sweep: unanalyzed rides keep
+   `liftDurationSeconds = NULL`.
+6. **"Mark Bike Park Ride" button (user-triggered analysis).** The one path for
+   historical rides: a per-ride button in the web app backed by the
+   `markBikeParkRide` mutation (§3.4), enqueueing a single detection job —
+   strictly one in flight per user, plus a per-user rate limit. A deliberate,
+   narrow exception to the no-user-facing-UI scope line: it triggers analysis
+   but does not expose or override classification.
+
+**Decided constraints, re-checked against the audit — all hold:**
+
+- *Strava first*: confirmed practical; Garmin has no equivalent stream fetch in
+  the current code, and its `activityDetails` webhook payload (which can carry
+  samples) is a natural later entry point. Source-specific code confined to
+  stream normalization (`RideStream.source` + per-source fetcher).
+- *Both layers, one score*: no audit conflict; the degradation ladder (§3.2)
+  keeps the combined-score design while surviving Overpass outages.
+- *Silent exclusion*: cheap here because all clients read the same GraphQL ride
+  fields (§4.1); segments + confidence persisted for auditability.
+- *Raw streams never mutated*: enforced structurally — detection writes only
+  `RideSegment` rows and `Ride.lift*` delta columns.

--- a/docs/plans/lift-detection-plan.md
+++ b/docs/plans/lift-detection-plan.md
@@ -553,8 +553,15 @@ before any number changes.
    import, plus user-triggered marks) draw from the same budget as live sync and
    webhook processing. Dropping bulk backfill removed the worst pressure;
    remaining mitigation is the per-user mark throttle (§3.4) and monitoring 429s.
-   Current limits should still be confirmed in the Strava dashboard before
-   increment 1.
+   Confirmed 2026-07-18 (developers.strava.com/docs/rate-limits): the binding
+   constraint is the read (non-upload) limit — 200 requests/15 min and
+   2,000/day at the first capacity-approved tier, scaling with approved athlete
+   capacity. Stream fetches double per-ride reads (detail + streams = 2); ~50
+   imported rides/day is ~100 reads, ≈5% of the daily read budget. Known soft
+   spot: on a 429, the lift queue's retry backoff (10s/20s/40s) stays inside
+   the same 15-min window, so a quota-exhausted job can fail permanently —
+   recoverable via POST /api/admin/lift/analyze/:rideId; not worth hardening at
+   current volume.
 2. **Strava API agreement on stored data.** Storing streams of a user's own
    activities is permitted, but data must be deleted on disconnect/deauthorization.
    `RideStream` cascades from `Ride`; the existing deauth webhook


### PR DESCRIPTION
## Summary

First three increments of the chairlift-detection plan ([docs/plans/lift-detection-plan.md](docs/plans/lift-detection-plan.md)). **Zero user-visible change** — this PR is the data-collection and validation foundation; metric exclusion comes later behind a flag.

- **Increment 1 — stream ingestion.** New `RideStream` table; a new BullMQ `lift` queue/worker fetches full-resolution Strava streams (`time,latlng,altitude,velocity_smooth,cadence,heartrate,moving`) after each ongoing import (sync worker + webhook; the historical-import route deliberately does not enqueue). Streams are deleted on Strava disconnect/deauth while rides survive.
- **Increment 2 — shadow-mode detection.** `RideSegment` + `OverpassCache` tables and nullable `lift*` delta columns on `Ride` (`NULL` = never analyzed, `0` = analyzed, no lift). The worker runs the two-layer detector (OSM aerialway geometry match + kinematic classifier) as a pure function over the persisted stream; Overpass lookups are cached per 0.05° grid cell with negative caching, throttled, and strictly best-effort — when unavailable, detection runs kinematic-only against stricter thresholds and persists `geometryScore = NULL` so the degradation is auditable. Nothing reads the results yet.
- **Increment 3 — admin validation surface.** `GET /api/admin/lift/report` (summary counts + per-ride segments/scores/deltas; segment count vs remembered laps is the validation check), `POST /api/admin/lift/analyze/:rideId` (seed known historical park rides; `force` re-runs; 5s per-ride cooldown), `GET /api/admin/lift/fixture/:rideId` (export stream + segments as a ground-truth Jest fixture).

## Operational notes

- Two additive migrations (new tables + nullable columns; no rewrites) run via the existing boot-time `prisma migrate deploy`.
- +1 Strava read per imported ride. Confirmed against current Strava limits: ~50 rides/day ≈ 5% of the 2,000/day read budget (details in plan §7 risk 1).
- Storage: ~300–600 KB JSON per ride with GPS, TOAST-compressed.
- Worker failures Sentry-log and leave rides unanalyzed; detection can never block or fail an import.
- Revert: stop the enqueues/worker — no consumer depends on the new data.

## Test plan

- 62 new tests: stream fetch lib (normalization, 404/429/timeout handling), detector (synthetic lift vs pedaled-climb fixtures, two-lap splitting, adjusted metrics), Overpass module (cache hit/negative/stale/failure paths, oversized-bbox skip), worker orchestration (skip conditions, re-detection without Strava calls, geometry degradation), admin routes (report shape/filters, force re-analyze, cooldown, fixture export).
- Full API suite green: 1,490 tests, 75/76 suites (the one failure is the pre-existing `@anthropic-ai/sdk` resolution issue in `advisor/summarize.test.ts`, untouched here).
- `tsc` introduces no new error kinds; the new queue/worker carry the same pre-existing BullMQ/ioredis type-pattern errors as every existing queue/worker.

## After merge

Deploy starts stream accrual immediately (it's peak park season — this data can't be collected retroactively without rate-limit cost). Validation loop: ride or `POST /analyze` known park days → read `/report` → compare segment counts to remembered laps → export fixtures → tune thresholds (increment 4). Metric exclusion (increment 5) stays parked until the plan's §6 acceptance bar is met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)