### PR TITLE
fix(attribution): invalidate prediction cache on webhook/worker ride writes

### DIFF
--- a/apps/api/src/lib/component-hours.test.ts
+++ b/apps/api/src/lib/component-hours.test.ts
@@ -358,4 +358,68 @@ describe('syncBikeComponentHours', () => {
     // A no-op must not touch component rows.
     expect(tx.component.updateMany).not.toHaveBeenCalled();
   });
+
+  // The rideId branch: when an existing ride changes, adjusted components
+  // (whose ComponentRideAdjustment rows reference it) get a canonical
+  // recompute, and THEIR bikes must union into the invalidation set — the
+  // cross-bike INCLUDE case the bulk update never touches.
+  it('unions in cross-bike adjusted components recomputed from the rideId', async () => {
+    const tx = makeTx();
+    // ride-9 carries an adjustment on comp-x, which lives on bike-3.
+    tx.componentRideAdjustment.findMany.mockResolvedValueOnce([{ componentId: 'comp-x' }]);
+    tx.component.findUnique.mockResolvedValue({
+      id: 'comp-x',
+      userId: 'user-1',
+      bikeId: 'bike-3',
+      installedAt: null,
+      hoursUsed: 5,
+    });
+
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 7200 },
+      'ride-9'
+    );
+
+    // bike-1 (its own hours grew) + bike-3 (the cross-bike adjusted component).
+    expect(new Set(affected)).toEqual(new Set(['bike-1', 'bike-3']));
+  });
+
+  it('de-dupes when the adjusted component sits on the same bike as the ride', async () => {
+    const tx = makeTx();
+    tx.componentRideAdjustment.findMany.mockResolvedValueOnce([{ componentId: 'comp-x' }]);
+    tx.component.findUnique.mockResolvedValue({
+      id: 'comp-x',
+      userId: 'user-1',
+      bikeId: 'bike-1',
+      installedAt: null,
+      hoursUsed: 5,
+    });
+
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 7200 },
+      'ride-9'
+    );
+
+    expect(affected).toEqual(['bike-1']);
+  });
+
+  it('skips the recompute entirely when rideId is passed but nothing changed', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      'ride-9'
+    );
+    expect(affected).toEqual([]);
+    // The (bikeChanged || hoursDiff !== 0) guard must gate the lookup.
+    expect(tx.componentRideAdjustment.findMany).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/lib/component-hours.test.ts
+++ b/apps/api/src/lib/component-hours.test.ts
@@ -4,6 +4,7 @@ import {
   recomputeComponentHours,
   recomputeAdjustedComponentsForRides,
   findAdjustedComponentIdsForRides,
+  syncBikeComponentHours,
   type ComponentAttribution,
 } from './component-hours';
 import type { Prisma } from '@prisma/client';
@@ -13,6 +14,7 @@ const makeTx = () => ({
   component: {
     findUnique: jest.fn(),
     update: jest.fn(),
+    updateMany: jest.fn(),
   },
   serviceLog: {
     findFirst: jest.fn(),
@@ -304,5 +306,56 @@ describe('findAdjustedComponentIdsForRides', () => {
     const tx = makeTx();
     expect(await findAdjustedComponentIdsForRides(asTx(tx), [])).toEqual([]);
     expect(tx.componentRideAdjustment.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncBikeComponentHours', () => {
+  // The return value is the invalidation contract: every bike whose hours
+  // this call actually moved, so callers can bust exactly those caches
+  // without reconstructing the primary bike themselves.
+  it('returns both the debited and credited bike when a ride moves bikes', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-2', durationSeconds: 3600 }
+    );
+    expect(new Set(affected)).toEqual(new Set(['bike-1', 'bike-2']));
+  });
+
+  it('returns the single bike when only its duration changed', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 7200 }
+    );
+    expect(affected).toEqual(['bike-1']);
+  });
+
+  it('returns the debited bike on delete (next bike null)', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: null, durationSeconds: 0 }
+    );
+    expect(affected).toEqual(['bike-1']);
+  });
+
+  it('returns nothing when neither bike nor duration changed', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 3600 }
+    );
+    expect(affected).toEqual([]);
+    // A no-op must not touch component rows.
+    expect(tx.component.updateMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/lib/component-hours.ts
+++ b/apps/api/src/lib/component-hours.ts
@@ -58,8 +58,12 @@ export async function decrementBikeComponentHours(
  * (cross-bike INCLUDE). Create paths omit rideId: a brand-new ride can't
  * be pre-adjusted (the adjustment row FK-references an existing ride).
  *
- * Returns the bikeIds of recomputed adjusted components (empty when none)
- * so callers can extend prediction-cache invalidation.
+ * Returns every bikeId whose component hours changed here — the debited
+ * previous bike, the credited next bike, AND any bikes owning adjusted
+ * components recomputed from `rideId` — deduped, nulls dropped. Callers pass
+ * this straight to `invalidateBikePredictionsForBikes`: the return is
+ * self-sufficient, so no caller has to reconstruct the primary bike (the
+ * cache key encodes no ride data, so a ride write can't self-invalidate).
  *
  * Previously duplicated inline in [webhooks.strava.ts] and [workers/sync.worker.ts].
  */
@@ -77,26 +81,36 @@ export async function syncBikeComponentHours(
   const bikeChanged = prevBikeId !== nextBikeId;
   const hoursDiff = nextHours - prevHours;
 
+  // Bikes whose hoursUsed this call actually mutates — only these need their
+  // cached predictions busted (a pure no-op leaves the set empty).
+  const affectedBikeIds = new Set<string>();
+
   if (prevBikeId) {
     if (bikeChanged) {
       await decrementBikeComponentHours(tx, { userId, bikeId: prevBikeId, hoursDelta: prevHours });
+      affectedBikeIds.add(prevBikeId);
     } else if (hoursDiff < 0) {
       await decrementBikeComponentHours(tx, { userId, bikeId: prevBikeId, hoursDelta: Math.abs(hoursDiff) });
+      affectedBikeIds.add(prevBikeId);
     }
   }
 
   if (nextBikeId) {
     if (bikeChanged) {
       await incrementBikeComponentHours(tx, { userId, bikeId: nextBikeId, hoursDelta: nextHours });
+      affectedBikeIds.add(nextBikeId);
     } else if (hoursDiff > 0) {
       await incrementBikeComponentHours(tx, { userId, bikeId: nextBikeId, hoursDelta: hoursDiff });
+      affectedBikeIds.add(nextBikeId);
     }
   }
 
   if (rideId && (bikeChanged || hoursDiff !== 0)) {
-    return recomputeAdjustedComponentsForRides(tx, { rideIds: [rideId] });
+    const adjustedBikeIds = await recomputeAdjustedComponentsForRides(tx, { rideIds: [rideId] });
+    for (const bikeId of adjustedBikeIds) affectedBikeIds.add(bikeId);
   }
-  return [];
+
+  return [...affectedBikeIds];
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/routes/webhooks.strava.ts
+++ b/apps/api/src/routes/webhooks.strava.ts
@@ -8,6 +8,7 @@ import {
   findAdjustedComponentIdsForRides,
   recomputeAdjustedComponentsForRides,
 } from '../lib/component-hours';
+import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { logError } from '../lib/logger';
 import { fireRideNotifications } from '../services/notification.service';
 import { enqueueWeatherJob, enqueueLiftDetectionJob } from '../lib/queue';
@@ -234,7 +235,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
 
   // Handle different event types
   if (aspect_type === 'delete') {
-    await prisma.$transaction(async (tx) => {
+    const affectedBikeIds = await prisma.$transaction(async (tx) => {
       const existing = await tx.ride.findUnique({
         where: { stravaActivityId: activityId.toString() },
         select: { id: true, userId: true, durationSeconds: true, bikeId: true },
@@ -242,7 +243,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
 
       if (!existing || existing.userId !== userAccount.userId) {
         console.log(`[Strava Activity Event] No ride to delete for activity ${activityId}`);
-        return;
+        return [] as string[];
       }
 
       // Capture BEFORE the delete — adjustment rows cascade away with the
@@ -250,7 +251,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
       // below never touches.
       const adjustedComponentIds = await findAdjustedComponentIdsForRides(tx, [existing.id]);
 
-      await syncBikeComponentHours(
+      const affected = await syncBikeComponentHours(
         tx,
         userAccount.userId,
         { bikeId: existing.bikeId ?? null, durationSeconds: existing.durationSeconds },
@@ -259,8 +260,12 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
 
       await tx.ride.delete({ where: { id: existing.id } });
 
-      await recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
+      const adjustedBikeIds = await recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
+      return [...affected, ...adjustedBikeIds];
     });
+    // Bust cached predictions for every bike whose hours changed (previously
+    // a gap — this webhook decremented hours without invalidating the cache).
+    await invalidateBikePredictionsForBikes(userAccount.userId, affectedBikeIds);
     console.log(`[Strava Activity Event] Deleted ride for activity ${activityId}`);
     return;
   }
@@ -342,7 +347,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
 
       const autoLocation = await extractStravaLocation(activity);
 
-      const { syncedRideId, isNewRide } = await prisma.$transaction(async (tx) => {
+      const { syncedRideId, isNewRide, affectedBikeIds } = await prisma.$transaction(async (tx) => {
         const existing = await tx.ride.findUnique({
           where: { stravaActivityId: activityId.toString() },
           select: { id: true, durationSeconds: true, bikeId: true, location: true },
@@ -392,7 +397,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
           },
         });
 
-        await syncBikeComponentHours(
+        const affectedBikeIds = await syncBikeComponentHours(
           tx,
           userAccount.userId,
           {
@@ -407,8 +412,12 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
           existing ? ride.id : undefined
         );
 
-        return { syncedRideId: ride.id, isNewRide: !existing };
+        return { syncedRideId: ride.id, isNewRide: !existing, affectedBikeIds };
       });
+
+      // Bust cached predictions for every bike whose hours changed (create or
+      // re-sync with a changed bike/duration both land here).
+      await invalidateBikePredictionsForBikes(userAccount.userId, affectedBikeIds);
 
       console.log(`[Strava Activity Event] Successfully stored ride for activity ${activityId}`);
 

--- a/apps/api/src/routes/webhooks.suunto.test.ts
+++ b/apps/api/src/routes/webhooks.suunto.test.ts
@@ -27,6 +27,12 @@ jest.mock('../lib/component-hours', () => ({
   syncBikeComponentHours: (...args: unknown[]) => mockSyncBikeComponentHours(...args),
 }));
 
+const mockInvalidateBikePredictionsForBikes = jest.fn();
+jest.mock('../services/prediction/cache', () => ({
+  invalidateBikePredictionsForBikes: (...args: unknown[]) =>
+    mockInvalidateBikePredictionsForBikes(...args),
+}));
+
 const mockFireRideNotifications = jest.fn();
 jest.mock('../services/notification.service', () => ({
   fireRideNotifications: (...args: unknown[]) => mockFireRideNotifications(...args),
@@ -97,6 +103,7 @@ describe('POST /webhooks/suunto/workouts', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsActiveSource.mockResolvedValue(true);
+    mockSyncBikeComponentHours.mockResolvedValue([]);
     mockUserAccountFindUnique.mockResolvedValue({ userId: 'user-1' });
     mockRideFindUnique.mockResolvedValue(null); // new ride by default
     mockBikeFindMany.mockResolvedValue([]); // 0 active bikes by default

--- a/apps/api/src/routes/webhooks.suunto.ts
+++ b/apps/api/src/routes/webhooks.suunto.ts
@@ -5,6 +5,7 @@ import { createLogger, logError } from '../lib/logger';
 import { isActiveSource } from '../lib/active-source';
 import { isSuuntoCyclingActivity, getSuuntoRideType, isKnownSuuntoActivity } from '../types/suunto';
 import { syncBikeComponentHours } from '../lib/component-hours';
+import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { fireRideNotifications } from '../services/notification.service';
 
 const log = createLogger('suunto-webhook');
@@ -197,6 +198,7 @@ async function processWorkoutCreated(event: WorkoutCreatedEvent): Promise<void> 
 
   let syncedRideId = '';
   let syncedBikeId: string | null = null;
+  let affectedBikeIds: string[] = [];
 
   await prisma.$transaction(async (tx) => {
     const ride = await tx.ride.upsert({
@@ -226,7 +228,7 @@ async function processWorkoutCreated(event: WorkoutCreatedEvent): Promise<void> 
       },
     });
 
-    await syncBikeComponentHours(
+    affectedBikeIds = await syncBikeComponentHours(
       tx,
       userAccount.userId,
       { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -238,6 +240,9 @@ async function processWorkoutCreated(event: WorkoutCreatedEvent): Promise<void> 
     syncedRideId = ride.id;
     syncedBikeId = ride.bikeId ?? null;
   });
+
+  // Bust cached predictions for every bike whose hours changed.
+  await invalidateBikePredictionsForBikes(userAccount.userId, affectedBikeIds);
 
   // Fire-and-forget: send "Ride Synced" + bike-select prompt for new rides.
   // Mirrors the Strava webhook + Garmin/WHOOP sync-worker call sites so all

--- a/apps/api/src/services/prediction/__tests__/cache.test.ts
+++ b/apps/api/src/services/prediction/__tests__/cache.test.ts
@@ -10,6 +10,7 @@ import {
   getCachedPrediction,
   setCachedPrediction,
   invalidateBikePrediction,
+  invalidateBikePredictionsForBikes,
   invalidateUserPredictions,
   clearMemoryCache,
   getMemoryCacheSize,
@@ -229,6 +230,34 @@ describe('prediction cache', () => {
         100
       );
       expect(mockRedis.del).toHaveBeenCalledWith('key1', 'key2');
+    });
+  });
+
+  describe('invalidateBikePredictionsForBikes', () => {
+    it('invalidates every listed bike, skips nulls, and de-dupes', async () => {
+      (isRedisReady as jest.Mock).mockReturnValue(false);
+
+      await setCachedPrediction({ ...cacheParams, bikeId: 'bike-a' }, { ...mockPrediction, bikeId: 'bike-a' });
+      await setCachedPrediction({ ...cacheParams, bikeId: 'bike-b' }, { ...mockPrediction, bikeId: 'bike-b' });
+      await setCachedPrediction({ ...cacheParams, bikeId: 'bike-c' }, { ...mockPrediction, bikeId: 'bike-c' });
+      expect(getMemoryCacheSize()).toBe(3);
+
+      // Duplicate 'bike-a' and a null/undefined entry must not throw and must
+      // not touch bike-c.
+      await invalidateBikePredictionsForBikes('user-123', ['bike-a', 'bike-a', null, undefined, 'bike-b']);
+
+      // bike-a + bike-b cleared, bike-c untouched.
+      expect(getMemoryCacheSize()).toBe(1);
+    });
+
+    it('is a no-op on an empty list', async () => {
+      (isRedisReady as jest.Mock).mockReturnValue(false);
+      await setCachedPrediction({ ...cacheParams, bikeId: 'bike-a' }, { ...mockPrediction, bikeId: 'bike-a' });
+      expect(getMemoryCacheSize()).toBe(1);
+
+      await invalidateBikePredictionsForBikes('user-123', []);
+
+      expect(getMemoryCacheSize()).toBe(1);
     });
   });
 

--- a/apps/api/src/services/prediction/cache.ts
+++ b/apps/api/src/services/prediction/cache.ts
@@ -229,6 +229,28 @@ export async function invalidateBikePrediction(
 }
 
 /**
+ * Invalidate prediction caches for several bikes at once, skipping nulls and
+ * de-duplicating first. The canonical post-commit call for any write path
+ * that changes component hours: feed it the bikeIds `syncBikeComponentHours`
+ * (or a `recompute*` helper) returns, and every affected bike's cached
+ * predictions get busted in one call. Centralized so a new sync path can't
+ * reintroduce the "hours changed, cache went stale" gap by hand-rolling
+ * (and forgetting part of) the loop.
+ */
+export async function invalidateBikePredictionsForBikes(
+  userId: string,
+  bikeIds: Iterable<string | null | undefined>
+): Promise<void> {
+  const unique = new Set<string>();
+  for (const bikeId of bikeIds) {
+    if (bikeId) unique.add(bikeId);
+  }
+  for (const bikeId of unique) {
+    await invalidateBikePrediction(userId, bikeId);
+  }
+}
+
+/**
  * Invalidate all predictions for a user.
  * Called when user role changes.
  *

--- a/apps/api/src/services/prediction/index.ts
+++ b/apps/api/src/services/prediction/index.ts
@@ -28,6 +28,7 @@ export {
 // Cache - Invalidation Functions
 export {
   invalidateBikePrediction,
+  invalidateBikePredictionsForBikes,
   invalidateUserPredictions,
 } from './cache';
 

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -13,6 +13,7 @@ import type { BackfillJobData, BackfillJobName } from '../lib/queue/backfill.que
 import { enqueueWeatherJob } from '../lib/queue';
 import { captureServerEvent } from '../lib/posthog';
 import { incrementBikeComponentHours, syncBikeComponentHours } from '../lib/component-hours';
+import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import {
   isSuuntoCyclingActivity,
   getSuuntoRideType,
@@ -523,6 +524,13 @@ async function processSuuntoBackfill(userId: string, year: string): Promise<void
     }
   }
 
+  // Bust the auto-assigned bike's cached predictions once — the loop credited
+  // its component hours for every imported ride (a per-ride invalidate would
+  // hit the same bike repeatedly for no gain).
+  if (autoAssignBikeId && importedCount > 0) {
+    await invalidateBikePredictionsForBikes(userId, [autoAssignBikeId]);
+  }
+
   // Update session's lastActivityReceivedAt if any rides were created, so the
   // idle-session checker doesn't prematurely close the import.
   if (runningSession && importedCount > 0) {
@@ -661,6 +669,7 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
     // rides match the behavior of webhook-delivered ones (see sync.worker.ts
     // `upsertGarminActivity`). Missing this was why Garmin backfill-imported
     // rides didn't accrue component wear.
+    let affectedBikeIds: string[] = [];
     const upsertedRide = await prisma.$transaction(async (tx) => {
       const ride = await tx.ride.upsert({
         where: { garminActivityId: activity.summaryId },
@@ -696,7 +705,7 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
         select: { id: true, bikeId: true, durationSeconds: true },
       });
 
-      await syncBikeComponentHours(
+      affectedBikeIds = await syncBikeComponentHours(
         tx,
         userId,
         { bikeId: existingRide?.bikeId ?? null, durationSeconds: existingRide?.durationSeconds ?? null },
@@ -707,6 +716,9 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
 
       return ride;
     });
+
+    // Bust cached predictions for every bike whose hours changed.
+    await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
     if (startLat != null && startLng != null) {
       enqueueWeatherJob({ rideId: upsertedRide.id }).catch((err) =>

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -10,6 +10,7 @@ import { getValidWhoopToken } from '../lib/whoop-token';
 import { getValidSuuntoToken } from '../lib/suunto-token';
 import { deriveLocation, deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
 import { syncBikeComponentHours } from '../lib/component-hours';
+import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { logger } from '../lib/logger';
 import { fireRideNotifications } from '../services/notification.service';
 import { config } from '../config/env';
@@ -325,6 +326,7 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
 
   let syncedRideId: string | null = null;
   let isNewRide = false;
+  let affectedBikeIds: string[] = [];
 
   await prisma.$transaction(async (tx) => {
     const existing = await tx.ride.findUnique({
@@ -380,7 +382,7 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
     syncedRideId = ride.id;
 
     // Sync component hours
-    await syncBikeComponentHours(
+    affectedBikeIds = await syncBikeComponentHours(
       tx,
       userId,
       { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -389,6 +391,9 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
       existing ? ride.id : undefined
     );
   });
+
+  // Bust cached predictions for every bike whose hours changed.
+  await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
   logger.debug({ stravaActivityId: activity.id }, '[SyncWorker] Upserted Strava activity');
 
@@ -634,9 +639,10 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
 
   // Sync component hours separately — secondary to recording the ride.
   // A failure here should not roll back the ride (Garmin won't resend it).
+  let affectedBikeIds: string[] = [];
   try {
-    await prisma.$transaction(async (tx) => {
-      await syncBikeComponentHours(
+    affectedBikeIds = await prisma.$transaction(async (tx) => {
+      return syncBikeComponentHours(
         tx,
         userId,
         { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -666,6 +672,10 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
       extra: { userId, rideId: ride.id, bikeId: ride.bikeId, durationSeconds: ride.durationSeconds },
     });
   }
+
+  // Bust cached predictions for every bike whose hours changed. Empty (so a
+  // no-op) when the sync above threw — nothing was credited to invalidate.
+  await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
   // Update session's lastActivityReceivedAt if there's a running session
   if (runningSession) {
@@ -805,6 +815,7 @@ async function upsertWhoopActivity(userId: string, workout: WhoopWorkout): Promi
 
   let syncedRideId: string | null = null;
   let isNewRide = false;
+  let affectedBikeIds: string[] = [];
 
   await prisma.$transaction(async (tx) => {
     const existing = await tx.ride.findUnique({
@@ -845,7 +856,7 @@ async function upsertWhoopActivity(userId: string, workout: WhoopWorkout): Promi
     syncedRideId = ride.id;
 
     // Sync component hours
-    await syncBikeComponentHours(
+    affectedBikeIds = await syncBikeComponentHours(
       tx,
       userId,
       { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -854,6 +865,9 @@ async function upsertWhoopActivity(userId: string, workout: WhoopWorkout): Promi
       existing ? ride.id : undefined
     );
   });
+
+  // Bust cached predictions for every bike whose hours changed.
+  await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
   // Fire-and-forget notifications
   if (syncedRideId) {
@@ -1062,9 +1076,10 @@ async function upsertSuuntoActivity(
 
   // Component hours are secondary — a failure here should not roll back the
   // ride because Suunto won't re-deliver it.
+  let affectedBikeIds: string[] = [];
   try {
-    await prisma.$transaction(async (tx) => {
-      await syncBikeComponentHours(
+    affectedBikeIds = await prisma.$transaction(async (tx) => {
+      return syncBikeComponentHours(
         tx,
         userId,
         { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -1094,6 +1109,10 @@ async function upsertSuuntoActivity(
       extra: { userId, rideId: ride.id, bikeId: ride.bikeId, durationSeconds: ride.durationSeconds },
     });
   }
+
+  // Bust cached predictions for every bike whose hours changed. Empty (so a
+  // no-op) when the sync above threw — nothing was credited to invalidate.
+  await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
   logger.debug({ suuntoWorkoutId: workout.workoutKey }, '[SyncWorker] Upserted Suunto workout');
 


### PR DESCRIPTION
Fixes #244. **Stacked on #243** — base is `fix/attribution-delete-path-parity`; retarget to `staging` once #243 merges.

## What

Provider **webhook** and **background-sync** ride writes changed component `hoursUsed` but never busted the cached bike predictions, so riders could see stale `hoursSinceService` until the 30-min cache TTL. The cache key encodes no ride data, so a ride write can't self-invalidate — only an explicit `invalidateBikePrediction` or TTL clears it. Pre-existing, discovered during the #242 audit.

## How — centralized so the gap can't come back

- **`syncBikeComponentHours` now returns every bike whose hours it moved** — debited previous ∪ credited next ∪ adjusted-component bikes, deduped — not just the adjusted ones. Callers no longer reconstruct the primary bike, which was the exact omission behind the bug.
- **New `invalidateBikePredictionsForBikes(userId, bikeIds)`** helper (dedupe + skip-null + loop) — the canonical post-commit call for any hours-changing write path.
- Because all 8 sites pass an interactive `tx`, invalidation is wired **post-commit** (never inside the transaction — that would be an invalidate-before-commit race).

Wired into every previously-stale surface:

| Surface | Paths |
|---|---|
| `webhooks.strava.ts` | activity create/update **and** delete |
| `webhooks.suunto.ts` | workout create/update |
| `sync.worker.ts` | Strava / Garmin / WHOOP / Suunto (Garmin & Suunto skip invalidation on the orphaned-hours `catch` — nothing changed) |
| `backfill.worker.ts` | Garmin upsert; Suunto bulk-create invalidates the auto-assigned bike **once after the loop**, not per ride |

The already-correct resolver / duplicates / `*.backfill` purge / WHOOP-webhook (#243) paths are untouched — they discard the sync return and invalidate via their own union, so the new return semantics don't affect them.

## Tests

- New unit coverage for the return semantics (move / duration-change / delete / no-op) and the helper (dedupe, null-skip, empty no-op).
- Updated the Suunto webhook test mocks for the new post-commit invalidation.
- **Full api suite green (1554 passed)**, typecheck + lint clean.

⚠️ Verified via the suites (mocked Prisma/Redis), not a live end-to-end run — driving real webhooks/sync needs Redis + provider setup. Behavior mirrors the already-proven duplicates/backfill invalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)