### PR TITLE
Promote Component Ride Attribution to main

### DIFF
--- a/apps/api/prisma/migrations/20260721003434_component_ride_adjustment/migration.sql
+++ b/apps/api/prisma/migrations/20260721003434_component_ride_adjustment/migration.sql
@@ -1,0 +1,33 @@
+-- CreateEnum
+CREATE TYPE "ComponentRideAdjustmentKind" AS ENUM ('EXCLUDE', 'INCLUDE');
+
+-- CreateTable
+CREATE TABLE "ComponentRideAdjustment" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "componentId" TEXT NOT NULL,
+    "rideId" TEXT NOT NULL,
+    "kind" "ComponentRideAdjustmentKind" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ComponentRideAdjustment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ComponentRideAdjustment_rideId_idx" ON "ComponentRideAdjustment"("rideId");
+
+-- CreateIndex
+CREATE INDEX "ComponentRideAdjustment_userId_idx" ON "ComponentRideAdjustment"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ComponentRideAdjustment_componentId_rideId_key" ON "ComponentRideAdjustment"("componentId", "rideId");
+
+-- AddForeignKey
+ALTER TABLE "ComponentRideAdjustment" ADD CONSTRAINT "ComponentRideAdjustment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ComponentRideAdjustment" ADD CONSTRAINT "ComponentRideAdjustment_componentId_fkey" FOREIGN KEY ("componentId") REFERENCES "Component"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ComponentRideAdjustment" ADD CONSTRAINT "ComponentRideAdjustment_rideId_fkey" FOREIGN KEY ("rideId") REFERENCES "Ride"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260721140756_ride_user_bike_starttime_index/migration.sql
+++ b/apps/api/prisma/migrations/20260721140756_ride_user_bike_starttime_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Ride_userId_bikeId_startTime_idx" ON "Ride"("userId", "bikeId", "startTime");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -8,72 +8,73 @@ datasource db {
 }
 
 model User {
-  id                  String              @id @default(uuid())
-  email               String              @unique
-  garminUserId        String?             @unique
-  accessToken         String?
-  refreshToken        String?
-  tokenExpiresAt      DateTime?
-  createdAt           DateTime            @default(now())
-  updatedAt           DateTime            @updatedAt
-  name                String?
-  avatarUrl           String?
-  emailVerified       DateTime?
-  passwordHash        String?
-  lastAuthAt          DateTime?           // Track last successful authentication time
-  age                 Int?
-  location            String?
-  onboardingCompleted Boolean             @default(false)
-  activeDataSource    AuthProvider?
-  stravaUserId        String?             @unique
-  suuntoUserId        String?             @unique
-  whoopUserId         String?             @unique
-  role                UserRole            @default(FREE)
-  mustChangePassword  Boolean             @default(false)
-  sessionTokenVersion Int                 @default(0)
-  activatedAt         DateTime?
-  activatedBy         String?
-  isFoundingRider     Boolean             @default(false)
-  subscriptionTier    SubscriptionTier    @default(FREE)
-  stripeCustomerId    String?             @unique
-  stripeSubscriptionId String?            @unique
-  needsDowngradeSelection Boolean         @default(false)
-  subscriptionProvider    SubscriptionProvider?
-  emailUnsubscribed   Boolean             @default(false)
-  hoursDisplayPreference String?          @default("remaining")
-  predictionMode         String?          @default("simple")
-  distanceUnit           String?          @default("mi")
-  calibrationCompletedAt DateTime?
-  calibrationDismissedAt DateTime?
+  id                             String                @id @default(uuid())
+  email                          String                @unique
+  garminUserId                   String?               @unique
+  accessToken                    String?
+  refreshToken                   String?
+  tokenExpiresAt                 DateTime?
+  createdAt                      DateTime              @default(now())
+  updatedAt                      DateTime              @updatedAt
+  name                           String?
+  avatarUrl                      String?
+  emailVerified                  DateTime?
+  passwordHash                   String?
+  lastAuthAt                     DateTime? // Track last successful authentication time
+  age                            Int?
+  location                       String?
+  onboardingCompleted            Boolean               @default(false)
+  activeDataSource               AuthProvider?
+  stravaUserId                   String?               @unique
+  suuntoUserId                   String?               @unique
+  whoopUserId                    String?               @unique
+  role                           UserRole              @default(FREE)
+  mustChangePassword             Boolean               @default(false)
+  sessionTokenVersion            Int                   @default(0)
+  activatedAt                    DateTime?
+  activatedBy                    String?
+  isFoundingRider                Boolean               @default(false)
+  subscriptionTier               SubscriptionTier      @default(FREE)
+  stripeCustomerId               String?               @unique
+  stripeSubscriptionId           String?               @unique
+  needsDowngradeSelection        Boolean               @default(false)
+  subscriptionProvider           SubscriptionProvider?
+  emailUnsubscribed              Boolean               @default(false)
+  hoursDisplayPreference         String?               @default("remaining")
+  predictionMode                 String?               @default("simple")
+  distanceUnit                   String?               @default("mi")
+  calibrationCompletedAt         DateTime?
+  calibrationDismissedAt         DateTime?
   pairedComponentMigrationSeenAt DateTime?
   trailStewardshipNoticeSeenAt   DateTime?
 
   // When true, suppress all server-side PostHog events for this user
   // (captureServerEvent short-circuits). Client-side opt-out is handled
   // separately via posthog.opt_out_capturing() from the browser SDK.
-  analyticsOptOut     Boolean             @default(false)
+  analyticsOptOut Boolean @default(false)
 
-  bikes               Bike[]
-  components          Component[]
-  tokens              OauthToken[]
-  rides               Ride[]
-  stravaGearMappings  StravaGearMapping[]
-  accounts            UserAccount[]
-  emailSends          EmailSend[]
-  termsAcceptances    TermsAcceptance[]
-  backfillRequests    BackfillRequest[]
-  importSessions      ImportSession[]
-  servicePreferences  UserServicePreference[]
-  componentInstalls   BikeComponentInstall[]
-  bikeNotes           BikeNote[]
-  oauthAttempts       OAuthAttempt[]
-  integrations        UserIntegration[]
-  notificationLogs    NotificationLog[]
-  passwordResetTokens PasswordResetToken[]
+  bikes                    Bike[]
+  components               Component[]
+  tokens                   OauthToken[]
+  rides                    Ride[]
+  stravaGearMappings       StravaGearMapping[]
+  accounts                 UserAccount[]
+  emailSends               EmailSend[]
+  termsAcceptances         TermsAcceptance[]
+  backfillRequests         BackfillRequest[]
+  importSessions           ImportSession[]
+  servicePreferences       UserServicePreference[]
+  componentInstalls        BikeComponentInstall[]
+  bikeNotes                BikeNote[]
+  oauthAttempts            OAuthAttempt[]
+  integrations             UserIntegration[]
+  notificationLogs         NotificationLog[]
+  passwordResetTokens      PasswordResetToken[]
+  componentRideAdjustments ComponentRideAdjustment[]
 
   // Push notification preferences
-  expoPushToken       String?
-  notifyOnRideUpload  Boolean             @default(true)
+  expoPushToken      String?
+  notifyOnRideUpload Boolean @default(true)
 }
 
 model OauthToken {
@@ -104,30 +105,30 @@ model UserAccount {
 }
 
 model Ride {
-  id                String          @id @default(uuid())
-  userId            String
-  garminActivityId  String?         @unique
-  startTime         DateTime
-  durationSeconds   Int
-  averageHr         Int?
-  rideType          String
-  bikeId            String?
-  createdAt         DateTime        @default(now())
-  updatedAt         DateTime        @updatedAt
-  distanceMeters    Float
-  elevationGainMeters Float
-  notes             String?
-  location          String?
-  trailSystem       String?
-  duplicateOfId     String?
-  isDuplicate       Boolean         @default(false)
-  stravaActivityId  String?         @unique
-  stravaGearId      String?
-  whoopWorkoutId    String?         @unique
-  suuntoWorkoutId   String?         @unique
-  importSessionId   String?
-  startLat          Float?
-  startLng          Float?
+  id                      String                    @id @default(uuid())
+  userId                  String
+  garminActivityId        String?                   @unique
+  startTime               DateTime
+  durationSeconds         Int
+  averageHr               Int?
+  rideType                String
+  bikeId                  String?
+  createdAt               DateTime                  @default(now())
+  updatedAt               DateTime                  @updatedAt
+  distanceMeters          Float
+  elevationGainMeters     Float
+  notes                   String?
+  location                String?
+  trailSystem             String?
+  duplicateOfId           String?
+  isDuplicate             Boolean                   @default(false)
+  stravaActivityId        String?                   @unique
+  stravaGearId            String?
+  whoopWorkoutId          String?                   @unique
+  suuntoWorkoutId         String?                   @unique
+  importSessionId         String?
+  startLat                Float?
+  startLng                Float?
   // Lift-detection deltas (docs/plans/lift-detection-plan.md §2.4). Sums over
   // this ride's LIFT segments; effective metrics = raw − delta. NULL means
   // "never analyzed", 0 means "analyzed, no lift found". Raw provider columns
@@ -136,20 +137,21 @@ model Ride {
   liftElevationGainMeters Float?
   liftDistanceMeters      Float?
   liftDetectorVersion     Int?
-  bike              Bike?           @relation(fields: [bikeId], references: [id])
-  duplicateOf       Ride?           @relation("DuplicateRides", fields: [duplicateOfId], references: [id], onDelete: SetNull)
-  duplicates        Ride[]          @relation("DuplicateRides")
-  user              User            @relation(fields: [userId], references: [id], onDelete: Cascade)
-  importSession     ImportSession?  @relation(fields: [importSessionId], references: [id], onDelete: SetNull)
-  weather           RideWeather?
-  stream            RideStream?
-  segments          RideSegment[]
-
-  @@index([importSessionId, bikeId])
+  bike                    Bike?                     @relation(fields: [bikeId], references: [id])
+  duplicateOf             Ride?                     @relation("DuplicateRides", fields: [duplicateOfId], references: [id], onDelete: SetNull)
+  duplicates              Ride[]                    @relation("DuplicateRides")
+  user                    User                      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  importSession           ImportSession?            @relation(fields: [importSessionId], references: [id], onDelete: SetNull)
+  weather                 RideWeather?
+  stream                  RideStream?
+  segments                RideSegment[]
+  componentAdjustments    ComponentRideAdjustment[]
   // NOTE: a partial index on (userId) WHERE startLat IS NOT NULL AND startLng IS NOT NULL
   // is defined via raw SQL in migration 20260415121000_ride_missing_weather_index
   // to keep the ridesMissingWeather COUNT(*) fast once the RideWeather table fills up.
   // Prisma doesn't support partial-index predicates, so the index is managed there.
+
+  @@index([importSessionId, bikeId])
 }
 
 enum WeatherCondition {
@@ -163,21 +165,21 @@ enum WeatherCondition {
 }
 
 model RideWeather {
-  id               String           @id @default(uuid())
-  rideId           String           @unique
-  tempC            Float
-  feelsLikeC       Float?
-  precipitationMm  Float
-  windSpeedKph     Float
-  humidity         Float?
-  wmoCode          Int
-  condition        WeatherCondition
-  lat              Float
-  lng              Float
-  source           String
-  fetchedAt        DateTime         @default(now())
-  rawJson          Json?
-  ride             Ride             @relation(fields: [rideId], references: [id], onDelete: Cascade)
+  id              String           @id @default(uuid())
+  rideId          String           @unique
+  tempC           Float
+  feelsLikeC      Float?
+  precipitationMm Float
+  windSpeedKph    Float
+  humidity        Float?
+  wmoCode         Int
+  condition       WeatherCondition
+  lat             Float
+  lng             Float
+  source          String
+  fetchedAt       DateTime         @default(now())
+  rawJson         Json?
+  ride            Ride             @relation(fields: [rideId], references: [id], onDelete: Cascade)
 
   @@index([condition])
 }
@@ -255,51 +257,51 @@ model WeatherCache {
 }
 
 model Bike {
-  id                 String              @id @default(uuid())
-  userId             String
-  nickname           String?
-  manufacturer       String
-  model              String
-  travelForkMm       Int?
-  travelShockMm      Int?
-  notes              String?
+  id                     String                      @id @default(uuid())
+  userId                 String
+  nickname               String?
+  manufacturer           String
+  model                  String
+  travelForkMm           Int?
+  travelShockMm          Int?
+  notes                  String?
   // Public share slug for the read-only bike-history page (loamlogger.app/share/<slug>).
   // Set on enableBikeShare, nulled on disable; unguessable random token.
-  shareSlug          String?             @unique
-  createdAt          DateTime            @default(now())
-  updatedAt          DateTime            @updatedAt
-  year               Int?
-  sortOrder          Int                 @default(0)
-  spokesId           String?
-  buildKind          String?
-  category           String?
-  family             String?
-  frameMaterial      String?
-  gender             String?
-  hangerStandard     String?
-  isEbike            Boolean             @default(false)
-  isFrameset         Boolean             @default(false)
-  spokesUrl          String?
-  subcategory        String?
-  batteryWh          Int?
-  motorMaker         String?
-  motorModel         String?
-  motorPowerW        Int?
-  motorTorqueNm      Int?
-  thumbnailUrl         String?
-  acquisitionCondition AcquisitionCondition?
-  acquisitionDate      DateTime?
-  status               BikeStatus          @default(ACTIVE)
-  retiredAt            DateTime?
-  user                 User                @relation(fields: [userId], references: [id], onDelete: Cascade)
-  components           Component[]
-  Ride                 Ride[]
-  stravaGearMappings   StravaGearMapping[]
-  servicePreferences       BikeServicePreference[]
-  notificationPreference   BikeNotificationPreference?
-  notificationLogs         NotificationLog[]
-  installs                 BikeComponentInstall[]
-  bikeNotes                BikeNote[]
+  shareSlug              String?                     @unique
+  createdAt              DateTime                    @default(now())
+  updatedAt              DateTime                    @updatedAt
+  year                   Int?
+  sortOrder              Int                         @default(0)
+  spokesId               String?
+  buildKind              String?
+  category               String?
+  family                 String?
+  frameMaterial          String?
+  gender                 String?
+  hangerStandard         String?
+  isEbike                Boolean                     @default(false)
+  isFrameset             Boolean                     @default(false)
+  spokesUrl              String?
+  subcategory            String?
+  batteryWh              Int?
+  motorMaker             String?
+  motorModel             String?
+  motorPowerW            Int?
+  motorTorqueNm          Int?
+  thumbnailUrl           String?
+  acquisitionCondition   AcquisitionCondition?
+  acquisitionDate        DateTime?
+  status                 BikeStatus                  @default(ACTIVE)
+  retiredAt              DateTime?
+  user                   User                        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  components             Component[]
+  Ride                   Ride[]
+  stravaGearMappings     StravaGearMapping[]
+  servicePreferences     BikeServicePreference[]
+  notificationPreference BikeNotificationPreference?
+  notificationLogs       NotificationLog[]
+  installs               BikeComponentInstall[]
+  bikeNotes              BikeNote[]
 
   @@index([spokesId])
   @@index([userId, status])
@@ -322,41 +324,42 @@ model StravaGearMapping {
 }
 
 model Component {
-  id                    String             @id @default(uuid())
-  bikeId                String?
-  type                  ComponentType
-  location              ComponentLocation  @default(NONE)
-  brand                 String
-  model                 String
-  installedAt           DateTime?
-  hoursUsed             Float              @default(0)
-  serviceDueAtHours     Float?
-  notes                 String?
-  createdAt             DateTime           @default(now())
-  updatedAt             DateTime           @updatedAt
-  isStock               Boolean            @default(false)
-  baselineWearPercent   Int?               @default(0)
-  baselineMethod        BaselineMethod     @default(DEFAULT)
-  baselineConfidence    BaselineConfidence @default(HIGH)
-  baselineSetAt         DateTime?
-  lastServicedAt        DateTime?
-  userId                String
-  status                ComponentStatus    @default(INSTALLED)
+  id                  String             @id @default(uuid())
+  bikeId              String?
+  type                ComponentType
+  location            ComponentLocation  @default(NONE)
+  brand               String
+  model               String
+  installedAt         DateTime?
+  hoursUsed           Float              @default(0)
+  serviceDueAtHours   Float?
+  notes               String?
+  createdAt           DateTime           @default(now())
+  updatedAt           DateTime           @updatedAt
+  isStock             Boolean            @default(false)
+  baselineWearPercent Int?               @default(0)
+  baselineMethod      BaselineMethod     @default(DEFAULT)
+  baselineConfidence  BaselineConfidence @default(HIGH)
+  baselineSetAt       DateTime?
+  lastServicedAt      DateTime?
+  userId              String
+  status              ComponentStatus    @default(INSTALLED)
 
   // Front/rear pairing support
-  pairGroupId           String?
-  retiredAt             DateTime?
-  replacedById          String?            @unique
+  pairGroupId  String?
+  retiredAt    DateTime?
+  replacedById String?   @unique
 
-  bike                  Bike?              @relation(fields: [bikeId], references: [id])
-  user                  User               @relation(fields: [userId], references: [id], onDelete: Cascade)
-  serviceLogs           ServiceLog[]
-  notificationLogs      NotificationLog[]
-  installs              BikeComponentInstall[]
+  bike             Bike?                     @relation(fields: [bikeId], references: [id])
+  user             User                      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  serviceLogs      ServiceLog[]
+  notificationLogs NotificationLog[]
+  installs         BikeComponentInstall[]
+  rideAdjustments  ComponentRideAdjustment[]
 
   // Self-referential relation for replacement chain
-  replacedBy            Component?         @relation("ComponentReplacement", fields: [replacedById], references: [id])
-  replaces              Component?         @relation("ComponentReplacement")
+  replacedBy Component? @relation("ComponentReplacement", fields: [replacedById], references: [id])
+  replaces   Component? @relation("ComponentReplacement")
 
   // Unique constraint: one active component per bike/type/location combination
   // Note: Retired components (retiredAt != null) should have bikeId set to null
@@ -403,6 +406,39 @@ model ServiceLog {
 
   @@index([componentId])
   @@index([performedAt])
+}
+
+enum ComponentRideAdjustmentKind {
+  // Ride is on the component's bike but should NOT count toward this
+  // component's hours (e.g. a different wheel was mounted for that ride).
+  EXCLUDE
+  // Ride is NOT on the component's bike (or is unassigned) but SHOULD count
+  // (e.g. this wheel was temporarily mounted on another bike).
+  INCLUDE
+}
+
+// Per-(component, ride) attribution override. State, not an event log: one
+// row per pair, upserted to set and deleted to clear. Absence of rows means
+// the default attribution rule (rides on the component's bike since the
+// last-service anchor). Rows survive service resets — an out-of-window
+// INCLUDE goes dormant, not deleted, and springs back if the anchor moves
+// (e.g. the service log is deleted or backdated).
+model ComponentRideAdjustment {
+  id          String                      @id @default(uuid())
+  userId      String
+  componentId String
+  rideId      String
+  kind        ComponentRideAdjustmentKind
+  createdAt   DateTime                    @default(now())
+  updatedAt   DateTime                    @updatedAt
+
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  component Component @relation(fields: [componentId], references: [id], onDelete: Cascade)
+  ride      Ride      @relation(fields: [rideId], references: [id], onDelete: Cascade)
+
+  @@unique([componentId, rideId])
+  @@index([rideId])
+  @@index([userId])
 }
 
 enum AuthProvider {
@@ -494,7 +530,7 @@ enum ComponentType {
   BRAKES
   DRIVETRAIN
   TIRES
-  WHEEL_HUBS @map("WHEELS")
+  WHEEL_HUBS      @map("WHEELS")
   DROPPER
   PEDALS
   CHAIN
@@ -547,7 +583,7 @@ enum ComponentStatus {
 
 enum BikeNoteType {
   MANUAL // User-created note with single snapshot
-  SWAP   // Auto-created during component swap/replace
+  SWAP // Auto-created during component swap/replace
 }
 
 enum EmailType {
@@ -649,16 +685,16 @@ model GeoCache {
 }
 
 model BackfillRequest {
-  id             String              @id @default(cuid())
+  id             String         @id @default(cuid())
   userId         String
-  user           User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user           User           @relation(fields: [userId], references: [id], onDelete: Cascade)
   provider       AuthProvider
-  year           String              // "ytd", "2025", "2024", etc.
-  status         BackfillStatus      @default(pending)
+  year           String // "ytd", "2025", "2024", etc.
+  status         BackfillStatus @default(pending)
   ridesFound     Int?
-  backfilledUpTo DateTime?           // For YTD: the end timestamp of last backfill
-  createdAt      DateTime            @default(now())
-  updatedAt      DateTime            @updatedAt
+  backfilledUpTo DateTime? // For YTD: the end timestamp of last backfill
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @updatedAt
   completedAt    DateTime?
 
   @@unique([userId, provider, year])
@@ -742,12 +778,12 @@ model BikeServicePreference {
 }
 
 model BikeNote {
-  id             String       @id @default(uuid())
-  bikeId         String
-  userId         String
-  text           String       @db.Text
-  noteType       BikeNoteType @default(MANUAL)
-  createdAt      DateTime     @default(now())
+  id        String       @id @default(uuid())
+  bikeId    String
+  userId    String
+  text      String       @db.Text
+  noteType  BikeNoteType @default(MANUAL)
+  createdAt DateTime     @default(now())
 
   // JSON snapshots (immutable once created)
   snapshot       Json? // For MANUAL notes
@@ -773,14 +809,14 @@ enum ServiceNotificationMode {
 }
 
 model BikeNotificationPreference {
-  id                          String                  @id @default(uuid())
-  bikeId                      String                  @unique
-  serviceNotificationsEnabled Boolean                 @default(true)
-  serviceNotificationMode     ServiceNotificationMode @default(RIDES_BEFORE)
-  serviceNotificationThreshold Int                    @default(3)
-  createdAt                   DateTime                @default(now())
-  updatedAt                   DateTime                @updatedAt
-  bike                        Bike                    @relation(fields: [bikeId], references: [id], onDelete: Cascade)
+  id                           String                  @id @default(uuid())
+  bikeId                       String                  @unique
+  serviceNotificationsEnabled  Boolean                 @default(true)
+  serviceNotificationMode      ServiceNotificationMode @default(RIDES_BEFORE)
+  serviceNotificationThreshold Int                     @default(3)
+  createdAt                    DateTime                @default(now())
+  updatedAt                    DateTime                @updatedAt
+  bike                         Bike                    @relation(fields: [bikeId], references: [id], onDelete: Cascade)
 }
 
 enum NotificationType {
@@ -817,4 +853,3 @@ model PasswordResetToken {
   @@index([userId])
   @@index([expiresAt])
 }
-

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -152,6 +152,11 @@ model Ride {
   // Prisma doesn't support partial-index predicates, so the index is managed there.
 
   @@index([importSessionId, bikeId])
+  // Backs the userId + bikeId + startTime(range/order) access pattern shared
+  // by componentRides (interactive, up to 60/min), the prediction engine's
+  // getAllRidesForBike / getRidesSinceDate, and the component-hours recompute
+  // aggregates — all previously seq-scanning the whole Ride table.
+  @@index([userId, bikeId, startTime])
 }
 
 enum WeatherCondition {

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -34,6 +34,12 @@ jest.mock('../../lib/prisma', () => ({
     rideWeather: {
       groupBy: jest.fn().mockResolvedValue([]),
     },
+    componentRideAdjustment: {
+      findMany: jest.fn().mockResolvedValue([]),
+      upsert: jest.fn(),
+      findUnique: jest.fn(),
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+    },
     stravaGearMapping: {
       deleteMany: jest.fn(),
     },
@@ -3198,6 +3204,7 @@ describe('GraphQL Resolvers', () => {
             update: mockComponentUpdate,
           },
           ride: { aggregate: mockRideAggregate },
+          componentRideAdjustment: mockPrisma.componentRideAdjustment,
         };
         return fn(tx);
       });
@@ -3322,6 +3329,9 @@ describe('GraphQL Resolvers', () => {
     it('recomputes when a non-latest log is moved past the previous latest', async () => {
       // A previously-non-latest log was moved forward to a date that now
       // beats the old latest — the anchor moves and the helper must run.
+      // The delegated recompute (lib/component-hours.ts) makes THREE
+      // serviceLog.findFirst calls total: the mutation's latest-check, the
+      // re-anchor, and loadComponentAttribution's anchor read.
       mockLogFindUnique.mockResolvedValueOnce({
         id: 'log-old',
         component: { id: 'comp-1', userId: 'user-123', bikeId: 'bike-1' },
@@ -3329,9 +3339,12 @@ describe('GraphQL Resolvers', () => {
       mockLogFindFirst
         .mockResolvedValueOnce({ id: 'log-latest', performedAt: new Date('2026-01-01') })
         // After the update, log-old is now the newest.
+        .mockResolvedValueOnce({ performedAt: new Date('2026-03-10') })
         .mockResolvedValueOnce({ performedAt: new Date('2026-03-10') });
-      mockComponentFindUnique.mockResolvedValueOnce({ id: 'comp-1', bikeId: 'bike-1' });
-      mockRideAggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 3600 } });
+      mockComponentFindUnique.mockResolvedValue({
+        id: 'comp-1', userId: 'user-123', bikeId: 'bike-1', installedAt: null, hoursUsed: 0,
+      });
+      mockRideAggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 3600 }, _count: 1 });
 
       const ctx = createMockContext('user-123');
       await mutation(
@@ -3340,9 +3353,14 @@ describe('GraphQL Resolvers', () => {
         ctx as never
       );
 
+      // Re-anchor and hours recompute are now two separate writes.
       expect(mockComponentUpdate).toHaveBeenCalledWith({
         where: { id: 'comp-1' },
-        data: { lastServicedAt: new Date('2026-03-10'), hoursUsed: 1 },
+        data: { lastServicedAt: new Date('2026-03-10') },
+      });
+      expect(mockComponentUpdate).toHaveBeenCalledWith({
+        where: { id: 'comp-1' },
+        data: { hoursUsed: 1 },
       });
     });
 
@@ -3354,10 +3372,13 @@ describe('GraphQL Resolvers', () => {
       // This log IS the latest
       mockLogFindFirst
         .mockResolvedValueOnce({ id: 'log-latest', performedAt: new Date('2026-03-01') })
-        // Second call: recompute helper asks for the newest remaining log
+        // Recompute re-anchor + attribution anchor both see the new date.
+        .mockResolvedValueOnce({ performedAt: new Date('2026-04-15') })
         .mockResolvedValueOnce({ performedAt: new Date('2026-04-15') });
-      mockComponentFindUnique.mockResolvedValueOnce({ id: 'comp-1', bikeId: 'bike-1' });
-      mockRideAggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 7200 } }); // 2 hours
+      mockComponentFindUnique.mockResolvedValue({
+        id: 'comp-1', userId: 'user-123', bikeId: 'bike-1', installedAt: null, hoursUsed: 0,
+      });
+      mockRideAggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 7200 }, _count: 2 }); // 2 hours
 
       const ctx = createMockContext('user-123');
       await mutation(
@@ -3366,17 +3387,24 @@ describe('GraphQL Resolvers', () => {
         ctx as never
       );
 
+      // Canonical aggregate: scoped to the user, duplicates filtered.
       expect(mockRideAggregate).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
+            userId: 'user-123',
             bikeId: 'bike-1',
+            isDuplicate: false,
             startTime: { gte: new Date('2026-04-15') },
           }),
         })
       );
       expect(mockComponentUpdate).toHaveBeenCalledWith({
         where: { id: 'comp-1' },
-        data: { lastServicedAt: new Date('2026-04-15'), hoursUsed: 2 },
+        data: { lastServicedAt: new Date('2026-04-15') },
+      });
+      expect(mockComponentUpdate).toHaveBeenCalledWith({
+        where: { id: 'comp-1' },
+        data: { hoursUsed: 2 },
       });
     });
 
@@ -3420,6 +3448,7 @@ describe('GraphQL Resolvers', () => {
             update: mockComponentUpdate,
           },
           ride: { aggregate: mockRideAggregate },
+          componentRideAdjustment: mockPrisma.componentRideAdjustment,
         };
         return fn(tx);
       });
@@ -3471,16 +3500,24 @@ describe('GraphQL Resolvers', () => {
       });
       mockLogFindFirst
         .mockResolvedValueOnce({ id: 'log-latest' }) // was latest
-        .mockResolvedValueOnce({ performedAt: new Date('2026-01-01') }); // prior log after delete
-      mockComponentFindUnique.mockResolvedValueOnce({ id: 'comp-1', bikeId: 'bike-1' });
-      mockRideAggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 18000 } }); // 5 hours
+        // Prior log after delete: recompute re-anchor + attribution anchor.
+        .mockResolvedValueOnce({ performedAt: new Date('2026-01-01') })
+        .mockResolvedValueOnce({ performedAt: new Date('2026-01-01') });
+      mockComponentFindUnique.mockResolvedValue({
+        id: 'comp-1', userId: 'user-123', bikeId: 'bike-1', installedAt: null, hoursUsed: 0,
+      });
+      mockRideAggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 18000 }, _count: 3 }); // 5 hours
 
       const ctx = createMockContext('user-123');
       await mutation({}, { id: 'log-latest' }, ctx as never);
 
       expect(mockComponentUpdate).toHaveBeenCalledWith({
         where: { id: 'comp-1' },
-        data: { lastServicedAt: new Date('2026-01-01'), hoursUsed: 5 },
+        data: { lastServicedAt: new Date('2026-01-01') },
+      });
+      expect(mockComponentUpdate).toHaveBeenCalledWith({
+        where: { id: 'comp-1' },
+        data: { hoursUsed: 5 },
       });
     });
 
@@ -3491,20 +3528,30 @@ describe('GraphQL Resolvers', () => {
       });
       mockLogFindFirst
         .mockResolvedValueOnce({ id: 'log-last' })
-        .mockResolvedValueOnce(null); // no remaining logs
-      mockComponentFindUnique.mockResolvedValueOnce({ id: 'comp-1', bikeId: 'bike-1' });
-      mockRideAggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 360000 } }); // 100 hours
+        .mockResolvedValueOnce(null) // no remaining logs (re-anchor)
+        .mockResolvedValueOnce(null); // no remaining logs (attribution)
+      mockComponentFindUnique.mockResolvedValue({
+        id: 'comp-1', userId: 'user-123', bikeId: 'bike-1', installedAt: null, hoursUsed: 0,
+      });
+      mockRideAggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 360000 }, _count: 10 }); // 100 hours
 
       const ctx = createMockContext('user-123');
       await mutation({}, { id: 'log-last' }, ctx as never);
 
+      // installedAt is null too, so the window is all-time (no startTime
+      // clause); canonical aggregate scopes by user and filters duplicates.
       expect(mockRideAggregate).toHaveBeenCalledWith({
-        where: { bikeId: 'bike-1' },
+        where: { userId: 'user-123', bikeId: 'bike-1', isDuplicate: false },
         _sum: { durationSeconds: true },
+        _count: true,
       });
       expect(mockComponentUpdate).toHaveBeenCalledWith({
         where: { id: 'comp-1' },
-        data: { lastServicedAt: null, hoursUsed: 100 },
+        data: { lastServicedAt: null },
+      });
+      expect(mockComponentUpdate).toHaveBeenCalledWith({
+        where: { id: 'comp-1' },
+        data: { hoursUsed: 100 },
       });
     });
 
@@ -5128,6 +5175,141 @@ describe('GraphQL Resolvers', () => {
       const eventProps = mockCaptureServerEvent.mock.calls[0][2] as Record<string, unknown>;
       expect(eventProps).not.toHaveProperty('text');
       expect(JSON.stringify(eventProps)).not.toContain(cachedResult.text);
+    });
+  });
+
+  describe('Query.componentRides', () => {
+    const resolver = resolvers.Query.componentRides;
+    const mockComponentFindUnique = prisma.component.findUnique as jest.Mock;
+    const mockServiceLogFindFirst = prisma.serviceLog.findFirst as jest.Mock;
+    const mockAdjustmentFindMany = prisma.componentRideAdjustment.findMany as jest.Mock;
+    const mockRideFindMany = prisma.ride.findMany as jest.Mock;
+    const mockRideAggregate = prisma.ride.aggregate as jest.Mock;
+
+    const ANCHOR = new Date('2026-06-01T00:00:00Z');
+
+    const ride = (id: string, over: Record<string, unknown> = {}) => ({
+      id,
+      bikeId: 'bike-1',
+      startTime: new Date('2026-06-15T00:00:00Z'),
+      durationSeconds: 3600,
+      ...over,
+    });
+
+    beforeEach(() => {
+      mockCheckQueryRateLimit.mockResolvedValue({ allowed: true, retryAfter: 0 });
+      mockComponentFindUnique.mockResolvedValue({
+        id: 'comp-1',
+        userId: 'user-123',
+        bikeId: 'bike-1',
+        installedAt: null,
+        hoursUsed: 12.5,
+      });
+      mockServiceLogFindFirst.mockResolvedValue({ performedAt: ANCHOR });
+      mockAdjustmentFindMany.mockResolvedValue([]);
+      mockRideFindMany.mockResolvedValue([]);
+      mockRideAggregate.mockResolvedValue({ _sum: { durationSeconds: 0 }, _count: 0 });
+    });
+
+    it('throws Unauthorized when unauthenticated', async () => {
+      const ctx = createMockContext(null);
+      await expect(
+        resolver({}, { componentId: 'comp-1' }, ctx as never)
+      ).rejects.toThrow('Unauthorized');
+    });
+
+    it('throws Component not found for a foreign component (strict IDOR check)', async () => {
+      mockComponentFindUnique.mockResolvedValue({
+        id: 'comp-1', userId: 'someone-else', bikeId: 'bike-1', installedAt: null, hoursUsed: 5,
+      });
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        resolver({}, { componentId: 'comp-1' }, ctx as never)
+      ).rejects.toThrow('Component not found');
+      expect(mockRideFindMany).not.toHaveBeenCalled();
+    });
+
+    it('rejects when rate limited', async () => {
+      mockCheckQueryRateLimit.mockResolvedValue({ allowed: false, retryAfter: 30 });
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        resolver({}, { componentId: 'comp-1' }, ctx as never)
+      ).rejects.toThrow('Rate limit exceeded');
+    });
+
+    it('flags entries: default counted, EXCLUDEd not counted, cross-bike INCLUDE counted, pre-anchor INCLUDE dormant', async () => {
+      mockAdjustmentFindMany.mockResolvedValue([
+        { rideId: 'r-excluded', kind: 'EXCLUDE' },
+        { rideId: 'r-included', kind: 'INCLUDE' },
+        { rideId: 'r-dormant', kind: 'INCLUDE' },
+      ]);
+      mockRideFindMany.mockResolvedValue([
+        ride('r-normal'),
+        ride('r-excluded'),
+        ride('r-included', { bikeId: 'bike-2' }),
+        ride('r-dormant', { bikeId: 'bike-2', startTime: new Date('2026-01-01T00:00:00Z') }),
+      ]);
+      const ctx = createMockContext('user-123');
+
+      const result = await resolver({}, { componentId: 'comp-1' }, ctx as never);
+
+      const byId = Object.fromEntries(
+        result.entries.map((e: { ride: { id: string } }) => [e.ride.id, e])
+      );
+      expect(byId['r-normal']).toMatchObject({ counted: true, adjustment: null, beforeAnchor: false });
+      expect(byId['r-excluded']).toMatchObject({ counted: false, adjustment: 'EXCLUDE' });
+      expect(byId['r-included']).toMatchObject({ counted: true, adjustment: 'INCLUDE', beforeAnchor: false });
+      expect(byId['r-dormant']).toMatchObject({ counted: false, adjustment: 'INCLUDE', beforeAnchor: true });
+    });
+
+    it('pages with an id cursor and reports hasMore via the take+1 sentinel', async () => {
+      const rides = Array.from({ length: 3 }, (_, i) => ride(`r-${i}`));
+      mockRideFindMany.mockResolvedValue(rides);
+      const ctx = createMockContext('user-123');
+
+      const result = await resolver(
+        {},
+        { componentId: 'comp-1', take: 2, after: 'r-cursor' },
+        ctx as never
+      );
+
+      expect(mockRideFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 3, // limit + 1 sentinel
+          skip: 1,
+          cursor: { id: 'r-cursor' },
+        })
+      );
+      expect(result.hasMore).toBe(true);
+      expect(result.entries).toHaveLength(2);
+    });
+
+    it('returns canonical totals alongside the stored counter', async () => {
+      mockRideAggregate.mockResolvedValue({ _sum: { durationSeconds: 7200 }, _count: 2 });
+      const ctx = createMockContext('user-123');
+
+      const result = await resolver({}, { componentId: 'comp-1' }, ctx as never);
+
+      expect(result.countedHours).toBe(2);
+      expect(result.countedRideCount).toBe(2);
+      expect(result.hoursUsed).toBe(12.5); // stored counter passed through untouched
+      expect(result.anchor).toBe(ANCHOR.toISOString());
+    });
+
+    it('handles a spare component with no included rides (empty list, zero totals)', async () => {
+      mockComponentFindUnique.mockResolvedValue({
+        id: 'comp-1', userId: 'user-123', bikeId: null, installedAt: null, hoursUsed: 4,
+      });
+      mockServiceLogFindFirst.mockResolvedValue(null);
+      const ctx = createMockContext('user-123');
+
+      const result = await resolver({}, { componentId: 'comp-1' }, ctx as never);
+
+      expect(result.entries).toEqual([]);
+      expect(result.countedHours).toBe(0);
+      expect(mockRideFindMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -5484,13 +5484,36 @@ describe('GraphQL Resolvers', () => {
       expect(result.counted).toBe(true); // in-window (no anchor)
     });
 
-    it('caps adjustments per component when creating a new row', async () => {
-      mockAdjustment.count.mockResolvedValue(500);
+    it('caps adjustments per component: over-cap insert throws inside the tx (rolls back)', async () => {
+      // Post-insert count exceeds the cap -> the tx throws, rolling the
+      // upsert back. Checked inside the transaction (not a pre-check) so
+      // concurrent requests can't race past it (TOCTOU).
+      mockAdjustment.count.mockResolvedValue(501);
       const ctx = createMockContext('user-123');
 
       await expect(
         setMutation({}, { componentId: 'comp-1', rideId: 'ride-1', kind: 'EXCLUDE' }, ctx as never)
       ).rejects.toThrow('Too many ride adjustments');
+      // The insert happened inside the tx (then rolled back by the throw)…
+      expect(mockAdjustment.upsert).toHaveBeenCalled();
+      // …and the recompute never ran.
+      expect(mockComponentUpdate).not.toHaveBeenCalledWith({
+        where: { id: 'comp-1' },
+        data: expect.objectContaining({ hoursUsed: expect.anything() }),
+      });
+    });
+
+    it('does not apply the cap when flipping an existing row', async () => {
+      mockAdjustment.findUnique.mockResolvedValue({ id: 'adj-existing' });
+      mockAdjustment.count.mockResolvedValue(501); // would trip for a new row
+      const ctx = createMockContext('user-123');
+
+      const result = await setMutation(
+        {}, { componentId: 'comp-1', rideId: 'ride-1', kind: 'EXCLUDE' }, ctx as never
+      );
+
+      expect(result.counted).toBe(false);
+      expect(mockAdjustment.count).not.toHaveBeenCalled();
     });
 
     it('clear is an idempotent success even when no row exists', async () => {

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -26,6 +26,7 @@ jest.mock('../../lib/prisma', () => ({
     },
     ride: {
       findFirst: jest.fn(),
+      findUnique: jest.fn(),
       findMany: jest.fn(),
       updateMany: jest.fn(),
       count: jest.fn().mockResolvedValue(0),
@@ -38,6 +39,7 @@ jest.mock('../../lib/prisma', () => ({
       findMany: jest.fn().mockResolvedValue([]),
       upsert: jest.fn(),
       findUnique: jest.fn(),
+      count: jest.fn().mockResolvedValue(0),
       deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
     },
     stravaGearMapping: {
@@ -257,6 +259,11 @@ describe('GraphQL Resolvers', () => {
           return [];
         });
         mockPrisma.serviceLog.create.mockResolvedValue({ id: 'log-1' } as never);
+        // The canonical recompute inside the tx aggregates rides.
+        (mockPrisma.ride.aggregate as jest.Mock).mockResolvedValue({
+          _sum: { durationSeconds: 0 },
+          _count: 0,
+        } as never);
         mockPrisma.component.update.mockResolvedValue({ id: 'comp-1', hoursUsed: 0 } as never);
 
         const result = await mutation({}, { id: 'comp-1', performedAt: validDate }, ctx as never);
@@ -292,6 +299,11 @@ describe('GraphQL Resolvers', () => {
           return [];
         });
         mockPrisma.serviceLog.create.mockResolvedValue({ id: 'log-1' } as never);
+        // The canonical recompute inside the tx aggregates rides.
+        (mockPrisma.ride.aggregate as jest.Mock).mockResolvedValue({
+          _sum: { durationSeconds: 0 },
+          _count: 0,
+        } as never);
         mockPrisma.component.update.mockResolvedValue({ id: 'comp-1', hoursUsed: 0 } as never);
 
         await mutation({}, { id: 'comp-1', performedAt: null }, ctx as never);
@@ -319,6 +331,11 @@ describe('GraphQL Resolvers', () => {
           return [];
         });
         mockPrisma.serviceLog.create.mockResolvedValue({ id: 'log-1' } as never);
+        // The canonical recompute inside the tx aggregates rides.
+        (mockPrisma.ride.aggregate as jest.Mock).mockResolvedValue({
+          _sum: { durationSeconds: 0 },
+          _count: 0,
+        } as never);
         mockPrisma.component.update.mockResolvedValue({ id: 'comp-1', hoursUsed: 0 } as never);
 
         const result = await mutation({}, { id: 'comp-1' }, ctx as never);
@@ -329,9 +346,15 @@ describe('GraphQL Resolvers', () => {
             hoursAtService: 50,
           }),
         });
+        // Recompute (canonical hours, 0 with no rides) and the anchor write
+        // are now two separate updates.
         expect(mockPrisma.component.update).toHaveBeenCalledWith({
           where: { id: 'comp-1' },
-          data: { hoursUsed: 0, lastServicedAt: expect.any(Date) },
+          data: { hoursUsed: 0 },
+        });
+        expect(mockPrisma.component.update).toHaveBeenCalledWith({
+          where: { id: 'comp-1' },
+          data: { lastServicedAt: expect.any(Date) },
         });
         expect(result).toEqual({ id: 'comp-1', hoursUsed: 0 });
       });
@@ -352,6 +375,11 @@ describe('GraphQL Resolvers', () => {
           return [];
         });
         mockPrisma.serviceLog.create.mockResolvedValue({ id: 'log-1' } as never);
+        // The canonical recompute inside the tx aggregates rides.
+        (mockPrisma.ride.aggregate as jest.Mock).mockResolvedValue({
+          _sum: { durationSeconds: 0 },
+          _count: 0,
+        } as never);
         mockPrisma.component.update.mockResolvedValue({ id: 'comp-1', hoursUsed: 0 } as never);
 
         await mutation({}, { id: 'comp-1' }, ctx as never);
@@ -3167,8 +3195,21 @@ describe('GraphQL Resolvers', () => {
       });
 
       const mockTx = {
-        serviceLog: { create: jest.fn() },
-        component: { update: jest.fn().mockResolvedValue({ id: 'comp-1' }) },
+        serviceLog: {
+          create: jest.fn(),
+          findFirst: jest.fn().mockResolvedValue(null),
+        },
+        component: {
+          update: jest.fn().mockResolvedValue({ id: 'comp-1' }),
+          // The canonical recompute reloads the component inside the tx.
+          findUnique: jest.fn().mockResolvedValue({
+            id: 'comp-1', userId: 'user-123', bikeId: 'bike-1', installedAt: null, hoursUsed: 50,
+          }),
+        },
+        ride: {
+          aggregate: jest.fn().mockResolvedValue({ _sum: { durationSeconds: 0 }, _count: 0 }),
+        },
+        componentRideAdjustment: { findMany: jest.fn().mockResolvedValue([]) },
       };
       (mockPrisma.$transaction as jest.Mock).mockImplementation((fn: (...args: unknown[]) => unknown) => fn(mockTx));
 
@@ -5310,6 +5351,216 @@ describe('GraphQL Resolvers', () => {
       expect(result.entries).toEqual([]);
       expect(result.countedHours).toBe(0);
       expect(mockRideFindMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('componentRideAdjustment mutations', () => {
+    const setMutation = resolvers.Mutation.setComponentRideAdjustment;
+    const clearMutation = resolvers.Mutation.clearComponentRideAdjustment;
+    const mockComponentFindUnique = prisma.component.findUnique as jest.Mock;
+    const mockComponentUpdate = prisma.component.update as jest.Mock;
+    const mockRideFindUnique = prisma.ride.findUnique as jest.Mock;
+    const mockRideAggregate = prisma.ride.aggregate as jest.Mock;
+    const mockServiceLogFindFirst = prisma.serviceLog.findFirst as jest.Mock;
+    const mockAdjustment = prisma.componentRideAdjustment as unknown as Record<string, jest.Mock>;
+    const mockTransaction = prisma.$transaction as jest.Mock;
+    const mockInvalidate = invalidateBikePrediction as jest.Mock;
+
+    beforeEach(() => {
+      mockCheckMutationRateLimit.mockResolvedValue({ allowed: true, retryAfter: 0 });
+      mockComponentFindUnique.mockResolvedValue({
+        id: 'comp-1', userId: 'user-123', bikeId: 'bike-1', installedAt: null, hoursUsed: 10,
+      });
+      mockRideFindUnique.mockResolvedValue({
+        id: 'ride-1',
+        userId: 'user-123',
+        bikeId: 'bike-1',
+        startTime: new Date('2026-06-15T00:00:00Z'),
+        isDuplicate: false,
+      });
+      mockServiceLogFindFirst.mockResolvedValue(null);
+      mockAdjustment.findUnique.mockResolvedValue(null);
+      mockAdjustment.count.mockResolvedValue(0);
+      mockAdjustment.findMany.mockResolvedValue([]);
+      mockAdjustment.upsert.mockResolvedValue({ id: 'adj-1' });
+      mockAdjustment.deleteMany.mockResolvedValue({ count: 1 });
+      mockRideAggregate.mockResolvedValue({ _sum: { durationSeconds: 3600 }, _count: 1 });
+      mockComponentUpdate.mockResolvedValue({ id: 'comp-1', hoursUsed: 1 });
+      // Passthrough tx sharing the module-level mocks
+      mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => fn(prisma));
+    });
+
+    it('rejects a foreign component (strict not-found)', async () => {
+      mockComponentFindUnique.mockResolvedValue({
+        id: 'comp-1', userId: 'other-user', bikeId: 'bike-1',
+      });
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        setMutation({}, { componentId: 'comp-1', rideId: 'ride-1', kind: 'EXCLUDE' }, ctx as never)
+      ).rejects.toThrow('Component not found');
+      expect(mockAdjustment.upsert).not.toHaveBeenCalled();
+    });
+
+    it('rejects a foreign ride independently of the component check', async () => {
+      mockRideFindUnique.mockResolvedValue({
+        id: 'ride-1', userId: 'other-user', bikeId: 'bike-1',
+        startTime: new Date(), isDuplicate: false,
+      });
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        setMutation({}, { componentId: 'comp-1', rideId: 'ride-1', kind: 'EXCLUDE' }, ctx as never)
+      ).rejects.toThrow('Ride not found');
+      expect(mockAdjustment.upsert).not.toHaveBeenCalled();
+    });
+
+    it('rejects adjusting a duplicate ride', async () => {
+      mockRideFindUnique.mockResolvedValue({
+        id: 'ride-1', userId: 'user-123', bikeId: 'bike-1',
+        startTime: new Date(), isDuplicate: true,
+      });
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        setMutation({}, { componentId: 'comp-1', rideId: 'ride-1', kind: 'EXCLUDE' }, ctx as never)
+      ).rejects.toThrow('Cannot adjust a duplicate ride');
+    });
+
+    it('validates kind against the ride/bike relationship', async () => {
+      const ctx = createMockContext('user-123');
+
+      // INCLUDE on an on-bike ride is invalid
+      await expect(
+        setMutation({}, { componentId: 'comp-1', rideId: 'ride-1', kind: 'INCLUDE' }, ctx as never)
+      ).rejects.toThrow('INCLUDE requires a ride that is not on the component’s bike.');
+
+      // EXCLUDE on an off-bike ride is invalid
+      mockRideFindUnique.mockResolvedValue({
+        id: 'ride-1', userId: 'user-123', bikeId: 'bike-2',
+        startTime: new Date(), isDuplicate: false,
+      });
+      await expect(
+        setMutation({}, { componentId: 'comp-1', rideId: 'ride-1', kind: 'EXCLUDE' }, ctx as never)
+      ).rejects.toThrow('EXCLUDE requires a ride on the component’s bike.');
+    });
+
+    it('EXCLUDE upserts the row, recomputes, and reports counted:false', async () => {
+      const ctx = createMockContext('user-123');
+
+      const result = await setMutation(
+        {}, { componentId: 'comp-1', rideId: 'ride-1', kind: 'EXCLUDE' }, ctx as never
+      );
+
+      expect(mockAdjustment.upsert).toHaveBeenCalledWith({
+        where: { componentId_rideId: { componentId: 'comp-1', rideId: 'ride-1' } },
+        create: { userId: 'user-123', componentId: 'comp-1', rideId: 'ride-1', kind: 'EXCLUDE' },
+        update: { kind: 'EXCLUDE' },
+      });
+      // The recompute persisted canonical hours inside the tx.
+      expect(mockComponentUpdate).toHaveBeenCalledWith({
+        where: { id: 'comp-1' },
+        data: { hoursUsed: 1 },
+      });
+      expect(result.counted).toBe(false);
+      expect(result.rideId).toBe('ride-1');
+    });
+
+    it('cross-bike INCLUDE invalidates BOTH bikes, before and after', async () => {
+      mockRideFindUnique.mockResolvedValue({
+        id: 'ride-1', userId: 'user-123', bikeId: 'bike-2',
+        startTime: new Date('2026-06-15T00:00:00Z'), isDuplicate: false,
+      });
+      mockInvalidate.mockClear();
+      const ctx = createMockContext('user-123');
+
+      const result = await setMutation(
+        {}, { componentId: 'comp-1', rideId: 'ride-1', kind: 'INCLUDE' }, ctx as never
+      );
+
+      const invalidatedBikes = mockInvalidate.mock.calls.map((c: unknown[]) => c[1]);
+      expect(invalidatedBikes.filter((b: unknown) => b === 'bike-1')).toHaveLength(2);
+      expect(invalidatedBikes.filter((b: unknown) => b === 'bike-2')).toHaveLength(2);
+      expect(result.counted).toBe(true); // in-window (no anchor)
+    });
+
+    it('caps adjustments per component when creating a new row', async () => {
+      mockAdjustment.count.mockResolvedValue(500);
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        setMutation({}, { componentId: 'comp-1', rideId: 'ride-1', kind: 'EXCLUDE' }, ctx as never)
+      ).rejects.toThrow('Too many ride adjustments');
+    });
+
+    it('clear is an idempotent success even when no row exists', async () => {
+      mockAdjustment.deleteMany.mockResolvedValue({ count: 0 });
+      const ctx = createMockContext('user-123');
+
+      const result = await clearMutation(
+        {}, { componentId: 'comp-1', rideId: 'ride-1' }, ctx as never
+      );
+
+      expect(mockAdjustment.deleteMany).toHaveBeenCalledWith({
+        where: { componentId: 'comp-1', rideId: 'ride-1' },
+      });
+      // On-bike, in-window (no anchor), no adjustment -> counts by default.
+      expect(result.counted).toBe(true);
+    });
+  });
+
+  describe('Mutation.deleteRide with adjusted ride', () => {
+    const mutation = resolvers.Mutation.deleteRide;
+    const mockInvalidate = invalidateBikePrediction as jest.Mock;
+
+    it('captures adjusted components before the delete and invalidates their bikes', async () => {
+      mockCheckMutationRateLimit.mockResolvedValue({ allowed: true, retryAfter: 0 });
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue({
+        userId: 'user-123', durationSeconds: 3600, bikeId: 'bike-1',
+      });
+      mockInvalidate.mockClear();
+
+      // Ride is INCLUDEd in a component living on ANOTHER bike (spare-swap
+      // correction): its counter must be recomputed after the delete and
+      // bike-2 invalidated even though the ride belonged to bike-1.
+      const txAdjustmentFindMany = jest.fn()
+        // findAdjustedComponentIdsForRides (pre-delete capture)
+        .mockResolvedValueOnce([{ componentId: 'comp-other' }])
+        // loadComponentAttribution inside the recompute
+        .mockResolvedValue([]);
+      const tx = {
+        ride: {
+          delete: jest.fn().mockResolvedValue({}),
+          aggregate: jest.fn().mockResolvedValue({ _sum: { durationSeconds: 0 }, _count: 0 }),
+        },
+        component: {
+          updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+          update: jest.fn().mockResolvedValue({}),
+          findUnique: jest.fn().mockResolvedValue({
+            id: 'comp-other', userId: 'user-123', bikeId: 'bike-2', installedAt: null, hoursUsed: 5,
+          }),
+        },
+        serviceLog: { findFirst: jest.fn().mockResolvedValue(null) },
+        componentRideAdjustment: { findMany: txAdjustmentFindMany },
+      };
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      const result = await mutation({}, { id: 'ride-1' }, createMockContext('user-123') as never);
+
+      expect(result).toEqual({ ok: true, id: 'ride-1' });
+      // Capture ran BEFORE the delete
+      expect(txAdjustmentFindMany.mock.invocationCallOrder[0]).toBeLessThan(
+        tx.ride.delete.mock.invocationCallOrder[0]
+      );
+      // The adjusted component was recomputed post-delete
+      expect(tx.component.update).toHaveBeenCalledWith({
+        where: { id: 'comp-other' },
+        data: { hoursUsed: 0 },
+      });
+      // Both the ride's bike and the adjusted component's bike invalidated
+      const invalidatedBikes = mockInvalidate.mock.calls.map((c: unknown[]) => c[1]);
+      expect(invalidatedBikes).toContain('bike-1');
+      expect(invalidatedBikes).toContain('bike-2');
     });
   });
 });

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -42,7 +42,13 @@ import { checkRecentAuth } from '../auth/recent-auth';
 import type { AcquisitionCondition, BaselineMethod, BaselineConfidence, ServiceNotificationMode } from '@prisma/client';
 import { getBikeById, isSpokesConfigured } from '../services/spokes';
 import { parseISO } from 'date-fns';
-import { incrementBikeComponentHours, decrementBikeComponentHours } from '../lib/component-hours';
+import {
+  incrementBikeComponentHours,
+  decrementBikeComponentHours,
+  loadComponentAttribution,
+  computeCountedHours,
+  recomputeComponentHours,
+} from '../lib/component-hours';
 import { captureSetupSnapshot } from '../lib/capture-snapshot';
 import type { SetupSnapshot } from '@loam/shared';
 import { randomBytes } from 'crypto';
@@ -290,8 +296,10 @@ const cleanText = (v: unknown, max = MAX_LABEL_LEN) =>
  * the last anchor, so anchor changes require recomputing it from scratch —
  * otherwise the counter keeps the old window of rides baked in.
  *
- * Uses ride duration on the component's current bike as the wear proxy,
- * matching how `incrementBikeComponentHours` ticks the counter on ride upload.
+ * Delegates the hours math to the canonical adjustment-aware recompute in
+ * lib/component-hours.ts (ride duration on the component's current bike as
+ * the wear proxy, ± ComponentRideAdjustment rows), so service-log edits
+ * respect per-ride include/exclude corrections automatically.
  *
  * **Missing-component tolerance:** the initial `component.findUnique` can
  * return null if the component was deleted between the caller's ownership
@@ -310,33 +318,28 @@ async function recomputeComponentAfterServiceChange(
 ): Promise<void> {
   const component = await tx.component.findUnique({
     where: { id: componentId },
-    select: { id: true, bikeId: true },
+    select: { id: true },
   });
   if (!component) return;
 
+  // Re-anchor lastServicedAt to the newest remaining log (null when the
+  // last one was deleted), then delegate the hours math to the canonical
+  // adjustment-aware recompute in lib/component-hours.ts. The canonical
+  // rule also filters isDuplicate rides and falls back to installedAt when
+  // no service log exists — both deliberate corrections over the old
+  // inline aggregate (engine parity; a never-serviced part must not absorb
+  // the bike's pre-install history).
   const latestLog = await tx.serviceLog.findFirst({
     where: { componentId },
     orderBy: [{ performedAt: 'desc' }, { createdAt: 'desc' }],
     select: { performedAt: true },
   });
-  const newAnchor = latestLog?.performedAt ?? null;
-
-  let hoursUsed = 0;
-  if (component.bikeId) {
-    const { _sum } = await tx.ride.aggregate({
-      where: {
-        bikeId: component.bikeId,
-        ...(newAnchor ? { startTime: { gte: newAnchor } } : {}),
-      },
-      _sum: { durationSeconds: true },
-    });
-    hoursUsed = (_sum.durationSeconds ?? 0) / 3600;
-  }
-
   await tx.component.update({
     where: { id: componentId },
-    data: { lastServicedAt: newAnchor, hoursUsed },
+    data: { lastServicedAt: latestLog?.performedAt ?? null },
   });
+
+  await recomputeComponentHours(tx, componentId);
 }
 
 const componentLabelMap: Partial<Record<ComponentType, string>> = {
@@ -910,6 +913,90 @@ export const resolvers = {
       }
 
       return getRideTrack(userId, rideId);
+    },
+
+    // The rides behind a component's current hoursUsed number, per the
+    // canonical attribution rule in lib/component-hours.ts. Lists on-bike
+    // in-window rides (EXCLUDEd ones included but flagged) merged with
+    // INCLUDEd cross-bike rides (dormant pre-anchor ones flagged), newest
+    // first, id-cursor paged. Totals come from the same computeCountedHours
+    // the recompute uses, so the displayed number cannot diverge from what
+    // an adjustment would snap the counter to.
+    componentRides: async (
+      _: unknown,
+      { componentId, take = 50, after }: { componentId: string; take?: number; after?: string | null },
+      ctx: GraphQLContext
+    ) => {
+      const userId = requireUserId(ctx);
+
+      const rateLimit = await checkQueryRateLimit('componentRides', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(`Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`, {
+          extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
+        });
+      }
+
+      const attribution = await loadComponentAttribution(prisma, componentId);
+      // Strict not-found on foreign ownership — never reveal existence.
+      if (!attribution || attribution.component.userId !== userId) {
+        throw new Error('Component not found');
+      }
+
+      const { component, anchor, excludedRideIds, includedRideIds } = attribution;
+      const excluded = new Set(excludedRideIds);
+      const included = new Set(includedRideIds);
+      const limit = Math.min(100, Math.max(1, take));
+
+      // On-bike in-window rides OR explicitly INCLUDEd rides (any bike, any
+      // date — pre-anchor INCLUDEs are listed so the UI can show them as
+      // dormant rather than silently dropping them).
+      const orBranches: Prisma.RideWhereInput[] = [];
+      if (component.bikeId) {
+        orBranches.push({
+          bikeId: component.bikeId,
+          ...(anchor ? { startTime: { gte: anchor } } : {}),
+        });
+      }
+      if (includedRideIds.length) {
+        orBranches.push({ id: { in: includedRideIds } });
+      }
+
+      const rides = orBranches.length
+        ? await prisma.ride.findMany({
+            where: { userId, isDuplicate: false, OR: orBranches },
+            orderBy: [{ startTime: 'desc' }, { id: 'desc' }],
+            take: limit + 1, // one extra to detect hasMore
+            ...(after ? { skip: 1, cursor: { id: after } } : {}),
+          })
+        : [];
+
+      const hasMore = rides.length > limit;
+      const pageRides = hasMore ? rides.slice(0, -1) : rides;
+
+      const entries = pageRides.map((ride) => {
+        const isOnBike = ride.bikeId != null && ride.bikeId === component.bikeId;
+        const inWindow = !anchor || ride.startTime >= anchor;
+        const isExcluded = excluded.has(ride.id);
+        const isIncluded = included.has(ride.id);
+        return {
+          ride,
+          counted: inWindow && !isExcluded && (isOnBike || isIncluded),
+          adjustment: isExcluded ? 'EXCLUDE' : isIncluded ? 'INCLUDE' : null,
+          beforeAnchor: isIncluded && !inWindow,
+        };
+      });
+
+      const counted = await computeCountedHours(prisma, attribution);
+
+      return {
+        componentId,
+        anchor: anchor ? anchor.toISOString() : null,
+        entries,
+        countedHours: counted.hours,
+        hoursUsed: component.hoursUsed,
+        countedRideCount: counted.rideCount,
+        hasMore,
+      };
     },
 
     rides: async (_: unknown, { take = 1000, after, filter }: RidesArgs, ctx: GraphQLContext) => {

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -3501,13 +3501,13 @@ export const resolvers = {
           }
         }
 
-        await recomputeComponentHours(tx, componentId);
-
-        // Derive whether the ride now counts, from the same canonical rule.
-        const attribution = await loadComponentAttribution(tx, componentId);
-        const inWindow = !attribution?.anchor || ride.startTime >= attribution.anchor;
-        const nowCounted =
-          kind === 'EXCLUDE' ? false : inWindow;
+        // The recompute runs after the upsert, so its attribution reflects
+        // the new row — reuse it for the `counted` flag instead of
+        // re-reading component/service-log/adjustments.
+        const recomputed = await recomputeComponentHours(tx, componentId);
+        const anchor = recomputed?.attribution.anchor ?? null;
+        const inWindow = !anchor || ride.startTime >= anchor;
+        const nowCounted = kind === 'EXCLUDE' ? false : inWindow;
 
         const fresh = await tx.component.findUnique({ where: { id: componentId } });
         return { updatedComponent: fresh, counted: nowCounted };
@@ -3562,12 +3562,12 @@ export const resolvers = {
           where: { componentId, rideId },
         });
 
-        await recomputeComponentHours(tx, componentId);
-
         // With no adjustment, the ride counts iff it's on the component's
-        // bike and inside the window.
-        const attribution = await loadComponentAttribution(tx, componentId);
-        const inWindow = !attribution?.anchor || ride.startTime >= attribution.anchor;
+        // bike and inside the window — anchor reused from the recompute's
+        // own attribution load.
+        const recomputed = await recomputeComponentHours(tx, componentId);
+        const anchor = recomputed?.attribution.anchor ?? null;
+        const inWindow = !anchor || ride.startTime >= anchor;
         const onBike = ride.bikeId != null && ride.bikeId === component.bikeId;
         const nowCounted = inWindow && onBike;
 

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -3460,9 +3460,17 @@ export const resolvers = {
         });
       }
 
-      // Invalidate BOTH bikes when they differ (cross-bike INCLUDE): the
-      // component's bike gains/loses hours, and the ride's own bike surface
-      // may render this component's data after a future reinstall.
+      // Invalidate the affected bikes' prediction caches before the
+      // transaction AND again after (below) — cache-aside double-delete, the
+      // same before/after convention as addRide/updateRide. The pre-invalidate
+      // stops a concurrent read during the tx window from recomputing off the
+      // pre-mutation state and re-caching a soon-stale value; the post-
+      // invalidate clears whatever lost that race so the cache ends up
+      // reflecting the committed result. (Redis cost is bounded — these
+      // mutations are rate-limited to 60/min.) BOTH bikes when they differ
+      // (cross-bike INCLUDE): the component's bike gains/loses hours, and the
+      // ride's own bike surface may render this component's data after a
+      // future reinstall.
       const bikesToInvalidate = [
         ...new Set([component.bikeId, ride.bikeId].filter((b): b is string => !!b)),
       ];
@@ -3513,6 +3521,7 @@ export const resolvers = {
         return { updatedComponent: fresh, counted: nowCounted };
       });
 
+      // Post-transaction half of the double-invalidation (see the pre-tx block).
       for (const bikeId of bikesToInvalidate) {
         await invalidateBikePrediction(userId, bikeId);
       }
@@ -3549,6 +3558,10 @@ export const resolvers = {
         throw new Error('Ride not found');
       }
 
+      // Before + after cache invalidation, same double-delete rationale as
+      // setComponentRideAdjustment above: the pre-invalidate closes the
+      // stale-recache race during the tx, the post-invalidate reflects the
+      // committed result. Both bikes when clearing a cross-bike INCLUDE.
       const bikesToInvalidate = [
         ...new Set([component.bikeId, ride.bikeId].filter((b): b is string => !!b)),
       ];
@@ -3575,6 +3588,7 @@ export const resolvers = {
         return { updatedComponent: fresh, counted: nowCounted };
       });
 
+      // Post-transaction half of the double-invalidation (see the pre-tx block).
       for (const bikeId of bikesToInvalidate) {
         await invalidateBikePrediction(userId, bikeId);
       }

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -48,6 +48,8 @@ import {
   loadComponentAttribution,
   computeCountedHours,
   recomputeComponentHours,
+  recomputeAdjustedComponentsForRides,
+  findAdjustedComponentIdsForRides,
 } from '../lib/component-hours';
 import { captureSetupSnapshot } from '../lib/capture-snapshot';
 import type { SetupSnapshot } from '@loam/shared';
@@ -274,6 +276,11 @@ const MAX_LABEL_LEN = 120;
  * 1000h.
  */
 const MAX_SERVICE_HOURS = 100_000;
+
+// Bound on ComponentRideAdjustment rows per component — keeps the
+// id IN (...) lists in the canonical recompute and componentRides
+// queries small. Far above any plausible manual-correction volume.
+const MAX_COMPONENT_RIDE_ADJUSTMENTS = 500;
 
 /**
  * Clean user input text.
@@ -1913,17 +1920,26 @@ export const resolvers = {
         await invalidateBikePrediction(userId, deletedBikeId);
       }
 
-      await prisma.$transaction(async (tx) => {
+      const adjustedBikeIds = await prisma.$transaction(async (tx) => {
+        // Capture BEFORE the delete — the adjustment rows cascade away with
+        // the ride. Components on OTHER bikes may have INCLUDEd this ride;
+        // the bulk decrement below never touches them, so they need a
+        // targeted canonical recompute after the row is gone.
+        const adjustedComponentIds = await findAdjustedComponentIdsForRides(tx, [id]);
+
         if (ride.bikeId) {
           await decrementBikeComponentHours(tx, { userId, bikeId: ride.bikeId, hoursDelta });
         }
 
         await tx.ride.delete({ where: { id } });
+
+        return recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
       });
 
-      // Invalidate prediction cache after transaction
-      if (deletedBikeId) {
-        await invalidateBikePrediction(userId, deletedBikeId);
+      // Invalidate prediction cache after transaction — the ride's own bike
+      // plus any bike holding a component whose adjustment referenced it.
+      for (const bikeId of new Set([deletedBikeId, ...adjustedBikeIds].filter((b): b is string => !!b))) {
+        await invalidateBikePrediction(userId, bikeId);
       }
 
       return { ok: true, id };
@@ -2039,7 +2055,9 @@ export const resolvers = {
         await invalidateBikePrediction(userId, nextBikeId);
       }
 
-      const updatedRide = await prisma.$transaction(async (tx) => {
+      const startChanged = start !== undefined;
+
+      const { updatedRide, adjustedBikeIds } = await prisma.$transaction(async (tx) => {
         const updated = await tx.ride.update({
           where: { id },
           data,
@@ -2065,15 +2083,30 @@ export const resolvers = {
           }
         }
 
-        return updated;
+        // Components with adjustments referencing this ride need a canonical
+        // recompute when the ride's bike, duration, or startTime changed —
+        // the bulk paths above either mis-credit them (EXCLUDE) or never
+        // touch them (cross-bike INCLUDE). startTime matters because it can
+        // move the ride across the component's attribution window; note the
+        // bulk paths deliberately ignore startTime-only edits for unadjusted
+        // components (existing semantics, kept).
+        const recomputedBikes =
+          bikeChanged || durationChanged || startChanged
+            ? await recomputeAdjustedComponentsForRides(tx, { rideIds: [id] })
+            : [];
+
+        return { updatedRide: updated, adjustedBikeIds: recomputedBikes };
       });
 
-      // Invalidate prediction cache after transaction
-      if (existing.bikeId) {
-        await invalidateBikePrediction(userId, existing.bikeId);
-      }
-      if (nextBikeId && nextBikeId !== existing.bikeId) {
-        await invalidateBikePrediction(userId, nextBikeId);
+      // Invalidate prediction cache after transaction, including bikes that
+      // hold adjusted components (may be neither the old nor the new bike).
+      const postInvalidate = new Set(
+        [existing.bikeId, nextBikeId !== existing.bikeId ? nextBikeId : null, ...adjustedBikeIds].filter(
+          (b): b is string => !!b
+        )
+      );
+      for (const bikeId of postInvalidate) {
+        await invalidateBikePrediction(userId, bikeId);
       }
 
       return updatedRide;
@@ -2614,7 +2647,7 @@ export const resolvers = {
         await invalidateBikePrediction(userId, existing.bikeId);
       }
 
-      // Use transaction to create service log AND reset hours atomically
+      // Use transaction to create service log AND recompute hours atomically
       const updated = await prisma.$transaction(async (tx) => {
         // Create service log to record this service event
         await tx.serviceLog.create({
@@ -2625,10 +2658,16 @@ export const resolvers = {
           },
         });
 
-        // Reset component hours and record service date
+        // Recompute instead of hardcoding 0: a service dated "now" still
+        // yields 0, but a BACKDATED service now correctly counts the rides
+        // that happened after it — matching what updateServiceLog already
+        // produces when the same log is later edited. Also keeps per-ride
+        // adjustments (ComponentRideAdjustment) applied.
+        await recomputeComponentHours(tx, id);
+
         return tx.component.update({
           where: { id },
-          data: { hoursUsed: 0, lastServicedAt: serviceDate },
+          data: { lastServicedAt: serviceDate },
         });
       });
 
@@ -2704,10 +2743,14 @@ export const resolvers = {
           },
         });
 
-        // Reset component hours and record service date
+        // Recompute instead of hardcoding 0 — backdated services count the
+        // rides after them, and per-ride adjustments stay applied. See the
+        // parallel note in logComponentService.
+        await recomputeComponentHours(tx, input.componentId);
+
         await tx.component.update({
           where: { id: input.componentId },
-          data: { hoursUsed: 0, lastServicedAt: performedAt },
+          data: { lastServicedAt: performedAt },
         });
 
         return log;
@@ -3364,6 +3407,173 @@ export const resolvers = {
       return updated;
     },
 
+    setComponentRideAdjustment: async (
+      _: unknown,
+      { componentId, rideId, kind }: { componentId: string; rideId: string; kind: 'EXCLUDE' | 'INCLUDE' },
+      ctx: GraphQLContext
+    ) => {
+      const userId = requireUserId(ctx);
+
+      const rateLimit = await checkMutationRateLimit('setComponentRideAdjustment', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(`Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`, {
+          extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
+        });
+      }
+
+      // Two independent strict ownership checks: cross-bike APPLY means the
+      // ride's ownership cannot be inferred from the component's.
+      const component = await prisma.component.findUnique({
+        where: { id: componentId },
+        select: { id: true, userId: true, bikeId: true },
+      });
+      if (!component || component.userId !== userId) {
+        throw new Error('Component not found');
+      }
+      const ride = await prisma.ride.findUnique({
+        where: { id: rideId },
+        select: { id: true, userId: true, bikeId: true, startTime: true, isDuplicate: true },
+      });
+      if (!ride || ride.userId !== userId) {
+        throw new Error('Ride not found');
+      }
+
+      // Duplicates never count toward hours on any path; an adjustment row
+      // on one would be inert and confusing.
+      if (ride.isDuplicate) {
+        throw new GraphQLError('Cannot adjust a duplicate ride.', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      // Keep rows canonical: EXCLUDE only makes sense for a ride currently
+      // on the component's bike; INCLUDE only for a ride that is not.
+      const rideOnComponentBike = ride.bikeId != null && ride.bikeId === component.bikeId;
+      if (kind === 'EXCLUDE' && !rideOnComponentBike) {
+        throw new GraphQLError('EXCLUDE requires a ride on the component’s bike.', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+      if (kind === 'INCLUDE' && rideOnComponentBike) {
+        throw new GraphQLError('INCLUDE requires a ride that is not on the component’s bike.', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      // Bound the id IN (...) lists the recompute and componentRides build.
+      const existingRow = await prisma.componentRideAdjustment.findUnique({
+        where: { componentId_rideId: { componentId, rideId } },
+        select: { id: true },
+      });
+      if (!existingRow) {
+        const adjustmentCount = await prisma.componentRideAdjustment.count({
+          where: { componentId },
+        });
+        if (adjustmentCount >= MAX_COMPONENT_RIDE_ADJUSTMENTS) {
+          throw new GraphQLError('Too many ride adjustments on this component.', {
+            extensions: { code: 'BAD_USER_INPUT' },
+          });
+        }
+      }
+
+      // Invalidate BOTH bikes when they differ (cross-bike INCLUDE): the
+      // component's bike gains/loses hours, and the ride's own bike surface
+      // may render this component's data after a future reinstall.
+      const bikesToInvalidate = [
+        ...new Set([component.bikeId, ride.bikeId].filter((b): b is string => !!b)),
+      ];
+      for (const bikeId of bikesToInvalidate) {
+        await invalidateBikePrediction(userId, bikeId);
+      }
+
+      const { updatedComponent, counted } = await prisma.$transaction(async (tx) => {
+        await tx.componentRideAdjustment.upsert({
+          where: { componentId_rideId: { componentId, rideId } },
+          create: { userId, componentId, rideId, kind },
+          update: { kind },
+        });
+
+        await recomputeComponentHours(tx, componentId);
+
+        // Derive whether the ride now counts, from the same canonical rule.
+        const attribution = await loadComponentAttribution(tx, componentId);
+        const inWindow = !attribution?.anchor || ride.startTime >= attribution.anchor;
+        const nowCounted =
+          kind === 'EXCLUDE' ? false : inWindow;
+
+        const fresh = await tx.component.findUnique({ where: { id: componentId } });
+        return { updatedComponent: fresh, counted: nowCounted };
+      });
+
+      for (const bikeId of bikesToInvalidate) {
+        await invalidateBikePrediction(userId, bikeId);
+      }
+
+      return { component: updatedComponent, rideId, counted };
+    },
+
+    clearComponentRideAdjustment: async (
+      _: unknown,
+      { componentId, rideId }: { componentId: string; rideId: string },
+      ctx: GraphQLContext
+    ) => {
+      const userId = requireUserId(ctx);
+
+      const rateLimit = await checkMutationRateLimit('clearComponentRideAdjustment', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(`Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`, {
+          extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
+        });
+      }
+
+      const component = await prisma.component.findUnique({
+        where: { id: componentId },
+        select: { id: true, userId: true, bikeId: true },
+      });
+      if (!component || component.userId !== userId) {
+        throw new Error('Component not found');
+      }
+      const ride = await prisma.ride.findUnique({
+        where: { id: rideId },
+        select: { id: true, userId: true, bikeId: true, startTime: true },
+      });
+      if (!ride || ride.userId !== userId) {
+        throw new Error('Ride not found');
+      }
+
+      const bikesToInvalidate = [
+        ...new Set([component.bikeId, ride.bikeId].filter((b): b is string => !!b)),
+      ];
+      for (const bikeId of bikesToInvalidate) {
+        await invalidateBikePrediction(userId, bikeId);
+      }
+
+      const { updatedComponent, counted } = await prisma.$transaction(async (tx) => {
+        // deleteMany so clearing a nonexistent row is an idempotent no-op.
+        await tx.componentRideAdjustment.deleteMany({
+          where: { componentId, rideId },
+        });
+
+        await recomputeComponentHours(tx, componentId);
+
+        // With no adjustment, the ride counts iff it's on the component's
+        // bike and inside the window.
+        const attribution = await loadComponentAttribution(tx, componentId);
+        const inWindow = !attribution?.anchor || ride.startTime >= attribution.anchor;
+        const onBike = ride.bikeId != null && ride.bikeId === component.bikeId;
+        const nowCounted = inWindow && onBike;
+
+        const fresh = await tx.component.findUnique({ where: { id: componentId } });
+        return { updatedComponent: fresh, counted: nowCounted };
+      });
+
+      for (const bikeId of bikesToInvalidate) {
+        await invalidateBikePrediction(userId, bikeId);
+      }
+
+      return { component: updatedComponent, rideId, counted };
+    },
+
     createStravaGearMapping: async (
       _: unknown,
       { input }: { input: { stravaGearId: string; stravaGearName?: string | null; bikeId: string } },
@@ -3396,7 +3606,7 @@ export const resolvers = {
         throw new Error('This Strava bike is already mapped');
       }
 
-      const mapping = await prisma.$transaction(async (tx) => {
+      const { mapping, adjustedBikeIds } = await prisma.$transaction(async (tx) => {
         const newMapping = await tx.stravaGearMapping.create({
           data: {
             userId,
@@ -3412,6 +3622,7 @@ export const resolvers = {
           select: { id: true, durationSeconds: true },
         });
 
+        let recomputedBikes: string[] = [];
         if (ridesToUpdate.length > 0) {
           await tx.ride.updateMany({
             where: { userId, stravaGearId: input.stravaGearId },
@@ -3422,13 +3633,22 @@ export const resolvers = {
           const totalHours = totalSeconds / 3600;
 
           await incrementBikeComponentHours(tx, { userId, bikeId: input.bikeId, hoursDelta: totalHours });
+
+          // Components with adjustments referencing the newly-assigned rides
+          // (e.g. an INCLUDE created while the ride was unassigned) need the
+          // canonical recompute to avoid double counting.
+          recomputedBikes = await recomputeAdjustedComponentsForRides(tx, {
+            rideIds: ridesToUpdate.map((r) => r.id),
+          });
         }
 
-        return newMapping;
+        return { mapping: newMapping, adjustedBikeIds: recomputedBikes };
       });
 
-      // Invalidate prediction cache for the bike
-      await invalidateBikePrediction(userId, input.bikeId);
+      // Invalidate prediction cache for the bike (plus adjusted components' bikes)
+      for (const affected of new Set([input.bikeId, ...adjustedBikeIds])) {
+        await invalidateBikePrediction(userId, affected);
+      }
 
       return mapping;
     },
@@ -3454,10 +3674,10 @@ export const resolvers = {
 
       const deletedBikeId = mapping.bikeId;
 
-      await prisma.$transaction(async (tx) => {
+      const adjustedBikeIds = await prisma.$transaction(async (tx) => {
         const rides = await tx.ride.findMany({
           where: { userId, stravaGearId: mapping.stravaGearId, bikeId: mapping.bikeId },
-          select: { durationSeconds: true },
+          select: { id: true, durationSeconds: true },
         });
 
         const totalSeconds = rides.reduce((sum, r) => sum + r.durationSeconds, 0);
@@ -3471,10 +3691,17 @@ export const resolvers = {
         await decrementBikeComponentHours(tx, { userId, bikeId: mapping.bikeId, hoursDelta: totalHours });
 
         await tx.stravaGearMapping.delete({ where: { id } });
+
+        // Rides just went bike-less: EXCLUDE rows on them go inert and any
+        // INCLUDEs elsewhere are unaffected, but components that carried
+        // those adjustments need their counters snapped to canonical.
+        return recomputeAdjustedComponentsForRides(tx, { rideIds: rides.map((r) => r.id) });
       });
 
-      // Invalidate prediction cache for the bike
-      await invalidateBikePrediction(userId, deletedBikeId);
+      // Invalidate prediction cache for the bike (plus adjusted components' bikes)
+      for (const affected of new Set([deletedBikeId, ...adjustedBikeIds])) {
+        await invalidateBikePrediction(userId, affected);
+      }
 
       return { ok: true, id };
     },
@@ -4214,7 +4441,7 @@ export const resolvers = {
       await invalidateBikePrediction(userId, bikeId);
 
       // Update rides and components in a transaction
-      await prisma.$transaction(async (tx) => {
+      const adjustedBikeIds = await prisma.$transaction(async (tx) => {
         // Assign bike to all rides
         await tx.ride.updateMany({
           where: { id: { in: rideIds } },
@@ -4223,10 +4450,19 @@ export const resolvers = {
 
         // Add hours to bike's components
         await incrementBikeComponentHours(tx, { userId, bikeId, hoursDelta: totalHours });
+
+        // A previously-unassigned ride can already be INCLUDEd in a
+        // component on the target bike — the bulk increment above would
+        // double-count it there (and adjusted components elsewhere keep
+        // stale sums). Targeted canonical recompute wins as the last write.
+        return recomputeAdjustedComponentsForRides(tx, { rideIds });
       });
 
-      // Invalidate prediction cache after transaction
-      await invalidateBikePrediction(userId, bikeId);
+      // Invalidate prediction cache after transaction (target bike plus any
+      // bike holding a component adjusted against these rides)
+      for (const affected of new Set([bikeId, ...adjustedBikeIds])) {
+        await invalidateBikePrediction(userId, affected);
+      }
 
       return {
         success: true,
@@ -4320,7 +4556,7 @@ export const resolvers = {
         await invalidateBikePrediction(userId, bikeId);
       }
 
-      // Create service logs and reset hours in transaction
+      // Create service logs and recompute hours in transaction
       await prisma.$transaction(async (tx) => {
         for (const component of components) {
           // Create service log
@@ -4332,11 +4568,10 @@ export const resolvers = {
             },
           });
 
-          // Reset component hours
-          await tx.component.update({
-            where: { id: component.id },
-            data: { hoursUsed: 0 },
-          });
+          // Recompute instead of hardcoding 0 — a backdated calibration
+          // service counts post-date rides, and per-ride adjustments stay
+          // applied. See the parallel note in logComponentService.
+          await recomputeComponentHours(tx, component.id);
         }
       });
 

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -3460,22 +3460,6 @@ export const resolvers = {
         });
       }
 
-      // Bound the id IN (...) lists the recompute and componentRides build.
-      const existingRow = await prisma.componentRideAdjustment.findUnique({
-        where: { componentId_rideId: { componentId, rideId } },
-        select: { id: true },
-      });
-      if (!existingRow) {
-        const adjustmentCount = await prisma.componentRideAdjustment.count({
-          where: { componentId },
-        });
-        if (adjustmentCount >= MAX_COMPONENT_RIDE_ADJUSTMENTS) {
-          throw new GraphQLError('Too many ride adjustments on this component.', {
-            extensions: { code: 'BAD_USER_INPUT' },
-          });
-        }
-      }
-
       // Invalidate BOTH bikes when they differ (cross-bike INCLUDE): the
       // component's bike gains/loses hours, and the ride's own bike surface
       // may render this component's data after a future reinstall.
@@ -3487,11 +3471,35 @@ export const resolvers = {
       }
 
       const { updatedComponent, counted } = await prisma.$transaction(async (tx) => {
+        const existingRow = await tx.componentRideAdjustment.findUnique({
+          where: { componentId_rideId: { componentId, rideId } },
+          select: { id: true },
+        });
+
         await tx.componentRideAdjustment.upsert({
           where: { componentId_rideId: { componentId, rideId } },
           create: { userId, componentId, rideId, kind },
           update: { kind },
         });
+
+        // Cap check AFTER the insert, inside the transaction: exceeding the
+        // bound rolls the insert back rather than racing a pre-check
+        // (TOCTOU). Under read-committed isolation truly simultaneous
+        // inserts can still overshoot by the concurrency degree, but the
+        // next insert then sees the committed count and is rejected — the
+        // cap is a soft guardrail bounding id IN (...) list sizes, not a
+        // security boundary, so bounded-and-self-correcting is sufficient
+        // without escalating to serializable isolation.
+        if (!existingRow) {
+          const adjustmentCount = await tx.componentRideAdjustment.count({
+            where: { componentId },
+          });
+          if (adjustmentCount > MAX_COMPONENT_RIDE_ADJUSTMENTS) {
+            throw new GraphQLError('Too many ride adjustments on this component.', {
+              extensions: { code: 'BAD_USER_INPUT' },
+            });
+          }
+        }
 
         await recomputeComponentHours(tx, componentId);
 

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -304,6 +304,14 @@ export const typeDefs = gql`
     beforeAnchor: Boolean!
   }
 
+  type ComponentRideAdjustmentResult {
+    # Fresh component (post-recompute hoursUsed) so Apollo renormalizes it.
+    component: Component!
+    rideId: ID!
+    # Whether the ride now counts toward the component's hours.
+    counted: Boolean!
+  }
+
   type ComponentRidesPayload {
     componentId: ID!
     # ISO timestamp the attribution window starts at; null = all-time.
@@ -1000,6 +1008,13 @@ export const typeDefs = gql`
     updateServiceLog(id: ID!, input: UpdateServiceLogInput!): ServiceLog!
     deleteServiceLog(id: ID!): Boolean!
     snoozeComponent(id: ID!, hours: Float): Component!
+    # Per-ride attribution corrections. EXCLUDE removes an on-bike ride's
+    # hours from the component; INCLUDE applies a ride from another bike
+    # (or unassigned) to it. Setting flips an existing row; clearing a
+    # nonexistent row is a success no-op. Both snap the component's
+    # hoursUsed to the canonical recomputed value.
+    setComponentRideAdjustment(componentId: ID!, rideId: ID!, kind: ComponentRideAdjustmentKind!): ComponentRideAdjustmentResult!
+    clearComponentRideAdjustment(componentId: ID!, rideId: ID!): ComponentRideAdjustmentResult!
     createStravaGearMapping(input: CreateStravaGearMappingInput!): StravaGearMapping!
     deleteStravaGearMapping(id: ID!): DeleteResult!
     triggerProviderSync(provider: SyncProvider!): TriggerSyncResult!

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -285,6 +285,39 @@ export const typeDefs = gql`
     createdAt: String!
   }
 
+  enum ComponentRideAdjustmentKind {
+    # Ride is on the component's bike but must not count toward its hours.
+    EXCLUDE
+    # Ride is on another bike (or unassigned) but should count.
+    INCLUDE
+  }
+
+  type ComponentRideEntry {
+    ride: Ride!
+    # Whether this ride currently contributes to countedHours.
+    counted: Boolean!
+    # The stored adjustment, if any. Null = default on-bike attribution.
+    adjustment: ComponentRideAdjustmentKind
+    # True for an INCLUDE stored on a ride that predates the anchor: it is
+    # recorded but dormant until the anchor moves (e.g. service log deleted
+    # or backdated). Surfaced so the UI never silently ignores an apply.
+    beforeAnchor: Boolean!
+  }
+
+  type ComponentRidesPayload {
+    componentId: ID!
+    # ISO timestamp the attribution window starts at; null = all-time.
+    anchor: String
+    entries: [ComponentRideEntry!]!
+    # Canonical derived total. May differ from hoursUsed until the first
+    # adjustment snaps the stored counter to the canonical value.
+    countedHours: Float!
+    # The stored counter as of this request.
+    hoursUsed: Float!
+    countedRideCount: Int!
+    hasMore: Boolean!
+  }
+
   type WearDriver {
     factor: String!
     contribution: Int!
@@ -1181,6 +1214,10 @@ export const typeDefs = gql`
     referralStats: ReferralStats! @deprecated(reason: "Referral program removed; returns zeros")
     bikeHistory(bikeId: ID!, startDate: String, endDate: String): BikeHistoryPayload!
     rideTrack(rideId: ID!): RideTrack!
+    # The rides behind a component's current hoursUsed number, per the
+    # canonical attribution rule (rides on the component's bike since the
+    # last-service anchor, ± per-ride adjustments). Owner-only.
+    componentRides(componentId: ID!, take: Int = 50, after: ID): ComponentRidesPayload!
     # Public (unauthenticated) sanitized history for a shared bike.
     # Returns null for unknown or revoked slugs.
     sharedBikeHistory(slug: String!): SharedBikeHistory

--- a/apps/api/src/lib/component-hours.test.ts
+++ b/apps/api/src/lib/component-hours.test.ts
@@ -190,7 +190,7 @@ describe('computeCountedHours', () => {
 });
 
 describe('recomputeComponentHours', () => {
-  it('persists the canonical value and returns it', async () => {
+  it('persists the canonical value and returns it with the attribution used', async () => {
     const tx = makeTx();
     tx.component.findUnique.mockResolvedValue({ ...BASE_COMPONENT });
     tx.serviceLog.findFirst.mockResolvedValue(null);
@@ -198,7 +198,11 @@ describe('recomputeComponentHours', () => {
 
     const result = await recomputeComponentHours(asTx(tx), 'comp-1');
 
-    expect(result).toBe(2.5);
+    expect(result?.hours).toBe(2.5);
+    // Attribution is returned so callers (e.g. the adjustment mutations'
+    // counted flag) don't re-run the same reads.
+    expect(result?.attribution.component.id).toBe('comp-1');
+    expect(result?.attribution.anchor).toBeNull();
     expect(tx.component.update).toHaveBeenCalledWith({
       where: { id: 'comp-1' },
       data: { hoursUsed: 2.5 },

--- a/apps/api/src/lib/component-hours.test.ts
+++ b/apps/api/src/lib/component-hours.test.ts
@@ -358,4 +358,68 @@ describe('syncBikeComponentHours', () => {
     // A no-op must not touch component rows.
     expect(tx.component.updateMany).not.toHaveBeenCalled();
   });
+
+  // The rideId branch: when an existing ride changes, adjusted components
+  // (whose ComponentRideAdjustment rows reference it) get a canonical
+  // recompute, and THEIR bikes must union into the invalidation set — the
+  // cross-bike INCLUDE case the bulk update never touches.
+  it('unions in cross-bike adjusted components recomputed from the rideId', async () => {
+    const tx = makeTx();
+    // ride-9 carries an adjustment on comp-x, which lives on bike-3.
+    tx.componentRideAdjustment.findMany.mockResolvedValueOnce([{ componentId: 'comp-x' }]);
+    tx.component.findUnique.mockResolvedValue({
+      id: 'comp-x',
+      userId: 'user-1',
+      bikeId: 'bike-3',
+      installedAt: null,
+      hoursUsed: 5,
+    });
+
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 7200 },
+      'ride-9'
+    );
+
+    // bike-1 (its own hours grew) + bike-3 (the cross-bike adjusted component).
+    expect(new Set(affected)).toEqual(new Set(['bike-1', 'bike-3']));
+  });
+
+  it('de-dupes when the adjusted component sits on the same bike as the ride', async () => {
+    const tx = makeTx();
+    tx.componentRideAdjustment.findMany.mockResolvedValueOnce([{ componentId: 'comp-x' }]);
+    tx.component.findUnique.mockResolvedValue({
+      id: 'comp-x',
+      userId: 'user-1',
+      bikeId: 'bike-1',
+      installedAt: null,
+      hoursUsed: 5,
+    });
+
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 7200 },
+      'ride-9'
+    );
+
+    expect(affected).toEqual(['bike-1']);
+  });
+
+  it('skips the recompute entirely when rideId is passed but nothing changed', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      'ride-9'
+    );
+    expect(affected).toEqual([]);
+    // The (bikeChanged || hoursDiff !== 0) guard must gate the lookup.
+    expect(tx.componentRideAdjustment.findMany).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/lib/component-hours.test.ts
+++ b/apps/api/src/lib/component-hours.test.ts
@@ -1,0 +1,278 @@
+import {
+  loadComponentAttribution,
+  computeCountedHours,
+  recomputeComponentHours,
+  recomputeAdjustedComponentsForRides,
+  findAdjustedComponentIdsForRides,
+  type ComponentAttribution,
+} from './component-hours';
+import type { Prisma } from '@prisma/client';
+
+// Minimal mock transaction client covering the models these helpers touch.
+const makeTx = () => ({
+  component: {
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+  serviceLog: {
+    findFirst: jest.fn(),
+  },
+  componentRideAdjustment: {
+    findMany: jest.fn().mockResolvedValue([]),
+  },
+  ride: {
+    aggregate: jest.fn().mockResolvedValue({ _sum: { durationSeconds: 0 }, _count: 0 }),
+  },
+});
+type MockTx = ReturnType<typeof makeTx>;
+const asTx = (tx: MockTx) => tx as unknown as Prisma.TransactionClient;
+
+const BASE_COMPONENT = {
+  id: 'comp-1',
+  userId: 'user-1',
+  bikeId: 'bike-1',
+  installedAt: null as Date | null,
+  hoursUsed: 10,
+};
+
+const attribution = (over: Partial<ComponentAttribution> = {}): ComponentAttribution => ({
+  component: { ...BASE_COMPONENT },
+  anchor: null,
+  excludedRideIds: [],
+  includedRideIds: [],
+  ...over,
+});
+
+describe('loadComponentAttribution', () => {
+  it('returns null for a missing component', async () => {
+    const tx = makeTx();
+    tx.component.findUnique.mockResolvedValue(null);
+
+    expect(await loadComponentAttribution(asTx(tx), 'nope')).toBeNull();
+    expect(tx.serviceLog.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('anchors on the latest service log when one exists', async () => {
+    const tx = makeTx();
+    const logDate = new Date('2026-06-01T00:00:00Z');
+    tx.component.findUnique.mockResolvedValue({ ...BASE_COMPONENT, installedAt: new Date('2026-01-01') });
+    tx.serviceLog.findFirst.mockResolvedValue({ performedAt: logDate });
+
+    const result = await loadComponentAttribution(asTx(tx), 'comp-1');
+
+    expect(result?.anchor).toEqual(logDate);
+    expect(tx.serviceLog.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { componentId: 'comp-1' },
+        orderBy: [{ performedAt: 'desc' }, { createdAt: 'desc' }],
+      })
+    );
+  });
+
+  it('falls back to installedAt, then null (all-time)', async () => {
+    const tx = makeTx();
+    const installedAt = new Date('2026-02-01T00:00:00Z');
+    tx.component.findUnique.mockResolvedValue({ ...BASE_COMPONENT, installedAt });
+    tx.serviceLog.findFirst.mockResolvedValue(null);
+
+    expect((await loadComponentAttribution(asTx(tx), 'comp-1'))?.anchor).toEqual(installedAt);
+
+    tx.component.findUnique.mockResolvedValue({ ...BASE_COMPONENT, installedAt: null });
+    expect((await loadComponentAttribution(asTx(tx), 'comp-1'))?.anchor).toBeNull();
+  });
+
+  it('splits adjustments into excluded and included ride ids', async () => {
+    const tx = makeTx();
+    tx.component.findUnique.mockResolvedValue({ ...BASE_COMPONENT });
+    tx.serviceLog.findFirst.mockResolvedValue(null);
+    tx.componentRideAdjustment.findMany.mockResolvedValue([
+      { rideId: 'r-ex', kind: 'EXCLUDE' },
+      { rideId: 'r-in', kind: 'INCLUDE' },
+    ]);
+
+    const result = await loadComponentAttribution(asTx(tx), 'comp-1');
+
+    expect(result?.excludedRideIds).toEqual(['r-ex']);
+    expect(result?.includedRideIds).toEqual(['r-in']);
+  });
+});
+
+describe('computeCountedHours', () => {
+  it('sums the on-bike window excluding EXCLUDEd rides and duplicates', async () => {
+    const tx = makeTx();
+    const anchor = new Date('2026-06-01T00:00:00Z');
+    tx.ride.aggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 7200 }, _count: 2 });
+
+    const result = await computeCountedHours(
+      asTx(tx),
+      attribution({ anchor, excludedRideIds: ['r-ex'] })
+    );
+
+    expect(result).toEqual({ hours: 2, rideCount: 2 });
+    expect(tx.ride.aggregate).toHaveBeenCalledTimes(1);
+    expect(tx.ride.aggregate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId: 'user-1',
+          bikeId: 'bike-1',
+          isDuplicate: false,
+          startTime: { gte: anchor },
+          id: { notIn: ['r-ex'] },
+        },
+      })
+    );
+  });
+
+  it('adds INCLUDEd cross-bike rides, guarding against stale-INCLUDE double count', async () => {
+    const tx = makeTx();
+    tx.ride.aggregate
+      .mockResolvedValueOnce({ _sum: { durationSeconds: 3600 }, _count: 1 }) // on-bike
+      .mockResolvedValueOnce({ _sum: { durationSeconds: 1800 }, _count: 1 }); // include
+
+    const result = await computeCountedHours(asTx(tx), attribution({ includedRideIds: ['r-in'] }));
+
+    expect(result).toEqual({ hours: 1.5, rideCount: 2 });
+    // Include branch must exclude the component's own bike (a stale INCLUDE
+    // on a ride that later moved onto this bike already counts on-bike).
+    expect(tx.ride.aggregate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { in: ['r-in'] },
+          isDuplicate: false,
+          NOT: { bikeId: 'bike-1' },
+        }),
+      })
+    );
+  });
+
+  it('handles spare components (no bike): include branch only, no NOT clause', async () => {
+    const tx = makeTx();
+    tx.ride.aggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 5400 }, _count: 3 });
+
+    const result = await computeCountedHours(
+      asTx(tx),
+      attribution({
+        component: { ...BASE_COMPONENT, bikeId: null },
+        includedRideIds: ['r1', 'r2', 'r3'],
+      })
+    );
+
+    expect(result).toEqual({ hours: 1.5, rideCount: 3 });
+    expect(tx.ride.aggregate).toHaveBeenCalledTimes(1);
+    const where = tx.ride.aggregate.mock.calls[0][0].where;
+    expect(where.NOT).toBeUndefined();
+    expect(where.id).toEqual({ in: ['r1', 'r2', 'r3'] });
+  });
+
+  it('applies the anchor window to the INCLUDE branch (pre-anchor INCLUDEs dormant)', async () => {
+    const tx = makeTx();
+    const anchor = new Date('2026-06-01T00:00:00Z');
+    tx.ride.aggregate
+      .mockResolvedValueOnce({ _sum: { durationSeconds: 0 }, _count: 0 })
+      .mockResolvedValueOnce({ _sum: { durationSeconds: 0 }, _count: 0 });
+
+    await computeCountedHours(asTx(tx), attribution({ anchor, includedRideIds: ['r-in'] }));
+
+    expect(tx.ride.aggregate.mock.calls[1][0].where.startTime).toEqual({ gte: anchor });
+  });
+
+  it('returns zero for a spare with no included rides without querying', async () => {
+    const tx = makeTx();
+    const result = await computeCountedHours(
+      asTx(tx),
+      attribution({ component: { ...BASE_COMPONENT, bikeId: null } })
+    );
+
+    expect(result).toEqual({ hours: 0, rideCount: 0 });
+    expect(tx.ride.aggregate).not.toHaveBeenCalled();
+  });
+});
+
+describe('recomputeComponentHours', () => {
+  it('persists the canonical value and returns it', async () => {
+    const tx = makeTx();
+    tx.component.findUnique.mockResolvedValue({ ...BASE_COMPONENT });
+    tx.serviceLog.findFirst.mockResolvedValue(null);
+    tx.ride.aggregate.mockResolvedValueOnce({ _sum: { durationSeconds: 9000 }, _count: 2 });
+
+    const result = await recomputeComponentHours(asTx(tx), 'comp-1');
+
+    expect(result).toBe(2.5);
+    expect(tx.component.update).toHaveBeenCalledWith({
+      where: { id: 'comp-1' },
+      data: { hoursUsed: 2.5 },
+    });
+  });
+
+  it('no-ops and returns null for a missing component', async () => {
+    const tx = makeTx();
+    tx.component.findUnique.mockResolvedValue(null);
+
+    expect(await recomputeComponentHours(asTx(tx), 'gone')).toBeNull();
+    expect(tx.component.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('recomputeAdjustedComponentsForRides', () => {
+  it('resolves components from rideIds and returns distinct affected bikeIds', async () => {
+    const tx = makeTx();
+    tx.componentRideAdjustment.findMany.mockResolvedValueOnce([
+      { componentId: 'comp-a' },
+      { componentId: 'comp-b' },
+    ]);
+    tx.component.findUnique
+      .mockResolvedValueOnce({ ...BASE_COMPONENT, id: 'comp-a', bikeId: 'bike-1' })
+      .mockResolvedValueOnce({ ...BASE_COMPONENT, id: 'comp-b', bikeId: null }); // spare
+    tx.serviceLog.findFirst.mockResolvedValue(null);
+    // comp-a on-bike aggregate; comp-b has no bike and no includes -> no query
+    tx.ride.aggregate.mockResolvedValue({ _sum: { durationSeconds: 3600 }, _count: 1 });
+    // Per-component adjustment loads (inside loadComponentAttribution)
+    tx.componentRideAdjustment.findMany.mockResolvedValue([]);
+
+    const bikeIds = await recomputeAdjustedComponentsForRides(asTx(tx), { rideIds: ['r-1'] });
+
+    expect(bikeIds).toEqual(['bike-1']); // spare contributes no bikeId
+    expect(tx.component.update).toHaveBeenCalledTimes(2);
+  });
+
+  it('accepts pre-captured componentIds (ride-delete path) without querying adjustments', async () => {
+    const tx = makeTx();
+    tx.component.findUnique.mockResolvedValue({ ...BASE_COMPONENT });
+    tx.serviceLog.findFirst.mockResolvedValue(null);
+
+    await recomputeAdjustedComponentsForRides(asTx(tx), { componentIds: ['comp-1'] });
+
+    expect(tx.component.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty for no inputs', async () => {
+    const tx = makeTx();
+    expect(await recomputeAdjustedComponentsForRides(asTx(tx), {})).toEqual([]);
+    expect(tx.component.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('findAdjustedComponentIdsForRides', () => {
+  it('returns distinct componentIds referencing the rides', async () => {
+    const tx = makeTx();
+    tx.componentRideAdjustment.findMany.mockResolvedValue([
+      { componentId: 'comp-a' },
+      { componentId: 'comp-b' },
+    ]);
+
+    expect(await findAdjustedComponentIdsForRides(asTx(tx), ['r-1', 'r-2'])).toEqual([
+      'comp-a',
+      'comp-b',
+    ]);
+    expect(tx.componentRideAdjustment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { rideId: { in: ['r-1', 'r-2'] } }, distinct: ['componentId'] })
+    );
+  });
+
+  it('short-circuits on empty input', async () => {
+    const tx = makeTx();
+    expect(await findAdjustedComponentIdsForRides(asTx(tx), [])).toEqual([]);
+    expect(tx.componentRideAdjustment.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/lib/component-hours.test.ts
+++ b/apps/api/src/lib/component-hours.test.ts
@@ -4,6 +4,7 @@ import {
   recomputeComponentHours,
   recomputeAdjustedComponentsForRides,
   findAdjustedComponentIdsForRides,
+  syncBikeComponentHours,
   type ComponentAttribution,
 } from './component-hours';
 import type { Prisma } from '@prisma/client';
@@ -13,6 +14,7 @@ const makeTx = () => ({
   component: {
     findUnique: jest.fn(),
     update: jest.fn(),
+    updateMany: jest.fn(),
   },
   serviceLog: {
     findFirst: jest.fn(),
@@ -304,5 +306,56 @@ describe('findAdjustedComponentIdsForRides', () => {
     const tx = makeTx();
     expect(await findAdjustedComponentIdsForRides(asTx(tx), [])).toEqual([]);
     expect(tx.componentRideAdjustment.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncBikeComponentHours', () => {
+  // The return value is the invalidation contract: every bike whose hours
+  // this call actually moved, so callers can bust exactly those caches
+  // without reconstructing the primary bike themselves.
+  it('returns both the debited and credited bike when a ride moves bikes', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-2', durationSeconds: 3600 }
+    );
+    expect(new Set(affected)).toEqual(new Set(['bike-1', 'bike-2']));
+  });
+
+  it('returns the single bike when only its duration changed', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 7200 }
+    );
+    expect(affected).toEqual(['bike-1']);
+  });
+
+  it('returns the debited bike on delete (next bike null)', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: null, durationSeconds: 0 }
+    );
+    expect(affected).toEqual(['bike-1']);
+  });
+
+  it('returns nothing when neither bike nor duration changed', async () => {
+    const tx = makeTx();
+    const affected = await syncBikeComponentHours(
+      asTx(tx),
+      'user-1',
+      { bikeId: 'bike-1', durationSeconds: 3600 },
+      { bikeId: 'bike-1', durationSeconds: 3600 }
+    );
+    expect(affected).toEqual([]);
+    // A no-op must not touch component rows.
+    expect(tx.component.updateMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/lib/component-hours.test.ts
+++ b/apps/api/src/lib/component-hours.test.ts
@@ -133,17 +133,43 @@ describe('computeCountedHours', () => {
 
     expect(result).toEqual({ hours: 1.5, rideCount: 2 });
     // Include branch must exclude the component's own bike (a stale INCLUDE
-    // on a ride that later moved onto this bike already counts on-bike).
+    // on a ride that later moved onto this bike already counts on-bike) —
+    // via the NULL-SAFE OR shape, never the scalar NOT. Prisma compiles
+    // NOT:{bikeId} to SQL `bikeId <> X`, which silently drops NULL-bikeId
+    // (unassigned) rides under three-valued logic.
     expect(tx.ride.aggregate).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         where: expect.objectContaining({
           id: { in: ['r-in'] },
           isDuplicate: false,
-          NOT: { bikeId: 'bike-1' },
+          OR: [{ bikeId: null }, { bikeId: { not: 'bike-1' } }],
         }),
       })
     );
+  });
+
+  it('counts an UNASSIGNED included ride for an on-bike component (null-safe guard)', async () => {
+    // Regression guard for the SQL three-valued-logic bug: with the old
+    // NOT:{bikeId} shape, real Postgres excluded bikeId=null rides, so an
+    // unassigned ride applied to an on-bike component showed counted:true
+    // in the UI while the aggregate silently omitted its hours.
+    const tx = makeTx();
+    tx.ride.aggregate
+      .mockResolvedValueOnce({ _sum: { durationSeconds: 7200 }, _count: 1 }) // on-bike
+      .mockResolvedValueOnce({ _sum: { durationSeconds: 3600 }, _count: 1 }); // unassigned INCLUDE
+
+    const result = await computeCountedHours(
+      asTx(tx),
+      attribution({ includedRideIds: ['r-unassigned'] })
+    );
+
+    expect(result).toEqual({ hours: 3, rideCount: 2 });
+    const includeWhere = tx.ride.aggregate.mock.calls[1][0].where;
+    // The OR must carry an explicit bikeId:null branch so unassigned rides
+    // survive the own-bike guard.
+    expect(includeWhere.OR).toEqual([{ bikeId: null }, { bikeId: { not: 'bike-1' } }]);
+    expect(includeWhere.NOT).toBeUndefined();
   });
 
   it('handles spare components (no bike): include branch only, no NOT clause', async () => {

--- a/apps/api/src/lib/component-hours.ts
+++ b/apps/api/src/lib/component-hours.ts
@@ -290,6 +290,18 @@ export async function recomputeAdjustedComponentsForRides(
   }
   if (!componentIds.length) return [];
 
+  // Sequential on purpose — DO NOT wrap this loop in Promise.all. `tx` is a
+  // Prisma interactive transaction: all its queries share one connection and
+  // must run one at a time; firing the per-component work concurrently on the
+  // same `tx` throws ("Transaction already closed") / corrupts the tx. The
+  // per-component cost (3 metadata reads + 1-2 aggregates + 1 update) is
+  // acceptable because `componentIds` is DISTINCT components carrying an
+  // adjustment that references the touched rides — normally 0, and bounded by
+  // the rarity of adjustments (manual corrections) plus the 500-per-component
+  // cap. A bulk op touching many distinct adjusted components would pay this
+  // serially; if that ever shows up in practice, batch the three metadata
+  // reads across all componentIds (the ride.aggregate step stays per-component
+  // — each has its own bike/anchor/excluded-id set) rather than parallelizing.
   const affectedBikeIds = new Set<string>();
   for (const componentId of componentIds) {
     const attribution = await loadComponentAttribution(tx, componentId);

--- a/apps/api/src/lib/component-hours.ts
+++ b/apps/api/src/lib/component-hours.ts
@@ -51,14 +51,25 @@ export async function decrementBikeComponentHours(
  *  - Same bike, shorter ride: decrement by the absolute delta.
  *  - No bike on either side: no-op.
  *
+ * When `rideId` is provided (upsert of an EXISTING ride) and the prev/next
+ * state actually differs, components whose ComponentRideAdjustment rows
+ * reference that ride get a targeted canonical recompute afterwards — the
+ * bulk updates above either mis-credit them (EXCLUDE) or never touch them
+ * (cross-bike INCLUDE). Create paths omit rideId: a brand-new ride can't
+ * be pre-adjusted (the adjustment row FK-references an existing ride).
+ *
+ * Returns the bikeIds of recomputed adjusted components (empty when none)
+ * so callers can extend prediction-cache invalidation.
+ *
  * Previously duplicated inline in [webhooks.strava.ts] and [workers/sync.worker.ts].
  */
 export async function syncBikeComponentHours(
   tx: Prisma.TransactionClient,
   userId: string,
   previous: { bikeId: string | null; durationSeconds: number | null | undefined },
-  next: { bikeId: string | null; durationSeconds: number | null | undefined }
-): Promise<void> {
+  next: { bikeId: string | null; durationSeconds: number | null | undefined },
+  rideId?: string
+): Promise<string[]> {
   const prevBikeId = previous.bikeId;
   const nextBikeId = next.bikeId;
   const prevHours = secondsToHours(previous.durationSeconds);
@@ -81,6 +92,11 @@ export async function syncBikeComponentHours(
       await incrementBikeComponentHours(tx, { userId, bikeId: nextBikeId, hoursDelta: hoursDiff });
     }
   }
+
+  if (rideId && (bikeChanged || hoursDiff !== 0)) {
+    return recomputeAdjustedComponentsForRides(tx, { rideIds: [rideId] });
+  }
+  return [];
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/lib/component-hours.ts
+++ b/apps/api/src/lib/component-hours.ts
@@ -58,8 +58,12 @@ export async function decrementBikeComponentHours(
  * (cross-bike INCLUDE). Create paths omit rideId: a brand-new ride can't
  * be pre-adjusted (the adjustment row FK-references an existing ride).
  *
- * Returns the bikeIds of recomputed adjusted components (empty when none)
- * so callers can extend prediction-cache invalidation.
+ * Returns every bikeId whose component hours changed here — the debited
+ * previous bike, the credited next bike, AND any bikes owning adjusted
+ * components recomputed from `rideId` — deduped, nulls dropped. Callers pass
+ * this straight to `invalidateBikePredictionsForBikes`: the return is
+ * self-sufficient, so no caller has to reconstruct the primary bike (the
+ * cache key encodes no ride data, so a ride write can't self-invalidate).
  *
  * Previously duplicated inline in [webhooks.strava.ts] and [workers/sync.worker.ts].
  */
@@ -77,26 +81,36 @@ export async function syncBikeComponentHours(
   const bikeChanged = prevBikeId !== nextBikeId;
   const hoursDiff = nextHours - prevHours;
 
+  // Bikes whose hoursUsed this call actually mutates — only these need their
+  // cached predictions busted (a pure no-op leaves the set empty).
+  const affectedBikeIds = new Set<string>();
+
   if (prevBikeId) {
     if (bikeChanged) {
       await decrementBikeComponentHours(tx, { userId, bikeId: prevBikeId, hoursDelta: prevHours });
+      affectedBikeIds.add(prevBikeId);
     } else if (hoursDiff < 0) {
       await decrementBikeComponentHours(tx, { userId, bikeId: prevBikeId, hoursDelta: Math.abs(hoursDiff) });
+      affectedBikeIds.add(prevBikeId);
     }
   }
 
   if (nextBikeId) {
     if (bikeChanged) {
       await incrementBikeComponentHours(tx, { userId, bikeId: nextBikeId, hoursDelta: nextHours });
+      affectedBikeIds.add(nextBikeId);
     } else if (hoursDiff > 0) {
       await incrementBikeComponentHours(tx, { userId, bikeId: nextBikeId, hoursDelta: hoursDiff });
+      affectedBikeIds.add(nextBikeId);
     }
   }
 
   if (rideId && (bikeChanged || hoursDiff !== 0)) {
-    return recomputeAdjustedComponentsForRides(tx, { rideIds: [rideId] });
+    const adjustedBikeIds = await recomputeAdjustedComponentsForRides(tx, { rideIds: [rideId] });
+    for (const bikeId of adjustedBikeIds) affectedBikeIds.add(bikeId);
   }
-  return [];
+
+  return [...affectedBikeIds];
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/lib/component-hours.ts
+++ b/apps/api/src/lib/component-hours.ts
@@ -212,6 +212,11 @@ export async function computeCountedHours(
   // stale INCLUDE row on a ride that later moved onto this bike must count
   // exactly once (it already counts via the on-bike branch).
   //
+  // Cheap regardless of ride-history size: the `id: { in }` predicate is
+  // served by the PK (Ride_pkey) and includedRideIds is bounded by the
+  // 500-per-component adjustment cap — this is a bounded PK lookup, not a
+  // window scan like the on-bike branch above.
+  //
   // NULL-safety: the guard must be the OR-null shape, NOT `NOT:{bikeId}`.
   // Prisma compiles the scalar NOT to SQL `bikeId <> X`, which evaluates
   // UNKNOWN (row excluded) for NULL bikeId under three-valued logic — that

--- a/apps/api/src/lib/component-hours.ts
+++ b/apps/api/src/lib/component-hours.ts
@@ -82,3 +82,212 @@ export async function syncBikeComponentHours(
     }
   }
 }
+
+// ---------------------------------------------------------------------------
+// Canonical per-component attribution (ComponentRideAdjustment-aware)
+// ---------------------------------------------------------------------------
+//
+// The increment/decrement helpers above are the FAST path: they bulk-update
+// every component currently on a bike and know nothing about per-component
+// ride adjustments. The functions below are the AUTHORITATIVE path: they
+// derive one component's hoursUsed from the canonical rule and overwrite the
+// counter. Convention: bulk helpers run first, then a targeted recompute for
+// the (rare) components whose adjustments reference the touched rides — the
+// recompute is the last write in the transaction, so it wins.
+//
+// Canonical rule:
+//   anchor  = latest ServiceLog.performedAt ?? component.installedAt ?? null
+//   counted = user's rides where isDuplicate = false
+//             AND (anchor is null OR startTime >= anchor)
+//             AND ( (bikeId == component.bikeId AND no EXCLUDE row)
+//                   OR has INCLUDE row )
+//   hoursUsed = sum(counted.durationSeconds) / 3600
+//
+// INCLUDE respects the anchor: the prediction engine's hoursSinceService is
+// definitionally "since last service", and counter/engine must agree. An
+// INCLUDE on a ride older than the anchor is stored but dormant; it springs
+// back if the anchor moves (service log deleted/backdated).
+
+/** Everything needed to evaluate the canonical rule for one component. */
+export interface ComponentAttribution {
+  component: {
+    id: string;
+    userId: string;
+    bikeId: string | null;
+    installedAt: Date | null;
+    hoursUsed: number;
+  };
+  anchor: Date | null;
+  excludedRideIds: string[];
+  includedRideIds: string[];
+}
+
+/**
+ * Load the attribution inputs for a component: the component row, its
+ * canonical anchor (latest service log, else installedAt, else null =
+ * all-time), and its adjustment rows. Returns null when the component no
+ * longer exists — callers treat that as a no-op, matching the tolerant
+ * behavior of the service-log recompute path.
+ */
+export async function loadComponentAttribution(
+  tx: Prisma.TransactionClient,
+  componentId: string
+): Promise<ComponentAttribution | null> {
+  const component = await tx.component.findUnique({
+    where: { id: componentId },
+    select: { id: true, userId: true, bikeId: true, installedAt: true, hoursUsed: true },
+  });
+  if (!component) return null;
+
+  const latestLog = await tx.serviceLog.findFirst({
+    where: { componentId },
+    orderBy: [{ performedAt: 'desc' }, { createdAt: 'desc' }],
+    select: { performedAt: true },
+  });
+  const anchor = latestLog?.performedAt ?? component.installedAt ?? null;
+
+  const adjustments = await tx.componentRideAdjustment.findMany({
+    where: { componentId },
+    select: { rideId: true, kind: true },
+  });
+
+  return {
+    component,
+    anchor,
+    excludedRideIds: adjustments.filter((a) => a.kind === 'EXCLUDE').map((a) => a.rideId),
+    includedRideIds: adjustments.filter((a) => a.kind === 'INCLUDE').map((a) => a.rideId),
+  };
+}
+
+/**
+ * Sum the counted hours (and ride count) for a component per the canonical
+ * rule. Shared by the recompute below and the componentRides query so the
+ * displayed total and the stored counter cannot diverge.
+ */
+export async function computeCountedHours(
+  tx: Prisma.TransactionClient,
+  attribution: ComponentAttribution
+): Promise<{ hours: number; rideCount: number }> {
+  const { component, anchor, excludedRideIds, includedRideIds } = attribution;
+  const windowFilter = anchor ? { startTime: { gte: anchor } } : {};
+
+  let seconds = 0;
+  let rideCount = 0;
+
+  // On-bike branch: rides on the component's bike, minus EXCLUDEs.
+  if (component.bikeId) {
+    const { _sum, _count } = await tx.ride.aggregate({
+      where: {
+        userId: component.userId,
+        bikeId: component.bikeId,
+        isDuplicate: false,
+        ...windowFilter,
+        ...(excludedRideIds.length ? { id: { notIn: excludedRideIds } } : {}),
+      },
+      _sum: { durationSeconds: true },
+      _count: true,
+    });
+    seconds += _sum.durationSeconds ?? 0;
+    rideCount += _count;
+  }
+
+  // INCLUDE branch: cross-bike (or unassigned) rides explicitly applied.
+  // When the component is on a bike, exclude that bike's rides here — a
+  // stale INCLUDE row on a ride that later moved onto this bike must count
+  // exactly once (it already counts via the on-bike branch).
+  if (includedRideIds.length) {
+    const { _sum, _count } = await tx.ride.aggregate({
+      where: {
+        userId: component.userId,
+        id: { in: includedRideIds },
+        isDuplicate: false,
+        ...windowFilter,
+        ...(component.bikeId ? { NOT: { bikeId: component.bikeId } } : {}),
+      },
+      _sum: { durationSeconds: true },
+      _count: true,
+    });
+    seconds += _sum.durationSeconds ?? 0;
+    rideCount += _count;
+  }
+
+  return { hours: seconds / 3600, rideCount };
+}
+
+/**
+ * Recompute one component's hoursUsed from the canonical rule and persist
+ * it. Returns the new value, or null when the component no longer exists
+ * (no-op). Callers are responsible for prediction-cache invalidation.
+ */
+export async function recomputeComponentHours(
+  tx: Prisma.TransactionClient,
+  componentId: string
+): Promise<number | null> {
+  const attribution = await loadComponentAttribution(tx, componentId);
+  if (!attribution) return null;
+
+  const { hours } = await computeCountedHours(tx, attribution);
+  await tx.component.update({
+    where: { id: componentId },
+    data: { hoursUsed: hours },
+  });
+  return hours;
+}
+
+/**
+ * After a mutation deletes rides or changes their bikeId/duration/startTime,
+ * recompute every component whose adjustments reference those rides. The
+ * bulk updateMany paths have already run; this targeted pass overwrites the
+ * few adjusted components with authoritative values.
+ *
+ * Ride DELETE callers must capture componentIds BEFORE the delete (the
+ * adjustment rows cascade away with the ride) and pass them via
+ * `componentIds`; update/reassignment callers can pass `rideIds`.
+ *
+ * Returns the distinct bikeIds of the recomputed components (non-null only)
+ * so callers can extend prediction-cache invalidation beyond the ride's own
+ * bike.
+ */
+export async function recomputeAdjustedComponentsForRides(
+  tx: Prisma.TransactionClient,
+  opts: { rideIds?: string[]; componentIds?: string[] }
+): Promise<string[]> {
+  let componentIds = opts.componentIds ?? [];
+  if (!componentIds.length && opts.rideIds?.length) {
+    const rows = await tx.componentRideAdjustment.findMany({
+      where: { rideId: { in: opts.rideIds } },
+      select: { componentId: true },
+      distinct: ['componentId'],
+    });
+    componentIds = rows.map((r) => r.componentId);
+  }
+  if (!componentIds.length) return [];
+
+  const affectedBikeIds = new Set<string>();
+  for (const componentId of componentIds) {
+    const attribution = await loadComponentAttribution(tx, componentId);
+    if (!attribution) continue;
+    const { hours } = await computeCountedHours(tx, attribution);
+    await tx.component.update({ where: { id: componentId }, data: { hoursUsed: hours } });
+    if (attribution.component.bikeId) affectedBikeIds.add(attribution.component.bikeId);
+  }
+  return [...affectedBikeIds];
+}
+
+/**
+ * Convenience for ride-delete paths: look up which components have
+ * adjustments referencing the given rides. MUST run before the delete —
+ * the rows cascade away with the ride.
+ */
+export async function findAdjustedComponentIdsForRides(
+  tx: Prisma.TransactionClient,
+  rideIds: string[]
+): Promise<string[]> {
+  if (!rideIds.length) return [];
+  const rows = await tx.componentRideAdjustment.findMany({
+    where: { rideId: { in: rideIds } },
+    select: { componentId: true },
+    distinct: ['componentId'],
+  });
+  return rows.map((r) => r.componentId);
+}

--- a/apps/api/src/lib/component-hours.ts
+++ b/apps/api/src/lib/component-hours.ts
@@ -232,13 +232,16 @@ export async function computeCountedHours(
 
 /**
  * Recompute one component's hoursUsed from the canonical rule and persist
- * it. Returns the new value, or null when the component no longer exists
- * (no-op). Callers are responsible for prediction-cache invalidation.
+ * it. Returns the new value together with the attribution used to derive
+ * it (so callers needing the anchor/adjustments — e.g. the adjustment
+ * mutations' `counted` flag — don't re-run the same three reads), or null
+ * when the component no longer exists (no-op). Callers are responsible
+ * for prediction-cache invalidation.
  */
 export async function recomputeComponentHours(
   tx: Prisma.TransactionClient,
   componentId: string
-): Promise<number | null> {
+): Promise<{ hours: number; attribution: ComponentAttribution } | null> {
   const attribution = await loadComponentAttribution(tx, componentId);
   if (!attribution) return null;
 
@@ -247,7 +250,7 @@ export async function recomputeComponentHours(
     where: { id: componentId },
     data: { hoursUsed: hours },
   });
-  return hours;
+  return { hours, attribution };
 }
 
 /**

--- a/apps/api/src/lib/component-hours.ts
+++ b/apps/api/src/lib/component-hours.ts
@@ -211,6 +211,12 @@ export async function computeCountedHours(
   // When the component is on a bike, exclude that bike's rides here — a
   // stale INCLUDE row on a ride that later moved onto this bike must count
   // exactly once (it already counts via the on-bike branch).
+  //
+  // NULL-safety: the guard must be the OR-null shape, NOT `NOT:{bikeId}`.
+  // Prisma compiles the scalar NOT to SQL `bikeId <> X`, which evaluates
+  // UNKNOWN (row excluded) for NULL bikeId under three-valued logic — that
+  // would silently drop UNASSIGNED included rides from the total (verified
+  // against real Postgres; mocked tests cannot catch this).
   if (includedRideIds.length) {
     const { _sum, _count } = await tx.ride.aggregate({
       where: {
@@ -218,7 +224,9 @@ export async function computeCountedHours(
         id: { in: includedRideIds },
         isDuplicate: false,
         ...windowFilter,
-        ...(component.bikeId ? { NOT: { bikeId: component.bikeId } } : {}),
+        ...(component.bikeId
+          ? { OR: [{ bikeId: null }, { bikeId: { not: component.bikeId } }] }
+          : {}),
       },
       _sum: { durationSeconds: true },
       _count: true,

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -129,6 +129,10 @@ export const QUERY_RATE_LIMITS = {
   importNotificationState: { windowSeconds: 60, maxRequests: 30 },
   /** rideTrack: max 60 requests per minute per user (map open + post-request polling) */
   rideTrack: { windowSeconds: 60, maxRequests: 60 },
+  /** componentRides: max 60 requests per minute per user (modal open +
+   *  pagination + post-adjustment refetches all hit it; each call is a few
+   *  bounded findMany/aggregate queries) */
+  componentRides: { windowSeconds: 60, maxRequests: 60 },
   /** advisorSummary: max 20 LLM calls per 5 minutes per user. Checked only
    *  on cache MISS in the resolver, not on cache-hit refreshes, so the
    *  limit bounds Anthropic dollar cost directly (~$0.96/hour worst case

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -76,6 +76,12 @@ export const MUTATION_RATE_LIMITS = {
   assignBikeToRides: { windowSeconds: 60, maxRequests: 20 },
   /** snoozeComponent: max 20 requests per minute per user */
   snoozeComponent: { windowSeconds: 60, maxRequests: 20 },
+  /** setComponentRideAdjustment: max 60/min — users toggle several rows in
+   *  quick succession in the component-rides modal; each call is a bounded
+   *  upsert + recompute */
+  setComponentRideAdjustment: { windowSeconds: 60, maxRequests: 60 },
+  /** clearComponentRideAdjustment: max 60/min (same modal interaction) */
+  clearComponentRideAdjustment: { windowSeconds: 60, maxRequests: 60 },
   /** migratePairedComponents: max 5 requests per minute per user (one-time migration) */
   migratePairedComponents: { windowSeconds: 60, maxRequests: 5 },
   /** replaceComponent: max 20 requests per minute per user */

--- a/apps/api/src/routes/duplicates.test.ts
+++ b/apps/api/src/routes/duplicates.test.ts
@@ -508,4 +508,17 @@ describe('POST /duplicates/merge', () => {
     expect(mockTransaction).not.toHaveBeenCalled();
     expect(mockRideDelete).not.toHaveBeenCalled();
   });
+
+  it('still returns success when post-commit cache invalidation throws', async () => {
+    seedPair({ bikeId: 'bike-1', durationSeconds: 3600 });
+    // The merge transaction already committed; a cache-bust failure must not
+    // turn into a 500 (a retry would 404 on the deleted ride).
+    mockInvalidateBikePrediction.mockRejectedValue(new Error('redis down'));
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(mockRideDelete).toHaveBeenCalledWith({ where: { id: 'del-1' } });
+    expect(mockRes.status).not.toHaveBeenCalledWith(500);
+    expect(jsonResponse).toMatchObject({ success: true, keptRideId: 'keep-1' });
+  });
 });

--- a/apps/api/src/routes/duplicates.test.ts
+++ b/apps/api/src/routes/duplicates.test.ts
@@ -27,6 +27,12 @@ jest.mock('../lib/logger', () => ({
   logError: jest.fn(),
 }));
 
+// The auto-merge route now invalidates prediction caches and recomputes
+// adjusted components; mock both so tests stay Redis/DB-free.
+jest.mock('../services/prediction/cache', () => ({
+  invalidateBikePrediction: jest.fn().mockResolvedValue(undefined),
+}));
+
 import router from './duplicates';
 
 interface RouteLayer {
@@ -274,6 +280,7 @@ describe('POST /duplicates/auto-merge', () => {
       fn({
         $executeRaw: mockExecuteRaw,
         ride: { deleteMany: mockDeleteMany, updateMany: mockUpdateMany },
+        componentRideAdjustment: { findMany: jest.fn().mockResolvedValue([]) },
       })
     );
     mockExecuteRaw.mockResolvedValue(undefined);
@@ -380,6 +387,7 @@ describe('POST /duplicates/auto-merge', () => {
       fn({
         $executeRaw: mockExecuteRaw,
         ride: { deleteMany: mockDeleteMany, updateMany: mockUpdateMany },
+        componentRideAdjustment: { findMany: jest.fn().mockResolvedValue([]) },
       })
     );
     const dup: DupRow = {

--- a/apps/api/src/routes/duplicates.test.ts
+++ b/apps/api/src/routes/duplicates.test.ts
@@ -4,14 +4,18 @@ const mockFindMany = jest.fn();
 const mockTransaction = jest.fn();
 const mockUpdate = jest.fn();
 const mockUserFindUnique = jest.fn();
+const mockRideFindUnique = jest.fn();
 const mockDeleteMany = jest.fn();
 const mockUpdateMany = jest.fn();
 const mockExecuteRaw = jest.fn();
+const mockRideDelete = jest.fn();
+const mockComponentUpdateMany = jest.fn();
 
 jest.mock('../lib/prisma', () => ({
   prisma: {
     ride: {
       findMany: mockFindMany,
+      findUnique: mockRideFindUnique,
       update: mockUpdate,
       deleteMany: mockDeleteMany,
       updateMany: mockUpdateMany,
@@ -34,6 +38,9 @@ jest.mock('../services/prediction/cache', () => ({
 }));
 
 import router from './duplicates';
+import { invalidateBikePrediction } from '../services/prediction/cache';
+
+const mockInvalidateBikePrediction = invalidateBikePrediction as jest.Mock;
 
 interface RouteLayer {
   route?: {
@@ -400,5 +407,105 @@ describe('POST /duplicates/auto-merge', () => {
     await invokeHandler(handler, mockReq as Request, mockRes as Response);
 
     expect(jsonResponse).toMatchObject({ message: expect.stringContaining('Suunto data') });
+  });
+});
+
+describe('POST /duplicates/merge', () => {
+  let handler: RequestHandler | undefined;
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let jsonResponse: unknown;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handler = getHandler('/duplicates/merge', 'post');
+    jsonResponse = undefined;
+
+    mockReq = {
+      user: { id: 'user-123' },
+      sessionUser: undefined,
+      body: { keepRideId: 'keep-1', deleteRideId: 'del-1' },
+    } as Partial<Request>;
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockImplementation((data) => {
+        jsonResponse = data;
+        return mockRes;
+      }),
+    };
+
+    // tx exposes exactly what the merge path + the real component-hours
+    // helpers touch: the adjustment lookup, the bulk component decrement,
+    // and the ride delete/update.
+    mockTransaction.mockImplementation(async (fn) =>
+      fn({
+        componentRideAdjustment: { findMany: jest.fn().mockResolvedValue([]) },
+        component: { updateMany: mockComponentUpdateMany },
+        ride: { delete: mockRideDelete, update: mockUpdate },
+      })
+    );
+    mockComponentUpdateMany.mockResolvedValue({ count: 1 });
+    mockRideDelete.mockResolvedValue({ id: 'del-1' });
+    mockUpdate.mockResolvedValue({ id: 'keep-1' });
+  });
+
+  function seedPair(deleteRide: {
+    bikeId: string | null;
+    durationSeconds: number | null;
+  }) {
+    mockRideFindUnique
+      .mockResolvedValueOnce({ userId: 'user-123', duplicateOfId: 'del-1' }) // keepRide
+      .mockResolvedValueOnce({ userId: 'user-123', duplicateOfId: 'keep-1', ...deleteRide }); // deleteRide
+  }
+
+  it('rejects unauthenticated requests', async () => {
+    mockReq.user = undefined;
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(mockRes.status).toHaveBeenCalledWith(401);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('decrements component hours and invalidates the prediction cache when deleting the duplicate', async () => {
+    seedPair({ bikeId: 'bike-1', durationSeconds: 3600 });
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    // Duplicate deleted inside the integrity transaction
+    expect(mockRideDelete).toHaveBeenCalledWith({ where: { id: 'del-1' } });
+    // Bike-1's components decremented by the deleted ride's hours (bulk helper)
+    expect(mockComponentUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: 'user-123', bikeId: 'bike-1' }),
+        data: { hoursUsed: { decrement: 1 } },
+      })
+    );
+    // Prediction cache busted for the affected bike
+    expect(mockInvalidateBikePrediction).toHaveBeenCalledWith('user-123', 'bike-1');
+    expect(jsonResponse).toMatchObject({ success: true, keptRideId: 'keep-1' });
+  });
+
+  it('skips hours decrement and cache invalidation for an unassigned deleted ride', async () => {
+    seedPair({ bikeId: null, durationSeconds: 3600 });
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(mockRideDelete).toHaveBeenCalledWith({ where: { id: 'del-1' } });
+    expect(mockComponentUpdateMany).not.toHaveBeenCalled();
+    expect(mockInvalidateBikePrediction).not.toHaveBeenCalled();
+    expect(jsonResponse).toMatchObject({ success: true });
+  });
+
+  it('rejects when the two rides are not marked as duplicates of each other', async () => {
+    mockRideFindUnique
+      .mockResolvedValueOnce({ userId: 'user-123', duplicateOfId: null })
+      .mockResolvedValueOnce({ userId: 'user-123', duplicateOfId: null, bikeId: 'bike-1', durationSeconds: 3600 });
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(mockRideDelete).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/duplicates.ts
+++ b/apps/api/src/routes/duplicates.ts
@@ -6,6 +6,7 @@ import { isDuplicateActivity } from '../lib/duplicate-detector';
 import {
   findAdjustedComponentIdsForRides,
   recomputeAdjustedComponentsForRides,
+  syncBikeComponentHours,
 } from '../lib/component-hours';
 import { invalidateBikePrediction } from '../services/prediction/cache';
 
@@ -82,7 +83,10 @@ r.post<Empty, void, { keepRideId: string; deleteRideId: string }>(
       // Verify both rides belong to this user and check duplicate relationship
       const [keepRide, deleteRide] = await Promise.all([
         prisma.ride.findUnique({ where: { id: keepRideId }, select: { userId: true, duplicateOfId: true } }),
-        prisma.ride.findUnique({ where: { id: deleteRideId }, select: { userId: true, duplicateOfId: true } }),
+        prisma.ride.findUnique({
+          where: { id: deleteRideId },
+          select: { userId: true, duplicateOfId: true, bikeId: true, durationSeconds: true },
+        }),
       ]);
 
       if (!keepRide || !deleteRide) {
@@ -102,19 +106,48 @@ r.post<Empty, void, { keepRideId: string; deleteRideId: string }>(
         return sendBadRequest(res, 'Rides are not marked as duplicates of each other');
       }
 
-      // Delete the duplicate
-      await prisma.ride.delete({
-        where: { id: deleteRideId },
+      // Delete the duplicate and keep component hours + ride adjustments in
+      // sync. The auto-merge route already does this; the manual merge was a
+      // gap — it deleted the ride without decrementing the bike's component
+      // hours, recomputing adjusted components, or busting the cached
+      // predictions.
+      const adjustedBikeIds = await prisma.$transaction(async (tx) => {
+        // Capture BEFORE the delete — adjustment rows cascade away with the
+        // ride, and cross-bike INCLUDEs live on components the decrement
+        // below never touches.
+        const adjustedComponentIds = await findAdjustedComponentIdsForRides(tx, [deleteRideId]);
+
+        await syncBikeComponentHours(
+          tx,
+          userId,
+          { bikeId: deleteRide.bikeId ?? null, durationSeconds: deleteRide.durationSeconds },
+          { bikeId: null, durationSeconds: 0 }
+        );
+
+        // Delete the duplicate
+        await tx.ride.delete({
+          where: { id: deleteRideId },
+        });
+
+        // Clear duplicate flags on the kept ride
+        await tx.ride.update({
+          where: { id: keepRideId },
+          data: {
+            isDuplicate: false,
+            duplicateOfId: null,
+          },
+        });
+
+        return recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
       });
 
-      // Clear duplicate flags on the kept ride
-      await prisma.ride.update({
-        where: { id: keepRideId },
-        data: {
-          isDuplicate: false,
-          duplicateOfId: null,
-        },
-      });
+      // Invalidate prediction caches for every bike whose component hours changed.
+      for (const bikeId of new Set([
+        ...(deleteRide.bikeId ? [deleteRide.bikeId] : []),
+        ...adjustedBikeIds,
+      ])) {
+        await invalidateBikePrediction(userId, bikeId);
+      }
 
       console.log(`[Duplicates] Merged: kept ${keepRideId}, deleted ${deleteRideId}`);
 

--- a/apps/api/src/routes/duplicates.ts
+++ b/apps/api/src/routes/duplicates.ts
@@ -3,6 +3,11 @@ import { prisma } from '../lib/prisma';
 import { sendBadRequest, sendUnauthorized, sendNotFound, sendForbidden, sendInternalError } from '../lib/api-response';
 import { logError } from '../lib/logger';
 import { isDuplicateActivity } from '../lib/duplicate-detector';
+import {
+  findAdjustedComponentIdsForRides,
+  recomputeAdjustedComponentsForRides,
+} from '../lib/component-hours';
+import { invalidateBikePrediction } from '../services/prediction/cache';
 
 type Empty = Record<string, never>;
 const r: Router = createRouter();
@@ -473,7 +478,12 @@ r.post('/duplicates/auto-merge', async (req: Request, res: Response) => {
     }
 
     // Perform deletions in transaction
-    await prisma.$transaction(async (tx) => {
+    const adjustedBikeIds = await prisma.$transaction(async (tx) => {
+      // Capture BEFORE the deleteMany — adjustment rows cascade away with
+      // their rides, and cross-bike INCLUDEs live on components the raw
+      // decrement below never touches.
+      const adjustedComponentIds = await findAdjustedComponentIdsForRides(tx, ridesToDelete);
+
       // Adjust component hours atomically (floor at 0 in single query)
       for (const [bikeId, hours] of hoursToDecrementByBike.entries()) {
         await tx.$executeRaw`
@@ -506,7 +516,16 @@ r.post('/duplicates/auto-merge', async (req: Request, res: Response) => {
         where: { userId, isDuplicate: true },
         data: { isDuplicate: false, duplicateOfId: null },
       });
+
+      return recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
     });
+
+    // Invalidate prediction caches for every bike whose component hours
+    // changed (previously a gap on this route — merges decremented hours
+    // without busting the cached predictions).
+    for (const bikeId of new Set([...hoursToDecrementByBike.keys(), ...adjustedBikeIds])) {
+      await invalidateBikePrediction(userId, bikeId);
+    }
 
     console.log(`[Duplicates] Auto-merge completed for user ${userId}: merged ${ridesToDelete.length} pairs, preferred: ${preferredSource}`);
 

--- a/apps/api/src/routes/duplicates.ts
+++ b/apps/api/src/routes/duplicates.ts
@@ -141,13 +141,14 @@ r.post<Empty, void, { keepRideId: string; deleteRideId: string }>(
         return recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
       });
 
-      // Invalidate prediction caches for every bike whose component hours changed.
-      for (const bikeId of new Set([
-        ...(deleteRide.bikeId ? [deleteRide.bikeId] : []),
-        ...adjustedBikeIds,
-      ])) {
-        await invalidateBikePrediction(userId, bikeId);
-      }
+      // Invalidate prediction caches for every bike whose component hours
+      // changed — independent cache busts, so fire them together.
+      await Promise.all(
+        [...new Set([
+          ...(deleteRide.bikeId ? [deleteRide.bikeId] : []),
+          ...adjustedBikeIds,
+        ])].map((bikeId) => invalidateBikePrediction(userId, bikeId))
+      );
 
       console.log(`[Duplicates] Merged: kept ${keepRideId}, deleted ${deleteRideId}`);
 

--- a/apps/api/src/routes/duplicates.ts
+++ b/apps/api/src/routes/duplicates.ts
@@ -142,13 +142,20 @@ r.post<Empty, void, { keepRideId: string; deleteRideId: string }>(
       });
 
       // Invalidate prediction caches for every bike whose component hours
-      // changed — independent cache busts, so fire them together.
-      await Promise.all(
-        [...new Set([
-          ...(deleteRide.bikeId ? [deleteRide.bikeId] : []),
-          ...adjustedBikeIds,
-        ])].map((bikeId) => invalidateBikePrediction(userId, bikeId))
-      );
+      // changed — independent cache busts, so fire them together. This runs
+      // AFTER the transaction committed, so a bust failure must NOT surface as
+      // a 500: the merge already happened and a client retry would then 404 on
+      // the deleted ride. Best-effort — the cache TTL backstops any staleness.
+      try {
+        await Promise.all(
+          [...new Set([
+            ...(deleteRide.bikeId ? [deleteRide.bikeId] : []),
+            ...adjustedBikeIds,
+          ])].map((bikeId) => invalidateBikePrediction(userId, bikeId))
+        );
+      } catch (err) {
+        logError('Duplicates merge cache invalidation', err);
+      }
 
       console.log(`[Duplicates] Merged: kept ${keepRideId}, deleted ${deleteRideId}`);
 
@@ -556,9 +563,17 @@ r.post('/duplicates/auto-merge', async (req: Request, res: Response) => {
 
     // Invalidate prediction caches for every bike whose component hours
     // changed (previously a gap on this route — merges decremented hours
-    // without busting the cached predictions).
-    for (const bikeId of new Set([...hoursToDecrementByBike.keys(), ...adjustedBikeIds])) {
-      await invalidateBikePrediction(userId, bikeId);
+    // without busting the cached predictions). Post-commit best-effort: a
+    // bust failure must not turn the committed merge into a client-visible
+    // 500 (a retry would re-scan against already-deleted rides).
+    try {
+      await Promise.all(
+        [...new Set([...hoursToDecrementByBike.keys(), ...adjustedBikeIds])].map(
+          (bikeId) => invalidateBikePrediction(userId, bikeId)
+        )
+      );
+    } catch (err) {
+      logError('Duplicates auto-merge cache invalidation', err);
     }
 
     console.log(`[Duplicates] Auto-merge completed for user ${userId}: merged ${ridesToDelete.length} pairs, preferred: ${preferredSource}`);

--- a/apps/api/src/routes/strava.backfill.ts
+++ b/apps/api/src/routes/strava.backfill.ts
@@ -5,7 +5,12 @@ import { prisma } from '../lib/prisma';
 import { formatLatLon, reverseGeocode } from '../lib/location';
 import { sendBadRequest, sendUnauthorized, sendForbidden, sendNotFound, sendInternalError } from '../lib/api-response';
 import { canBackfillYear } from '../auth/tier-access';
-import { incrementBikeComponentHours, decrementBikeComponentHours } from '../lib/component-hours';
+import {
+  incrementBikeComponentHours,
+  decrementBikeComponentHours,
+  findAdjustedComponentIdsForRides,
+  recomputeAdjustedComponentsForRides,
+} from '../lib/component-hours';
 import { logError } from '../lib/logger';
 import { enqueueWeatherJob } from '../lib/queue';
 import { requireAdmin } from '../auth/adminMiddleware';
@@ -555,6 +560,14 @@ r.delete<Empty, void, Empty>(
       }, new Map());
 
       await prisma.$transaction(async (tx) => {
+        // Capture BEFORE the deleteMany — adjustment rows cascade away with
+        // their rides; adjusted components (incl. cross-bike INCLUDEs) need
+        // a canonical recompute after the purge.
+        const adjustedComponentIds = await findAdjustedComponentIdsForRides(
+          tx,
+          rides.map((r) => r.id)
+        );
+
         for (const [bikeId, hours] of hoursByBike.entries()) {
           await decrementBikeComponentHours(tx, { userId, bikeId, hoursDelta: hours });
         }
@@ -565,6 +578,8 @@ r.delete<Empty, void, Empty>(
             stravaActivityId: { not: null },
           },
         });
+
+        await recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
       });
 
       return res.json({

--- a/apps/api/src/routes/strava.backfill.ts
+++ b/apps/api/src/routes/strava.backfill.ts
@@ -11,6 +11,7 @@ import {
   findAdjustedComponentIdsForRides,
   recomputeAdjustedComponentsForRides,
 } from '../lib/component-hours';
+import { invalidateBikePrediction } from '../services/prediction/cache';
 import { logError } from '../lib/logger';
 import { enqueueWeatherJob } from '../lib/queue';
 import { requireAdmin } from '../auth/adminMiddleware';
@@ -559,7 +560,7 @@ r.delete<Empty, void, Empty>(
         return map;
       }, new Map());
 
-      await prisma.$transaction(async (tx) => {
+      const adjustedBikeIds = await prisma.$transaction(async (tx) => {
         // Capture BEFORE the deleteMany — adjustment rows cascade away with
         // their rides; adjusted components (incl. cross-bike INCLUDEs) need
         // a canonical recompute after the purge.
@@ -579,8 +580,15 @@ r.delete<Empty, void, Empty>(
           },
         });
 
-        await recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
+        return recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
       });
+
+      // Invalidate prediction caches for every bike whose component hours
+      // changed — the decremented bikes plus any bike holding a component
+      // with cross-bike INCLUDE adjustments (mirrors duplicates auto-merge).
+      for (const bikeId of new Set([...hoursByBike.keys(), ...adjustedBikeIds])) {
+        await invalidateBikePrediction(userId, bikeId);
+      }
 
       return res.json({
         success: true,

--- a/apps/api/src/routes/suunto.backfill.test.ts
+++ b/apps/api/src/routes/suunto.backfill.test.ts
@@ -86,6 +86,8 @@ const mockDecrementBikeComponentHours = jest.fn();
 jest.mock('../lib/component-hours', () => ({
   incrementBikeComponentHours: mockIncrementBikeComponentHours,
   decrementBikeComponentHours: mockDecrementBikeComponentHours,
+  findAdjustedComponentIdsForRides: jest.fn().mockResolvedValue([]),
+  recomputeAdjustedComponentsForRides: jest.fn().mockResolvedValue([]),
 }));
 
 const mockFetch = jest.fn();

--- a/apps/api/src/routes/suunto.backfill.ts
+++ b/apps/api/src/routes/suunto.backfill.ts
@@ -16,6 +16,7 @@ import {
   findAdjustedComponentIdsForRides,
   recomputeAdjustedComponentsForRides,
 } from '../lib/component-hours';
+import { invalidateBikePrediction } from '../services/prediction/cache';
 import { logError, logger } from '../lib/logger';
 import { acquireLock, releaseLock, extendLock, LOCK_TTL } from '../lib/rate-limit';
 import {
@@ -705,7 +706,7 @@ r.delete<Empty, void, Empty>(
         return map;
       }, new Map());
 
-      await prisma.$transaction(async (tx) => {
+      const adjustedBikeIds = await prisma.$transaction(async (tx) => {
         // Capture BEFORE the deleteMany — adjustment rows cascade away with
         // their rides; adjusted components need a canonical recompute after.
         const adjustedComponentIds = await findAdjustedComponentIdsForRides(
@@ -729,8 +730,15 @@ r.delete<Empty, void, Empty>(
           where: { userId, provider: 'suunto' },
         });
 
-        await recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
+        return recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
       });
+
+      // Invalidate prediction caches for every bike whose component hours
+      // changed — the decremented bikes plus any bike holding a component
+      // with cross-bike INCLUDE adjustments (mirrors duplicates auto-merge).
+      for (const bikeId of new Set([...hoursByBike.keys(), ...adjustedBikeIds])) {
+        await invalidateBikePrediction(userId, bikeId);
+      }
 
       return res.json({
         success: true,

--- a/apps/api/src/routes/suunto.backfill.ts
+++ b/apps/api/src/routes/suunto.backfill.ts
@@ -13,6 +13,8 @@ import { canBackfillYear } from '../auth/tier-access';
 import {
   incrementBikeComponentHours,
   decrementBikeComponentHours,
+  findAdjustedComponentIdsForRides,
+  recomputeAdjustedComponentsForRides,
 } from '../lib/component-hours';
 import { logError, logger } from '../lib/logger';
 import { acquireLock, releaseLock, extendLock, LOCK_TTL } from '../lib/rate-limit';
@@ -704,6 +706,13 @@ r.delete<Empty, void, Empty>(
       }, new Map());
 
       await prisma.$transaction(async (tx) => {
+        // Capture BEFORE the deleteMany — adjustment rows cascade away with
+        // their rides; adjusted components need a canonical recompute after.
+        const adjustedComponentIds = await findAdjustedComponentIdsForRides(
+          tx,
+          rides.map((r) => r.id)
+        );
+
         for (const [bikeId, hours] of hoursByBike.entries()) {
           await decrementBikeComponentHours(tx, {
             userId,
@@ -719,6 +728,8 @@ r.delete<Empty, void, Empty>(
         await tx.backfillRequest.deleteMany({
           where: { userId, provider: 'suunto' },
         });
+
+        await recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
       });
 
       return res.json({

--- a/apps/api/src/routes/webhooks.strava.ts
+++ b/apps/api/src/routes/webhooks.strava.ts
@@ -8,6 +8,7 @@ import {
   findAdjustedComponentIdsForRides,
   recomputeAdjustedComponentsForRides,
 } from '../lib/component-hours';
+import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { logError } from '../lib/logger';
 import { fireRideNotifications } from '../services/notification.service';
 import { enqueueWeatherJob, enqueueLiftDetectionJob } from '../lib/queue';
@@ -234,7 +235,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
 
   // Handle different event types
   if (aspect_type === 'delete') {
-    await prisma.$transaction(async (tx) => {
+    const affectedBikeIds = await prisma.$transaction(async (tx) => {
       const existing = await tx.ride.findUnique({
         where: { stravaActivityId: activityId.toString() },
         select: { id: true, userId: true, durationSeconds: true, bikeId: true },
@@ -242,7 +243,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
 
       if (!existing || existing.userId !== userAccount.userId) {
         console.log(`[Strava Activity Event] No ride to delete for activity ${activityId}`);
-        return;
+        return [] as string[];
       }
 
       // Capture BEFORE the delete — adjustment rows cascade away with the
@@ -250,7 +251,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
       // below never touches.
       const adjustedComponentIds = await findAdjustedComponentIdsForRides(tx, [existing.id]);
 
-      await syncBikeComponentHours(
+      const affected = await syncBikeComponentHours(
         tx,
         userAccount.userId,
         { bikeId: existing.bikeId ?? null, durationSeconds: existing.durationSeconds },
@@ -259,8 +260,12 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
 
       await tx.ride.delete({ where: { id: existing.id } });
 
-      await recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
+      const adjustedBikeIds = await recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
+      return [...affected, ...adjustedBikeIds];
     });
+    // Bust cached predictions for every bike whose hours changed (previously
+    // a gap — this webhook decremented hours without invalidating the cache).
+    await invalidateBikePredictionsForBikes(userAccount.userId, affectedBikeIds);
     console.log(`[Strava Activity Event] Deleted ride for activity ${activityId}`);
     return;
   }
@@ -342,7 +347,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
 
       const autoLocation = await extractStravaLocation(activity);
 
-      const { syncedRideId, isNewRide } = await prisma.$transaction(async (tx) => {
+      const { syncedRideId, isNewRide, affectedBikeIds } = await prisma.$transaction(async (tx) => {
         const existing = await tx.ride.findUnique({
           where: { stravaActivityId: activityId.toString() },
           select: { id: true, durationSeconds: true, bikeId: true, location: true },
@@ -392,7 +397,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
           },
         });
 
-        await syncBikeComponentHours(
+        const affectedBikeIds = await syncBikeComponentHours(
           tx,
           userAccount.userId,
           {
@@ -407,8 +412,12 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
           existing ? ride.id : undefined
         );
 
-        return { syncedRideId: ride.id, isNewRide: !existing };
+        return { syncedRideId: ride.id, isNewRide: !existing, affectedBikeIds };
       });
+
+      // Bust cached predictions for every bike whose hours changed (create or
+      // re-sync with a changed bike/duration both land here).
+      await invalidateBikePredictionsForBikes(userAccount.userId, affectedBikeIds);
 
       console.log(`[Strava Activity Event] Successfully stored ride for activity ${activityId}`);
 

--- a/apps/api/src/routes/webhooks.strava.ts
+++ b/apps/api/src/routes/webhooks.strava.ts
@@ -3,7 +3,11 @@ import type { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { getValidStravaToken } from '../lib/strava-token';
 import { deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
-import { syncBikeComponentHours } from '../lib/component-hours';
+import {
+  syncBikeComponentHours,
+  findAdjustedComponentIdsForRides,
+  recomputeAdjustedComponentsForRides,
+} from '../lib/component-hours';
 import { logError } from '../lib/logger';
 import { fireRideNotifications } from '../services/notification.service';
 import { enqueueWeatherJob, enqueueLiftDetectionJob } from '../lib/queue';
@@ -241,6 +245,11 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
         return;
       }
 
+      // Capture BEFORE the delete — adjustment rows cascade away with the
+      // ride. Cross-bike INCLUDEs live on components the bulk decrement
+      // below never touches.
+      const adjustedComponentIds = await findAdjustedComponentIdsForRides(tx, [existing.id]);
+
       await syncBikeComponentHours(
         tx,
         userAccount.userId,
@@ -249,6 +258,8 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
       );
 
       await tx.ride.delete({ where: { id: existing.id } });
+
+      await recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
     });
     console.log(`[Strava Activity Event] Deleted ride for activity ${activityId}`);
     return;
@@ -391,7 +402,9 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
           {
             bikeId: ride.bikeId ?? null,
             durationSeconds: ride.durationSeconds,
-          }
+          },
+          // Existing ride: adjusted components need the canonical recompute.
+          existing ? ride.id : undefined
         );
 
         return { syncedRideId: ride.id, isNewRide: !existing };

--- a/apps/api/src/routes/webhooks.suunto.test.ts
+++ b/apps/api/src/routes/webhooks.suunto.test.ts
@@ -27,6 +27,12 @@ jest.mock('../lib/component-hours', () => ({
   syncBikeComponentHours: (...args: unknown[]) => mockSyncBikeComponentHours(...args),
 }));
 
+const mockInvalidateBikePredictionsForBikes = jest.fn();
+jest.mock('../services/prediction/cache', () => ({
+  invalidateBikePredictionsForBikes: (...args: unknown[]) =>
+    mockInvalidateBikePredictionsForBikes(...args),
+}));
+
 const mockFireRideNotifications = jest.fn();
 jest.mock('../services/notification.service', () => ({
   fireRideNotifications: (...args: unknown[]) => mockFireRideNotifications(...args),
@@ -97,6 +103,7 @@ describe('POST /webhooks/suunto/workouts', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsActiveSource.mockResolvedValue(true);
+    mockSyncBikeComponentHours.mockResolvedValue([]);
     mockUserAccountFindUnique.mockResolvedValue({ userId: 'user-1' });
     mockRideFindUnique.mockResolvedValue(null); // new ride by default
     mockBikeFindMany.mockResolvedValue([]); // 0 active bikes by default

--- a/apps/api/src/routes/webhooks.suunto.ts
+++ b/apps/api/src/routes/webhooks.suunto.ts
@@ -5,6 +5,7 @@ import { createLogger, logError } from '../lib/logger';
 import { isActiveSource } from '../lib/active-source';
 import { isSuuntoCyclingActivity, getSuuntoRideType, isKnownSuuntoActivity } from '../types/suunto';
 import { syncBikeComponentHours } from '../lib/component-hours';
+import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { fireRideNotifications } from '../services/notification.service';
 
 const log = createLogger('suunto-webhook');
@@ -197,6 +198,7 @@ async function processWorkoutCreated(event: WorkoutCreatedEvent): Promise<void> 
 
   let syncedRideId = '';
   let syncedBikeId: string | null = null;
+  let affectedBikeIds: string[] = [];
 
   await prisma.$transaction(async (tx) => {
     const ride = await tx.ride.upsert({
@@ -226,7 +228,7 @@ async function processWorkoutCreated(event: WorkoutCreatedEvent): Promise<void> 
       },
     });
 
-    await syncBikeComponentHours(
+    affectedBikeIds = await syncBikeComponentHours(
       tx,
       userAccount.userId,
       { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -238,6 +240,9 @@ async function processWorkoutCreated(event: WorkoutCreatedEvent): Promise<void> 
     syncedRideId = ride.id;
     syncedBikeId = ride.bikeId ?? null;
   });
+
+  // Bust cached predictions for every bike whose hours changed.
+  await invalidateBikePredictionsForBikes(userAccount.userId, affectedBikeIds);
 
   // Fire-and-forget: send "Ride Synced" + bike-select prompt for new rides.
   // Mirrors the Strava webhook + Garmin/WHOOP sync-worker call sites so all

--- a/apps/api/src/routes/webhooks.suunto.ts
+++ b/apps/api/src/routes/webhooks.suunto.ts
@@ -230,7 +230,9 @@ async function processWorkoutCreated(event: WorkoutCreatedEvent): Promise<void> 
       tx,
       userAccount.userId,
       { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
-      { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds }
+      { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds },
+      // Existing ride: adjusted components need the canonical recompute.
+      existing ? ride.id : undefined
     );
 
     syncedRideId = ride.id;

--- a/apps/api/src/routes/webhooks.whoop.test.ts
+++ b/apps/api/src/routes/webhooks.whoop.test.ts
@@ -295,6 +295,40 @@ describe('WHOOP Webhook Handler', () => {
       expect(mockInvalidateBikePrediction).toHaveBeenCalledWith('user-123', 'bike-2');
     });
 
+    it('logs a targeted error (not "Processing failed") when invalidation fails after delete', async () => {
+      const handler = getRouteHandler('post', '/whoop');
+      const req = mockRequest({
+        body: {
+          user_id: 123456,
+          id: 'workout-uuid-to-delete',
+          event_type: 'workout.deleted',
+          timestamp: '2024-01-15T10:00:00Z',
+        },
+      });
+      const res = mockResponse();
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-123' });
+      mockRideFindMany.mockResolvedValue([
+        { id: 'ride-1', bikeId: 'bike-1', durationSeconds: 3600 },
+      ]);
+      // The delete commits, then the post-commit cache bust fails.
+      mockInvalidateBikePrediction.mockRejectedValue(new Error('redis down'));
+
+      await handler!(req as Request, res as Response);
+
+      // Ride still deleted; failure logged specifically, NOT via the generic
+      // outer catch-all (which would fire misleading "Processing failed" alerts).
+      expect(mockRideDeleteMany).toHaveBeenCalledWith({ where: { id: { in: ['ride-1'] } } });
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ workoutId: 'workout-uuid-to-delete', userId: 'user-123' }),
+        '[WHOOP Webhook] Cache invalidation failed after workout.deleted'
+      );
+      expect(logger.error).not.toHaveBeenCalledWith(
+        expect.anything(),
+        '[WHOOP Webhook] Processing failed'
+      );
+    });
+
     it('should log debug when deleting non-existent workout', async () => {
       const handler = getRouteHandler('post', '/whoop');
       const req = mockRequest({

--- a/apps/api/src/routes/webhooks.whoop.test.ts
+++ b/apps/api/src/routes/webhooks.whoop.test.ts
@@ -1,6 +1,14 @@
 import { Request, Response } from 'express';
 
 // Mock dependencies before importing the module
+const mockTransaction = jest.fn();
+const mockRideFindMany = jest.fn();
+const mockRideDeleteMany = jest.fn();
+const mockSyncBikeComponentHours = jest.fn();
+const mockFindAdjustedComponentIdsForRides = jest.fn();
+const mockRecomputeAdjustedComponentsForRides = jest.fn();
+const mockInvalidateBikePrediction = jest.fn();
+
 jest.mock('../lib/prisma', () => ({
   prisma: {
     user: {
@@ -8,9 +16,22 @@ jest.mock('../lib/prisma', () => ({
     },
     ride: {
       updateMany: jest.fn(),
-      deleteMany: jest.fn(),
+      deleteMany: mockRideDeleteMany,
+      findMany: mockRideFindMany,
     },
+    $transaction: mockTransaction,
   },
+}));
+
+jest.mock('../lib/component-hours', () => ({
+  syncBikeComponentHours: (...args: unknown[]) => mockSyncBikeComponentHours(...args),
+  findAdjustedComponentIdsForRides: (...args: unknown[]) => mockFindAdjustedComponentIdsForRides(...args),
+  recomputeAdjustedComponentsForRides: (...args: unknown[]) =>
+    mockRecomputeAdjustedComponentsForRides(...args),
+}));
+
+jest.mock('../services/prediction/cache', () => ({
+  invalidateBikePrediction: (...args: unknown[]) => mockInvalidateBikePrediction(...args),
 }));
 
 jest.mock('../lib/queue/sync.queue', () => ({
@@ -66,6 +87,15 @@ describe('WHOOP Webhook Handler', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsActiveSource.mockResolvedValue(true);
+    // Run the delete transaction against a tx exposing just what the handler
+    // touches; the component-hours helpers are mocked so the tx stays thin.
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+      fn({ ride: { findMany: mockRideFindMany, deleteMany: mockRideDeleteMany } })
+    );
+    mockFindAdjustedComponentIdsForRides.mockResolvedValue([]);
+    mockRecomputeAdjustedComponentsForRides.mockResolvedValue([]);
+    mockSyncBikeComponentHours.mockResolvedValue([]);
+    mockRideDeleteMany.mockResolvedValue({ count: 1 });
   });
 
   describe('GET /whoop (verification)', () => {
@@ -213,17 +243,56 @@ describe('WHOOP Webhook Handler', () => {
       const res = mockResponse();
 
       (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-123' });
-      (prisma.ride.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
+      mockRideFindMany.mockResolvedValue([
+        { id: 'ride-1', bikeId: 'bike-1', durationSeconds: 3600 },
+      ]);
 
       await handler!(req as Request, res as Response);
 
-      expect(prisma.ride.deleteMany).toHaveBeenCalledWith({
+      expect(mockRideFindMany).toHaveBeenCalledWith({
         where: { userId: 'user-123', whoopWorkoutId: 'workout-uuid-to-delete' },
+        select: { id: true, bikeId: true, durationSeconds: true },
       });
+      expect(mockRideDeleteMany).toHaveBeenCalledWith({ where: { id: { in: ['ride-1'] } } });
       expect(logger.info).toHaveBeenCalledWith(
-        expect.objectContaining({ workoutId: 'workout-uuid-to-delete', userId: 'user-123' }),
+        expect.objectContaining({ workoutId: 'workout-uuid-to-delete', userId: 'user-123', count: 1 }),
         '[WHOOP Webhook] Marked workout as deleted'
       );
+    });
+
+    it('should decrement component hours and invalidate prediction caches on workout.deleted', async () => {
+      const handler = getRouteHandler('post', '/whoop');
+      const req = mockRequest({
+        body: {
+          user_id: 123456,
+          id: 'workout-uuid-to-delete',
+          event_type: 'workout.deleted',
+          timestamp: '2024-01-15T10:00:00Z',
+        },
+      });
+      const res = mockResponse();
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-123' });
+      mockRideFindMany.mockResolvedValue([
+        { id: 'ride-1', bikeId: 'bike-1', durationSeconds: 3600 },
+      ]);
+      // A cross-bike INCLUDE adjustment lives on a component of bike-2.
+      mockRecomputeAdjustedComponentsForRides.mockResolvedValue(['bike-2']);
+
+      await handler!(req as Request, res as Response);
+
+      // Captured the adjusted components BEFORE the delete cascades the rows away
+      expect(mockFindAdjustedComponentIdsForRides).toHaveBeenCalledWith(expect.anything(), ['ride-1']);
+      // Debited the ride's hours off bike-1's components
+      expect(mockSyncBikeComponentHours).toHaveBeenCalledWith(
+        expect.anything(),
+        'user-123',
+        { bikeId: 'bike-1', durationSeconds: 3600 },
+        { bikeId: null, durationSeconds: 0 }
+      );
+      // Both the ride's own bike and the recomputed cross-bike component's bike get busted
+      expect(mockInvalidateBikePrediction).toHaveBeenCalledWith('user-123', 'bike-1');
+      expect(mockInvalidateBikePrediction).toHaveBeenCalledWith('user-123', 'bike-2');
     });
 
     it('should log debug when deleting non-existent workout', async () => {
@@ -239,7 +308,7 @@ describe('WHOOP Webhook Handler', () => {
       const res = mockResponse();
 
       (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-123' });
-      (prisma.ride.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
+      mockRideFindMany.mockResolvedValue([]);
 
       await handler!(req as Request, res as Response);
 
@@ -247,6 +316,8 @@ describe('WHOOP Webhook Handler', () => {
         expect.objectContaining({ workoutId: 'non-existent-workout' }),
         '[WHOOP Webhook] Workout not found (may not have been imported)'
       );
+      expect(mockRideDeleteMany).not.toHaveBeenCalled();
+      expect(mockInvalidateBikePrediction).not.toHaveBeenCalled();
     });
 
     it('should enqueue sync job on workout.created event', async () => {

--- a/apps/api/src/routes/webhooks.whoop.ts
+++ b/apps/api/src/routes/webhooks.whoop.ts
@@ -3,6 +3,12 @@ import { prisma } from '../lib/prisma';
 import { enqueueSyncJob } from '../lib/queue/sync.queue';
 import { logger } from '../lib/logger';
 import { isActiveSource } from '../lib/active-source';
+import {
+  findAdjustedComponentIdsForRides,
+  recomputeAdjustedComponentsForRides,
+  syncBikeComponentHours,
+} from '../lib/component-hours';
+import { invalidateBikePrediction } from '../services/prediction/cache';
 
 const r = createRouter();
 
@@ -97,21 +103,64 @@ r.post('/whoop', async (req: Request, res: Response) => {
     // Handle different event types
     switch (event_type) {
       case 'workout.deleted': {
-        // Delete the ride
-        const updateResult = await prisma.ride.deleteMany({
-          where: { userId: user.id, whoopWorkoutId: workoutId },
-        });
+        // Delete the ride(s) and keep component hours + ride adjustments in
+        // sync — mirrors the Strava delete webhook. Without this, a deleted
+        // WHOOP workout leaves its hours credited to the bike's components
+        // and orphans any cross-bike INCLUDE adjustment that referenced it.
+        const affectedBikeIds = await prisma.$transaction(async (tx) => {
+          const rides = await tx.ride.findMany({
+            where: { userId: user.id, whoopWorkoutId: workoutId },
+            select: { id: true, bikeId: true, durationSeconds: true },
+          });
 
-        if (updateResult.count > 0) {
+          if (rides.length === 0) {
+            logger.debug(
+              { workoutId, userId: user.id },
+              '[WHOOP Webhook] Workout not found (may not have been imported)'
+            );
+            return [] as string[];
+          }
+
+          // Capture BEFORE the delete — adjustment rows cascade away with the
+          // ride, and cross-bike INCLUDEs live on components the per-ride
+          // decrement below never touches.
+          const adjustedComponentIds = await findAdjustedComponentIdsForRides(
+            tx,
+            rides.map((ride) => ride.id)
+          );
+
+          const bikeIds = new Set<string>();
+          for (const ride of rides) {
+            if (ride.bikeId) bikeIds.add(ride.bikeId);
+            await syncBikeComponentHours(
+              tx,
+              user.id,
+              { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds },
+              { bikeId: null, durationSeconds: 0 }
+            );
+          }
+
+          await tx.ride.deleteMany({
+            where: { id: { in: rides.map((ride) => ride.id) } },
+          });
+
+          const adjustedBikeIds = await recomputeAdjustedComponentsForRides(tx, {
+            componentIds: adjustedComponentIds,
+          });
+          for (const bikeId of adjustedBikeIds) bikeIds.add(bikeId);
+
           logger.info(
-            { workoutId, userId: user.id },
+            { workoutId, userId: user.id, count: rides.length },
             '[WHOOP Webhook] Marked workout as deleted'
           );
-        } else {
-          logger.debug(
-            { workoutId, userId: user.id },
-            '[WHOOP Webhook] Workout not found (may not have been imported)'
-          );
+
+          return [...bikeIds];
+        });
+
+        // Invalidate prediction caches for every bike whose component hours
+        // changed (the bulk decrement and any adjusted-component recompute).
+        for (const bikeId of affectedBikeIds) {
+          await invalidateBikePrediction(user.id, bikeId);
         }
         break;
       }

--- a/apps/api/src/routes/webhooks.whoop.ts
+++ b/apps/api/src/routes/webhooks.whoop.ts
@@ -159,10 +159,20 @@ r.post('/whoop', async (req: Request, res: Response) => {
 
         // Invalidate prediction caches for every bike whose component hours
         // changed (the bulk decrement and any adjusted-component recompute) —
-        // independent cache busts, so fire them together.
-        await Promise.all(
-          affectedBikeIds.map((bikeId) => invalidateBikePrediction(user.id, bikeId))
-        );
+        // independent cache busts, so fire them together. Best-effort: the
+        // delete already committed, so catch a bust failure here rather than
+        // letting it bubble to the outer catch and log a misleading
+        // "Processing failed" (a stale prediction self-heals at the cache TTL).
+        try {
+          await Promise.all(
+            affectedBikeIds.map((bikeId) => invalidateBikePrediction(user.id, bikeId))
+          );
+        } catch (err) {
+          logger.error(
+            { err, workoutId, userId: user.id },
+            '[WHOOP Webhook] Cache invalidation failed after workout.deleted'
+          );
+        }
         break;
       }
 

--- a/apps/api/src/routes/webhooks.whoop.ts
+++ b/apps/api/src/routes/webhooks.whoop.ts
@@ -158,10 +158,11 @@ r.post('/whoop', async (req: Request, res: Response) => {
         });
 
         // Invalidate prediction caches for every bike whose component hours
-        // changed (the bulk decrement and any adjusted-component recompute).
-        for (const bikeId of affectedBikeIds) {
-          await invalidateBikePrediction(user.id, bikeId);
-        }
+        // changed (the bulk decrement and any adjusted-component recompute) —
+        // independent cache busts, so fire them together.
+        await Promise.all(
+          affectedBikeIds.map((bikeId) => invalidateBikePrediction(user.id, bikeId))
+        );
         break;
       }
 

--- a/apps/api/src/routes/whoop.backfill.test.ts
+++ b/apps/api/src/routes/whoop.backfill.test.ts
@@ -632,6 +632,7 @@ describe('whoop.backfill routes', () => {
         component: { updateMany: mockUpdateMany },
         ride: { deleteMany: mockDeleteMany },
         backfillRequest: { deleteMany: mockDeleteMany },
+        componentRideAdjustment: { findMany: jest.fn().mockResolvedValue([]) },
       }));
     });
 

--- a/apps/api/src/routes/whoop.backfill.test.ts
+++ b/apps/api/src/routes/whoop.backfill.test.ts
@@ -2,6 +2,12 @@ import type { Request, Response, NextFunction, RequestHandler } from 'express';
 
 // Mock dependencies before imports
 const mockGetValidWhoopToken = jest.fn();
+// The purge route invalidates prediction caches for affected bikes; mock so
+// tests can assert the fan-out without touching Redis.
+jest.mock('../services/prediction/cache', () => ({
+  invalidateBikePrediction: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.mock('../lib/whoop-token', () => ({
   getValidWhoopToken: mockGetValidWhoopToken,
 }));
@@ -680,6 +686,20 @@ describe('whoop.backfill routes', () => {
       await invokeHandler(handler, mockReq as Request, mockRes as Response);
 
       expect(mockUpdateMany).toHaveBeenCalled();
+    });
+
+    it('should invalidate prediction caches for the decremented bikes', async () => {
+      const { invalidateBikePrediction } = jest.requireMock<
+        typeof import('../services/prediction/cache')
+      >('../services/prediction/cache');
+      (invalidateBikePrediction as jest.Mock).mockClear();
+      mockFindMany.mockResolvedValue([
+        { id: 'ride-1', durationSeconds: 3600, bikeId: 'bike-1' },
+      ]);
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(invalidateBikePrediction).toHaveBeenCalledWith('user-123', 'bike-1');
     });
 
     it('should handle rides without bike assignment', async () => {

--- a/apps/api/src/routes/whoop.backfill.ts
+++ b/apps/api/src/routes/whoop.backfill.ts
@@ -4,7 +4,12 @@ import { subDays } from 'date-fns';
 import { prisma } from '../lib/prisma';
 import { sendBadRequest, sendUnauthorized, sendForbidden, sendInternalError } from '../lib/api-response';
 import { canBackfillYear } from '../auth/tier-access';
-import { incrementBikeComponentHours, decrementBikeComponentHours } from '../lib/component-hours';
+import {
+  incrementBikeComponentHours,
+  decrementBikeComponentHours,
+  findAdjustedComponentIdsForRides,
+  recomputeAdjustedComponentsForRides,
+} from '../lib/component-hours';
 import { logError, logger } from '../lib/logger';
 import { acquireLock, releaseLock } from '../lib/rate-limit';
 import { findPotentialDuplicates, type DuplicateCandidate } from '../lib/duplicate-detector';
@@ -427,6 +432,13 @@ r.delete<Empty, void, Empty>(
       }, new Map());
 
       await prisma.$transaction(async (tx) => {
+        // Capture BEFORE the deleteMany — adjustment rows cascade away with
+        // their rides; adjusted components need a canonical recompute after.
+        const adjustedComponentIds = await findAdjustedComponentIdsForRides(
+          tx,
+          rides.map((r) => r.id)
+        );
+
         for (const [bikeId, hours] of hoursByBike.entries()) {
           await decrementBikeComponentHours(tx, { userId, bikeId, hoursDelta: hours });
         }
@@ -442,6 +454,8 @@ r.delete<Empty, void, Empty>(
         await tx.backfillRequest.deleteMany({
           where: { userId, provider: 'whoop' },
         });
+
+        await recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
       });
 
       return res.json({

--- a/apps/api/src/routes/whoop.backfill.ts
+++ b/apps/api/src/routes/whoop.backfill.ts
@@ -10,6 +10,7 @@ import {
   findAdjustedComponentIdsForRides,
   recomputeAdjustedComponentsForRides,
 } from '../lib/component-hours';
+import { invalidateBikePrediction } from '../services/prediction/cache';
 import { logError, logger } from '../lib/logger';
 import { acquireLock, releaseLock } from '../lib/rate-limit';
 import { findPotentialDuplicates, type DuplicateCandidate } from '../lib/duplicate-detector';
@@ -431,7 +432,7 @@ r.delete<Empty, void, Empty>(
         return map;
       }, new Map());
 
-      await prisma.$transaction(async (tx) => {
+      const adjustedBikeIds = await prisma.$transaction(async (tx) => {
         // Capture BEFORE the deleteMany — adjustment rows cascade away with
         // their rides; adjusted components need a canonical recompute after.
         const adjustedComponentIds = await findAdjustedComponentIdsForRides(
@@ -455,8 +456,15 @@ r.delete<Empty, void, Empty>(
           where: { userId, provider: 'whoop' },
         });
 
-        await recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
+        return recomputeAdjustedComponentsForRides(tx, { componentIds: adjustedComponentIds });
       });
+
+      // Invalidate prediction caches for every bike whose component hours
+      // changed — the decremented bikes plus any bike holding a component
+      // with cross-bike INCLUDE adjustments (mirrors duplicates auto-merge).
+      for (const bikeId of new Set([...hoursByBike.keys(), ...adjustedBikeIds])) {
+        await invalidateBikePrediction(userId, bikeId);
+      }
 
       return res.json({
         success: true,

--- a/apps/api/src/services/prediction/__tests__/cache.test.ts
+++ b/apps/api/src/services/prediction/__tests__/cache.test.ts
@@ -10,6 +10,7 @@ import {
   getCachedPrediction,
   setCachedPrediction,
   invalidateBikePrediction,
+  invalidateBikePredictionsForBikes,
   invalidateUserPredictions,
   clearMemoryCache,
   getMemoryCacheSize,
@@ -229,6 +230,34 @@ describe('prediction cache', () => {
         100
       );
       expect(mockRedis.del).toHaveBeenCalledWith('key1', 'key2');
+    });
+  });
+
+  describe('invalidateBikePredictionsForBikes', () => {
+    it('invalidates every listed bike, skips nulls, and de-dupes', async () => {
+      (isRedisReady as jest.Mock).mockReturnValue(false);
+
+      await setCachedPrediction({ ...cacheParams, bikeId: 'bike-a' }, { ...mockPrediction, bikeId: 'bike-a' });
+      await setCachedPrediction({ ...cacheParams, bikeId: 'bike-b' }, { ...mockPrediction, bikeId: 'bike-b' });
+      await setCachedPrediction({ ...cacheParams, bikeId: 'bike-c' }, { ...mockPrediction, bikeId: 'bike-c' });
+      expect(getMemoryCacheSize()).toBe(3);
+
+      // Duplicate 'bike-a' and a null/undefined entry must not throw and must
+      // not touch bike-c.
+      await invalidateBikePredictionsForBikes('user-123', ['bike-a', 'bike-a', null, undefined, 'bike-b']);
+
+      // bike-a + bike-b cleared, bike-c untouched.
+      expect(getMemoryCacheSize()).toBe(1);
+    });
+
+    it('is a no-op on an empty list', async () => {
+      (isRedisReady as jest.Mock).mockReturnValue(false);
+      await setCachedPrediction({ ...cacheParams, bikeId: 'bike-a' }, { ...mockPrediction, bikeId: 'bike-a' });
+      expect(getMemoryCacheSize()).toBe(1);
+
+      await invalidateBikePredictionsForBikes('user-123', []);
+
+      expect(getMemoryCacheSize()).toBe(1);
     });
   });
 

--- a/apps/api/src/services/prediction/__tests__/cache.test.ts
+++ b/apps/api/src/services/prediction/__tests__/cache.test.ts
@@ -19,6 +19,7 @@ import {
   invalidateBikeAdvisorSummary,
   invalidateUserAdvisorSummaries,
 } from '../cache';
+import { ALGO_VERSION } from '../config';
 import type { BikePredictionSummary } from '../types';
 import type { AdvisorSummaryResult } from '../../advisor/summarize';
 
@@ -32,13 +33,15 @@ describe('prediction cache', () => {
     dueNowCount: 0,
     dueSoonCount: 1,
     generatedAt: new Date('2024-01-15T10:00:00Z'),
-    algoVersion: 'v1',
+    algoVersion: ALGO_VERSION,
   };
 
+  // Seed with the live ALGO_VERSION — invalidation scans version-prefixed
+  // keys, so hardcoding a stale version here would silently test nothing.
   const cacheParams = {
     userId: 'user-123',
     bikeId: 'bike-123',
-    algoVersion: 'v1',
+    algoVersion: ALGO_VERSION,
     planTier: 'PRO' as const,
     predictionMode: 'simple' as const,
   };
@@ -51,7 +54,7 @@ describe('prediction cache', () => {
   describe('buildCacheKey', () => {
     it('should build correct cache key format', () => {
       const key = buildCacheKey(cacheParams);
-      expect(key).toBe('pred:v1:user:user-123:bike:bike-123:tier:PRO:mode:simple');
+      expect(key).toBe(`pred:${ALGO_VERSION}:user:user-123:bike:bike-123:tier:PRO:mode:simple`);
     });
 
     it('should differentiate FREE and PRO keys', () => {

--- a/apps/api/src/services/prediction/__tests__/engine.test.ts
+++ b/apps/api/src/services/prediction/__tests__/engine.test.ts
@@ -119,7 +119,7 @@ describe('prediction engine', () => {
       expect(result.bikeId).toBe('bike-123');
       expect(result.bikeName).toBe('Trail Slayer');
       expect(result.components).toHaveLength(2);
-      expect(result.algoVersion).toBe('v1');
+      expect(result.algoVersion).toBe('v2');
     });
 
     it('should throw for unauthorized bike access', async () => {
@@ -921,6 +921,48 @@ describe('prediction engine', () => {
         expect(result.components[0].status).toBe('ALL_GOOD');
         expect(result.components[0].hoursRemaining).toBe(11);
       });
+    });
+  });
+
+  describe('installedAt anchor (canonical-counter parity)', () => {
+    it('an installed-but-never-serviced component does not absorb pre-install rides', async () => {
+      (prisma.bike.findUnique as jest.Mock).mockResolvedValue({
+        ...mockBike,
+        components: [
+          {
+            id: 'comp-new-fork',
+            type: 'FORK',
+            location: 'NONE',
+            brand: 'Fox',
+            model: '38',
+            hoursUsed: 1,
+            serviceDueAtHours: 50,
+            // Installed between the two rides — only the later ride counts,
+            // matching the canonical hoursUsed anchor in component-hours.ts.
+            installedAt: new Date('2024-01-14T12:00:00Z'),
+          },
+        ],
+      });
+      (prisma.ride.findMany as jest.Mock).mockResolvedValue([
+        { id: 'ride-old', durationSeconds: 7200, distanceMeters: 32187, elevationGainMeters: 914, startTime: new Date('2024-01-14') },
+        { id: 'ride-new', durationSeconds: 3600, distanceMeters: 16093, elevationGainMeters: 457, startTime: new Date('2024-01-15') },
+      ]);
+      (prisma.ride.findFirst as jest.Mock).mockResolvedValue({
+        startTime: new Date('2024-01-01'),
+      });
+      (prisma.serviceLog.findFirst as jest.Mock).mockResolvedValue(null);
+      (prisma.serviceLog.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await generateBikePredictions({
+        userId: 'user-123',
+        bikeId: 'bike-123',
+        userRole: 'FREE',
+      });
+
+      // Anchored at installedAt (2024-01-14 noon), not the bike's first
+      // ride: only the 1h post-install ride counts.
+      expect(result.components[0].hoursSinceService).toBe(1);
+      expect(result.components[0].ridesSinceService).toBe(1);
     });
   });
 

--- a/apps/api/src/services/prediction/__tests__/engine.test.ts
+++ b/apps/api/src/services/prediction/__tests__/engine.test.ts
@@ -23,6 +23,9 @@ jest.mock('../../../lib/prisma', () => ({
     bikeServicePreference: {
       findMany: jest.fn(),
     },
+    componentRideAdjustment: {
+      findMany: jest.fn().mockResolvedValue([]),
+    },
   },
 }));
 
@@ -49,6 +52,8 @@ describe('prediction engine', () => {
     // Default: no service preferences set (all components enabled with default intervals)
     (prisma.userServicePreference as unknown as { findMany: jest.Mock }).findMany.mockResolvedValue([]);
     (prisma.bikeServicePreference as unknown as { findMany: jest.Mock }).findMany.mockResolvedValue([]);
+    // Default: no per-component ride adjustments
+    (prisma.componentRideAdjustment as unknown as { findMany: jest.Mock }).findMany.mockResolvedValue([]);
   });
 
   const mockBike = {
@@ -916,6 +921,91 @@ describe('prediction engine', () => {
         expect(result.components[0].status).toBe('ALL_GOOD');
         expect(result.components[0].hoursRemaining).toBe(11);
       });
+    });
+  });
+
+  describe('per-component ride adjustments', () => {
+    const ridesWithIds: RideMetrics[] = [
+      {
+        id: 'ride-a',
+        durationSeconds: 3600, // 1h
+        distanceMeters: 16093,
+        elevationGainMeters: 457,
+        startTime: new Date('2024-01-15'),
+      },
+      {
+        id: 'ride-b',
+        durationSeconds: 7200, // 2h
+        distanceMeters: 32187,
+        elevationGainMeters: 914,
+        startTime: new Date('2024-01-14'),
+      },
+    ];
+
+    const setup = () => {
+      (prisma.bike.findUnique as jest.Mock).mockResolvedValue(mockBike);
+      (prisma.ride.findMany as jest.Mock).mockResolvedValue(ridesWithIds);
+      (prisma.ride.findFirst as jest.Mock).mockResolvedValue({
+        startTime: new Date('2024-01-01'),
+      });
+      (prisma.serviceLog.findFirst as jest.Mock).mockResolvedValue(null);
+      (prisma.serviceLog.findMany as jest.Mock).mockResolvedValue([]);
+    };
+
+    it('EXCLUDE removes the ride from that component only', async () => {
+      setup();
+      (prisma.componentRideAdjustment as unknown as { findMany: jest.Mock }).findMany.mockResolvedValue([
+        { componentId: 'comp-fork', rideId: 'ride-a', kind: 'EXCLUDE' },
+      ]);
+
+      const result = await generateBikePredictions({
+        userId: 'user-123',
+        bikeId: 'bike-123',
+        userRole: 'FREE',
+      });
+
+      const fork = result.components.find((c) => c.componentId === 'comp-fork');
+      const chain = result.components.find((c) => c.componentId === 'comp-chain');
+      // Chain keeps both rides (3h); fork drops the excluded 1h ride (2h)
+      expect(chain?.hoursSinceService).toBe(3);
+      expect(fork?.hoursSinceService).toBe(2);
+      expect(fork?.ridesSinceService).toBe(1);
+    });
+
+    it('INCLUDE merges a cross-bike ride into that component only', async () => {
+      setup();
+      (prisma.componentRideAdjustment as unknown as { findMany: jest.Mock }).findMany.mockResolvedValue([
+        { componentId: 'comp-fork', rideId: 'ride-x', kind: 'INCLUDE' },
+      ]);
+      // ride.findMany serves getAllRidesForBike / getRecentRides (bike rides)
+      // AND the included-rides fetch (where.id.in) — branch on the args.
+      (prisma.ride.findMany as jest.Mock).mockImplementation((args: { where?: { id?: { in?: string[] } } }) => {
+        if (args?.where?.id?.in) {
+          return Promise.resolve([
+            {
+              id: 'ride-x',
+              durationSeconds: 5400, // 1.5h, on another bike
+              distanceMeters: 10000,
+              elevationGainMeters: 300,
+              startTime: new Date('2024-01-16'),
+            },
+          ]);
+        }
+        return Promise.resolve(ridesWithIds);
+      });
+
+      const result = await generateBikePredictions({
+        userId: 'user-123',
+        bikeId: 'bike-123',
+        userRole: 'FREE',
+      });
+
+      const fork = result.components.find((c) => c.componentId === 'comp-fork');
+      const chain = result.components.find((c) => c.componentId === 'comp-chain');
+      // Chain unchanged (3h); fork gains the included 1.5h ride (4.5h)
+      expect(chain?.hoursSinceService).toBe(3);
+      expect(fork?.hoursSinceService).toBe(4.5);
+      expect(fork?.ridesSinceService).toBe(3);
     });
   });
 });

--- a/apps/api/src/services/prediction/__tests__/engine.test.ts
+++ b/apps/api/src/services/prediction/__tests__/engine.test.ts
@@ -1021,8 +1021,10 @@ describe('prediction engine', () => {
       ]);
       // ride.findMany serves getAllRidesForBike / getRecentRides (bike rides)
       // AND the included-rides fetch (where.id.in) — branch on the args.
+      let includeFetchWhere: Record<string, unknown> | undefined;
       (prisma.ride.findMany as jest.Mock).mockImplementation((args: { where?: { id?: { in?: string[] } } }) => {
         if (args?.where?.id?.in) {
+          includeFetchWhere = args.where as Record<string, unknown>;
           return Promise.resolve([
             {
               id: 'ride-x',
@@ -1048,6 +1050,14 @@ describe('prediction engine', () => {
       expect(chain?.hoursSinceService).toBe(3);
       expect(fork?.hoursSinceService).toBe(4.5);
       expect(fork?.ridesSinceService).toBe(3);
+      // The own-bike guard must be the NULL-SAFE OR shape, never NOT:{bikeId}
+      // — the scalar NOT compiles to SQL `<>` which silently drops
+      // unassigned (bikeId=null) included rides on a real database.
+      expect(includeFetchWhere?.OR).toEqual([
+        { bikeId: null },
+        { bikeId: { not: 'bike-123' } },
+      ]);
+      expect(includeFetchWhere?.NOT).toBeUndefined();
     });
   });
 });

--- a/apps/api/src/services/prediction/cache.ts
+++ b/apps/api/src/services/prediction/cache.ts
@@ -229,6 +229,28 @@ export async function invalidateBikePrediction(
 }
 
 /**
+ * Invalidate prediction caches for several bikes at once, skipping nulls and
+ * de-duplicating first. The canonical post-commit call for any write path
+ * that changes component hours: feed it the bikeIds `syncBikeComponentHours`
+ * (or a `recompute*` helper) returns, and every affected bike's cached
+ * predictions get busted in one call. Centralized so a new sync path can't
+ * reintroduce the "hours changed, cache went stale" gap by hand-rolling
+ * (and forgetting part of) the loop.
+ */
+export async function invalidateBikePredictionsForBikes(
+  userId: string,
+  bikeIds: Iterable<string | null | undefined>
+): Promise<void> {
+  const unique = new Set<string>();
+  for (const bikeId of bikeIds) {
+    if (bikeId) unique.add(bikeId);
+  }
+  for (const bikeId of unique) {
+    await invalidateBikePrediction(userId, bikeId);
+  }
+}
+
+/**
  * Invalidate all predictions for a user.
  * Called when user role changes.
  *

--- a/apps/api/src/services/prediction/cache.ts
+++ b/apps/api/src/services/prediction/cache.ts
@@ -245,9 +245,10 @@ export async function invalidateBikePredictionsForBikes(
   for (const bikeId of bikeIds) {
     if (bikeId) unique.add(bikeId);
   }
-  for (const bikeId of unique) {
-    await invalidateBikePrediction(userId, bikeId);
-  }
+  // Independent cache busts — fire them together rather than serially.
+  await Promise.all(
+    [...unique].map((bikeId) => invalidateBikePrediction(userId, bikeId))
+  );
 }
 
 /**

--- a/apps/api/src/services/prediction/config.ts
+++ b/apps/api/src/services/prediction/config.ts
@@ -1,8 +1,11 @@
 import type { ComponentType, ComponentLocation } from '@prisma/client';
 import type { ComponentWearWeights } from './types';
 
-/** Algorithm version for cache keys */
-export const ALGO_VERSION = 'v1';
+/** Algorithm version for cache keys. v2: the since-service window anchors
+ * on component.installedAt when no service log exists (parity with the
+ * canonical hoursUsed anchor in lib/component-hours.ts) — bumped so cached
+ * v1 predictions computed with the old bike-level anchor can't linger. */
+export const ALGO_VERSION = 'v2';
 
 /** Default cache TTL in seconds (30 minutes) */
 export const DEFAULT_CACHE_TTL_SECONDS = 30 * 60;

--- a/apps/api/src/services/prediction/engine.ts
+++ b/apps/api/src/services/prediction/engine.ts
@@ -132,16 +132,30 @@ function estimateRidesRemaining(
 
 /**
  * Get the last service date for a component using pre-fetched context.
- * Falls back to first ride date or bike creation date.
+ * Falls back to the component's install date, then first ride date, then
+ * bike creation date.
+ *
+ * The installedAt fallback keeps the engine's window in lockstep with the
+ * canonical hoursUsed anchor (lib/component-hours.ts: latest service log
+ * ?? installedAt ?? all-time): a component installed mid-history but never
+ * serviced must not absorb the bike's pre-install rides into
+ * hoursSinceService while its counter correctly starts at install. The
+ * remaining fallbacks are equivalent to the counter's all-time window —
+ * "since the bike's first ride" covers every ride that exists.
  */
 function getLastServiceDateFromContext(
-  componentId: string,
+  component: Component,
   ctx: PredictionContext
 ): Date {
   // Try to get from pre-fetched service log map
-  const lastServiceDate = ctx.serviceLogMap.get(componentId);
+  const lastServiceDate = ctx.serviceLogMap.get(component.id);
   if (lastServiceDate) {
     return lastServiceDate;
+  }
+
+  // Fallback: the component's install date (canonical-anchor parity)
+  if (component.installedAt) {
+    return component.installedAt;
   }
 
   // Fallback: first ride date for this bike
@@ -204,7 +218,7 @@ function predictComponent(
     getBaseInterval(component.type, component.location);
 
   // Get last service date from pre-fetched context
-  const lastServiceDate = getLastServiceDateFromContext(component.id, ctx);
+  const lastServiceDate = getLastServiceDateFromContext(component, ctx);
 
   // Get rides and hours since last service from pre-fetched context,
   // honoring this component's ride adjustments

--- a/apps/api/src/services/prediction/engine.ts
+++ b/apps/api/src/services/prediction/engine.ts
@@ -190,7 +190,11 @@ function getRidesSinceDateForComponent(
     .filter((ride): ride is RideMetrics => !!ride && ride.startTime >= sinceDate);
   if (included.length === 0) return base;
 
-  // Keep ascending startTime order, matching allRides' contract.
+  // Keep ascending startTime order, matching allRides' contract — note
+  // getAllRidesForBike fetches desc only to apply its most-recent-2000 cap,
+  // then reverses to ascending (window.ts). The included rides come from a
+  // separate unordered fetch, so without this sort the merged array would
+  // break ascending order precisely for INCLUDE-carrying components.
   return [...base, ...included].sort(
     (a, b) => a.startTime.getTime() - b.startTime.getTime()
   );

--- a/apps/api/src/services/prediction/engine.ts
+++ b/apps/api/src/services/prediction/engine.ts
@@ -529,7 +529,11 @@ export async function generateBikePredictions(
         id: { in: allIncludedRideIds },
         userId,
         isDuplicate: false,
-        NOT: { bikeId },
+        // OR-null, not `NOT:{bikeId}`: the scalar NOT compiles to SQL
+        // `bikeId <> X`, which excludes NULL rows — silently dropping
+        // UNASSIGNED included rides (see the parallel note in
+        // lib/component-hours.ts; verified against real Postgres).
+        OR: [{ bikeId: null }, { bikeId: { not: bikeId } }],
       },
       select: {
         id: true,

--- a/apps/api/src/services/prediction/engine.ts
+++ b/apps/api/src/services/prediction/engine.ts
@@ -66,6 +66,20 @@ type PredictionContext = {
   allRides: RideMetrics[];
   /** Map of componentType -> effective service preference (bike override > global > system default) */
   effectivePreferences: Map<string, EffectiveServicePreference>;
+  /**
+   * Per-component ride attribution overrides (ComponentRideAdjustment).
+   * Excluded rides are dropped from that component's since-service window;
+   * included rides (from other bikes / unassigned) are added to it. Keeps
+   * hoursSinceService, ridesSinceService, and the PRO adaptive wear math in
+   * agreement with the corrected hoursUsed counter.
+   */
+  adjustmentMap: Map<string, { excluded: Set<string>; includedRideIds: string[] }>;
+  /**
+   * Metrics for INCLUDEd rides that are NOT on this bike (this bike's own
+   * rides already live in allRides — a stale INCLUDE on one must not count
+   * twice, so the fetch excludes them).
+   */
+  includedRideMap: Map<string, RideMetrics>;
 };
 
 /**
@@ -140,13 +154,32 @@ function getLastServiceDateFromContext(
 }
 
 /**
- * Get rides since a specific date from pre-fetched rides array.
+ * Get the rides attributed to a component since a date, from pre-fetched
+ * context. Applies the component's ride adjustments: EXCLUDEd rides are
+ * dropped, INCLUDEd cross-bike rides are merged in (window-filtered like
+ * everything else). Without adjustments this reduces to the plain
+ * bike-rides-since-date filter.
  */
-function getRidesSinceDateFromContext(
+function getRidesSinceDateForComponent(
+  componentId: string,
   sinceDate: Date,
   ctx: PredictionContext
 ): RideMetrics[] {
-  return ctx.allRides.filter((ride) => ride.startTime >= sinceDate);
+  const adj = ctx.adjustmentMap.get(componentId);
+  const base = ctx.allRides.filter(
+    (ride) => ride.startTime >= sinceDate && !adj?.excluded.has(ride.id)
+  );
+  if (!adj || adj.includedRideIds.length === 0) return base;
+
+  const included = adj.includedRideIds
+    .map((id) => ctx.includedRideMap.get(id))
+    .filter((ride): ride is RideMetrics => !!ride && ride.startTime >= sinceDate);
+  if (included.length === 0) return base;
+
+  // Keep ascending startTime order, matching allRides' contract.
+  return [...base, ...included].sort(
+    (a, b) => a.startTime.getTime() - b.startTime.getTime()
+  );
 }
 
 /**
@@ -173,8 +206,9 @@ function predictComponent(
   // Get last service date from pre-fetched context
   const lastServiceDate = getLastServiceDateFromContext(component.id, ctx);
 
-  // Get rides and hours since last service from pre-fetched context
-  const ridesSinceService = getRidesSinceDateFromContext(lastServiceDate, ctx);
+  // Get rides and hours since last service from pre-fetched context,
+  // honoring this component's ride adjustments
+  const ridesSinceService = getRidesSinceDateForComponent(component.id, lastServiceDate, ctx);
   const hoursSinceService = calculateTotalHours(ridesSinceService);
   const rideCountSinceService = ridesSinceService.length;
 
@@ -424,7 +458,7 @@ export async function generateBikePredictions(
   // Batch fetch all data needed for predictions to avoid N+1 queries
   const componentIds = trackableComponents.map((c) => c.id);
 
-  const [serviceLogs, firstRideDate, allRides, recentRides] = await Promise.all([
+  const [serviceLogs, firstRideDate, allRides, recentRides, rideAdjustments] = await Promise.all([
     // Fetch all service logs for all components at once
     prisma.serviceLog.findMany({
       where: { componentId: { in: componentIds } },
@@ -437,6 +471,11 @@ export async function generateBikePredictions(
     getAllRidesForBike(userId, bikeId),
     // Get recent rides for wear analysis
     getRecentRides(userId, bikeId),
+    // Per-component ride attribution overrides
+    prisma.componentRideAdjustment.findMany({
+      where: { componentId: { in: componentIds } },
+      select: { componentId: true, rideId: true, kind: true },
+    }),
   ]);
 
   // Build service log map (componentId -> most recent service date)
@@ -448,6 +487,45 @@ export async function generateBikePredictions(
     }
   }
 
+  // Build adjustment map and fetch metrics for INCLUDEd rides. The fetch
+  // excludes this bike's own rides: those already live in allRides, and a
+  // stale INCLUDE row (ride later reassigned onto this bike) must count once.
+  const adjustmentMap = new Map<string, { excluded: Set<string>; includedRideIds: string[] }>();
+  for (const adj of rideAdjustments) {
+    let entry = adjustmentMap.get(adj.componentId);
+    if (!entry) {
+      entry = { excluded: new Set<string>(), includedRideIds: [] };
+      adjustmentMap.set(adj.componentId, entry);
+    }
+    if (adj.kind === 'EXCLUDE') entry.excluded.add(adj.rideId);
+    else entry.includedRideIds.push(adj.rideId);
+  }
+
+  const allIncludedRideIds = [
+    ...new Set(rideAdjustments.filter((a) => a.kind === 'INCLUDE').map((a) => a.rideId)),
+  ];
+  const includedRideMap = new Map<string, RideMetrics>();
+  if (allIncludedRideIds.length > 0) {
+    const includedRides = await prisma.ride.findMany({
+      where: {
+        id: { in: allIncludedRideIds },
+        userId,
+        isDuplicate: false,
+        NOT: { bikeId },
+      },
+      select: {
+        id: true,
+        durationSeconds: true,
+        distanceMeters: true,
+        elevationGainMeters: true,
+        startTime: true,
+      },
+    });
+    for (const ride of includedRides) {
+      includedRideMap.set(ride.id, ride as RideMetrics);
+    }
+  }
+
   // Create prediction context
   const ctx: PredictionContext = {
     serviceLogMap,
@@ -455,6 +533,8 @@ export async function generateBikePredictions(
     bikeCreatedAt: bike.createdAt,
     allRides,
     effectivePreferences: effectivePreferencesMap,
+    adjustmentMap,
+    includedRideMap,
   };
 
   // Generate predictions for each component (synchronously - no more DB calls)

--- a/apps/api/src/services/prediction/index.ts
+++ b/apps/api/src/services/prediction/index.ts
@@ -28,6 +28,7 @@ export {
 // Cache - Invalidation Functions
 export {
   invalidateBikePrediction,
+  invalidateBikePredictionsForBikes,
   invalidateUserPredictions,
 } from './cache';
 

--- a/apps/api/src/services/prediction/types.ts
+++ b/apps/api/src/services/prediction/types.ts
@@ -33,6 +33,8 @@ export interface ComponentWearWeights {
 
 /** Ride metrics needed for wear calculation */
 export interface RideMetrics {
+  /** Ride id — used to apply per-component ride adjustments (exclude/include). */
+  id: string;
   durationSeconds: number;
   distanceMeters: number;
   elevationGainMeters: number;

--- a/apps/api/src/services/prediction/window.ts
+++ b/apps/api/src/services/prediction/window.ts
@@ -32,6 +32,7 @@ export async function getRecentRides(
     orderBy: { startTime: 'desc' },
     take: RECENT_RIDES_TARGET,
     select: {
+      id: true,
       durationSeconds: true,
       distanceMeters: true,
       elevationGainMeters: true,
@@ -65,6 +66,7 @@ export async function getRidesSinceDate(
     },
     orderBy: { startTime: 'asc' },
     select: {
+      id: true,
       durationSeconds: true,
       distanceMeters: true,
       elevationGainMeters: true,
@@ -162,6 +164,7 @@ export async function getAllRidesForBike(
     orderBy: { startTime: 'desc' },
     take: 2000,
     select: {
+      id: true,
       durationSeconds: true,
       distanceMeters: true,
       elevationGainMeters: true,

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -700,7 +700,9 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
         tx,
         userId,
         { bikeId: existingRide?.bikeId ?? null, durationSeconds: existingRide?.durationSeconds ?? null },
-        { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds }
+        { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds },
+        // Existing ride: adjusted components need the canonical recompute.
+        existingRide ? ride.id : undefined
       );
 
       return ride;

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -13,6 +13,7 @@ import type { BackfillJobData, BackfillJobName } from '../lib/queue/backfill.que
 import { enqueueWeatherJob } from '../lib/queue';
 import { captureServerEvent } from '../lib/posthog';
 import { incrementBikeComponentHours, syncBikeComponentHours } from '../lib/component-hours';
+import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import {
   isSuuntoCyclingActivity,
   getSuuntoRideType,
@@ -523,6 +524,13 @@ async function processSuuntoBackfill(userId: string, year: string): Promise<void
     }
   }
 
+  // Bust the auto-assigned bike's cached predictions once — the loop credited
+  // its component hours for every imported ride (a per-ride invalidate would
+  // hit the same bike repeatedly for no gain).
+  if (autoAssignBikeId && importedCount > 0) {
+    await invalidateBikePredictionsForBikes(userId, [autoAssignBikeId]);
+  }
+
   // Update session's lastActivityReceivedAt if any rides were created, so the
   // idle-session checker doesn't prematurely close the import.
   if (runningSession && importedCount > 0) {
@@ -661,6 +669,7 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
     // rides match the behavior of webhook-delivered ones (see sync.worker.ts
     // `upsertGarminActivity`). Missing this was why Garmin backfill-imported
     // rides didn't accrue component wear.
+    let affectedBikeIds: string[] = [];
     const upsertedRide = await prisma.$transaction(async (tx) => {
       const ride = await tx.ride.upsert({
         where: { garminActivityId: activity.summaryId },
@@ -696,7 +705,7 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
         select: { id: true, bikeId: true, durationSeconds: true },
       });
 
-      await syncBikeComponentHours(
+      affectedBikeIds = await syncBikeComponentHours(
         tx,
         userId,
         { bikeId: existingRide?.bikeId ?? null, durationSeconds: existingRide?.durationSeconds ?? null },
@@ -707,6 +716,9 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
 
       return ride;
     });
+
+    // Bust cached predictions for every bike whose hours changed.
+    await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
     if (startLat != null && startLng != null) {
       enqueueWeatherJob({ rideId: upsertedRide.id }).catch((err) =>

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -10,6 +10,7 @@ import { getValidWhoopToken } from '../lib/whoop-token';
 import { getValidSuuntoToken } from '../lib/suunto-token';
 import { deriveLocation, deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
 import { syncBikeComponentHours } from '../lib/component-hours';
+import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { logger } from '../lib/logger';
 import { fireRideNotifications } from '../services/notification.service';
 import { config } from '../config/env';
@@ -325,6 +326,7 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
 
   let syncedRideId: string | null = null;
   let isNewRide = false;
+  let affectedBikeIds: string[] = [];
 
   await prisma.$transaction(async (tx) => {
     const existing = await tx.ride.findUnique({
@@ -380,7 +382,7 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
     syncedRideId = ride.id;
 
     // Sync component hours
-    await syncBikeComponentHours(
+    affectedBikeIds = await syncBikeComponentHours(
       tx,
       userId,
       { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -389,6 +391,9 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
       existing ? ride.id : undefined
     );
   });
+
+  // Bust cached predictions for every bike whose hours changed.
+  await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
   logger.debug({ stravaActivityId: activity.id }, '[SyncWorker] Upserted Strava activity');
 
@@ -634,9 +639,10 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
 
   // Sync component hours separately — secondary to recording the ride.
   // A failure here should not roll back the ride (Garmin won't resend it).
+  let affectedBikeIds: string[] = [];
   try {
-    await prisma.$transaction(async (tx) => {
-      await syncBikeComponentHours(
+    affectedBikeIds = await prisma.$transaction(async (tx) => {
+      return syncBikeComponentHours(
         tx,
         userId,
         { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -666,6 +672,10 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
       extra: { userId, rideId: ride.id, bikeId: ride.bikeId, durationSeconds: ride.durationSeconds },
     });
   }
+
+  // Bust cached predictions for every bike whose hours changed. Empty (so a
+  // no-op) when the sync above threw — nothing was credited to invalidate.
+  await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
   // Update session's lastActivityReceivedAt if there's a running session
   if (runningSession) {
@@ -805,6 +815,7 @@ async function upsertWhoopActivity(userId: string, workout: WhoopWorkout): Promi
 
   let syncedRideId: string | null = null;
   let isNewRide = false;
+  let affectedBikeIds: string[] = [];
 
   await prisma.$transaction(async (tx) => {
     const existing = await tx.ride.findUnique({
@@ -845,7 +856,7 @@ async function upsertWhoopActivity(userId: string, workout: WhoopWorkout): Promi
     syncedRideId = ride.id;
 
     // Sync component hours
-    await syncBikeComponentHours(
+    affectedBikeIds = await syncBikeComponentHours(
       tx,
       userId,
       { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -854,6 +865,9 @@ async function upsertWhoopActivity(userId: string, workout: WhoopWorkout): Promi
       existing ? ride.id : undefined
     );
   });
+
+  // Bust cached predictions for every bike whose hours changed.
+  await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
   // Fire-and-forget notifications
   if (syncedRideId) {
@@ -1062,9 +1076,10 @@ async function upsertSuuntoActivity(
 
   // Component hours are secondary — a failure here should not roll back the
   // ride because Suunto won't re-deliver it.
+  let affectedBikeIds: string[] = [];
   try {
-    await prisma.$transaction(async (tx) => {
-      await syncBikeComponentHours(
+    affectedBikeIds = await prisma.$transaction(async (tx) => {
+      return syncBikeComponentHours(
         tx,
         userId,
         { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
@@ -1094,6 +1109,10 @@ async function upsertSuuntoActivity(
       extra: { userId, rideId: ride.id, bikeId: ride.bikeId, durationSeconds: ride.durationSeconds },
     });
   }
+
+  // Bust cached predictions for every bike whose hours changed. Empty (so a
+  // no-op) when the sync above threw — nothing was credited to invalidate.
+  await invalidateBikePredictionsForBikes(userId, affectedBikeIds);
 
   logger.debug({ suuntoWorkoutId: workout.workoutKey }, '[SyncWorker] Upserted Suunto workout');
 

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -384,7 +384,9 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
       tx,
       userId,
       { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
-      { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds }
+      { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds },
+      // Existing ride: adjusted components need the canonical recompute.
+      existing ? ride.id : undefined
     );
   });
 
@@ -638,7 +640,9 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
         tx,
         userId,
         { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
-        { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds }
+        { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds },
+        // Existing ride: adjusted components need the canonical recompute.
+        existing ? ride.id : undefined
       );
     });
   } catch (err) {
@@ -845,7 +849,9 @@ async function upsertWhoopActivity(userId: string, workout: WhoopWorkout): Promi
       tx,
       userId,
       { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
-      { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds }
+      { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds },
+      // Existing ride: adjusted components need the canonical recompute.
+      existing ? ride.id : undefined
     );
   });
 
@@ -1062,7 +1068,9 @@ async function upsertSuuntoActivity(
         tx,
         userId,
         { bikeId: existing?.bikeId ?? null, durationSeconds: existing?.durationSeconds ?? null },
-        { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds }
+        { bikeId: ride.bikeId ?? null, durationSeconds: ride.durationSeconds },
+        // Existing ride: adjusted components need the canonical recompute.
+        existing ? ride.id : undefined
       );
     });
   } catch (err) {

--- a/apps/web/src/components/gear/ComponentDetailRow.tsx
+++ b/apps/web/src/components/gear/ComponentDetailRow.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
-import { ChevronDown, Pencil, ArrowLeftRight, RefreshCw, Wrench } from 'lucide-react';
+import { ChevronDown, Pencil, ArrowLeftRight, RefreshCw, Wrench, History } from 'lucide-react';
 import { StatusDot } from '../dashboard/StatusDot';
 import type { PredictionStatus } from '../../types/prediction';
 import { formatComponentLabel } from '../../utils/formatters';
 import { useHoursDisplay } from '../../hooks/useHoursDisplay';
 import { EditServiceModal, type EditableServiceLog } from '../dashboard/EditServiceModal';
+import { ComponentRidesModal } from './ComponentRidesModal';
 
 type ServiceLogDto = {
   id: string;
@@ -101,6 +102,7 @@ export function ComponentDetailRow({
 }: ComponentDetailRowProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [editingService, setEditingService] = useState<EditableServiceLog | null>(null);
+  const [showRides, setShowRides] = useState(false);
   const { hoursDisplay } = useHoursDisplay();
 
   const latestServiceLog = component.latestServiceLog ?? null;
@@ -318,31 +320,38 @@ export function ComponentDetailRow({
                 </div>
               )}
 
-              {/* Replace / Swap actions */}
-              {(onReplace || (showSwap && onSwap)) && (
-                <div className="component-detail-swap-actions">
-                  {onReplace && (
-                    <button
-                      type="button"
-                      className="component-detail-action-btn"
-                      onClick={(e) => { e.stopPropagation(); onReplace(); }}
-                    >
-                      <ArrowLeftRight size={11} />
-                      Replace
-                    </button>
-                  )}
-                  {showSwap && onSwap && (
-                    <button
-                      type="button"
-                      className="component-detail-action-btn"
-                      onClick={(e) => { e.stopPropagation(); onSwap(); }}
-                    >
-                      <RefreshCw size={11} />
-                      Swap with another bike
-                    </button>
-                  )}
-                </div>
-              )}
+              {/* View-rides / Replace / Swap actions. View rides is always
+                  available — every component has an hours history to inspect. */}
+              <div className="component-detail-swap-actions">
+                <button
+                  type="button"
+                  className="component-detail-action-btn"
+                  onClick={(e) => { e.stopPropagation(); setShowRides(true); }}
+                >
+                  <History size={11} />
+                  View rides
+                </button>
+                {onReplace && (
+                  <button
+                    type="button"
+                    className="component-detail-action-btn"
+                    onClick={(e) => { e.stopPropagation(); onReplace(); }}
+                  >
+                    <ArrowLeftRight size={11} />
+                    Replace
+                  </button>
+                )}
+                {showSwap && onSwap && (
+                  <button
+                    type="button"
+                    className="component-detail-action-btn"
+                    onClick={(e) => { e.stopPropagation(); onSwap(); }}
+                  >
+                    <RefreshCw size={11} />
+                    Swap with another bike
+                  </button>
+                )}
+              </div>
             </div>
           </motion.div>
         )}
@@ -357,6 +366,17 @@ export function ComponentDetailRow({
           componentLabel={fullLabel}
           bikeId={component.bikeId ?? undefined}
           onClose={() => setEditingService(null)}
+        />
+      )}
+
+      {/* Same lazy-mount rationale as EditServiceModal above: the modal owns
+          Apollo queries, so only mount it while open. */}
+      {showRides && (
+        <ComponentRidesModal
+          componentId={component.id}
+          componentLabel={fullLabel}
+          bikeId={component.bikeId}
+          onClose={() => setShowRides(false)}
         />
       )}
     </div>

--- a/apps/web/src/components/gear/ComponentRidesModal.test.tsx
+++ b/apps/web/src/components/gear/ComponentRidesModal.test.tsx
@@ -222,6 +222,46 @@ describe('ComponentRidesModal', () => {
     );
   });
 
+  it('Add tab date range is passed to the server as a rides filter', () => {
+    renderModal();
+    fireEvent.click(screen.getByText('Add rides'));
+
+    fireEvent.change(screen.getByLabelText('Rides from date'), {
+      target: { value: '2026-06-01' },
+    });
+    fireEvent.change(screen.getByLabelText('Rides to date'), {
+      target: { value: '2026-06-30' },
+    });
+
+    const lastCall = mockRidesQuery.mock.calls[mockRidesQuery.mock.calls.length - 1];
+    expect(lastCall[1].variables.filter).toEqual({
+      startDate: new Date('2026-06-01T00:00:00').toISOString(),
+      endDate: new Date('2026-06-30T23:59:59.999').toISOString(),
+    });
+  });
+
+  it('Add tab search filters loaded rides client-side', () => {
+    mockRidesQuery.mockReturnValue({
+      data: {
+        rides: [
+          { id: 'r-galby', startTime: '2026-06-20T00:00:00.000Z', durationSeconds: 1800, bikeId: 'bike-2', location: 'Galbraith' },
+          { id: 'r-chuck', startTime: '2026-06-21T00:00:00.000Z', durationSeconds: 1800, bikeId: 'bike-2', location: 'Chuckanut' },
+        ],
+      },
+      loading: false,
+      fetchMore: vi.fn(),
+    });
+    renderModal();
+    fireEvent.click(screen.getByText('Add rides'));
+
+    fireEvent.change(screen.getByLabelText('Search rides'), {
+      target: { value: 'galb' },
+    });
+
+    expect(screen.getByTestId('component-ride-add-r-galby')).toBeInTheDocument();
+    expect(screen.queryByTestId('component-ride-add-r-chuck')).not.toBeInTheDocument();
+  });
+
   it('Add tab shows no truncation UI when the first page came back short', () => {
     mockRidesQuery.mockReturnValue({
       data: {

--- a/apps/web/src/components/gear/ComponentRidesModal.test.tsx
+++ b/apps/web/src/components/gear/ComponentRidesModal.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ComponentRidesModal } from './ComponentRidesModal';
+
+// Dispatch mocked useQuery/useMutation by the raw gql document text (gql is
+// mocked to return the template's first string).
+const mockSetAdjustment = vi.fn().mockResolvedValue({});
+const mockClearAdjustment = vi.fn().mockResolvedValue({});
+const mockComponentRidesQuery = vi.fn();
+const mockRidesQuery = vi.fn();
+
+vi.mock('@apollo/client', () => ({
+  gql: (strings: TemplateStringsArray) => strings.join(''),
+  useQuery: (doc: string, opts: { skip?: boolean }) =>
+    String(doc).includes('componentRides')
+      ? mockComponentRidesQuery(doc, opts)
+      : mockRidesQuery(doc, opts),
+  useMutation: (doc: string) =>
+    String(doc).includes('SetComponentRideAdjustment')
+      ? [mockSetAdjustment, { loading: false }]
+      : [mockClearAdjustment, { loading: false }],
+}));
+
+vi.mock('../ui/Modal', () => ({
+  Modal: ({ isOpen, title, children }: { isOpen: boolean; title: string; children: React.ReactNode }) =>
+    isOpen ? (
+      <div data-testid="modal">
+        <h2>{title}</h2>
+        {children}
+      </div>
+    ) : null,
+}));
+
+vi.mock('../ui/Button', () => ({
+  Button: ({ children, onClick, disabled }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+const entry = (
+  id: string,
+  over: Partial<{ counted: boolean; adjustment: 'EXCLUDE' | 'INCLUDE' | null; beforeAnchor: boolean; bikeId: string | null }> = {}
+) => ({
+  counted: over.counted ?? true,
+  adjustment: over.adjustment ?? null,
+  beforeAnchor: over.beforeAnchor ?? false,
+  ride: {
+    id,
+    startTime: '2026-06-15T00:00:00.000Z',
+    durationSeconds: 3600,
+    distanceMeters: 10000,
+    location: `Trail ${id}`,
+    trailSystem: null,
+    rideType: 'TRAIL',
+    bikeId: over.bikeId === undefined ? 'bike-1' : over.bikeId,
+  },
+});
+
+const basePayload = {
+  componentRides: {
+    componentId: 'comp-1',
+    anchor: '2026-06-01T00:00:00.000Z',
+    countedHours: 2,
+    hoursUsed: 2,
+    countedRideCount: 2,
+    hasMore: false,
+    entries: [
+      entry('r-normal'),
+      entry('r-excluded', { counted: false, adjustment: 'EXCLUDE' }),
+      entry('r-included', { adjustment: 'INCLUDE', bikeId: 'bike-2' }),
+    ],
+  },
+};
+
+const renderModal = () =>
+  render(
+    <ComponentRidesModal
+      componentId="comp-1"
+      componentLabel="Fox 36"
+      bikeId="bike-1"
+      onClose={() => {}}
+    />
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockComponentRidesQuery.mockReturnValue({
+    data: basePayload,
+    loading: false,
+    fetchMore: vi.fn(),
+    refetch: vi.fn(),
+  });
+  mockRidesQuery.mockReturnValue({ data: { rides: [] }, loading: false });
+});
+
+describe('ComponentRidesModal', () => {
+  it('renders totals and the anchor window', () => {
+    renderModal();
+    expect(screen.getByText('2.0h')).toBeInTheDocument();
+    expect(screen.getByText(/from 2 rides/)).toBeInTheDocument();
+    expect(screen.getByText(/since service on/)).toBeInTheDocument();
+  });
+
+  it('shows the recalculation hint only when stored hours drifted', () => {
+    const { rerender } = renderModal();
+    expect(screen.queryByText(/will be recalculated/)).not.toBeInTheDocument();
+
+    mockComponentRidesQuery.mockReturnValue({
+      data: {
+        componentRides: { ...basePayload.componentRides, hoursUsed: 5.5 },
+      },
+      loading: false,
+      fetchMore: vi.fn(),
+      refetch: vi.fn(),
+    });
+    rerender(
+      <ComponentRidesModal componentId="comp-1" componentLabel="Fox 36" bikeId="bike-1" onClose={() => {}} />
+    );
+    expect(screen.getByText(/will be recalculated/)).toBeInTheDocument();
+  });
+
+  it('marks excluded and cross-bike-included rides', () => {
+    renderModal();
+    expect(screen.getByTestId('component-ride-r-excluded')).toHaveTextContent('Restore');
+    expect(screen.getByTestId('component-ride-r-included')).toHaveTextContent(
+      'applied from another bike'
+    );
+  });
+
+  it('flags dormant pre-anchor INCLUDEs instead of silently ignoring them', () => {
+    mockComponentRidesQuery.mockReturnValue({
+      data: {
+        componentRides: {
+          ...basePayload.componentRides,
+          entries: [entry('r-dormant', { counted: false, adjustment: 'INCLUDE', beforeAnchor: true, bikeId: 'bike-2' })],
+        },
+      },
+      loading: false,
+      fetchMore: vi.fn(),
+      refetch: vi.fn(),
+    });
+    renderModal();
+    expect(screen.getByText(/predates last service/)).toBeInTheDocument();
+  });
+
+  it('Remove on a default ride sets an EXCLUDE adjustment', () => {
+    renderModal();
+    const row = screen.getByTestId('component-ride-r-normal');
+    fireEvent.click(row.querySelector('button')!);
+
+    expect(mockSetAdjustment).toHaveBeenCalledWith({
+      variables: { componentId: 'comp-1', rideId: 'r-normal', kind: 'EXCLUDE' },
+    });
+  });
+
+  it('Restore on an excluded ride clears the adjustment', () => {
+    renderModal();
+    const row = screen.getByTestId('component-ride-r-excluded');
+    fireEvent.click(row.querySelector('button')!);
+
+    expect(mockClearAdjustment).toHaveBeenCalledWith({
+      variables: { componentId: 'comp-1', rideId: 'r-excluded' },
+    });
+  });
+
+  it('Add tab lists only unadjusted rides from other bikes and applies INCLUDE', () => {
+    mockRidesQuery.mockReturnValue({
+      data: {
+        rides: [
+          { id: 'r-other', startTime: '2026-06-20T00:00:00.000Z', durationSeconds: 1800, bikeId: 'bike-2', location: 'Other trail' },
+          { id: 'r-own-bike', startTime: '2026-06-20T00:00:00.000Z', durationSeconds: 1800, bikeId: 'bike-1', location: 'Same bike' },
+          { id: 'r-included', startTime: '2026-06-20T00:00:00.000Z', durationSeconds: 1800, bikeId: 'bike-2', location: 'Already applied' },
+        ],
+      },
+      loading: false,
+    });
+    renderModal();
+    fireEvent.click(screen.getByText('Add rides'));
+
+    // Own-bike and already-adjusted rides are filtered out.
+    expect(screen.getByTestId('component-ride-add-r-other')).toBeInTheDocument();
+    expect(screen.queryByTestId('component-ride-add-r-own-bike')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('component-ride-add-r-included')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Apply'));
+    expect(mockSetAdjustment).toHaveBeenCalledWith({
+      variables: { componentId: 'comp-1', rideId: 'r-other', kind: 'INCLUDE' },
+    });
+  });
+});

--- a/apps/web/src/components/gear/ComponentRidesModal.test.tsx
+++ b/apps/web/src/components/gear/ComponentRidesModal.test.tsx
@@ -222,6 +222,37 @@ describe('ComponentRidesModal', () => {
     );
   });
 
+  it('Add tab lists unassigned rides for a SPARE component (null !== null trap)', () => {
+    // Regression: nullish equality made spare component (bikeId null) +
+    // unassigned ride (bikeId null) compare "same bike", hiding exactly the
+    // rides most relevant to apply to a spare. The backend allows this
+    // INCLUDE; the tab must offer it.
+    mockRidesQuery.mockReturnValue({
+      data: {
+        rides: [
+          { id: 'r-unassigned', startTime: '2026-06-20T00:00:00.000Z', durationSeconds: 1800, bikeId: null, location: 'Somewhere' },
+          { id: 'r-on-a-bike', startTime: '2026-06-21T00:00:00.000Z', durationSeconds: 1800, bikeId: 'bike-9', location: 'Elsewhere' },
+        ],
+      },
+      loading: false,
+      fetchMore: vi.fn(),
+    });
+    render(
+      <ComponentRidesModal
+        componentId="comp-spare"
+        componentLabel="Spare wheel"
+        bikeId={null}
+        onClose={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByText('Add rides'));
+
+    // Both the unassigned ride AND rides on any bike are valid candidates
+    // for a spare component.
+    expect(screen.getByTestId('component-ride-add-r-unassigned')).toBeInTheDocument();
+    expect(screen.getByTestId('component-ride-add-r-on-a-bike')).toBeInTheDocument();
+  });
+
   it('Add tab date range is passed to the server as a rides filter', () => {
     renderModal();
     fireEvent.click(screen.getByText('Add rides'));

--- a/apps/web/src/components/gear/ComponentRidesModal.test.tsx
+++ b/apps/web/src/components/gear/ComponentRidesModal.test.tsx
@@ -193,4 +193,49 @@ describe('ComponentRidesModal', () => {
       variables: { componentId: 'comp-1', rideId: 'r-other', kind: 'INCLUDE' },
     });
   });
+
+  it('Add tab advertises the window and loads older rides via cursor when a full page came back', () => {
+    // Exactly one full page (300) -> older rides may exist beyond the window.
+    const fullPage = Array.from({ length: 300 }, (_, i) => ({
+      id: `r-${i}`,
+      startTime: '2026-06-20T00:00:00.000Z',
+      durationSeconds: 1800,
+      bikeId: 'bike-2',
+      location: `Trail ${i}`,
+    }));
+    const mockFetchMoreRides = vi.fn();
+    mockRidesQuery.mockReturnValue({
+      data: { rides: fullPage },
+      loading: false,
+      fetchMore: mockFetchMoreRides,
+    });
+    renderModal();
+    fireEvent.click(screen.getByText('Add rides'));
+
+    expect(screen.getByText(/Showing your 300 most recent rides/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Load older rides'));
+    expect(mockFetchMoreRides).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({ after: 'r-299', take: 300 }),
+      })
+    );
+  });
+
+  it('Add tab shows no truncation UI when the first page came back short', () => {
+    mockRidesQuery.mockReturnValue({
+      data: {
+        rides: [
+          { id: 'r-only', startTime: '2026-06-20T00:00:00.000Z', durationSeconds: 1800, bikeId: 'bike-2', location: 'Trail' },
+        ],
+      },
+      loading: false,
+      fetchMore: vi.fn(),
+    });
+    renderModal();
+    fireEvent.click(screen.getByText('Add rides'));
+
+    expect(screen.queryByText(/most recent rides/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Load older rides')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/gear/ComponentRidesModal.tsx
+++ b/apps/web/src/components/gear/ComponentRidesModal.tsx
@@ -1,0 +1,335 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery } from '@apollo/client';
+import { CircleMinus, CirclePlus, History, RotateCcw, TriangleAlert } from 'lucide-react';
+
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import {
+  COMPONENT_RIDES,
+  SET_COMPONENT_RIDE_ADJUSTMENT,
+  CLEAR_COMPONENT_RIDE_ADJUSTMENT,
+} from '../../graphql/componentRides';
+import { RIDES } from '../../graphql/rides';
+import { BIKES } from '../../graphql/bikes';
+import { formatDurationCompact } from '../../utils/formatters';
+
+const PAGE_SIZE = 50;
+// Bounded pull for the Add-rides tab; plenty for manual swap corrections.
+const ADD_RIDES_TAKE = 300;
+
+type RideDto = {
+  id: string;
+  startTime: string;
+  durationSeconds: number;
+  distanceMeters?: number | null;
+  location?: string | null;
+  trailSystem?: string | null;
+  rideType?: string | null;
+  bikeId?: string | null;
+};
+
+type ComponentRideEntry = {
+  counted: boolean;
+  adjustment: 'EXCLUDE' | 'INCLUDE' | null;
+  beforeAnchor: boolean;
+  ride: RideDto;
+};
+
+type ComponentRidesPayload = {
+  componentRides: {
+    componentId: string;
+    anchor: string | null;
+    countedHours: number;
+    hoursUsed: number;
+    countedRideCount: number;
+    hasMore: boolean;
+    entries: ComponentRideEntry[];
+  };
+};
+
+interface ComponentRidesModalProps {
+  componentId: string;
+  componentLabel: string;
+  /** The component's bike — used to filter the Add-rides tab to other bikes. */
+  bikeId?: string | null;
+  onClose: () => void;
+}
+
+function formatRideDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  } catch {
+    return '—';
+  }
+}
+
+function rideTitle(ride: RideDto): string {
+  return ride.trailSystem || ride.location || ride.rideType || 'Ride';
+}
+
+/**
+ * "View rides" modal for one component: lists the rides that sum to its
+ * current hours (canonical attribution), lets the rider Remove/Restore an
+ * on-bike ride's hours, and Apply rides from other bikes (swap correction).
+ * Totals come from the server's canonical recompute — no optimistic math.
+ */
+export function ComponentRidesModal({
+  componentId,
+  componentLabel,
+  bikeId,
+  onClose,
+}: ComponentRidesModalProps) {
+  const [tab, setTab] = useState<'counted' | 'add'>('counted');
+  const [pendingRideId, setPendingRideId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { data, loading, fetchMore, refetch } = useQuery<ComponentRidesPayload>(COMPONENT_RIDES, {
+    variables: { componentId, take: PAGE_SIZE },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  // Rides from other bikes / unassigned, for the Apply tab. Only fetched
+  // once the rider opens that tab.
+  const { data: ridesData, loading: ridesLoading } = useQuery<{ rides: RideDto[] }>(RIDES, {
+    variables: { take: ADD_RIDES_TAKE },
+    skip: tab !== 'add',
+    fetchPolicy: 'cache-first',
+  });
+
+  const payload = data?.componentRides;
+  const entries = useMemo(() => payload?.entries ?? [], [payload]);
+
+  // Refetch the modal's own list + the bike predictions after any change.
+  const refetchAfterMutation = {
+    refetchQueries: [{ query: BIKES }],
+    onCompleted: () => {
+      refetch();
+      setPendingRideId(null);
+    },
+    onError: (err: Error) => {
+      setError(err.message || 'Something went wrong.');
+      setPendingRideId(null);
+    },
+  };
+  const [setAdjustment] = useMutation(SET_COMPONENT_RIDE_ADJUSTMENT, refetchAfterMutation);
+  const [clearAdjustment] = useMutation(CLEAR_COMPONENT_RIDE_ADJUSTMENT, refetchAfterMutation);
+
+  const runForRide = (rideId: string, run: () => Promise<unknown>) => {
+    setError(null);
+    setPendingRideId(rideId);
+    run().catch(() => {
+      /* handled in onError */
+    });
+  };
+
+  // Candidate rides for Apply: not on this component's bike, not already
+  // adjusted (the entries list carries every INCLUDE row, incl. dormant).
+  const adjustedRideIds = useMemo(
+    () => new Set(entries.filter((e) => e.adjustment != null).map((e) => e.ride.id)),
+    [entries]
+  );
+  const addCandidates = useMemo(
+    () =>
+      (ridesData?.rides ?? []).filter(
+        (ride) => (ride.bikeId ?? null) !== (bikeId ?? null) && !adjustedRideIds.has(ride.id)
+      ),
+    [ridesData, bikeId, adjustedRideIds]
+  );
+
+  const totalsDiffer =
+    payload != null && Math.abs(payload.countedHours - payload.hoursUsed) >= 0.05;
+
+  return (
+    <Modal isOpen onClose={onClose} title={`Rides · ${componentLabel}`} size="lg">
+      <div className="space-y-3">
+        {/* Totals header */}
+        <div className="flex items-center gap-2 text-sm">
+          <History size={14} className="icon-sage" />
+          <span className="font-medium">
+            {payload ? `${payload.countedHours.toFixed(1)}h` : '—'}
+          </span>
+          <span className="text-muted">
+            from {payload?.countedRideCount ?? '—'} rides
+            {payload?.anchor
+              ? ` since service on ${formatRideDate(payload.anchor)}`
+              : ' (all time)'}
+          </span>
+        </div>
+        {totalsDiffer && (
+          <p className="text-xs text-muted">
+            Stored hours ({payload!.hoursUsed.toFixed(1)}h) will be recalculated from ride
+            history on your first change.
+          </p>
+        )}
+
+        {/* Tabs */}
+        <div className="flex items-center gap-2">
+          <Button
+            variant={tab === 'counted' ? 'primary' : 'outline'}
+            size="sm"
+            onClick={() => setTab('counted')}
+          >
+            Counted rides
+          </Button>
+          <Button
+            variant={tab === 'add' ? 'primary' : 'outline'}
+            size="sm"
+            onClick={() => setTab('add')}
+          >
+            Add rides
+          </Button>
+        </div>
+
+        {error && (
+          <div className="alert-inline alert-inline-error">
+            <TriangleAlert size={14} />
+            {error}
+          </div>
+        )}
+
+        {tab === 'counted' ? (
+          <div className="space-y-1">
+            {loading && entries.length === 0 && (
+              <p className="text-sm text-muted">Loading rides…</p>
+            )}
+            {!loading && entries.length === 0 && (
+              <p className="text-sm text-muted">
+                No rides are counted toward this component yet.
+              </p>
+            )}
+            {entries.map((entry) => {
+              const { ride } = entry;
+              const busy = pendingRideId === ride.id;
+              return (
+                <div
+                  key={ride.id}
+                  className="flex items-center justify-between gap-3 rounded-md border border-app px-3 py-2"
+                  data-testid={`component-ride-${ride.id}`}
+                >
+                  <div className="min-w-0">
+                    <div className={`text-sm truncate ${entry.counted ? '' : 'text-muted line-through'}`}>
+                      {rideTitle(ride)}
+                    </div>
+                    <div className="text-xs text-muted">
+                      {formatRideDate(ride.startTime)} · {formatDurationCompact(ride.durationSeconds)}
+                      {entry.adjustment === 'INCLUDE' && ' · applied from another bike'}
+                      {entry.beforeAnchor && (
+                        <span className="text-warning"> · predates last service</span>
+                      )}
+                    </div>
+                  </div>
+                  {entry.adjustment === 'EXCLUDE' ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={busy}
+                      onClick={() =>
+                        runForRide(ride.id, () =>
+                          clearAdjustment({ variables: { componentId, rideId: ride.id } })
+                        )
+                      }
+                    >
+                      <RotateCcw size={12} className="icon-left" />
+                      {busy ? 'Restoring…' : 'Restore'}
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={busy}
+                      onClick={() =>
+                        runForRide(ride.id, () =>
+                          entry.adjustment === 'INCLUDE'
+                            ? clearAdjustment({ variables: { componentId, rideId: ride.id } })
+                            : setAdjustment({
+                                variables: { componentId, rideId: ride.id, kind: 'EXCLUDE' },
+                              })
+                        )
+                      }
+                    >
+                      <CircleMinus size={12} className="icon-left" />
+                      {busy ? 'Removing…' : 'Remove'}
+                    </Button>
+                  )}
+                </div>
+              );
+            })}
+            {payload?.hasMore && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  fetchMore({
+                    variables: { after: entries[entries.length - 1]?.ride.id },
+                    updateQuery: (prev: ComponentRidesPayload, { fetchMoreResult }) => {
+                      if (!fetchMoreResult) return prev;
+                      return {
+                        componentRides: {
+                          ...fetchMoreResult.componentRides,
+                          entries: [
+                            ...prev.componentRides.entries,
+                            ...fetchMoreResult.componentRides.entries,
+                          ],
+                        },
+                      };
+                    },
+                  })
+                }
+              >
+                Load more
+              </Button>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-1">
+            <p className="text-xs text-muted">
+              Apply a ride from another bike (or an unassigned ride) to this component —
+              e.g. when this part was temporarily mounted elsewhere.
+            </p>
+            {ridesLoading && <p className="text-sm text-muted">Loading rides…</p>}
+            {!ridesLoading && addCandidates.length === 0 && (
+              <p className="text-sm text-muted">No rides from other bikes to apply.</p>
+            )}
+            {addCandidates.map((ride) => {
+              const busy = pendingRideId === ride.id;
+              return (
+                <div
+                  key={ride.id}
+                  className="flex items-center justify-between gap-3 rounded-md border border-app px-3 py-2"
+                  data-testid={`component-ride-add-${ride.id}`}
+                >
+                  <div className="min-w-0">
+                    <div className="text-sm truncate">{rideTitle(ride)}</div>
+                    <div className="text-xs text-muted">
+                      {formatRideDate(ride.startTime)} · {formatDurationCompact(ride.durationSeconds)}
+                      {ride.bikeId == null && ' · unassigned'}
+                    </div>
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={busy}
+                    onClick={() =>
+                      runForRide(ride.id, () =>
+                        setAdjustment({
+                          variables: { componentId, rideId: ride.id, kind: 'INCLUDE' },
+                        })
+                      )
+                    }
+                  >
+                    <CirclePlus size={12} className="icon-left" />
+                    {busy ? 'Applying…' : 'Apply'}
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/gear/ComponentRidesModal.tsx
+++ b/apps/web/src/components/gear/ComponentRidesModal.tsx
@@ -88,21 +88,39 @@ export function ComponentRidesModal({
   const [error, setError] = useState<string | null>(null);
   // True once a load-older page comes back short — no more rides to fetch.
   const [addExhausted, setAddExhausted] = useState(false);
+  // Add-tab narrowing: date range is applied SERVER-side (RidesFilterInput,
+  // so it reaches rides beyond any loaded window); text search is applied
+  // client-side over the loaded rides.
+  const [searchText, setSearchText] = useState('');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
 
   const { data, loading, fetchMore, refetch } = useQuery<ComponentRidesPayload>(COMPONENT_RIDES, {
     variables: { componentId, take: PAGE_SIZE },
     fetchPolicy: 'cache-and-network',
   });
 
+  // Local-day boundaries, matching the Rides page convention (start of the
+  // from-day to end of the to-day, inclusive).
+  const addFilter = useMemo(() => {
+    if (!dateFrom && !dateTo) return undefined;
+    return {
+      ...(dateFrom ? { startDate: new Date(`${dateFrom}T00:00:00`).toISOString() } : {}),
+      ...(dateTo ? { endDate: new Date(`${dateTo}T23:59:59.999`).toISOString() } : {}),
+    };
+  }, [dateFrom, dateTo]);
+
   // Rides from other bikes / unassigned, for the Apply tab. Only fetched
   // once the rider opens that tab; cursor-paged via "Load older rides" so
-  // an old ride on another bike is reachable, not silently cut off.
+  // an old ride on another bike is reachable, not silently cut off. A date
+  // change produces new query variables — Apollo refetches a fresh window
+  // for that range, and paging continues within it.
   const {
     data: ridesData,
     loading: ridesLoading,
     fetchMore: fetchMoreRides,
   } = useQuery<{ rides: RideDto[] }>(RIDES, {
-    variables: { take: ADD_RIDES_TAKE },
+    variables: { take: ADD_RIDES_TAKE, ...(addFilter ? { filter: addFilter } : {}) },
     skip: tab !== 'add',
     fetchPolicy: 'cache-first',
   });
@@ -139,28 +157,40 @@ export function ComponentRidesModal({
     () => new Set(entries.filter((e) => e.adjustment != null).map((e) => e.ride.id)),
     [entries]
   );
-  const addCandidates = useMemo(
-    () =>
-      (ridesData?.rides ?? []).filter(
-        (ride) => (ride.bikeId ?? null) !== (bikeId ?? null) && !adjustedRideIds.has(ride.id)
-      ),
-    [ridesData, bikeId, adjustedRideIds]
-  );
+  const addCandidates = useMemo(() => {
+    const needle = searchText.trim().toLowerCase();
+    return (ridesData?.rides ?? []).filter((ride) => {
+      if ((ride.bikeId ?? null) === (bikeId ?? null) || adjustedRideIds.has(ride.id)) return false;
+      if (!needle) return true;
+      return [ride.location, ride.trailSystem, ride.rideType]
+        .some((field) => field?.toLowerCase().includes(needle));
+    });
+  }, [ridesData, bikeId, adjustedRideIds, searchText]);
 
-  // A full page means there may be older rides beyond the window.
+  // A full page means there may be older rides beyond the window (within
+  // the active date range, if one is set).
   const allFetchedRides = ridesData?.rides ?? [];
   const addMayHaveMore =
     !addExhausted && allFetchedRides.length > 0 && allFetchedRides.length % ADD_RIDES_TAKE === 0;
 
   const loadOlderRides = () =>
     fetchMoreRides({
-      variables: { take: ADD_RIDES_TAKE, after: allFetchedRides[allFetchedRides.length - 1]?.id },
+      variables: {
+        take: ADD_RIDES_TAKE,
+        after: allFetchedRides[allFetchedRides.length - 1]?.id,
+        ...(addFilter ? { filter: addFilter } : {}),
+      },
       updateQuery: (prev: { rides: RideDto[] }, { fetchMoreResult }) => {
         if (!fetchMoreResult) return prev;
         if (fetchMoreResult.rides.length < ADD_RIDES_TAKE) setAddExhausted(true);
         return { rides: [...prev.rides, ...fetchMoreResult.rides] };
       },
     });
+
+  // The exhausted flag tracks the CURRENT window; a new date range starts a
+  // fresh window with its own paging state.
+  const setDateFromAndReset = (v: string) => { setDateFrom(v); setAddExhausted(false); };
+  const setDateToAndReset = (v: string) => { setDateTo(v); setAddExhausted(false); };
 
   const totalsDiffer =
     payload != null && Math.abs(payload.countedHours - payload.hoursUsed) >= 0.05;
@@ -312,11 +342,42 @@ export function ComponentRidesModal({
               Apply a ride from another bike (or an unassigned ride) to this component —
               e.g. when this part was temporarily mounted elsewhere.
             </p>
+
+            {/* Search (client-side over loaded rides) + date range (server-
+                side — reaches rides beyond the loaded window) */}
+            <div className="flex flex-wrap items-center gap-2">
+              <input
+                type="search"
+                value={searchText}
+                onChange={(e) => setSearchText(e.target.value)}
+                placeholder="Search location, trail, type…"
+                aria-label="Search rides"
+                className="flex-1 min-w-40 rounded-md border border-app bg-surface px-3 py-1.5 text-sm text-app placeholder:text-muted focus:border-forest focus:outline-none focus:ring-1 focus:ring-forest"
+              />
+              <input
+                type="date"
+                value={dateFrom}
+                onChange={(e) => setDateFromAndReset(e.target.value)}
+                aria-label="Rides from date"
+                className="log-service-date-input"
+              />
+              <span className="text-xs text-muted">to</span>
+              <input
+                type="date"
+                value={dateTo}
+                onChange={(e) => setDateToAndReset(e.target.value)}
+                aria-label="Rides to date"
+                className="log-service-date-input"
+              />
+            </div>
+
             {ridesLoading && <p className="text-sm text-muted">Loading rides…</p>}
             {!ridesLoading && addCandidates.length === 0 && (
               <p className="text-sm text-muted">
-                No rides from other bikes to apply
-                {addMayHaveMore ? ' in your recent rides — load older rides below.' : '.'}
+                {searchText.trim()
+                  ? 'No loaded rides match your search'
+                  : 'No rides from other bikes to apply'}
+                {addMayHaveMore ? ' in this window — load older rides below.' : '.'}
               </p>
             )}
             {addCandidates.map((ride) => {

--- a/apps/web/src/components/gear/ComponentRidesModal.tsx
+++ b/apps/web/src/components/gear/ComponentRidesModal.tsx
@@ -86,6 +86,8 @@ export function ComponentRidesModal({
   const [tab, setTab] = useState<'counted' | 'add'>('counted');
   const [pendingRideId, setPendingRideId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // True once a load-older page comes back short — no more rides to fetch.
+  const [addExhausted, setAddExhausted] = useState(false);
 
   const { data, loading, fetchMore, refetch } = useQuery<ComponentRidesPayload>(COMPONENT_RIDES, {
     variables: { componentId, take: PAGE_SIZE },
@@ -93,8 +95,13 @@ export function ComponentRidesModal({
   });
 
   // Rides from other bikes / unassigned, for the Apply tab. Only fetched
-  // once the rider opens that tab.
-  const { data: ridesData, loading: ridesLoading } = useQuery<{ rides: RideDto[] }>(RIDES, {
+  // once the rider opens that tab; cursor-paged via "Load older rides" so
+  // an old ride on another bike is reachable, not silently cut off.
+  const {
+    data: ridesData,
+    loading: ridesLoading,
+    fetchMore: fetchMoreRides,
+  } = useQuery<{ rides: RideDto[] }>(RIDES, {
     variables: { take: ADD_RIDES_TAKE },
     skip: tab !== 'add',
     fetchPolicy: 'cache-first',
@@ -139,6 +146,21 @@ export function ComponentRidesModal({
       ),
     [ridesData, bikeId, adjustedRideIds]
   );
+
+  // A full page means there may be older rides beyond the window.
+  const allFetchedRides = ridesData?.rides ?? [];
+  const addMayHaveMore =
+    !addExhausted && allFetchedRides.length > 0 && allFetchedRides.length % ADD_RIDES_TAKE === 0;
+
+  const loadOlderRides = () =>
+    fetchMoreRides({
+      variables: { take: ADD_RIDES_TAKE, after: allFetchedRides[allFetchedRides.length - 1]?.id },
+      updateQuery: (prev: { rides: RideDto[] }, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return prev;
+        if (fetchMoreResult.rides.length < ADD_RIDES_TAKE) setAddExhausted(true);
+        return { rides: [...prev.rides, ...fetchMoreResult.rides] };
+      },
+    });
 
   const totalsDiffer =
     payload != null && Math.abs(payload.countedHours - payload.hoursUsed) >= 0.05;
@@ -292,7 +314,10 @@ export function ComponentRidesModal({
             </p>
             {ridesLoading && <p className="text-sm text-muted">Loading rides…</p>}
             {!ridesLoading && addCandidates.length === 0 && (
-              <p className="text-sm text-muted">No rides from other bikes to apply.</p>
+              <p className="text-sm text-muted">
+                No rides from other bikes to apply
+                {addMayHaveMore ? ' in your recent rides — load older rides below.' : '.'}
+              </p>
             )}
             {addCandidates.map((ride) => {
               const busy = pendingRideId === ride.id;
@@ -327,6 +352,16 @@ export function ComponentRidesModal({
                 </div>
               );
             })}
+            {addMayHaveMore && (
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" onClick={loadOlderRides}>
+                  Load older rides
+                </Button>
+                <span className="text-xs text-muted">
+                  Showing your {allFetchedRides.length} most recent rides
+                </span>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/apps/web/src/components/gear/ComponentRidesModal.tsx
+++ b/apps/web/src/components/gear/ComponentRidesModal.tsx
@@ -160,7 +160,13 @@ export function ComponentRidesModal({
   const addCandidates = useMemo(() => {
     const needle = searchText.trim().toLowerCase();
     return (ridesData?.rides ?? []).filter((ride) => {
-      if ((ride.bikeId ?? null) === (bikeId ?? null) || adjustedRideIds.has(ride.id)) return false;
+      // Mirror the backend's rideOnComponentBike check (`!= null &&` first):
+      // a ride is "on the component's bike" only when both sides are real
+      // bikes. Nullish equality would make spare component (bikeId null) +
+      // unassigned ride (bikeId null) compare equal and hide exactly the
+      // rides most relevant to apply to a spare.
+      const onComponentBike = bikeId != null && ride.bikeId === bikeId;
+      if (onComponentBike || adjustedRideIds.has(ride.id)) return false;
       if (!needle) return true;
       return [ride.location, ride.trailSystem, ride.rideType]
         .some((field) => field?.toLowerCase().includes(needle));

--- a/apps/web/src/graphql/componentRides.ts
+++ b/apps/web/src/graphql/componentRides.ts
@@ -1,0 +1,60 @@
+import { gql } from '@apollo/client';
+
+// The rides behind a component's current hoursUsed number, per the canonical
+// attribution rule (rides on the component's bike since the last-service
+// anchor, ± per-ride adjustments). Cursor-paged newest first.
+export const COMPONENT_RIDES = gql`
+  query ComponentRides($componentId: ID!, $take: Int, $after: ID) {
+    componentRides(componentId: $componentId, take: $take, after: $after) {
+      componentId
+      anchor
+      countedHours
+      hoursUsed
+      countedRideCount
+      hasMore
+      entries {
+        counted
+        adjustment
+        beforeAnchor
+        ride {
+          id
+          startTime
+          durationSeconds
+          distanceMeters
+          location
+          trailSystem
+          rideType
+          bikeId
+        }
+      }
+    }
+  }
+`;
+
+// Both mutations return the fresh component so Apollo renormalizes
+// Component.hoursUsed everywhere it's displayed.
+export const SET_COMPONENT_RIDE_ADJUSTMENT = gql`
+  mutation SetComponentRideAdjustment($componentId: ID!, $rideId: ID!, $kind: ComponentRideAdjustmentKind!) {
+    setComponentRideAdjustment(componentId: $componentId, rideId: $rideId, kind: $kind) {
+      component {
+        id
+        hoursUsed
+      }
+      rideId
+      counted
+    }
+  }
+`;
+
+export const CLEAR_COMPONENT_RIDE_ADJUSTMENT = gql`
+  mutation ClearComponentRideAdjustment($componentId: ID!, $rideId: ID!) {
+    clearComponentRideAdjustment(componentId: $componentId, rideId: $rideId) {
+      component {
+        id
+        hoursUsed
+      }
+      rideId
+      counted
+    }
+  }
+`;


### PR DESCRIPTION
Promotes the complete **Component Ride Attribution** feature from `staging` to `main`. The `staging..main` delta is exactly this feature — 26 commits, 35 files (+3666/−375), no unrelated work — and it merges cleanly (no conflicts; `main`'s build-config commits are untouched).

## What the feature does

Clicking a component shows every ride that sums to its current hours, and the rider can **remove** a ride's hours from it or **apply** a ride from another bike (or a spare) — full retroactive swap correction for when a part was temporarily swapped. Both the `hoursUsed` counter **and** the prediction engine honor these adjustments, so status never contradicts the corrected number.

## What's included

| Was | Content |
|---|---|
| #242 | Foundation: `ComponentRideAdjustment` model + `componentRides` query; adjustment mutations + hour-integrity sweep; prediction-engine integration; `ComponentRidesModal` web UI |
| #243 | Delete-path attribution parity (`/duplicates/merge` + WHOOP `workout.deleted`); prediction-cache invalidation across **all** sync paths (Strava/Suunto webhooks, 4 `sync.worker` providers, backfill); centralized `invalidateBikePredictionsForBikes`; best-effort/parallelized invalidation. **Closes #244** |
| #245 | Folded into #243 before the staging merge |

## ⚠️ Deploy note

Includes a Prisma migration — `20260721003434_component_ride_adjustment` (new `ComponentRideAdjustment` table + `Ride(userId, bikeId, startTime)` index). Promoting to `main` will run it against production on deploy.

## Verification

- Full api suite green — **1559 passed (78 suites)**; typecheck + lint clean.
- Staging CI green (Vercel deploy + claude-review pass).
- Merges into `main` with no conflicts (`git merge-tree` clean).

Suite/CI-verified; not driven live end-to-end against prod data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)