### PR TITLE
Ride track map v1: route maps for any ride, with on-demand stream fetch

### DIFF
--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -12,7 +12,8 @@ import type {
 } from '@prisma/client';
 import { checkRateLimit, checkMutationRateLimit, checkQueryRateLimit, checkAuthRateLimit } from '../lib/rate-limit';
 import { getClientIp } from '../auth/utils';
-import { enqueueSyncJob, enqueueWeatherJob, type SyncProvider } from '../lib/queue';
+import { enqueueSyncJob, enqueueWeatherJob, enqueueLiftDetectionJob, type SyncProvider } from '../lib/queue';
+import { getRideTrack } from '../lib/ride-track';
 import { invalidateBikePrediction, getCachedAdvisorSummary, setCachedAdvisorSummary } from '../services/prediction/cache';
 import { generateSummary, DEFAULT_ADVISOR_MODEL } from '../services/advisor/summarize';
 import type { BikePredictionSummary } from '../services/prediction/types';
@@ -895,6 +896,20 @@ export const resolvers = {
       return prisma.ride.findFirst({
         where: { id, userId },
       });
+    },
+
+    rideTrack: async (_: unknown, { rideId }: { rideId: string }, ctx: GraphQLContext) => {
+      const userId = requireUserId(ctx);
+
+      // Polled after requestRideTrack, so rate-limited like other pollers.
+      const rateLimit = await checkQueryRateLimit('rideTrack', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(`Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`, {
+          extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
+        });
+      }
+
+      return getRideTrack(userId, rideId);
     },
 
     rides: async (_: unknown, { take = 1000, after, filter }: RidesArgs, ctx: GraphQLContext) => {
@@ -3441,6 +3456,31 @@ export const resolvers = {
         message: `${provider} sync has been queued`,
         jobId: enqueueResult.jobId,
       };
+    },
+
+    requestRideTrack: async (_: unknown, { rideId }: { rideId: string }, ctx: GraphQLContext) => {
+      const userId = requireUserId(ctx);
+
+      // Each fetch costs a Strava API read from the shared app-wide budget.
+      const rateLimit = await checkMutationRateLimit('requestRideTrack', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(`Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`, {
+          extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
+        });
+      }
+
+      // Ownership check + current state; also makes the mutation idempotent —
+      // an AVAILABLE track just returns without enqueueing.
+      const track = await getRideTrack(userId, rideId);
+      if (track.status !== 'FETCHABLE') {
+        return track;
+      }
+
+      // The lift job fetches + persists the stream (and runs detection) with
+      // an idempotent per-ride job ID; the client polls rideTrack until
+      // AVAILABLE.
+      await enqueueLiftDetectionJob({ rideId });
+      return track;
     },
 
     bulkUpdateComponentBaselines: async (

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -162,6 +162,26 @@ export const typeDefs = gql`
     weather: RideWeather
   }
 
+  enum RideTrackStatus {
+    # Stream persisted; points returned.
+    AVAILABLE
+    # Strava ride with coords but no stream yet - requestRideTrack can load it.
+    FETCHABLE
+    # No GPS source (manual entry, Whoop, Garmin/Suunto for now).
+    UNAVAILABLE
+  }
+
+  # Owner-only GPS track for one ride, downsampled server-side. Deliberately a
+  # dedicated query rather than a field on Ride so the stream blob is never
+  # read for list queries and can never leak into shared-page types.
+  type RideTrack {
+    status: RideTrackStatus!
+    # [lat, lng] pairs; null unless status is AVAILABLE.
+    points: [[Float!]!]
+    # Point count of the raw stream the track was sampled from.
+    sampledFrom: Int
+  }
+
   enum WeatherCondition {
     SUNNY
     CLOUDY
@@ -950,6 +970,10 @@ export const typeDefs = gql`
     createStravaGearMapping(input: CreateStravaGearMappingInput!): StravaGearMapping!
     deleteStravaGearMapping(id: ID!): DeleteResult!
     triggerProviderSync(provider: SyncProvider!): TriggerSyncResult!
+    # Enqueue a stream fetch for a Strava ride imported before stream
+    # ingestion existed. Returns the track's current state; poll rideTrack
+    # until AVAILABLE.
+    requestRideTrack(rideId: ID!): RideTrack!
     bulkUpdateComponentBaselines(input: BulkUpdateBaselinesInput!): [Component!]!
     acceptTerms(input: AcceptTermsInput!): AcceptTermsResult!
     updateUserPreferences(input: UpdateUserPreferencesInput!): User!
@@ -1156,6 +1180,7 @@ export const typeDefs = gql`
     bikeNotes(bikeId: ID!, take: Int = 20, after: ID): BikeNotesPage!
     referralStats: ReferralStats! @deprecated(reason: "Referral program removed; returns zeros")
     bikeHistory(bikeId: ID!, startDate: String, endDate: String): BikeHistoryPayload!
+    rideTrack(rideId: ID!): RideTrack!
     # Public (unauthenticated) sanitized history for a shared bike.
     # Returns null for unknown or revoked slugs.
     sharedBikeHistory(slug: String!): SharedBikeHistory

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -64,6 +64,8 @@ export const MUTATION_RATE_LIMITS = {
   logBulkComponentService: { windowSeconds: 60, maxRequests: 20 },
   /** updateComponent: max 30 requests per minute per user */
   updateComponent: { windowSeconds: 60, maxRequests: 30 },
+  /** requestRideTrack: max 10 stream fetches per hour per user (each costs a Strava API read) */
+  requestRideTrack: { windowSeconds: 3600, maxRequests: 10 },
   /** createStravaGearMapping: max 10 requests per minute per user */
   createStravaGearMapping: { windowSeconds: 60, maxRequests: 10 },
   /** deleteStravaGearMapping: max 10 requests per minute per user */
@@ -125,6 +127,8 @@ export const QUERY_RATE_LIMITS = {
   unassignedRides: { windowSeconds: 60, maxRequests: 60 },
   /** importNotificationState: max 30 requests per minute per user (supports 30s polling) */
   importNotificationState: { windowSeconds: 60, maxRequests: 30 },
+  /** rideTrack: max 60 requests per minute per user (map open + post-request polling) */
+  rideTrack: { windowSeconds: 60, maxRequests: 60 },
   /** advisorSummary: max 20 LLM calls per 5 minutes per user. Checked only
    *  on cache MISS in the resolver, not on cache-hit refreshes, so the
    *  limit bounds Anthropic dollar cost directly (~$0.96/hour worst case

--- a/apps/api/src/lib/ride-track.test.ts
+++ b/apps/api/src/lib/ride-track.test.ts
@@ -1,0 +1,92 @@
+jest.mock('./prisma', () => ({
+  prisma: {
+    ride: { findUnique: jest.fn() },
+  },
+}));
+
+import { downsampleTrack, getRideTrack, TRACK_TARGET_POINTS } from './ride-track';
+import { prisma } from './prisma';
+
+const mockFindUnique = prisma.ride.findUnique as jest.Mock;
+
+const makeLatLng = (n: number): [number, number][] =>
+  Array.from({ length: n }, (_, i) => [45 + i * 0.0001, -122] as [number, number]);
+
+describe('downsampleTrack', () => {
+  it('returns short tracks untouched', () => {
+    const track = makeLatLng(500);
+    expect(downsampleTrack(track)).toBe(track);
+  });
+
+  it('samples long tracks to the target, keeping both endpoints', () => {
+    const track = makeLatLng(10_000);
+    const sampled = downsampleTrack(track);
+
+    expect(sampled).toHaveLength(TRACK_TARGET_POINTS);
+    expect(sampled[0]).toEqual(track[0]);
+    expect(sampled[sampled.length - 1]).toEqual(track[track.length - 1]);
+    // Monotone progression — no duplicate bunching at the ends.
+    expect(sampled[1][0]).toBeGreaterThan(sampled[0][0]);
+    expect(sampled[400][0]).toBeCloseTo(45 + 5000 * 0.0001, 2);
+  });
+});
+
+describe('getRideTrack', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const base = {
+    userId: 'user-1',
+    stravaActivityId: '9876',
+    startLat: 45.0,
+    startLng: -122.0,
+    stream: null as unknown,
+  };
+
+  it('throws identically for missing rides and other users rides', async () => {
+    mockFindUnique.mockResolvedValueOnce(null);
+    await expect(getRideTrack('user-1', 'ride-x')).rejects.toThrow('Ride not found');
+
+    mockFindUnique.mockResolvedValueOnce({ ...base, userId: 'someone-else' });
+    await expect(getRideTrack('user-1', 'ride-x')).rejects.toThrow('Ride not found');
+  });
+
+  it('returns AVAILABLE with downsampled points when a stream exists', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      ...base,
+      stream: { pointCount: 3, data: { latlng: makeLatLng(3), time: [0, 1, 2] } },
+    });
+
+    const track = await getRideTrack('user-1', 'ride-1');
+
+    expect(track.status).toBe('AVAILABLE');
+    expect(track.points).toHaveLength(3);
+    expect(track.sampledFrom).toBe(3);
+  });
+
+  it('returns FETCHABLE for a Strava ride with coords and no stream', async () => {
+    mockFindUnique.mockResolvedValueOnce(base);
+
+    await expect(getRideTrack('user-1', 'ride-1')).resolves.toEqual({
+      status: 'FETCHABLE',
+      points: null,
+      sampledFrom: null,
+    });
+  });
+
+  it('returns UNAVAILABLE for non-Strava rides and rides without coords', async () => {
+    mockFindUnique.mockResolvedValueOnce({ ...base, stravaActivityId: null });
+    await expect(getRideTrack('user-1', 'r')).resolves.toMatchObject({ status: 'UNAVAILABLE' });
+
+    mockFindUnique.mockResolvedValueOnce({ ...base, startLat: null, startLng: null });
+    await expect(getRideTrack('user-1', 'r')).resolves.toMatchObject({ status: 'UNAVAILABLE' });
+  });
+
+  it('degrades a latlng-less stream to UNAVAILABLE instead of throwing', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      ...base,
+      stream: { pointCount: 10, data: { time: [0, 1] } },
+    });
+
+    await expect(getRideTrack('user-1', 'r')).resolves.toMatchObject({ status: 'UNAVAILABLE' });
+  });
+});

--- a/apps/api/src/lib/ride-track.ts
+++ b/apps/api/src/lib/ride-track.ts
@@ -1,0 +1,70 @@
+import { prisma } from './prisma';
+import type { NormalizedStreams } from './strava-streams';
+
+// Keep payloads map-friendly: ~800 points is visually indistinguishable from
+// the raw track at any zoom the web UI offers, and ~25 KB on the wire vs
+// ~300 KB raw. Downsampled indices deliberately do NOT align with
+// RideSegment stream indices — segment overlays slice the raw stream.
+export const TRACK_TARGET_POINTS = 800;
+
+export type RideTrackStatus = 'AVAILABLE' | 'FETCHABLE' | 'UNAVAILABLE';
+
+export interface RideTrackResult {
+  status: RideTrackStatus;
+  points: [number, number][] | null;
+  sampledFrom: number | null;
+}
+
+/** Stride-sample a polyline to ~target points, always keeping both endpoints. */
+export function downsampleTrack(
+  latlng: [number, number][],
+  target: number = TRACK_TARGET_POINTS
+): [number, number][] {
+  if (latlng.length <= target) return latlng;
+  const stride = (latlng.length - 1) / (target - 1);
+  const out: [number, number][] = [];
+  for (let i = 0; i < target - 1; i++) {
+    out.push(latlng[Math.round(i * stride)]);
+  }
+  out.push(latlng[latlng.length - 1]);
+  return out;
+}
+
+/**
+ * Owner-scoped track lookup. Throws "Ride not found" for missing rides and
+ * for other users' rides alike (no existence oracle).
+ */
+export async function getRideTrack(userId: string, rideId: string): Promise<RideTrackResult> {
+  const ride = await prisma.ride.findUnique({
+    where: { id: rideId },
+    select: {
+      userId: true,
+      stravaActivityId: true,
+      startLat: true,
+      startLng: true,
+      stream: { select: { pointCount: true, data: true } },
+    },
+  });
+
+  if (!ride || ride.userId !== userId) {
+    throw new Error('Ride not found');
+  }
+
+  if (ride.stream) {
+    const latlng = (ride.stream.data as NormalizedStreams).latlng;
+    if (latlng?.length) {
+      return {
+        status: 'AVAILABLE',
+        points: downsampleTrack(latlng),
+        sampledFrom: ride.stream.pointCount,
+      };
+    }
+    // Persisted stream without latlng shouldn't exist (the fetch lib rejects
+    // those), but degrade to UNAVAILABLE rather than 500.
+    return { status: 'UNAVAILABLE', points: null, sampledFrom: null };
+  }
+
+  const fetchable =
+    ride.stravaActivityId != null && ride.startLat != null && ride.startLng != null;
+  return { status: fetchable ? 'FETCHABLE' : 'UNAVAILABLE', points: null, sampledFrom: null };
+}

--- a/apps/web/src/components/EditRideModal.tsx
+++ b/apps/web/src/components/EditRideModal.tsx
@@ -8,6 +8,7 @@ import { Modal, Input, Textarea, Select, Button } from './ui';
 import { usePreferences } from '../hooks/usePreferences';
 import { useUserTier } from '../hooks/useUserTier';
 import RideWeatherPanel from './RideWeatherPanel';
+import RideTrackMap from './RideTrackMap';
 import { UpsellCard } from './UpgradePrompt';
 import type { RideWeather } from '../models/Ride';
 
@@ -136,7 +137,9 @@ export default function EditRideModal({
         </>
       }
     >
-      <form onSubmit={onSave} className="space-y-4">
+      <RideTrackMap rideId={ride.id} />
+
+      <form onSubmit={onSave} className="mt-4 space-y-4">
         <Input
           label="Start (local)"
           type="datetime-local"

--- a/apps/web/src/components/RideTrackMap.test.tsx
+++ b/apps/web/src/components/RideTrackMap.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockUseQuery = vi.fn();
+const mockRequestTrack = vi.fn();
+const mockUseMutation = vi.fn();
+vi.mock('@apollo/client', () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useMutation: (...args: unknown[]) => mockUseMutation(...args),
+  gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+// Leaflet needs a real DOM with layout; stub the lazy inner map.
+vi.mock('./TrackMapInner', () => ({
+  default: ({ points }: { points: [number, number][] }) => (
+    <div data-testid="track-map">{points.length} points</div>
+  ),
+}));
+
+vi.mock('./ui', () => ({
+  Button: ({ children, ...props }: React.ComponentProps<'button'>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+import RideTrackMap from './RideTrackMap';
+
+const startPolling = vi.fn();
+const stopPolling = vi.fn();
+
+const queryResult = (rideTrack: unknown, loading = false) => ({
+  data: rideTrack ? { rideTrack } : undefined,
+  loading,
+  startPolling,
+  stopPolling,
+});
+
+describe('RideTrackMap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseMutation.mockReturnValue([mockRequestTrack, { loading: false, error: undefined }]);
+    mockRequestTrack.mockResolvedValue({});
+  });
+
+  it('renders a skeleton while the initial query loads', () => {
+    mockUseQuery.mockReturnValue(queryResult(null, true));
+    const { container } = render(<RideTrackMap rideId="ride-1" />);
+    expect(container.querySelector('[aria-hidden="true"]')).toBeTruthy();
+  });
+
+  it('renders the map for an AVAILABLE track', async () => {
+    mockUseQuery.mockReturnValue(
+      queryResult({ status: 'AVAILABLE', points: [[45, -122], [45.01, -122]], sampledFrom: 5000 })
+    );
+    render(<RideTrackMap rideId="ride-1" />);
+    expect(await screen.findByTestId('track-map')).toHaveTextContent('2 points');
+  });
+
+  it('renders nothing for UNAVAILABLE rides', () => {
+    mockUseQuery.mockReturnValue(
+      queryResult({ status: 'UNAVAILABLE', points: null, sampledFrom: null })
+    );
+    const { container } = render(<RideTrackMap rideId="ride-1" />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('offers "Load route map" for FETCHABLE rides and polls after requesting', async () => {
+    mockUseQuery.mockReturnValue(
+      queryResult({ status: 'FETCHABLE', points: null, sampledFrom: null })
+    );
+    render(<RideTrackMap rideId="ride-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /load route map/i }));
+
+    await waitFor(() => expect(mockRequestTrack).toHaveBeenCalledTimes(1));
+    expect(startPolling).toHaveBeenCalledWith(2500);
+    expect(await screen.findByText(/loading route from strava/i)).toBeTruthy();
+  });
+
+  it('stops polling once the track becomes AVAILABLE', async () => {
+    // First render FETCHABLE, request, then re-render as AVAILABLE.
+    mockUseQuery.mockReturnValue(
+      queryResult({ status: 'FETCHABLE', points: null, sampledFrom: null })
+    );
+    const { rerender } = render(<RideTrackMap rideId="ride-1" />);
+    fireEvent.click(screen.getByRole('button', { name: /load route map/i }));
+    await waitFor(() => expect(startPolling).toHaveBeenCalled());
+
+    mockUseQuery.mockReturnValue(
+      queryResult({ status: 'AVAILABLE', points: [[45, -122]], sampledFrom: 100 })
+    );
+    rerender(<RideTrackMap rideId="ride-1" />);
+
+    await waitFor(() => expect(stopPolling).toHaveBeenCalled());
+  });
+});

--- a/apps/web/src/components/RideTrackMap.tsx
+++ b/apps/web/src/components/RideTrackMap.tsx
@@ -1,0 +1,110 @@
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
+import { useMutation, useQuery } from '@apollo/client';
+import { RIDE_TRACK, REQUEST_RIDE_TRACK } from '../graphql/rideTrack';
+import { Button } from './ui';
+
+const TrackMapInner = lazy(() => import('./TrackMapInner'));
+
+type RideTrack = {
+  status: 'AVAILABLE' | 'FETCHABLE' | 'UNAVAILABLE';
+  points: [number, number][] | null;
+  sampledFrom: number | null;
+};
+
+const POLL_INTERVAL_MS = 2_500;
+// Stream fetch is a queued job with retries; give it a generous window
+// before telling the user to come back later.
+const POLL_TIMEOUT_MS = 90_000;
+
+const MapSkeleton = () => (
+  <div className="h-56 w-full animate-pulse rounded-lg bg-surface-2" aria-hidden="true" />
+);
+
+/**
+ * Route map for one ride. Self-hides for rides with no GPS source; offers a
+ * one-tap "Load route map" for Strava rides imported before stream ingestion
+ * existed (fetches on demand, then polls until the track lands).
+ */
+export default function RideTrackMap({ rideId }: { rideId: string }) {
+  const { data, loading, startPolling, stopPolling } = useQuery<{ rideTrack: RideTrack }>(
+    RIDE_TRACK,
+    { variables: { rideId }, fetchPolicy: 'cache-and-network' }
+  );
+  const [requestTrack, { loading: requesting, error: requestError }] = useMutation(
+    REQUEST_RIDE_TRACK,
+    { variables: { rideId } }
+  );
+
+  const [waiting, setWaiting] = useState(false);
+  const [timedOut, setTimedOut] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const track = data?.rideTrack;
+
+  // Stop polling as soon as the track lands (or on unmount).
+  useEffect(() => {
+    if (waiting && track?.status === 'AVAILABLE') {
+      stopPolling();
+      setWaiting(false);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    }
+  }, [waiting, track?.status, stopPolling]);
+
+  useEffect(
+    () => () => {
+      stopPolling();
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    },
+    [stopPolling]
+  );
+
+  const handleLoadMap = async () => {
+    setTimedOut(false);
+    try {
+      await requestTrack();
+    } catch {
+      return; // surfaced via requestError
+    }
+    setWaiting(true);
+    startPolling(POLL_INTERVAL_MS);
+    timeoutRef.current = setTimeout(() => {
+      stopPolling();
+      setWaiting(false);
+      setTimedOut(true);
+    }, POLL_TIMEOUT_MS);
+  };
+
+  if (!track) {
+    return loading ? <MapSkeleton /> : null;
+  }
+
+  if (track.status === 'AVAILABLE' && track.points?.length) {
+    return (
+      <Suspense fallback={<MapSkeleton />}>
+        <TrackMapInner points={track.points} />
+      </Suspense>
+    );
+  }
+
+  if (track.status === 'FETCHABLE') {
+    return (
+      <div className="flex h-24 w-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border">
+        {waiting ? (
+          <span className="text-sm text-muted">Loading route from Strava…</span>
+        ) : (
+          <Button type="button" variant="secondary" onClick={handleLoadMap} disabled={requesting}>
+            {requesting ? 'Requesting…' : 'Load route map'}
+          </Button>
+        )}
+        {timedOut && (
+          <span className="text-xs text-muted">
+            Still working on it — check back in a minute.
+          </span>
+        )}
+        {requestError && <span className="text-xs text-danger">{requestError.message}</span>}
+      </div>
+    );
+  }
+
+  return null; // UNAVAILABLE: no GPS source, nothing to show
+}

--- a/apps/web/src/components/TrackMapInner.tsx
+++ b/apps/web/src/components/TrackMapInner.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { MapContainer, TileLayer, Polyline } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import type { LatLngBoundsExpression, LatLngExpression } from 'leaflet';
+
+// Loaded via React.lazy from RideTrackMap so Leaflet (and its CSS) only ship
+// when a ride with a track is actually opened.
+export default function TrackMapInner({ points }: { points: [number, number][] }) {
+  const bounds = useMemo<LatLngBoundsExpression>(() => {
+    let south = Infinity;
+    let north = -Infinity;
+    let west = Infinity;
+    let east = -Infinity;
+    for (const [lat, lng] of points) {
+      if (lat < south) south = lat;
+      if (lat > north) north = lat;
+      if (lng < west) west = lng;
+      if (lng > east) east = lng;
+    }
+    return [
+      [south, west],
+      [north, east],
+    ];
+  }, [points]);
+
+  return (
+    <div className="h-56 w-full overflow-hidden rounded-lg border border-border">
+      <MapContainer
+        bounds={bounds}
+        boundsOptions={{ padding: [20, 20] }}
+        scrollWheelZoom={false}
+        style={{ height: '100%', width: '100%' }}
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        <Polyline
+          positions={points as LatLngExpression[]}
+          pathOptions={{ color: '#f43f5e', weight: 3, opacity: 0.9 }}
+        />
+      </MapContainer>
+    </div>
+  );
+}

--- a/apps/web/src/graphql/rideTrack.ts
+++ b/apps/web/src/graphql/rideTrack.ts
@@ -1,0 +1,25 @@
+import { gql } from '@apollo/client';
+
+// Owner-only downsampled GPS track for one ride. Fetched lazily when a ride
+// is opened (never in the rides list — the blob read stays per-ride).
+export const RIDE_TRACK = gql`
+  query RideTrack($rideId: ID!) {
+    rideTrack(rideId: $rideId) {
+      status
+      points
+      sampledFrom
+    }
+  }
+`;
+
+// Enqueues a stream fetch for a pre-stream-era Strava ride, then the client
+// polls RIDE_TRACK until AVAILABLE.
+export const REQUEST_RIDE_TRACK = gql`
+  mutation RequestRideTrack($rideId: ID!) {
+    requestRideTrack(rideId: $rideId) {
+      status
+      points
+      sampledFrom
+    }
+  }
+`;

--- a/docs/plans/lift-detection-plan.md
+++ b/docs/plans/lift-detection-plan.md
@@ -636,3 +636,88 @@ before any number changes.
   fields (§4.1); segments + confidence persisted for auditability.
 - *Raw streams never mutated*: enforced structurally — detection writes only
   `RideSegment` rows and `Ride.lift*` delta columns.
+
+---
+
+## Appendix A: Ride track map, v1 (addendum, approved 2026-07-18)
+
+A user-facing map of any completed ride's GPS track. Not part of the original
+brief; approved after increments 1–3 merged because the stream infrastructure
+makes it cheap. This is the first user-visible consumer of stream data — it
+ships read-only display before metric exclusion, which is low-risk but makes
+the stream pipeline production-visible.
+
+### Scope
+
+**v1 in:** an interactive track map on a ride's expanded/detail view, for the
+ride's owner only, backed by the persisted `RideStream`. On-demand stream
+fetch for Strava rides that predate stream ingestion. Web app only.
+
+**v1 out (explicitly):**
+- **Segment overlays** (lift portions colored on the map): held until
+  detection passes the §6 validation bar, so users never see a wrong
+  classification. The index-based `RideSegment` design makes this a pure
+  frontend slice later.
+- The external mobile app (consumes the same GraphQL when its team wants it).
+- Maps on the ride *list* (per-row maps need a tile-snapshot service; not v1).
+- Any GPS on shared/public surfaces — `sharedBikeHistory` deliberately
+  excludes GPS today and the new API must not change that.
+
+### API design
+
+GraphQL, following the schema.ts / resolvers.ts convention:
+
+```graphql
+enum RideTrackStatus {
+  AVAILABLE    # stream persisted; points returned
+  FETCHABLE    # Strava ride with coords but no stream yet — offer "Load map"
+  UNAVAILABLE  # no GPS source (manual, Whoop, Garmin/Suunto for now)
+}
+
+type RideTrack {
+  status: RideTrackStatus!
+  points: [[Float!]!]      # [lat, lng] pairs, downsampled server-side; null unless AVAILABLE
+  sampledFrom: Int         # original point count
+}
+
+extend type Query {
+  rideTrack(rideId: ID!): RideTrack!       # owner-only
+}
+extend type Mutation {
+  requestRideTrack(rideId: ID!): RideTrack! # enqueues the existing lift job; rate-limited
+}
+```
+
+A dedicated query (rather than a field on `Ride`) keeps the blob read out of
+the 400-ride list query, makes ownership one explicit check, and cannot leak
+into shared-page types.
+
+- **Downsampling:** stride sampling to ~800 points, always keeping first and
+  last. Downsampled indices deliberately do NOT align with `RideSegment`
+  indices; the segment-overlay v2 slices the raw stream per segment instead.
+- **On-demand fetch = organic backfill.** `requestRideTrack` enqueues the
+  existing lift-detection job (which fetches the stream, then analyzes),
+  reusing its token handling, 404 semantics, idempotent job ID, and retries.
+  This softly amends the no-backfill decision (§7 decision 5): history gets
+  streams in proportion to what owners actually look at, ~1 Strava read per
+  viewed ride. Per-user rate limit via a new `MUTATION_RATE_LIMITS` entry.
+  Client polls `rideTrack` after requesting until AVAILABLE (or gives up).
+
+### Web design
+
+- New dependency: **Leaflet + react-leaflet**, OSM raster tiles (fine at
+  current scale; revisit provider terms if usage grows). Component lazy-loaded
+  (`React.lazy`) so the map bundle isn't paid on dashboard load.
+- `RideTrackMap` component: polyline + fitBounds; rendered only when a ride is
+  expanded/opened, never per list row. FETCHABLE state renders a "Load map"
+  button wired to `requestRideTrack` + polling; UNAVAILABLE renders nothing.
+
+### Risks / notes
+
+- Strava privacy zones don't redact the athlete's own token, so tracks may
+  include starts users hide publicly on Strava. Owner-only display is the
+  mitigation; the disconnect-deletes-streams behavior already shipped.
+- Tile requests go from the user's browser to the tile provider (their IP,
+  our referer). Acceptable for v1; self-hosted or keyed tiles if it matters.
+- A failed on-demand fetch surfaces as a user-visible non-loading map (vs
+  invisible shadow failure). The FETCHABLE→retry path is the recovery.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "libs/*"
       ],
       "dependencies": {
+        "leaflet": "^1.9.4",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "react-leaflet": "^5.0.0"
       },
       "devDependencies": {
         "@ampproject/remapping": "^2.3.0",
@@ -24,6 +26,7 @@
         "@nx/vite": "^22.6.1",
         "@nx/workspace": "^22.6.1",
         "@react-email/preview-server": "^5.2.5",
+        "@types/leaflet": "^1.9.21",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.32.0",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -8436,6 +8439,17 @@
         "react": "^18.0 || ^19.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@react-oauth/google": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.5.tgz",
@@ -11349,6 +11363,13 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -11437,6 +11458,16 @@
       "dependencies": {
         "@types/ms": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/long": {
@@ -20209,6 +20240,12 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -23701,6 +23738,20 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nx/vite": "^22.6.1",
     "@nx/workspace": "^22.6.1",
     "@react-email/preview-server": "^5.2.5",
+    "@types/leaflet": "^1.9.21",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.32.0",
     "eslint-plugin-react-hooks": "^7.0.1",
@@ -42,8 +43,10 @@
     "typescript-eslint": "^8.39.0"
   },
   "dependencies": {
+    "leaflet": "^1.9.4",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "react-leaflet": "^5.0.0"
   },
   "version": "1.0.0"
 }


### PR DESCRIPTION
## Summary

User-facing route map for completed rides, built on the stream infrastructure from #239. Documented as **Appendix A** in [docs/plans/lift-detection-plan.md](docs/plans/lift-detection-plan.md).

- **API**: dedicated owner-only `rideTrack(rideId)` GraphQL query returning the persisted stream's GPS line downsampled server-side to ~800 points (~25 KB vs ~300 KB raw), with a three-state result: `AVAILABLE` (points returned), `FETCHABLE` (Strava ride predating stream ingestion), `UNAVAILABLE` (no GPS source). A dedicated query — not a `Ride` field — keeps the blob read out of the 400-ride list query and structurally out of shared-page types (GPS stays off `sharedBikeHistory`).
- **On-demand backfill**: `requestRideTrack(rideId)` enqueues the *existing* lift-detection job (same idempotent job ID, token handling, retries; the ride also gets shadow-analyzed as a side effect). Historical rides get streams in proportion to what owners actually open — ~1 Strava read per requested ride, rate-limited to 10/hour per user. This softly amends the no-backfill decision, as recorded in Appendix A.
- **Web**: Leaflet + react-leaflet (new dependency), lazy-loaded so the map chunk ships only when a ride with a track is opened. `RideTrackMap` in the ride modal renders the OSM-tiled polyline; `FETCHABLE` rides get a one-tap "Load route map" with 2.5 s polling and a 90 s timeout; rides with no GPS source render nothing.

**Deliberately out (Appendix A):** lift-segment overlays on the map (held until detection passes the validation bar so users never see a wrong classification), per-row maps in the ride list, mobile app, any GPS on shared/public pages.

## Operational notes

- First user-visible consumer of stream data: a failed fetch now surfaces as a non-loading map (retry button is the recovery) instead of an invisible shadow failure.
- Tile requests go browser → OSM public tiles; fine at current scale, revisit provider if usage grows.
- No schema/DB migration in this PR.

## Test plan

- 15 new tests: API (downsampling endpoints/monotonicity, ownership indistinguishable-404, all three statuses, degradation on malformed stream) and web (skeleton, map render, self-hide, request-then-poll, poll-stop on arrival).
- Full suites green: API 1,505 tests (77/77 — including the previously failing advisor suite, healed by the fresh `npm install` this PR's lockfile change came from), web 892 tests (54/54). Both typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)