### PR TITLE
fix(attribution): delete-path parity + prediction-cache invalidation across all sync paths

### DIFF
--- a/apps/api/src/lib/component-hours.test.ts
+++ b/apps/api/src/lib/component-hours.test.ts
@@ -358,4 +358,68 @@ describe('syncBikeComponentHours', () => {
     // A no-op must not touch component rows.
     expect(tx.component.updateMany).not.toHaveBeenCalled();
   });
+
+  // The rideId branch: when an existing ride changes, adjusted components
+  // (whose ComponentRideAdjustment rows reference it) get a canonical
+  // recompute, and THEIR bikes must union into the invalidation set — the
+  // cross-bike INCLUDE case the bulk update never touches.
+  it('unions in cross-bike adjusted components recomputed from the rideId', async () => {
+    const tx = makeTx();
+    // ride-9 carries an adjustment on comp-x, which lives on bike-3.
+    tx.componentRideAdjustment.findMany.mockResolvedValueOnce([{ componentId: 'comp-x' }]);
+    tx.component.findUnique.mockResolvedValue({
+      id: 'comp-x',
+      userId: 'user-1',
+      bikeId: 'bike-3',
+      installedAt: null,
+      hoursUsed: 5,
+    });
+
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 7200 },
+      'ride-9'
+    );
+
+    // bike-1 (its own hours grew) + bike-3 (the cross-bike adjusted component).
+    expect(new Set(affected)).toEqual(new Set(['bike-1', 'bike-3']));
+  });
+
+  it('de-dupes when the adjusted component sits on the same bike as the ride', async () => {
+    const tx = makeTx();
+    tx.componentRideAdjustment.findMany.mockResolvedValueOnce([{ componentId: 'comp-x' }]);
+    tx.component.findUnique.mockResolvedValue({
+      id: 'comp-x',
+      userId: 'user-1',
+      bikeId: 'bike-1',
+      installedAt: null,
+      hoursUsed: 5,
+    });
+
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 7200 },
+      'ride-9'
+    );
+
+    expect(affected).toEqual(['bike-1']);
+  });
+
+  it('skips the recompute entirely when rideId is passed but nothing changed', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      'ride-9'
+    );
+    expect(affected).toEqual([]);
+    // The (bikeChanged || hoursDiff !== 0) guard must gate the lookup.
+    expect(tx.componentRideAdjustment.findMany).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/lib/component-hours.test.ts
+++ b/apps/api/src/lib/component-hours.test.ts
@@ -4,6 +4,7 @@ import {
   recomputeComponentHours,
   recomputeAdjustedComponentsForRides,
   findAdjustedComponentIdsForRides,
+  syncBikeComponentHours,
   type ComponentAttribution,
 } from './component-hours';
 import type { Prisma } from '@prisma/client';
@@ -13,6 +14,7 @@ const makeTx = () => ({
   component: {
     findUnique: jest.fn(),
     update: jest.fn(),
+    updateMany: jest.fn(),
   },
   serviceLog: {
     findFirst: jest.fn(),
@@ -304,5 +306,56 @@ describe('findAdjustedComponentIdsForRides', () => {
     const tx = makeTx();
     expect(await findAdjustedComponentIdsForRides(asTx(tx), [])).toEqual([]);
     expect(tx.componentRideAdjustment.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncBikeComponentHours', () => {
+  // The return value is the invalidation contract: every bike whose hours
+  // this call actually moved, so callers can bust exactly those caches
+  // without reconstructing the primary bike themselves.
+  it('returns both the debited and credited bike when a ride moves bikes', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-2', durationSeconds: 3600 }
+    );
+    expect(new Set(affected)).toEqual(new Set(['bike-1', 'bike-2']));
+  });
+
+  it('returns the single bike when only its duration changed', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 7200 }
+    );
+    expect(affected).toEqual(['bike-1']);
+  });
+
+  it('returns the debited bike on delete (next bike null)', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: null, durationSeconds: 0 }
+    );
+    expect(affected).toEqual(['bike-1']);
+  });
+
+  it('returns nothing when neither bike nor duration changed', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 3600 }
+    );
+    expect(affected).toEqual([]);
+    // A no-op must not touch component rows.
+    expect(tx.component.updateMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/lib/component-hours.ts
+++ b/apps/api/src/lib/component-hours.ts
@@ -58,8 +58,12 @@ export async function decrementBikeComponentHours(
  * (cross-bike INCLUDE). Create paths omit rideId: a brand-new ride can't
  * be pre-adjusted (the adjustment row FK-references an existing ride).
  *
- * Returns the bikeIds of recomputed adjusted components (empty when none)
- * so callers can extend prediction-cache invalidation.
+ * Returns every bikeId whose component hours changed here — the debited
+ * previous bike, the credited next bike, AND any bikes owning adjusted
+ * components recomputed from `rideId` — deduped, nulls dropped. Callers pass
+ * this straight to `invalidateBikePredictionsForBikes`: the return is
+ * self-sufficient, so no caller has to reconstruct the primary bike (the
+ * cache key encodes no ride data, so a ride write can't self-invalidate).
  *
  * Previously duplicated inline in [webhooks.strava.ts] and [workers/sync.worker.ts].
  */
@@ -77,26 +81,36 @@ export async function syncBikeComponentHours(
   const bikeChanged = prevBikeId !== nextBikeId;
   const hoursDiff = nextHours - prevHours;
 
+  // Bikes whose hoursUsed this call actually mutates — only these need their
+  // cached predictions busted (a pure no-op leaves the set empty).
+  const affectedBikeIds = new Set<string>();
+
   if (prevBikeId) {
     if (bikeChanged) {
       await decrementBikeComponentHours(tx, { userId, bikeId: prevBikeId, hoursDelta: prevHours });
+      affectedBikeIds.add(prevBikeId);
     } else if (hoursDiff < 0) {
       await decrementBikeComponentHours(tx, { userId, bikeId: prevBikeId, hoursDelta: Math.abs(hoursDiff) });
+      affectedBikeIds.add(prevBikeId);
     }
   }
 
   if (nextBikeId) {
     if (bikeChanged) {
       await incrementBikeComponentHours(tx, { userId, bikeId: nextBikeId, hoursDelta: nextHours });
+      affectedBikeIds.add(nextBikeId);
     } else if (hoursDiff > 0) {
       await incrementBikeComponentHours(tx, { userId, bikeId: nextBikeId, hoursDelta: hoursDiff });
+      affectedBikeIds.add(nextBikeId);
     }
   }
 
   if (rideId && (bikeChanged || hoursDiff !== 0)) {
-    return recomputeAdjustedComponentsForRides(tx, { rideIds: [rideId] });
+    const adjustedBikeIds = await recomputeAdjustedComponentsForRides(tx, { rideIds: [rideId] });
+    for (const bikeId of adjustedBikeIds) affectedBikeIds.add(bikeId);
   }
-  return [];
+
+  return [...affectedBikeIds];
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/routes/duplicates.test.ts
+++ b/apps/api/src/routes/duplicates.test.ts
@@ -508,4 +508,17 @@ describe('POST /duplicates/merge', () => {
     expect(mockTransaction).not.toHaveBeenCalled();
     expect(mockRideDelete).not.toHaveBeenCalled();
   });
+
+  it('still returns success when post-commit cache invalidation throws', async () => {
+    seedPair({ bikeId: 'bike-1', durationSeconds: 3600 });
+    // The merge transaction already committed; a cache-bust failure must not
+    // turn into a 500 (a retry would 404 on the deleted ride).
+    mockInvalidateBikePrediction.mockRejectedValue(new Error('redis down'));
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(mockRideDelete).toHaveBeenCalledWith({ where: { id: 'del-1' } });
+    expect(mockRes.status).not.toHaveBeenCalledWith(500);
+    expect(jsonResponse).toMatchObject({ success: true, keptRideId: 'keep-1' });
+  });
 });

--- a/apps/api/src/routes/duplicates.test.ts
+++ b/apps/api/src/routes/duplicates.test.ts
@@ -4,14 +4,18 @@ const mockFindMany = jest.fn();
 const mockTransaction = jest.fn();
 const mockUpdate = jest.fn();
 const mockUserFindUnique = jest.fn();
+const mockRideFindUnique = jest.fn();
 const mockDeleteMany = jest.fn();
 const mockUpdateMany = jest.fn();
 const mockExecuteRaw = jest.fn();
+const mockRideDelete = jest.fn();
+const mockComponentUpdateMany = jest.fn();
 
 jest.mock('../lib/prisma', () => ({
   prisma: {
     ride: {
       findMany: mockFindMany,
+      findUnique: mockRideFindUnique,
       update: mockUpdate,
       deleteMany: mockDeleteMany,
       updateMany: mockUpdateMany,
@@ -34,6 +38,9 @@ jest.mock('../services/prediction/cache', () => ({
 }));
 
 import router from './duplicates';
+import { invalidateBikePrediction } from '../services/prediction/cache';
+
+const mockInvalidateBikePrediction = invalidateBikePrediction as jest.Mock;
 
 interface RouteLayer {
   route?: {
@@ -400,5 +407,105 @@ describe('POST /duplicates/auto-merge', () => {
     await invokeHandler(handler, mockReq as Request, mockRes as Response);
 
     expect(jsonResponse).toMatchObject({ message: expect.stringContaining('Suunto data') });
+  });
+});
+
+describe('POST /duplicates/merge', () => {
+  let handler: RequestHandler | undefined;
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let jsonResponse: unknown;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handler = getHandler('/duplicates/merge', 'post');
+    jsonResponse = undefined;
+
+    mockReq = {
+      user: { id: 'user-123' },
+      sessionUser: undefined,
+      body: { keepRideId: 'keep-1', deleteRideId: 'del-1' },
+    } as Partial<Request>;
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockImplementation((data) => {
+        jsonResponse = data;
+        return mockRes;
+      }),
+    };
+
+    // tx exposes exactly what the merge path + the real component-hours
+    // helpers touch: the adjustment lookup, the bulk component decrement,
+    // and the ride delete/update.
+    mockTransaction.mockImplementation(async (fn) =>
+      fn({
+        componentRideAdjustment: { findMany: jest.fn().mockResolvedValue([]) },
+        component: { updateMany: mockComponentUpdateMany },
+        ride: { delete: mockRideDelete, update: mockUpdate },
+      })
+    );
+    mockComponentUpdateMany.mockResolvedValue({ count: 1 });
+    mockRideDelete.mockResolvedValue({ id: 'del-1' });
+    mockUpdate.mockResolvedValue({ id: 'keep-1' });
+  });
+
+  function seedPair(deleteRide: {
+    bikeId: string | null;
+    durationSeconds: number | null;
+  }) {
+    mockRideFindUnique
+      .mockResolvedValueOnce({ userId: 'user-123', duplicateOfId: 'del-1' }) // keepRide
+      .mockResolvedValueOnce({ userId: 'user-123', duplicateOfId: 'keep-1', ...deleteRide }); // deleteRide
+  }
+
+  it('rejects unauthenticated requests', async () => {
+    mockReq.user = undefined;
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(mockRes.status).toHaveBeenCalledWith(401);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('decrements component hours and invalidates the prediction cache when deleting the duplicate', async () => {
+    seedPair({ bikeId: 'bike-1', durationSeconds: 3600 });
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    // Duplicate deleted inside the integrity transaction
+    expect(mockRideDelete).toHaveBeenCalledWith({ where: { id: 'del-1' } });
+    // Bike-1's components decremented by the deleted ride's hours (bulk helper)
+    expect(mockComponentUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: 'user-123', bikeId: 'bike-1' }),
+        data: { hoursUsed: { decrement: 1 } },
+      })
+    );
+    // Prediction cache busted for the affected bike
+    expect(mockInvalidateBikePrediction).toHaveBeenCalledWith('user-123', 'bike-1');
+    expect(jsonResponse).toMatchObject({ success: true, keptRideId: 'keep-1' });
+  });
+
+  it('skips hours decrement and cache invalidation for an unassigned deleted ride', async () => {
+    seedPair({ bikeId: null, durationSeconds: 3600 });
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(mockRideDelete).toHaveBeenCalledWith({ where: { id: 'del-1' } });
+    expect(mockComponentUpdateMany).not.toHaveBeenCalled();
+    expect(mockInvalidateBikePrediction).not.toHaveBeenCalled();
+    expect(jsonResponse).toMatchObject({ success: true });
+  });
+
+  it('rejects when the two rides are not marked as duplicates of each other', async () => {
+    mockRideFindUnique
+      .mockResolvedValueOnce({ userId: 'user-123', duplicateOfId: null })
+      .mockResolvedValueOnce({ userId: 'user-123', duplicateOfId: null, bikeId: 'bike-1', durationSeconds: 3600 });
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(mockRideDelete).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/duplicates.ts
+++ b/apps/api/src/routes/duplicates.ts
@@ -6,6 +6,7 @@ import { isDuplicateActivity } from '../lib/duplicate-detector';
 import {
   findAdjustedComponentIdsForRides,
   recomputeAdjustedComponentsForRides,
+  syncBikeComponentHours,
 } from '../lib/component-hours';
 import { invalidateBikePrediction } from '../services/prediction/cache';
 
@@ -82,7 +83,10 @@ r.post<Empty, void, { keepRideId: string; deleteRideId: string }>(
       // Verify both rides belong to this user and check duplicate relationship
       const [keepRide, deleteRide] = await Promise.all([
         prisma.ride.findUnique({ where: { id: keepRideId }, select: { userId: true, duplicateOfId: true } }),
-        prisma.ride.findUnique({ where: { id: deleteRideId }, select: { userId: true, duplicateOfId: true } }),
+        prisma.ride.findUnique({
+          where: { id: deleteRideId },
+          select: { userId: true, duplicateOfId: true, bikeId: true, durationSeconds: true },
+        }),
       ]);
 
       if (!keepRide || !deleteRide) {
@@ -102,19 +106,48 @@ r.post<Empty, void, { keepRideId: string; deleteRideId: string }>(
         return sendBadRequest(res, 'Rides are not marked as duplicates of each other');
       }
 
-      // Delete the duplicate
-      await prisma.ride.delete({
-        where: { id: deleteRideId },
+      // Delete the duplicate and keep component hours + ride adjustments in
+      // sync. The auto-merge route already does this; the manual merge was a
+      // gap — it deleted the ride without decrementing the bike's component
+      // hours, recomputing adjusted components, or busting the cached
+      // predictions.
+      const adjustedBikeIds = await prisma.$transaction(async (tx) => {
+        // Capture BEFORE the delete — adjustment rows cascade away with the
+        // ride, and cross-bike INCLUDEs live on components the decrement
+        // below never touches.
+        const adjustedComponentIds = await findAdjustedComponentIdsForRides(tx, [deleteRideId]);
+
+        await syncBikeComponentHours(
+          tx,
+          userId,
+          { bikeId: deleteRide.bikeId ?? null, durationSeconds: deleteRide.durationSeconds },
+          { bikeId: null, durationSeconds: 0 }
+        );
+
+        // Delete the duplicate
+        await tx.ride.delete({
+          where: { id: deleteRideId },
+        });
+
+        // Clear duplicate flags on the kept ride
+        await tx.ride.update({
+          where: { id: keepRideId },
+          data: {
+            isDuplicate: false,
+            duplicateOfId: null,
+          },
+        });
+
+        return recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
       });
 
-      // Clear duplicate flags on the kept ride
-      await prisma.ride.update({
-        where: { id: keepRideId },
-        data: {
-          isDuplicate: false,
-          duplicateOfId: null,
-        },
-      });
+      // Invalidate prediction caches for every bike whose component hours changed.
+      for (const bikeId of new Set([
+        ...(deleteRide.bikeId ? [deleteRide.bikeId] : []),
+        ...adjustedBikeIds,
+      ])) {
+        await invalidateBikePrediction(userId, bikeId);
+      }
 
       console.log(`[Duplicates] Merged: kept ${keepRideId}, deleted ${deleteRideId}`);
 

--- a/apps/api/src/routes/duplicates.ts
+++ b/apps/api/src/routes/duplicates.ts
@@ -141,13 +141,14 @@ r.post<Empty, void, { keepRideId: string; deleteRideId: string }>(
         return recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
       });
 
-      // Invalidate prediction caches for every bike whose component hours changed.
-      for (const bikeId of new Set([
-        ...(deleteRide.bikeId ? [deleteRide.bikeId] : []),
-        ...adjustedBikeIds,
-      ])) {
-        await invalidateBikePrediction(userId, bikeId);
-      }
+      // Invalidate prediction caches for every bike whose component hours
+      // changed — independent cache busts, so fire them together.
+      await Promise.all(
+        [...new Set([
+          ...(deleteRide.bikeId ? [deleteRide.bikeId] : []),
+          ...adjustedBikeIds,
+        ])].map((bikeId) => invalidateBikePrediction(userId, bikeId))
+      );
 
       console.log(`[Duplicates] Merged: kept ${keepRideId}, deleted ${deleteRideId}`);
 

--- a/apps/api/src/routes/duplicates.ts
+++ b/apps/api/src/routes/duplicates.ts
@@ -142,13 +142,20 @@ r.post<Empty, void, { keepRideId: string; deleteRideId: string }>(
       });
 
       // Invalidate prediction caches for every bike whose component hours
-      // changed — independent cache busts, so fire them together.
-      await Promise.all(
-        [...new Set([
-          ...(deleteRide.bikeId ? [deleteRide.bikeId] : []),
-          ...adjustedBikeIds,
-        ])].map((bikeId) => invalidateBikePrediction(userId, bikeId))
-      );
+      // changed — independent cache busts, so fire them together. This runs
+      // AFTER the transaction committed, so a bust failure must NOT surface as
+      // a 500: the merge already happened and a client retry would then 404 on
+      // the deleted ride. Best-effort — the cache TTL backstops any staleness.
+      try {
+        await Promise.all(
+          [...new Set([
+            ...(deleteRide.bikeId ? [deleteRide.bikeId] : []),
+            ...adjustedBikeIds,
+          ])].map((bikeId) => invalidateBikePrediction(userId, bikeId))
+        );
+      } catch (err) {
+        logError('Duplicates merge cache invalidation', err);
+      }
 
       console.log(`[Duplicates] Merged: kept ${keepRideId}, deleted ${deleteRideId}`);
 
@@ -556,9 +563,17 @@ r.post('/duplicates/auto-merge', async (req: Request, res: Response) => {
 
     // Invalidate prediction caches for every bike whose component hours
     // changed (previously a gap on this route — merges decremented hours
-    // without busting the cached predictions).
-    for (const bikeId of new Set([...hoursToDecrementByBike.keys(), ...adjustedBikeIds])) {
-      await invalidateBikePrediction(userId, bikeId);
+    // without busting the cached predictions). Post-commit best-effort: a
+    // bust failure must not turn the committed merge into a client-visible
+    // 500 (a retry would re-scan against already-deleted rides).
+    try {
+      await Promise.all(
+        [...new Set([...hoursToDecrementByBike.keys(), ...adjustedBikeIds])].map(
+          (bikeId) => invalidateBikePrediction(userId, bikeId)
+        )
+      );
+    } catch (err) {
+      logError('Duplicates auto-merge cache invalidation', err);
     }
 
     console.log(`[Duplicates] Auto-merge completed for user ${userId}: merged ${ridesToDelete.length} pairs, preferred: ${preferredSource}`);

--- a/apps/api/src/routes/webhooks.strava.ts
+++ b/apps/api/src/routes/webhooks.strava.ts
@@ -8,6 +8,7 @@ import {
   findAdjustedComponentIdsForRides,
   recomputeAdjustedComponentsForRides,
 } from '../lib/component-hours';
+import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { logError } from '../lib/logger';
 import { fireRideNotifications } from '../services/notification.service';
 import { enqueueWeatherJob, enqueueLiftDetectionJob } from '../lib/queue';
@@ -234,7 +235,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
 
   // Handle different event types
   if (aspect_type === 'delete') {
-    await prisma.$transaction(async (tx) => {
+    const affectedBikeIds = await prisma.$transaction(async (tx) => {
       const existing = await tx.ride.findUnique({
         where: { stravaActivityId: activityId.toString() },
         select: { id: true, userId: true, durationSeconds: true, bikeId: true },
@@ -242,7 +243,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
 
       if (!existing || existing.userId !== userAccount.userId) {
         console.log(`[Strava Activity Event] No ride to delete for activity ${activityId}`);
-        return;
+        return [] as string[];
       }
 
       // Capture BEFORE the delete — adjustment rows cascade away with the
@@ -250,7 +251,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
       // below never touches.
       const adjustedComponentIds = await findAdjustedComponentIdsForRides(tx, [existing.id]);
 
-      await syncBikeComponentHours(
+      const affected = await syncBikeComponentHours(
         tx,
         userAccount.userId,
         { bikeId: existing.bikeId ?? null, durationSeconds: existing.durationSeconds },
@@ -259,8 +260,12 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
 
       await tx.ride.delete({ where: { id: existing.id } });
 
-      await recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
+      const adjustedBikeIds = await recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
+      return [...affected, ...adjustedBikeIds];
     });
+    // Bust cached predictions for every bike whose hours changed (previously
+    // a gap — this webhook decremented hours without invalidating the cache).
+    await invalidateBikePredictionsForBikes(userAccount.userId, affectedBikeIds);
     console.log(`[Strava Activity Event] Deleted ride for activity ${activityId}`);
     return;
   }
@@ -342,7 +347,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
 
       const autoLocation = await extractStravaLocation(activity);
 
-      const { syncedRideId, isNewRide } = await prisma.$transaction(async (tx) => {
+      const { syncedRideId, isNewRide, affectedBikeIds } = await prisma.$transaction(async (tx) => {
         const existing = await tx.ride.findUnique({
           where: { stravaActivityId: activityId.toString() },
           select: { id: true, durationSeconds: true, bikeId: true, location: true },
@@ -392,7 +397,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
           },
         });
 
-        await syncBikeComponentHours(
+        const affectedBikeIds = await syncBikeComponentHours(
           tx,
           userAccount.userId,
           {
@@ -407,8 +412,12 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
           existing ? ride.id : undefined
         );
 
-        return { syncedRideId: ride.id, isNewRide: !existing };
+        return { syncedRideId: ride.id, isNewRide: !existing, affectedBikeIds };
       });
+
+      // Bust cached predictions for every bike whose hours changed (create or
+      // re-sync with a changed bike/duration both land here).
+      await invalidateBikePredictionsForBikes(userAccount.userId, affectedBikeIds);
 
       console.log(`[Strava Activity Event] Successfully stored ride for activity ${activityId}`);
 

--- a/apps/api/src/routes/webhooks.suunto.test.ts
+++ b/apps/api/src/routes/webhooks.suunto.test.ts
@@ -27,6 +27,12 @@ jest.mock('../lib/component-hours', () => ({
   syncBikeComponentHours: (...args: unknown[]) => mockSyncBikeComponentHours(...args),
 }));
 
+const mockInvalidateBikePredictionsForBikes = jest.fn();
+jest.mock('../services/prediction/cache', () => ({
+  invalidateBikePredictionsForBikes: (...args: unknown[]) =>
+    mockInvalidateBikePredictionsForBikes(...args),
+}));
+
 const mockFireRideNotifications = jest.fn();
 jest.mock('../services/notification.service', () => ({
   fireRideNotifications: (...args: unknown[]) => mockFireRideNotifications(...args),
@@ -97,6 +103,7 @@ describe('POST /webhooks/suunto/workouts', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsActiveSource.mockResolvedValue(true);
+    mockSyncBikeComponentHours.mockResolvedValue([]);
     mockUserAccountFindUnique.mockResolvedValue({ userId: 'user-1' });
     mockRideFindUnique.mockResolvedValue(null); // new ride by default
     mockBikeFindMany.mockResolvedValue([]); // 0 active bikes by default

--- a/apps/api/src/routes/webhooks.suunto.ts
+++ b/apps/api/src/routes/webhooks.suunto.ts
@@ -5,6 +5,7 @@ import { createLogger, logError } from '../lib/logger';
 import { isActiveSource } from '../lib/active-source';
 import { isSuuntoCyclingActivity, getSuuntoRideType, isKnownSuuntoActivity } from '../types/suunto';
 import { syncBikeComponentHours } from '../lib/component-hours';
+import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { fireRideNotifications } from '../services/notification.service';
 
 const log = createLogger('suunto-webhook');
@@ -197,6 +198,7 @@ async function processWorkoutCreated(event: WorkoutCreatedEvent): Promise<void> 
 
   let syncedRideId = '';
   let syncedBikeId: string | null = null;
+  let affectedBikeIds: string[] = [];
 
   await prisma.$transaction(async (tx) => {
     const ride = await tx.ride.upsert({
@@ -226,7 +228,7 @@ async function processWorkoutCreated(event: WorkoutCreatedEvent): Promise<void> 
       },
     });
 
-    await syncBikeComponentHours(
+    affectedBikeIds = await syncBikeComponentHours(
       tx,
       userAccount.userId,
       { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -238,6 +240,9 @@ async function processWorkoutCreated(event: WorkoutCreatedEvent): Promise<void> 
     syncedRideId = ride.id;
     syncedBikeId = ride.bikeId ?? null;
   });
+
+  // Bust cached predictions for every bike whose hours changed.
+  await invalidateBikePredictionsForBikes(userAccount.userId, affectedBikeIds);
 
   // Fire-and-forget: send "Ride Synced" + bike-select prompt for new rides.
   // Mirrors the Strava webhook + Garmin/WHOOP sync-worker call sites so all

--- a/apps/api/src/routes/webhooks.whoop.test.ts
+++ b/apps/api/src/routes/webhooks.whoop.test.ts
@@ -295,6 +295,40 @@ describe('WHOOP Webhook Handler', () => {
       expect(mockInvalidateBikePrediction).toHaveBeenCalledWith('user-123', 'bike-2');
     });
 
+    it('logs a targeted error (not "Processing failed") when invalidation fails after delete', async () => {
+      const handler = getRouteHandler('post', '/whoop');
+      const req = mockRequest({
+        body: {
+          user_id: 123456,
+          id: 'workout-uuid-to-delete',
+          event_type: 'workout.deleted',
+          timestamp: '2024-01-15T10:00:00Z',
+        },
+      });
+      const res = mockResponse();
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-123' });
+      mockRideFindMany.mockResolvedValue([
+        { id: 'ride-1', bikeId: 'bike-1', durationSeconds: 3600 },
+      ]);
+      // The delete commits, then the post-commit cache bust fails.
+      mockInvalidateBikePrediction.mockRejectedValue(new Error('redis down'));
+
+      await handler!(req as Request, res as Response);
+
+      // Ride still deleted; failure logged specifically, NOT via the generic
+      // outer catch-all (which would fire misleading "Processing failed" alerts).
+      expect(mockRideDeleteMany).toHaveBeenCalledWith({ where: { id: { in: ['ride-1'] } } });
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ workoutId: 'workout-uuid-to-delete', userId: 'user-123' }),
+        '[WHOOP Webhook] Cache invalidation failed after workout.deleted'
+      );
+      expect(logger.error).not.toHaveBeenCalledWith(
+        expect.anything(),
+        '[WHOOP Webhook] Processing failed'
+      );
+    });
+
     it('should log debug when deleting non-existent workout', async () => {
       const handler = getRouteHandler('post', '/whoop');
       const req = mockRequest({

--- a/apps/api/src/routes/webhooks.whoop.test.ts
+++ b/apps/api/src/routes/webhooks.whoop.test.ts
@@ -1,6 +1,14 @@
 import { Request, Response } from 'express';
 
 // Mock dependencies before importing the module
+const mockTransaction = jest.fn();
+const mockRideFindMany = jest.fn();
+const mockRideDeleteMany = jest.fn();
+const mockSyncBikeComponentHours = jest.fn();
+const mockFindAdjustedComponentIdsForRides = jest.fn();
+const mockRecomputeAdjustedComponentsForRides = jest.fn();
+const mockInvalidateBikePrediction = jest.fn();
+
 jest.mock('../lib/prisma', () => ({
   prisma: {
     user: {
@@ -8,9 +16,22 @@ jest.mock('../lib/prisma', () => ({
     },
     ride: {
       updateMany: jest.fn(),
-      deleteMany: jest.fn(),
+      deleteMany: mockRideDeleteMany,
+      findMany: mockRideFindMany,
     },
+    $transaction: mockTransaction,
   },
+}));
+
+jest.mock('../lib/component-hours', () => ({
+  syncBikeComponentHours: (...args: unknown[]) => mockSyncBikeComponentHours(...args),
+  findAdjustedComponentIdsForRides: (...args: unknown[]) => mockFindAdjustedComponentIdsForRides(...args),
+  recomputeAdjustedComponentsForRides: (...args: unknown[]) =>
+    mockRecomputeAdjustedComponentsForRides(...args),
+}));
+
+jest.mock('../services/prediction/cache', () => ({
+  invalidateBikePrediction: (...args: unknown[]) => mockInvalidateBikePrediction(...args),
 }));
 
 jest.mock('../lib/queue/sync.queue', () => ({
@@ -66,6 +87,15 @@ describe('WHOOP Webhook Handler', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsActiveSource.mockResolvedValue(true);
+    // Run the delete transaction against a tx exposing just what the handler
+    // touches; the component-hours helpers are mocked so the tx stays thin.
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+      fn({ ride: { findMany: mockRideFindMany, deleteMany: mockRideDeleteMany } })
+    );
+    mockFindAdjustedComponentIdsForRides.mockResolvedValue([]);
+    mockRecomputeAdjustedComponentsForRides.mockResolvedValue([]);
+    mockSyncBikeComponentHours.mockResolvedValue([]);
+    mockRideDeleteMany.mockResolvedValue({ count: 1 });
   });
 
   describe('GET /whoop (verification)', () => {
@@ -213,17 +243,56 @@ describe('WHOOP Webhook Handler', () => {
       const res = mockResponse();
 
       (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-123' });
-      (prisma.ride.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
+      mockRideFindMany.mockResolvedValue([
+        { id: 'ride-1', bikeId: 'bike-1', durationSeconds: 3600 },
+      ]);
 
       await handler!(req as Request, res as Response);
 
-      expect(prisma.ride.deleteMany).toHaveBeenCalledWith({
+      expect(mockRideFindMany).toHaveBeenCalledWith({
         where: { userId: 'user-123', whoopWorkoutId: 'workout-uuid-to-delete' },
+        select: { id: true, bikeId: true, durationSeconds: true },
       });
+      expect(mockRideDeleteMany).toHaveBeenCalledWith({ where: { id: { in: ['ride-1'] } } });
       expect(logger.info).toHaveBeenCalledWith(
-        expect.objectContaining({ workoutId: 'workout-uuid-to-delete', userId: 'user-123' }),
+        expect.objectContaining({ workoutId: 'workout-uuid-to-delete', userId: 'user-123', count: 1 }),
         '[WHOOP Webhook] Marked workout as deleted'
       );
+    });
+
+    it('should decrement component hours and invalidate prediction caches on workout.deleted', async () => {
+      const handler = getRouteHandler('post', '/whoop');
+      const req = mockRequest({
+        body: {
+          user_id: 123456,
+          id: 'workout-uuid-to-delete',
+          event_type: 'workout.deleted',
+          timestamp: '2024-01-15T10:00:00Z',
+        },
+      });
+      const res = mockResponse();
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-123' });
+      mockRideFindMany.mockResolvedValue([
+        { id: 'ride-1', bikeId: 'bike-1', durationSeconds: 3600 },
+      ]);
+      // A cross-bike INCLUDE adjustment lives on a component of bike-2.
+      mockRecomputeAdjustedComponentsForRides.mockResolvedValue(['bike-2']);
+
+      await handler!(req as Request, res as Response);
+
+      // Captured the adjusted components BEFORE the delete cascades the rows away
+      expect(mockFindAdjustedComponentIdsForRides).toHaveBeenCalledWith(expect.anything(), ['ride-1']);
+      // Debited the ride's hours off bike-1's components
+      expect(mockSyncBikeComponentHours).toHaveBeenCalledWith(
+        expect.anything(),
+        'user-123',
+        { bikeId: 'bike-1', durationSeconds: 3600 },
+        { bikeId: null, durationSeconds: 0 }
+      );
+      // Both the ride's own bike and the recomputed cross-bike component's bike get busted
+      expect(mockInvalidateBikePrediction).toHaveBeenCalledWith('user-123', 'bike-1');
+      expect(mockInvalidateBikePrediction).toHaveBeenCalledWith('user-123', 'bike-2');
     });
 
     it('should log debug when deleting non-existent workout', async () => {
@@ -239,7 +308,7 @@ describe('WHOOP Webhook Handler', () => {
       const res = mockResponse();
 
       (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-123' });
-      (prisma.ride.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
+      mockRideFindMany.mockResolvedValue([]);
 
       await handler!(req as Request, res as Response);
 
@@ -247,6 +316,8 @@ describe('WHOOP Webhook Handler', () => {
         expect.objectContaining({ workoutId: 'non-existent-workout' }),
         '[WHOOP Webhook] Workout not found (may not have been imported)'
       );
+      expect(mockRideDeleteMany).not.toHaveBeenCalled();
+      expect(mockInvalidateBikePrediction).not.toHaveBeenCalled();
     });
 
     it('should enqueue sync job on workout.created event', async () => {

--- a/apps/api/src/routes/webhooks.whoop.ts
+++ b/apps/api/src/routes/webhooks.whoop.ts
@@ -3,6 +3,12 @@ import { prisma } from '../lib/prisma';
 import { enqueueSyncJob } from '../lib/queue/sync.queue';
 import { logger } from '../lib/logger';
 import { isActiveSource } from '../lib/active-source';
+import {
+  findAdjustedComponentIdsForRides,
+  recomputeAdjustedComponentsForRides,
+  syncBikeComponentHours,
+} from '../lib/component-hours';
+import { invalidateBikePrediction } from '../services/prediction/cache';
 
 const r = createRouter();
 
@@ -97,21 +103,64 @@ r.post('/whoop', async (req: Request, res: Response) => {
     // Handle different event types
     switch (event_type) {
       case 'workout.deleted': {
-        // Delete the ride
-        const updateResult = await prisma.ride.deleteMany({
-          where: { userId: user.id, whoopWorkoutId: workoutId },
-        });
+        // Delete the ride(s) and keep component hours + ride adjustments in
+        // sync — mirrors the Strava delete webhook. Without this, a deleted
+        // WHOOP workout leaves its hours credited to the bike's components
+        // and orphans any cross-bike INCLUDE adjustment that referenced it.
+        const affectedBikeIds = await prisma.$transaction(async (tx) => {
+          const rides = await tx.ride.findMany({
+            where: { userId: user.id, whoopWorkoutId: workoutId },
+            select: { id: true, bikeId: true, durationSeconds: true },
+          });
 
-        if (updateResult.count > 0) {
+          if (rides.length === 0) {
+            logger.debug(
+              { workoutId, userId: user.id },
+              '[WHOOP Webhook] Workout not found (may not have been imported)'
+            );
+            return [] as string[];
+          }
+
+          // Capture BEFORE the delete — adjustment rows cascade away with the
+          // ride, and cross-bike INCLUDEs live on components the per-ride
+          // decrement below never touches.
+          const adjustedComponentIds = await findAdjustedComponentIdsForRides(
+            tx,
+            rides.map((ride) => ride.id)
+          );
+
+          const bikeIds = new Set<string>();
+          for (const ride of rides) {
+            if (ride.bikeId) bikeIds.add(ride.bikeId);
+            await syncBikeComponentHours(
+              tx,
+              user.id,
+              { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds },
+              { bikeId: null, durationSeconds: 0 }
+            );
+          }
+
+          await tx.ride.deleteMany({
+            where: { id: { in: rides.map((ride) => ride.id) } },
+          });
+
+          const adjustedBikeIds = await recomputeAdjustedComponentsForRides(tx, {
+            componentIds: adjustedComponentIds,
+          });
+          for (const bikeId of adjustedBikeIds) bikeIds.add(bikeId);
+
           logger.info(
-            { workoutId, userId: user.id },
+            { workoutId, userId: user.id, count: rides.length },
             '[WHOOP Webhook] Marked workout as deleted'
           );
-        } else {
-          logger.debug(
-            { workoutId, userId: user.id },
-            '[WHOOP Webhook] Workout not found (may not have been imported)'
-          );
+
+          return [...bikeIds];
+        });
+
+        // Invalidate prediction caches for every bike whose component hours
+        // changed (the bulk decrement and any adjusted-component recompute).
+        for (const bikeId of affectedBikeIds) {
+          await invalidateBikePrediction(user.id, bikeId);
         }
         break;
       }

--- a/apps/api/src/routes/webhooks.whoop.ts
+++ b/apps/api/src/routes/webhooks.whoop.ts
@@ -159,10 +159,20 @@ r.post('/whoop', async (req: Request, res: Response) => {
 
         // Invalidate prediction caches for every bike whose component hours
         // changed (the bulk decrement and any adjusted-component recompute) —
-        // independent cache busts, so fire them together.
-        await Promise.all(
-          affectedBikeIds.map((bikeId) => invalidateBikePrediction(user.id, bikeId))
-        );
+        // independent cache busts, so fire them together. Best-effort: the
+        // delete already committed, so catch a bust failure here rather than
+        // letting it bubble to the outer catch and log a misleading
+        // "Processing failed" (a stale prediction self-heals at the cache TTL).
+        try {
+          await Promise.all(
+            affectedBikeIds.map((bikeId) => invalidateBikePrediction(user.id, bikeId))
+          );
+        } catch (err) {
+          logger.error(
+            { err, workoutId, userId: user.id },
+            '[WHOOP Webhook] Cache invalidation failed after workout.deleted'
+          );
+        }
         break;
       }
 

--- a/apps/api/src/routes/webhooks.whoop.ts
+++ b/apps/api/src/routes/webhooks.whoop.ts
@@ -158,10 +158,11 @@ r.post('/whoop', async (req: Request, res: Response) => {
         });
 
         // Invalidate prediction caches for every bike whose component hours
-        // changed (the bulk decrement and any adjusted-component recompute).
-        for (const bikeId of affectedBikeIds) {
-          await invalidateBikePrediction(user.id, bikeId);
-        }
+        // changed (the bulk decrement and any adjusted-component recompute) —
+        // independent cache busts, so fire them together.
+        await Promise.all(
+          affectedBikeIds.map((bikeId) => invalidateBikePrediction(user.id, bikeId))
+        );
         break;
       }
 

--- a/apps/api/src/services/prediction/__tests__/cache.test.ts
+++ b/apps/api/src/services/prediction/__tests__/cache.test.ts
@@ -10,6 +10,7 @@ import {
   getCachedPrediction,
   setCachedPrediction,
   invalidateBikePrediction,
+  invalidateBikePredictionsForBikes,
   invalidateUserPredictions,
   clearMemoryCache,
   getMemoryCacheSize,
@@ -229,6 +230,34 @@ describe('prediction cache', () => {
         100
       );
       expect(mockRedis.del).toHaveBeenCalledWith('key1', 'key2');
+    });
+  });
+
+  describe('invalidateBikePredictionsForBikes', () => {
+    it('invalidates every listed bike, skips nulls, and de-dupes', async () => {
+      (isRedisReady as jest.Mock).mockReturnValue(false);
+
+      await setCachedPrediction({ ...cacheParams, bikeId: 'bike-a' }, { ...mockPrediction, bikeId: 'bike-a' });
+      await setCachedPrediction({ ...cacheParams, bikeId: 'bike-b' }, { ...mockPrediction, bikeId: 'bike-b' });
+      await setCachedPrediction({ ...cacheParams, bikeId: 'bike-c' }, { ...mockPrediction, bikeId: 'bike-c' });
+      expect(getMemoryCacheSize()).toBe(3);
+
+      // Duplicate 'bike-a' and a null/undefined entry must not throw and must
+      // not touch bike-c.
+      await invalidateBikePredictionsForBikes('user-123', ['bike-a', 'bike-a', null, undefined, 'bike-b']);
+
+      // bike-a + bike-b cleared, bike-c untouched.
+      expect(getMemoryCacheSize()).toBe(1);
+    });
+
+    it('is a no-op on an empty list', async () => {
+      (isRedisReady as jest.Mock).mockReturnValue(false);
+      await setCachedPrediction({ ...cacheParams, bikeId: 'bike-a' }, { ...mockPrediction, bikeId: 'bike-a' });
+      expect(getMemoryCacheSize()).toBe(1);
+
+      await invalidateBikePredictionsForBikes('user-123', []);
+
+      expect(getMemoryCacheSize()).toBe(1);
     });
   });
 

--- a/apps/api/src/services/prediction/cache.ts
+++ b/apps/api/src/services/prediction/cache.ts
@@ -229,6 +229,28 @@ export async function invalidateBikePrediction(
 }
 
 /**
+ * Invalidate prediction caches for several bikes at once, skipping nulls and
+ * de-duplicating first. The canonical post-commit call for any write path
+ * that changes component hours: feed it the bikeIds `syncBikeComponentHours`
+ * (or a `recompute*` helper) returns, and every affected bike's cached
+ * predictions get busted in one call. Centralized so a new sync path can't
+ * reintroduce the "hours changed, cache went stale" gap by hand-rolling
+ * (and forgetting part of) the loop.
+ */
+export async function invalidateBikePredictionsForBikes(
+  userId: string,
+  bikeIds: Iterable<string | null | undefined>
+): Promise<void> {
+  const unique = new Set<string>();
+  for (const bikeId of bikeIds) {
+    if (bikeId) unique.add(bikeId);
+  }
+  for (const bikeId of unique) {
+    await invalidateBikePrediction(userId, bikeId);
+  }
+}
+
+/**
  * Invalidate all predictions for a user.
  * Called when user role changes.
  *

--- a/apps/api/src/services/prediction/cache.ts
+++ b/apps/api/src/services/prediction/cache.ts
@@ -245,9 +245,10 @@ export async function invalidateBikePredictionsForBikes(
   for (const bikeId of bikeIds) {
     if (bikeId) unique.add(bikeId);
   }
-  for (const bikeId of unique) {
-    await invalidateBikePrediction(userId, bikeId);
-  }
+  // Independent cache busts — fire them together rather than serially.
+  await Promise.all(
+    [...unique].map((bikeId) => invalidateBikePrediction(userId, bikeId))
+  );
 }
 
 /**

--- a/apps/api/src/services/prediction/index.ts
+++ b/apps/api/src/services/prediction/index.ts
@@ -28,6 +28,7 @@ export {
 // Cache - Invalidation Functions
 export {
   invalidateBikePrediction,
+  invalidateBikePredictionsForBikes,
   invalidateUserPredictions,
 } from './cache';
 

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -13,6 +13,7 @@ import type { BackfillJobData, BackfillJobName } from '../lib/queue/backfill.que
 import { enqueueWeatherJob } from '../lib/queue';
 import { captureServerEvent } from '../lib/posthog';
 import { incrementBikeComponentHours, syncBikeComponentHours } from '../lib/component-hours';
+import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import {
   isSuuntoCyclingActivity,
   getSuuntoRideType,
@@ -523,6 +524,13 @@ async function processSuuntoBackfill(userId: string, year: string): Promise<void
     }
   }
 
+  // Bust the auto-assigned bike's cached predictions once — the loop credited
+  // its component hours for every imported ride (a per-ride invalidate would
+  // hit the same bike repeatedly for no gain).
+  if (autoAssignBikeId && importedCount > 0) {
+    await invalidateBikePredictionsForBikes(userId, [autoAssignBikeId]);
+  }
+
   // Update session's lastActivityReceivedAt if any rides were created, so the
   // idle-session checker doesn't prematurely close the import.
   if (runningSession && importedCount > 0) {
@@ -661,6 +669,7 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
     // rides match the behavior of webhook-delivered ones (see sync.worker.ts
     // `upsertGarminActivity`). Missing this was why Garmin backfill-imported
     // rides didn't accrue component wear.
+    let affectedBikeIds: string[] = [];
     const upsertedRide = await prisma.$transaction(async (tx) => {
       const ride = await tx.ride.upsert({
         where: { garminActivityId: activity.summaryId },
@@ -696,7 +705,7 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
         select: { id: true, bikeId: true, durationSeconds: true },
       });
 
-      await syncBikeComponentHours(
+      affectedBikeIds = await syncBikeComponentHours(
         tx,
         userId,
         { bikeId: existingRide?.bikeId ?? null, durationSeconds: existingRide?.durationSeconds ?? null },
@@ -707,6 +716,9 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
 
       return ride;
     });
+
+    // Bust cached predictions for every bike whose hours changed.
+    await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
     if (startLat != null && startLng != null) {
       enqueueWeatherJob({ rideId: upsertedRide.id }).catch((err) =>

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -10,6 +10,7 @@ import { getValidWhoopToken } from '../lib/whoop-token';
 import { getValidSuuntoToken } from '../lib/suunto-token';
 import { deriveLocation, deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
 import { syncBikeComponentHours } from '../lib/component-hours';
+import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { logger } from '../lib/logger';
 import { fireRideNotifications } from '../services/notification.service';
 import { config } from '../config/env';
@@ -325,6 +326,7 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
 
   let syncedRideId: string | null = null;
   let isNewRide = false;
+  let affectedBikeIds: string[] = [];
 
   await prisma.$transaction(async (tx) => {
     const existing = await tx.ride.findUnique({
@@ -380,7 +382,7 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
     syncedRideId = ride.id;
 
     // Sync component hours
-    await syncBikeComponentHours(
+    affectedBikeIds = await syncBikeComponentHours(
       tx,
       userId,
       { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -389,6 +391,9 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
       existing ? ride.id : undefined
     );
   });
+
+  // Bust cached predictions for every bike whose hours changed.
+  await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
   logger.debug({ stravaActivityId: activity.id }, '[SyncWorker] Upserted Strava activity');
 
@@ -634,9 +639,10 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
 
   // Sync component hours separately — secondary to recording the ride.
   // A failure here should not roll back the ride (Garmin won't resend it).
+  let affectedBikeIds: string[] = [];
   try {
-    await prisma.$transaction(async (tx) => {
-      await syncBikeComponentHours(
+    affectedBikeIds = await prisma.$transaction(async (tx) => {
+      return syncBikeComponentHours(
         tx,
         userId,
         { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -666,6 +672,10 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
       extra: { userId, rideId: ride.id, bikeId: ride.bikeId, durationSeconds: ride.durationSeconds },
     });
   }
+
+  // Bust cached predictions for every bike whose hours changed. Empty (so a
+  // no-op) when the sync above threw — nothing was credited to invalidate.
+  await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
   // Update session's lastActivityReceivedAt if there's a running session
   if (runningSession) {
@@ -805,6 +815,7 @@ async function upsertWhoopActivity(userId: string, workout: WhoopWorkout): Promi
 
   let syncedRideId: string | null = null;
   let isNewRide = false;
+  let affectedBikeIds: string[] = [];
 
   await prisma.$transaction(async (tx) => {
     const existing = await tx.ride.findUnique({
@@ -845,7 +856,7 @@ async function upsertWhoopActivity(userId: string, workout: WhoopWorkout): Promi
     syncedRideId = ride.id;
 
     // Sync component hours
-    await syncBikeComponentHours(
+    affectedBikeIds = await syncBikeComponentHours(
       tx,
       userId,
       { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -854,6 +865,9 @@ async function upsertWhoopActivity(userId: string, workout: WhoopWorkout): Promi
       existing ? ride.id : undefined
     );
   });
+
+  // Bust cached predictions for every bike whose hours changed.
+  await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
   // Fire-and-forget notifications
   if (syncedRideId) {
@@ -1062,9 +1076,10 @@ async function upsertSuuntoActivity(
 
   // Component hours are secondary — a failure here should not roll back the
   // ride because Suunto won't re-deliver it.
+  let affectedBikeIds: string[] = [];
   try {
-    await prisma.$transaction(async (tx) => {
-      await syncBikeComponentHours(
+    affectedBikeIds = await prisma.$transaction(async (tx) => {
+      return syncBikeComponentHours(
         tx,
         userId,
         { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -1094,6 +1109,10 @@ async function upsertSuuntoActivity(
       extra: { userId, rideId: ride.id, bikeId: ride.bikeId, durationSeconds: ride.durationSeconds },
     });
   }
+
+  // Bust cached predictions for every bike whose hours changed. Empty (so a
+  // no-op) when the sync above threw — nothing was credited to invalidate.
+  await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
   logger.debug({ suuntoWorkoutId: workout.workoutKey }, '[SyncWorker] Upserted Suunto workout');
 


### PR DESCRIPTION
Umbrella PR for the Component Ride Attribution follow-ups. **#245 has been merged into this branch**, so the diff is now larger than the original title implied — it bundles three related pieces plus review hardening. Base: `staging`.

**Closes #244** (via the included #245 work).

## 1. Delete-path attribution parity (original scope)

Two ride-delete paths deleted rides **without** the integrity steps every other delete path runs, leaving component `hoursUsed` overstated and cross-bike `INCLUDE` adjustments orphaned:
- `POST /duplicates/merge` (manual merge)
- WHOOP `workout.deleted` webhook

Both now run the standard capture-before-delete → decrement → delete → `recomputeAdjustedComponentsForRides` → invalidate.

## 2. Prediction-cache invalidation across all sync paths (was #245)

Provider **webhook** and **background-sync** ride writes changed `hoursUsed` but never busted the cached predictions — the cache key encodes no ride data, so a ride write can't self-invalidate, and stale `hoursSinceService` survived until the 30-min TTL. Fixed on every surface:

| Surface | Paths |
|---|---|
| `webhooks.strava.ts` | activity create/update **and** delete |
| `webhooks.suunto.ts` | workout create/update |
| `sync.worker.ts` | Strava / Garmin / WHOOP / Suunto (Garmin & Suunto skip on the orphaned-hours `catch`) |
| `backfill.worker.ts` | Garmin upsert; Suunto bulk-create invalidates the auto-assigned bike **once after the loop** |

## 3. Centralization — so the gap can't return

- **`syncBikeComponentHours` now returns every bike whose hours it moved** (debited prev ∪ credited next ∪ adjusted-component bikes), deduped — callers no longer reconstruct the primary bike, which was the exact omission behind the bug.
- **New `invalidateBikePredictionsForBikes(userId, bikeIds)`** helper: dedupe + null-skip + parallel fan-out. The canonical post-commit invalidator for any hours-changing write path.

## 4. Robustness (review follow-ups)

- Invalidation fan-outs use `Promise.all` (independent busts), including inside the shared helper.
- Post-commit invalidation is **best-effort**: `/duplicates/merge`, `/duplicates/auto-merge`, and the WHOOP delete handler wrap it in try/catch + a targeted log. A cache-bust failure can no longer turn a **committed** merge into a client-visible 500 (a retry would 404 on the deleted ride), nor trip the WHOOP handler's misleading "Processing failed" alert. Stale predictions self-heal at the TTL.

## Tests

New/updated coverage for: delete-path recompute + invalidation; `syncBikeComponentHours` return semantics (move / duration / delete / no-op + the `rideId`-driven cross-bike union + same-bike dedupe); the helper (dedupe / null-skip / empty no-op); and the best-effort behavior (invalidation throws → merge still returns success; WHOOP logs the targeted error, not "Processing failed"). Updated the Strava/Suunto/WHOOP/duplicates test mocks for the new post-commit invalidation.

**Full api suite green — 1559 passed (78 suites)**; typecheck + lint clean.

⚠️ Suite-verified (mocked Prisma/Redis), not a live end-to-end run — driving real webhooks/sync/merge needs Redis + provider setup. Behavior mirrors the already-proven resolver/backfill invalidation paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)