### PR TITLE
fix(attribution): track ComponentRidesModal pending state per-row

### DIFF
--- a/apps/web/src/components/gear/ComponentRidesModal.test.tsx
+++ b/apps/web/src/components/gear/ComponentRidesModal.test.tsx
@@ -169,6 +169,42 @@ describe('ComponentRidesModal', () => {
     });
   });
 
+  it('keeps an in-flight row disabled when another row is clicked (no double-submit)', () => {
+    mockComponentRidesQuery.mockReturnValue({
+      data: {
+        componentRides: {
+          ...basePayload.componentRides,
+          entries: [entry('r-a'), entry('r-b')],
+        },
+      },
+      loading: false,
+      fetchMore: vi.fn(),
+      refetch: vi.fn(),
+    });
+    // Never resolves — both mutations stay in flight for the whole test.
+    mockSetAdjustment.mockReturnValue(new Promise(() => {}));
+
+    renderModal();
+    const btnA = () => screen.getByTestId('component-ride-r-a').querySelector('button')!;
+    const btnB = () => screen.getByTestId('component-ride-r-b').querySelector('button')!;
+
+    fireEvent.click(btnA());
+    expect(btnA()).toBeDisabled();
+
+    // Clicking B must NOT re-enable A (a single pendingRideId would flip to B
+    // and re-open A to a second, concurrent submit).
+    fireEvent.click(btnB());
+    expect(btnA()).toBeDisabled();
+    expect(btnB()).toBeDisabled();
+
+    // Attempted double-submit on the still-pending A — disabled, so a no-op.
+    fireEvent.click(btnA());
+    const aSubmits = mockSetAdjustment.mock.calls.filter(
+      (call) => call[0]?.variables?.rideId === 'r-a'
+    );
+    expect(aSubmits).toHaveLength(1);
+  });
+
   it('Add tab lists only unadjusted rides from other bikes and applies INCLUDE', () => {
     mockRidesQuery.mockReturnValue({
       data: {

--- a/apps/web/src/components/gear/ComponentRidesModal.tsx
+++ b/apps/web/src/components/gear/ComponentRidesModal.tsx
@@ -84,7 +84,10 @@ export function ComponentRidesModal({
   onClose,
 }: ComponentRidesModalProps) {
   const [tab, setTab] = useState<'counted' | 'add'>('counted');
-  const [pendingRideId, setPendingRideId] = useState<string | null>(null);
+  // Per-row in-flight tracking (a Set, not a single id): clicking a second
+  // row while the first mutation is still pending must not re-enable the
+  // first row's button — that would allow a double-submit on it.
+  const [pendingRideIds, setPendingRideIds] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
   // True once a load-older page comes back short — no more rides to fetch.
   const [addExhausted, setAddExhausted] = useState(false);
@@ -133,11 +136,9 @@ export function ComponentRidesModal({
     refetchQueries: [{ query: BIKES }],
     onCompleted: () => {
       refetch();
-      setPendingRideId(null);
     },
     onError: (err: Error) => {
       setError(err.message || 'Something went wrong.');
-      setPendingRideId(null);
     },
   };
   const [setAdjustment] = useMutation(SET_COMPONENT_RIDE_ADJUSTMENT, refetchAfterMutation);
@@ -145,10 +146,20 @@ export function ComponentRidesModal({
 
   const runForRide = (rideId: string, run: () => Promise<unknown>) => {
     setError(null);
-    setPendingRideId(rideId);
-    run().catch(() => {
-      /* handled in onError */
-    });
+    setPendingRideIds((prev) => new Set(prev).add(rideId));
+    run()
+      .catch(() => {
+        /* surfaced via onError */
+      })
+      // Clear only THIS ride's pending flag, so a still-in-flight sibling
+      // row stays disabled.
+      .finally(() => {
+        setPendingRideIds((prev) => {
+          const next = new Set(prev);
+          next.delete(rideId);
+          return next;
+        });
+      });
   };
 
   // Candidate rides for Apply: not on this component's bike, not already
@@ -261,7 +272,7 @@ export function ComponentRidesModal({
             )}
             {entries.map((entry) => {
               const { ride } = entry;
-              const busy = pendingRideId === ride.id;
+              const busy = pendingRideIds.has(ride.id);
               return (
                 <div
                   key={ride.id}
@@ -387,7 +398,7 @@ export function ComponentRidesModal({
               </p>
             )}
             {addCandidates.map((ride) => {
-              const busy = pendingRideId === ride.id;
+              const busy = pendingRideIds.has(ride.id);
               return (
                 <div
                   key={ride.id}


### PR DESCRIPTION
## What

Nit follow-up on the Component Ride Attribution modal. `pendingRideId` was a single `string`, so this sequence left a row double-submittable:

1. Click **Remove**/**Apply** on ride A → `pendingRideId = 'A'`, A's button disables.
2. Before A's mutation resolves, click the action on ride B → `pendingRideId = 'B'`.
3. A's button re-enables (`busy = pendingRideId === 'A'` is now false) **while A's mutation is still in flight** → A can be submitted again.

Low impact today — the mutation is an idempotent upsert — but a real per-row race.

## How

- Track pending rides in a `Set<string>` instead of a single id.
- Add the ride's id on click; remove **only that id** in the mutation's `.finally()`, so an in-flight row stays disabled no matter what else is clicked (previously `onCompleted`/`onError` cleared the single id globally).
- `busy` is now `pendingRideIds.has(ride.id)`.

## Tests

Adds a regression test: with a never-resolving mutation, clicking a second row keeps the first disabled, and a repeat click on the still-pending first row does not fire a second submit. `ComponentRidesModal.test.tsx` 13/13 green; web type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)