### PR TITLE
Weather for Garmin & Suunto rides + self-service backfill

### DIFF
--- a/apps/api/scripts/backfill-garmin-coords.ts
+++ b/apps/api/scripts/backfill-garmin-coords.ts
@@ -1,0 +1,163 @@
+/**
+ * Repair backfill for Garmin rides missing start coordinates.
+ *
+ * Background: a field-name bug meant Garmin rides were stored with null
+ * startLat/startLng (see lib/garmin-coords.ts), so they never got weather or
+ * reverse-geocoded location. The ingestion code is now fixed, but existing
+ * rows still have null coords. Garmin doesn't allow arbitrary re-reads of old
+ * activity data — the compliant fix is to re-trigger Garmin's backfill over the
+ * affected date range so Garmin re-delivers the activities via webhooks, which
+ * the (now-fixed) processGarminCallback re-upserts with coords + weather.
+ *
+ * DRY RUN BY DEFAULT: prints the plan and fires NOTHING at Garmin. Pass
+ * --execute to actually trigger backfill requests.
+ *
+ * Usage (from apps/api):
+ *   DATABASE_URL="…" npx tsx scripts/backfill-garmin-coords.ts               # dry run, all users
+ *   DATABASE_URL="…" npx tsx scripts/backfill-garmin-coords.ts --execute      # fire Garmin requests
+ *   …scripts/backfill-garmin-coords.ts --user <userId>                        # scope to one user
+ *   …scripts/backfill-garmin-coords.ts --limit 5                              # cap users processed
+ *   …scripts/backfill-garmin-coords.ts --since 2026-04-15                     # clamp range start
+ *
+ * Note: Garmin returns 409 for a range it has already backfilled and will NOT
+ * re-send those activities — such rides can't be recovered this way and are
+ * reported as duplicates. Rides originally imported via real-time ping (the
+ * common case) have no prior backfill for their range, so they re-deliver.
+ */
+import { prisma } from '../src/lib/prisma';
+import { getValidGarminToken } from '../src/lib/garmin-token';
+import { triggerGarminBackfillChunks } from '../src/services/garmin-backfill';
+
+type Args = {
+  execute: boolean;
+  user?: string;
+  limit?: number;
+  since?: Date;
+};
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { execute: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--execute') args.execute = true;
+    else if (a === '--user') args.user = argv[++i];
+    else if (a === '--limit') args.limit = Number(argv[++i]);
+    else if (a === '--since') {
+      const d = new Date(argv[++i]);
+      if (Number.isNaN(d.getTime())) throw new Error(`--since must be a valid date (got "${argv[i]}")`);
+      args.since = d;
+    }
+  }
+  return args;
+}
+
+const fmtDate = (d: Date): string => d.toISOString().slice(0, 10);
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  console.log(
+    `\nGarmin coord-repair backfill — ${args.execute ? 'EXECUTE (will call Garmin)' : 'DRY RUN (no Garmin calls)'}\n`
+  );
+
+  // One row per user with at least one null-coord Garmin ride, plus the date
+  // span we need to cover.
+  const grouped = await prisma.ride.groupBy({
+    by: ['userId'],
+    where: {
+      garminActivityId: { not: null },
+      startLat: null,
+      ...(args.user ? { userId: args.user } : {}),
+      ...(args.since ? { startTime: { gte: args.since } } : {}),
+    },
+    _count: { _all: true },
+    _min: { startTime: true },
+    _max: { startTime: true },
+  });
+
+  // Deterministic order (most-affected users first); apply --limit after sort.
+  grouped.sort((a, b) => b._count._all - a._count._all);
+  const targets = args.limit ? grouped.slice(0, args.limit) : grouped;
+
+  if (targets.length === 0) {
+    console.log('No Garmin rides with null coordinates found. Nothing to do.\n');
+    await prisma.$disconnect();
+    return;
+  }
+
+  let totalRides = 0;
+  let usersTriggered = 0;
+  let usersSkipped = 0;
+  let chunksAccepted = 0;
+
+  for (const g of targets) {
+    const count = g._count._all;
+    const minStart = g._min.startTime;
+    const maxStart = g._max.startTime;
+    totalRides += count;
+
+    if (!minStart || !maxStart) {
+      console.log(`user ${g.userId}: ${count} rides but no start times — skipping`);
+      usersSkipped++;
+      continue;
+    }
+
+    // Clamp the window start to --since if given, and end one day past the last
+    // ride so its 30-day chunk is fully covered.
+    const startDate = args.since && args.since > minStart ? args.since : minStart;
+    const endDate = new Date(maxStart.getTime() + 24 * 60 * 60 * 1000);
+
+    console.log(
+      `user ${g.userId}: ${count} null-coord rides, range ${fmtDate(startDate)} → ${fmtDate(endDate)}`
+    );
+
+    if (!args.execute) {
+      usersTriggered++; // "would trigger"
+      continue;
+    }
+
+    const token = await getValidGarminToken(g.userId);
+    if (!token) {
+      console.log(`  ↳ SKIP: no valid Garmin token (disconnected or expired)`);
+      usersSkipped++;
+      continue;
+    }
+
+    try {
+      const result = await triggerGarminBackfillChunks({ accessToken: token, startDate, endDate });
+      chunksAccepted += result.totalChunks;
+      usersTriggered++;
+      const dupNote = result.allDuplicates ? ' (all duplicates — Garmin already backfilled this range)' : '';
+      console.log(
+        `  ↳ ${result.totalChunks} chunk(s) accepted${dupNote}` +
+          (result.errors.length ? `; ${result.errors.length} note(s): ${result.errors.join('; ')}` : '')
+      );
+    } catch (err) {
+      console.log(`  ↳ ERROR: ${err instanceof Error ? err.message : String(err)}`);
+      usersSkipped++;
+    }
+  }
+
+  console.log(
+    `\nSummary: ${targets.length} user(s), ${totalRides} null-coord rides, ` +
+      `${usersTriggered} ${args.execute ? 'triggered' : 'would trigger'}, ${usersSkipped} skipped` +
+      (args.execute ? `, ${chunksAccepted} Garmin chunk(s) accepted` : '')
+  );
+  if (!args.execute) {
+    console.log('Dry run only — re-run with --execute to fire Garmin backfill requests.');
+  } else {
+    console.log(
+      'Activities will arrive asynchronously via Garmin webhooks; coords + weather ' +
+        'repopulate as processGarminCallback re-upserts each ride.'
+    );
+  }
+  console.log('');
+
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -12,7 +12,7 @@ import type {
 } from '@prisma/client';
 import { checkRateLimit, checkMutationRateLimit, checkQueryRateLimit, checkAuthRateLimit } from '../lib/rate-limit';
 import { getClientIp } from '../auth/utils';
-import { enqueueSyncJob, enqueueWeatherJob, enqueueLiftDetectionJob, type SyncProvider } from '../lib/queue';
+import { enqueueSyncJob, enqueueWeatherJob, enqueueLiftDetectionJob, enqueueGarminCoordRepairJob, type SyncProvider } from '../lib/queue';
 import { getRideTrack } from '../lib/ride-track';
 import { invalidateBikePrediction, getCachedAdvisorSummary, setCachedAdvisorSummary } from '../services/prediction/cache';
 import { generateSummary, DEFAULT_ADVISOR_MODEL } from '../services/advisor/summarize';
@@ -5787,6 +5787,60 @@ export const resolvers = {
       return { enqueuedCount, ridesWithoutCoords, remainingAfterBatch };
     },
 
+    // Re-import Garmin rides that are missing coordinates (a past ingestion bug
+    // stored null lat/lng, so they never got weather). Re-triggers Garmin's
+    // backfill over the affected span via a throttled, per-user queued job;
+    // Garmin re-delivers the activities and the fixed callback repopulates
+    // coords + weather. Returns a status the client can act on.
+    backfillGarminWeather: async (_: unknown, _args: unknown, ctx: GraphQLContext) => {
+      const userId = requireUserId(ctx);
+
+      const user = await prisma.user.findUniqueOrThrow({
+        where: { id: userId },
+        select: { subscriptionTier: true, isFoundingRider: true, role: true },
+      });
+      requirePro(user, 'Weather backfill');
+
+      const rateLimit = await checkMutationRateLimit('backfillGarminWeather', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(
+          `Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`,
+          { extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter } }
+        );
+      }
+
+      // Garmin's backfill API requires the HISTORICAL_DATA_EXPORT scope. Users
+      // who connected before we requested it get a 412 from Garmin, so surface
+      // a reconnect prompt instead of silently enqueueing doomed work.
+      const integration = await prisma.userIntegration.findUnique({
+        where: { userId_provider: { userId, provider: 'GARMIN' } },
+        select: { revokedAt: true, scopes: true },
+      });
+
+      if (!integration || integration.revokedAt) {
+        return { status: 'NOT_CONNECTED', ridesToRepair: 0 };
+      }
+      // Only block when scopes are recorded AND clearly lack the permission.
+      // A null scopes string is unknown, not proof of absence — let the worker
+      // attempt it rather than false-positive a reconnect.
+      if (integration.scopes && !integration.scopes.includes('HISTORICAL_DATA_EXPORT')) {
+        return { status: 'NEEDS_RECONNECT', ridesToRepair: 0 };
+      }
+
+      const ridesToRepair = await prisma.ride.count({
+        where: { userId, garminActivityId: { not: null }, startLat: null },
+      });
+      if (ridesToRepair === 0) {
+        return { status: 'NOTHING_TO_DO', ridesToRepair: 0 };
+      }
+
+      const enqueue = await enqueueGarminCoordRepairJob({ userId });
+      return {
+        status: enqueue.status === 'already_queued' ? 'ALREADY_RUNNING' : 'STARTED',
+        ridesToRepair,
+      };
+    },
+
     // Enable public sharing of a bike's history. Available to all tiers —
     // the branded share page is a growth surface, not a paid feature.
     // Idempotent: re-enabling returns the existing link.
@@ -6142,6 +6196,19 @@ export const resolvers = {
           weather: null,
           startLat: { not: null },
           startLng: { not: null },
+        },
+      });
+    },
+    // Garmin rides stored without coordinates → the "re-import from Garmin"
+    // repair prompt. Pro-only to match the weather feature it feeds.
+    garminRidesMissingCoords: async (parent: { id: string }, _args: unknown, ctx: GraphQLContext) => {
+      const tierUser = await ctx.loaders.tierUserById.load(parent.id);
+      if (!tierUser || !canSeeWeather(tierUser)) return 0;
+      return prisma.ride.count({
+        where: {
+          userId: parent.id,
+          garminActivityId: { not: null },
+          startLat: null,
         },
       });
     },

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -222,6 +222,18 @@ export const typeDefs = gql`
     remainingAfterBatch: Int!
   }
 
+  # Result of triggering a Garmin coordinate/weather repair backfill.
+  # status is one of:
+  #   STARTED         — a repair job was enqueued
+  #   ALREADY_RUNNING — a repair for this user is already in flight
+  #   NEEDS_RECONNECT — Garmin connected but lacks HISTORICAL_DATA_EXPORT scope
+  #   NOT_CONNECTED   — no active Garmin connection
+  #   NOTHING_TO_DO   — no Garmin rides are missing coordinates
+  type GarminWeatherBackfillResult {
+    status: String!
+    ridesToRepair: Int!
+  }
+
   # Server-side aggregation so dashboards don't have to pull a full list of
   # weather blobs just to count buckets. Returned for the authenticated user
   # only — the resolver enforces userId from context.
@@ -1051,6 +1063,9 @@ export const typeDefs = gql`
     createBillingPortalSession(platform: CheckoutPlatform): BillingPortalResult!
     selectBikeForDowngrade(bikeId: ID!): Bike!
     backfillWeatherForMyRides: BackfillWeatherResult!
+    # Re-import Garmin rides that are missing coordinates (and therefore weather)
+    # by re-triggering Garmin's backfill; throttled server-side via a queued job.
+    backfillGarminWeather: GarminWeatherBackfillResult!
     # Enable public sharing of a bike's history; returns the share URL.
     # Idempotent — re-enabling returns the existing link.
     enableBikeShare(bikeId: ID!): String!
@@ -1121,6 +1136,10 @@ export const typeDefs = gql`
     notifyOnRideUpload: Boolean!
     createdAt: String!
     ridesMissingWeather: Int!
+    # Count of the viewer's Garmin rides stored without coordinates (a past
+    # ingestion bug), which is why they have no weather. Drives the "re-import
+    # from Garmin" repair prompt. Pro-only (0 otherwise), mirroring weather.
+    garminRidesMissingCoords: Int!
     # Aggregated condition counts across the authenticated user's rides,
     # filtered by date/bike. Replaces client-side aggregation over the
     # rides list so dashboards don't have to pull full weather blobs.

--- a/apps/api/src/lib/garmin-coords.test.ts
+++ b/apps/api/src/lib/garmin-coords.test.ts
@@ -1,0 +1,72 @@
+import { extractGarminStartCoords } from './garmin-coords';
+
+describe('extractGarminStartCoords', () => {
+  it('reads Garmin\'s real Activity Summary field names (startingLatitudeInDegrees)', () => {
+    // Regression guard for the field-name bug: every Garmin ride was landing
+    // with null coords — and therefore no weather — because the code read
+    // `startLatitudeInDegrees` (no "ing"). Garmin actually sends "starting…".
+    expect(
+      extractGarminStartCoords({
+        startingLatitudeInDegrees: 48.7174,
+        startingLongitudeInDegrees: -122.3512,
+      })
+    ).toEqual({ lat: 48.7174, lng: -122.3512 });
+  });
+
+  it('accepts the singular "…Degree" casing seen in Garmin CSV exports', () => {
+    expect(
+      extractGarminStartCoords({
+        startingLatitudeInDegree: 48.7174,
+        startingLongitudeInDegree: -122.3512,
+      })
+    ).toEqual({ lat: 48.7174, lng: -122.3512 });
+  });
+
+  it('falls back to legacy/misspelled names without throwing', () => {
+    expect(
+      extractGarminStartCoords({
+        startLatitudeInDegrees: 1.5,
+        startLongitudeInDegrees: 2.5,
+      })
+    ).toEqual({ lat: 1.5, lng: 2.5 });
+    expect(
+      extractGarminStartCoords({ beginLatitude: 3.5, beginLongitude: 4.5 })
+    ).toEqual({ lat: 3.5, lng: 4.5 });
+  });
+
+  it('prefers the correct name when multiple are present', () => {
+    expect(
+      extractGarminStartCoords({
+        startingLatitudeInDegrees: 10,
+        startLatitudeInDegrees: 99,
+        startingLongitudeInDegrees: 20,
+        startLongitudeInDegrees: 99,
+      })
+    ).toEqual({ lat: 10, lng: 20 });
+  });
+
+  it('returns null for missing or non-finite coordinates', () => {
+    expect(extractGarminStartCoords({})).toEqual({ lat: null, lng: null });
+    expect(
+      extractGarminStartCoords({
+        startingLatitudeInDegrees: 'nope',
+        startingLongitudeInDegrees: NaN,
+      })
+    ).toEqual({ lat: null, lng: null });
+  });
+
+  it('allows a valid latitude even when longitude is missing (and vice versa)', () => {
+    expect(
+      extractGarminStartCoords({ startingLatitudeInDegrees: 48.7 })
+    ).toEqual({ lat: 48.7, lng: null });
+  });
+
+  it('treats 0 as a valid coordinate (equator/prime meridian), not missing', () => {
+    expect(
+      extractGarminStartCoords({
+        startingLatitudeInDegrees: 0,
+        startingLongitudeInDegrees: 0,
+      })
+    ).toEqual({ lat: 0, lng: 0 });
+  });
+});

--- a/apps/api/src/lib/garmin-coords.ts
+++ b/apps/api/src/lib/garmin-coords.ts
@@ -1,0 +1,37 @@
+// Garmin start-coordinate extraction.
+//
+// Garmin's Activity Summary carries the ride's start position under
+// `startingLatitudeInDegrees` / `startingLongitudeInDegrees` (see Garmin's
+// "Activity Summary Export Format"). An earlier version of the ingestion code
+// read `startLatitudeInDegrees` (missing the "ing") and the Strava-style
+// `beginLatitude` / `beginLongitude` — names Garmin never sends. With the
+// activity type's `[key: string]: unknown` index signature, those bad reads
+// compiled fine and silently produced `undefined` for every Garmin ride, so
+// coords were always null. That skipped both weather enrichment (the weather
+// worker bails on null coords) and reverse-geocoded location.
+//
+// We read the correct keys first and keep the legacy names as harmless
+// fallbacks. Garmin's docs spell the suffix inconsistently ("…Degrees" in the
+// JSON vs "…Degree" in the CSV export), so we accept both to avoid gambling on
+// the exact casing.
+
+const asFiniteNumber = (v: unknown): number | null =>
+  typeof v === 'number' && Number.isFinite(v) ? v : null;
+
+export type GarminStartCoords = { lat: number | null; lng: number | null };
+
+export function extractGarminStartCoords(
+  activity: Record<string, unknown>
+): GarminStartCoords {
+  const lat =
+    asFiniteNumber(activity.startingLatitudeInDegrees) ??
+    asFiniteNumber(activity.startingLatitudeInDegree) ??
+    asFiniteNumber(activity.startLatitudeInDegrees) ??
+    asFiniteNumber(activity.beginLatitude);
+  const lng =
+    asFiniteNumber(activity.startingLongitudeInDegrees) ??
+    asFiniteNumber(activity.startingLongitudeInDegree) ??
+    asFiniteNumber(activity.startLongitudeInDegrees) ??
+    asFiniteNumber(activity.beginLongitude);
+  return { lat, lng };
+}

--- a/apps/api/src/lib/queue/backfill.queue.test.ts
+++ b/apps/api/src/lib/queue/backfill.queue.test.ts
@@ -11,12 +11,14 @@ jest.mock('./connection', () => ({
 // Create mock functions we can control per test
 const mockQueueAdd = jest.fn();
 const mockQueueClose = jest.fn().mockResolvedValue(undefined);
+const mockQueueGetJob = jest.fn();
 
 // Mock bullmq
 jest.mock('bullmq', () => ({
   Queue: jest.fn().mockImplementation(() => ({
     add: mockQueueAdd,
     close: mockQueueClose,
+    getJob: mockQueueGetJob,
   })),
 }));
 
@@ -32,8 +34,10 @@ jest.mock('../logger', () => ({
 import {
   buildBackfillJobId,
   buildCallbackJobId,
+  buildCoordRepairJobId,
   enqueueBackfillJob,
   enqueueCallbackJob,
+  enqueueGarminCoordRepairJob,
   getBackfillQueue,
   closeBackfillQueue,
 } from './backfill.queue';
@@ -215,6 +219,60 @@ describe('enqueueCallbackJob', () => {
     };
 
     await expect(enqueueCallbackJob(data)).rejects.toThrow('Queue unavailable');
+  });
+});
+
+describe('buildCoordRepairJobId', () => {
+  it('builds a per-user id (one repair in flight per user)', () => {
+    expect(buildCoordRepairJobId('user123')).toBe('repairGarminCoords_user123');
+    expect(buildCoordRepairJobId('user-abc')).not.toBe(buildCoordRepairJobId('user-xyz'));
+  });
+});
+
+describe('enqueueGarminCoordRepairJob', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    closeBackfillQueue();
+    mockQueueAdd.mockResolvedValue({});
+    mockQueueGetJob.mockResolvedValue(undefined); // no existing job by default
+  });
+
+  afterEach(async () => {
+    await closeBackfillQueue();
+  });
+
+  it('queues a garmin-provider job under the per-user id when none exists', async () => {
+    const result = await enqueueGarminCoordRepairJob({ userId: 'user123' });
+
+    expect(result).toEqual({ status: 'queued', jobId: 'repairGarminCoords_user123' });
+    expect(mockQueueAdd).toHaveBeenCalledWith(
+      'repairGarminCoords',
+      { userId: 'user123', provider: 'garmin' },
+      { jobId: 'repairGarminCoords_user123' }
+    );
+  });
+
+  it('reports already_queued when a prior repair is still active', async () => {
+    mockQueueGetJob.mockResolvedValue({ getState: jest.fn().mockResolvedValue('active') });
+
+    const result = await enqueueGarminCoordRepairJob({ userId: 'user123' });
+
+    expect(result.status).toBe('already_queued');
+    expect(mockQueueAdd).not.toHaveBeenCalled();
+  });
+
+  it('removes a completed prior job and re-queues so repair can run again', async () => {
+    const remove = jest.fn().mockResolvedValue(undefined);
+    mockQueueGetJob.mockResolvedValue({
+      getState: jest.fn().mockResolvedValue('completed'),
+      remove,
+    });
+
+    const result = await enqueueGarminCoordRepairJob({ userId: 'user123' });
+
+    expect(remove).toHaveBeenCalled();
+    expect(result.status).toBe('queued');
+    expect(mockQueueAdd).toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/lib/queue/backfill.queue.ts
+++ b/apps/api/src/lib/queue/backfill.queue.ts
@@ -16,7 +16,7 @@ const LOW_PRIORITY = 10; // Lower priority than sync jobs (which are 1)
 
 export type BackfillProvider = 'garmin' | 'suunto';
 
-export type BackfillJobName = 'backfillYear' | 'processCallback';
+export type BackfillJobName = 'backfillYear' | 'processCallback' | 'repairGarminCoords';
 
 export type BackfillJobData = {
   userId: string;
@@ -138,6 +138,45 @@ export async function enqueueCallbackJob(
 
     throw err;
   }
+}
+
+/**
+ * Build a deterministic job ID for a Garmin coord-repair backfill.
+ * One job per user → concurrent/repeated button clicks dedupe to a single
+ * in-flight repair.
+ */
+export function buildCoordRepairJobId(userId: string): string {
+  return `repairGarminCoords_${userId}`;
+}
+
+/**
+ * Enqueue a Garmin coordinate-repair backfill for a user. Idempotent by userId:
+ * while one repair is queued/running, further calls report `already_queued`
+ * instead of stacking duplicate work (and duplicate Garmin API load).
+ */
+export async function enqueueGarminCoordRepairJob(
+  data: { userId: string }
+): Promise<EnqueueBackfillResult> {
+  const queue = getBackfillQueue();
+  const jobId = buildCoordRepairJobId(data.userId);
+
+  // A prior repair that's still queued/active blocks a duplicate. But BullMQ
+  // retains completed/failed jobs (removeOnComplete), so re-check state and
+  // allow a fresh run once the previous one has finished — the user may have
+  // ridden more since, or the last run only partially recovered.
+  const existing = await queue.getJob(jobId);
+  if (existing) {
+    const state = await existing.getState();
+    if (state !== 'completed' && state !== 'failed' && state !== 'unknown') {
+      return { status: 'already_queued', jobId };
+    }
+    // Stale terminal job under this id — remove it so the id can be reused.
+    await existing.remove();
+  }
+
+  await queue.add('repairGarminCoords', { userId: data.userId, provider: 'garmin' }, { jobId });
+  logger.info({ jobId, userId: data.userId }, '[BackfillQueue] Enqueued Garmin coord-repair job');
+  return { status: 'queued', jobId };
 }
 
 /**

--- a/apps/api/src/lib/queue/index.ts
+++ b/apps/api/src/lib/queue/index.ts
@@ -2,7 +2,7 @@
 export { getSyncQueue, closeSyncQueue, enqueueSyncJob, buildSyncJobId } from './sync.queue';
 export type { SyncJobName, SyncJobData, SyncProvider, EnqueueSyncResult } from './sync.queue';
 
-export { getBackfillQueue, closeBackfillQueue, enqueueBackfillJob, buildBackfillJobId } from './backfill.queue';
+export { getBackfillQueue, closeBackfillQueue, enqueueBackfillJob, buildBackfillJobId, enqueueGarminCoordRepairJob, buildCoordRepairJobId } from './backfill.queue';
 export type { BackfillJobName, BackfillJobData, BackfillProvider, EnqueueBackfillResult } from './backfill.queue';
 
 export { getNotificationQueue, closeNotificationQueue, enqueueReceiptCheck } from './notification.queue';

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -122,6 +122,10 @@ export const MUTATION_RATE_LIMITS = {
    *  exists to stop a runaway client loop while still allowing legitimate
    *  "Fetch more" clicks to drain a large history over a few batches. */
   backfillWeatherForMyRides: { windowSeconds: 300, maxRequests: 3 },
+  /** backfillGarminWeather: max 3 requests per 5 minutes. Each call enqueues a
+   *  single throttled per-user job that fires Garmin backfill requests, so the
+   *  limit just stops a client loop from re-queuing needlessly. */
+  backfillGarminWeather: { windowSeconds: 300, maxRequests: 3 },
 } as const;
 
 /**

--- a/apps/api/src/routes/garmin.backfill.ts
+++ b/apps/api/src/routes/garmin.backfill.ts
@@ -6,6 +6,7 @@ import { sendBadRequest, sendUnauthorized, sendForbidden, sendNotFound, sendInte
 import { logError, logger } from '../lib/logger';
 import { enqueueBackfillJob } from '../lib/queue/backfill.queue';
 import { canBackfillYear } from '../auth/tier-access';
+import { triggerGarminBackfillChunks } from '../services/garmin-backfill';
 
 type Empty = Record<string, never>;
 const r: Router = createRouter();
@@ -140,108 +141,18 @@ r.get<Empty, void, Empty, { days?: string; year?: string }>(
 
       logger.info({ importSessionId: importSession.id }, 'Created import session for Garmin backfill');
 
-      // Garmin Wellness API: Use the async backfill endpoint
-      // This triggers Garmin to send activities via webhooks
-      const API_BASE = process.env.GARMIN_API_BASE || 'https://apis.garmin.com/wellness-api';
-
-      // Wellness API: Trigger backfill in 30-day chunks (API limit)
-      const CHUNK_DAYS = 30;
-      let currentStartDate = new Date(startDate);
-      let totalChunks = 0;
-      const errors: string[] = [];
-
+      // Garmin Wellness API: trigger the async backfill in 30-day chunks.
+      // Garmin re-delivers the activities via webhooks (activities-ping →
+      // processGarminCallback). This shared helper owns the chunk loop and the
+      // 202/409/400 handling; see services/garmin-backfill.ts.
       logger.debug('Triggering async Garmin backfill requests');
-
-      while (currentStartDate < endDate) {
-        // Calculate chunk end date (30 days from chunk start, or endDate if sooner)
-        const chunkEndDate = new Date(currentStartDate);
-        chunkEndDate.setDate(chunkEndDate.getDate() + CHUNK_DAYS);
-        const actualChunkEndDate = chunkEndDate > endDate ? endDate : chunkEndDate;
-
-        const chunkStartSeconds = Math.floor(currentStartDate.getTime() / 1000);
-        const chunkEndSeconds = Math.floor(actualChunkEndDate.getTime() / 1000);
-
-        logger.debug(
-          { chunkStart: currentStartDate.toISOString(), chunkEnd: actualChunkEndDate.toISOString() },
-          'Triggering Garmin backfill chunk'
-        );
-
-        const url = `${API_BASE}/rest/backfill/activities?summaryStartTimeInSeconds=${chunkStartSeconds}&summaryEndTimeInSeconds=${chunkEndSeconds}`;
-
-        // Track whether we should advance to the next chunk or retry with adjusted date
-        let advanceToNextChunk = true;
-
-        try {
-          const backfillRes = await fetch(url, {
-            headers: {
-              'Authorization': `Bearer ${accessToken}`,
-              'Accept': 'application/json',
-            },
-          });
-
-          if (backfillRes.status === 202) {
-            // 202 Accepted - backfill request accepted
-            logger.info({ chunk: totalChunks + 1 }, 'Garmin backfill request accepted');
-            totalChunks++;
-          } else if (backfillRes.status === 409) {
-            // 409 Conflict - duplicate request (already requested this time period)
-            // This means backfill was already done for this date range
-            logger.warn(
-              { startDate: currentStartDate.toISOString().split('T')[0] },
-              'Garmin backfill already completed for this time period'
-            );
-            errors.push(`Duplicate request for period ${currentStartDate.toISOString().split('T')[0]}`);
-          } else if (backfillRes.status === 400) {
-            const text = await backfillRes.text();
-            const minStartDate = extractMinStartDate(text);
-            if (minStartDate && minStartDate > currentStartDate) {
-              // Garmin rejected this chunk because it's before the minimum allowed date
-              // Adjust start date and retry (don't advance to next chunk)
-              logger.warn(
-                { originalStart: currentStartDate.toISOString(), adjustedStart: minStartDate.toISOString() },
-                'Garmin backfill chunk rejected, adjusting to minimum start date and retrying'
-              );
-              errors.push(
-                `Adjusted start date to ${minStartDate.toISOString()} due to Garmin min start restriction`
-              );
-              const alignedMinStart = new Date(Math.ceil(minStartDate.getTime() / 1000) * 1000);
-              currentStartDate = alignedMinStart;
-              advanceToNextChunk = false; // Retry with adjusted date
-            } else {
-              logger.error(
-                { status: backfillRes.status, response: text },
-                'Garmin backfill chunk failed'
-              );
-              errors.push(
-                `Failed for period ${currentStartDate.toISOString().split('T')[0]}: ${backfillRes.status}`
-              );
-            }
-          } else {
-            const text = await backfillRes.text();
-            logger.error(
-              { status: backfillRes.status, response: text },
-              'Garmin backfill chunk failed'
-            );
-            errors.push(`Failed for period ${currentStartDate.toISOString().split('T')[0]}: ${backfillRes.status}`);
-          }
-        } catch (error) {
-          logError('Garmin Backfill chunk', error);
-          errors.push(`Error for period ${currentStartDate.toISOString().split('T')[0]}`);
-        }
-
-        // Move to next chunk unless we're retrying with an adjusted date
-        // Start at the same timestamp the previous chunk ended (creates 1-second overlap,
-        // but Garmin deduplicates by activity ID)
-        if (advanceToNextChunk) {
-          currentStartDate = new Date(actualChunkEndDate);
-        }
-      }
+      const { totalChunks, errors, allDuplicates } = await triggerGarminBackfillChunks({
+        accessToken,
+        startDate,
+        endDate,
+      });
 
       logger.info({ totalChunks }, 'Garmin backfill requests triggered');
-
-      // Check if all requests were duplicates (backfill already in progress)
-      const duplicateErrors = errors.filter(e => e.includes('Duplicate request'));
-      const allDuplicates = duplicateErrors.length === errors.length && errors.length > 0;
 
       // Track backfill request in database (only for year-based requests)
       // Uses atomic conditional update to prevent race condition with webhook completion
@@ -588,29 +499,3 @@ r.get<Empty, void, Empty, Empty>(
 );
 
 export default r;
-
-/**
- * Extracts minimum start date from Garmin API 400 error response.
- * When a backfill request is too far in the past, Garmin returns an error like:
- * { errorMessage: "summaryStartTimeInSeconds must be greater than or equal to min start time of 2023-01-15T00:00:00Z" }
- *
- * @param errorText - Raw error text (JSON) from Garmin API
- * @returns Parsed minimum start Date, or null if not found/parseable
- */
-function extractMinStartDate(errorText: string): Date | null {
-  try {
-    const parsed = JSON.parse(errorText);
-    const message =
-      typeof parsed?.errorMessage === 'string' ? parsed.errorMessage : String(parsed ?? '');
-    const match = message.match(/min start time of ([0-9T:.-]+Z)/i);
-    if (match && match[1]) {
-      const dt = new Date(match[1]);
-      if (!Number.isNaN(dt.getTime())) {
-        return dt;
-      }
-    }
-  } catch {
-    // ignore JSON parse errors and fall through
-  }
-  return null;
-}

--- a/apps/api/src/routes/webhooks.suunto.test.ts
+++ b/apps/api/src/routes/webhooks.suunto.test.ts
@@ -38,6 +38,11 @@ jest.mock('../services/notification.service', () => ({
   fireRideNotifications: (...args: unknown[]) => mockFireRideNotifications(...args),
 }));
 
+const mockEnqueueWeatherJob = jest.fn();
+jest.mock('../lib/queue', () => ({
+  enqueueWeatherJob: (...args: unknown[]) => mockEnqueueWeatherJob(...args),
+}));
+
 jest.mock('../lib/logger', () => ({
   createLogger: () => ({
     info: jest.fn(),
@@ -103,6 +108,7 @@ describe('POST /webhooks/suunto/workouts', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsActiveSource.mockResolvedValue(true);
+    mockEnqueueWeatherJob.mockResolvedValue(undefined);
     mockSyncBikeComponentHours.mockResolvedValue([]);
     mockUserAccountFindUnique.mockResolvedValue({ userId: 'user-1' });
     mockRideFindUnique.mockResolvedValue(null); // new ride by default
@@ -179,6 +185,35 @@ describe('POST /webhooks/suunto/workouts', () => {
     expect(mockFireRideNotifications).toHaveBeenCalledWith(
       expect.objectContaining({ isNewRide: false, isBackfill: false })
     );
+  });
+
+  it('enqueues a weather job for a cycling ride that has start coordinates', async () => {
+    // Regression guard: this webhook is the real-time Suunto path, and it
+    // previously never enqueued weather — so Suunto rides got none despite
+    // having valid coords. startPosition is {x: lng, y: lat}.
+    const handler = getPostHandler('/workouts');
+    const req = makeRequest(
+      makeWorkoutPayload({ startPosition: { x: -122.3512, y: 48.7174 } })
+    );
+    const res = makeResponse();
+
+    await handler!(req as Request, res as Response);
+    await flushAsync();
+
+    expect(mockEnqueueWeatherJob).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueWeatherJob).toHaveBeenCalledWith({ rideId: 'ride-new-1' });
+  });
+
+  it('does not enqueue a weather job when the ride has no start coordinates', async () => {
+    // No startPosition → null coords → the weather worker would skip it anyway.
+    const handler = getPostHandler('/workouts');
+    const req = makeRequest(makeWorkoutPayload());
+    const res = makeResponse();
+
+    await handler!(req as Request, res as Response);
+    await flushAsync();
+
+    expect(mockEnqueueWeatherJob).not.toHaveBeenCalled();
   });
 
   it('does not fire notifications for non-cycling activities', async () => {

--- a/apps/api/src/routes/webhooks.suunto.ts
+++ b/apps/api/src/routes/webhooks.suunto.ts
@@ -7,6 +7,7 @@ import { isSuuntoCyclingActivity, getSuuntoRideType, isKnownSuuntoActivity } fro
 import { syncBikeComponentHours } from '../lib/component-hours';
 import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { fireRideNotifications } from '../services/notification.service';
+import { enqueueWeatherJob } from '../lib/queue';
 
 const log = createLogger('suunto-webhook');
 const r: Router = createRouter();
@@ -243,6 +244,17 @@ async function processWorkoutCreated(event: WorkoutCreatedEvent): Promise<void> 
 
   // Bust cached predictions for every bike whose hours changed.
   await invalidateBikePredictionsForBikes(userAccount.userId, affectedBikeIds);
+
+  // Fire-and-forget weather fetch. This webhook is the real-time Suunto
+  // ingestion path, so without this call Suunto rides never get weather even
+  // though the sync-worker and backfill paths enqueue it (see
+  // sync.worker.ts:upsertSuuntoActivity). Guarded on coords: the weather
+  // worker skips rides with null lat/lng anyway.
+  if (startLat != null && startLng != null) {
+    enqueueWeatherJob({ rideId: syncedRideId }).catch((err) =>
+      log.warn({ rideId: syncedRideId, err }, 'Failed to enqueue weather job (Suunto webhook)')
+    );
+  }
 
   // Fire-and-forget: send "Ride Synced" + bike-select prompt for new rides.
   // Mirrors the Strava webhook + Garmin/WHOOP sync-worker call sites so all

--- a/apps/api/src/services/garmin-backfill.test.ts
+++ b/apps/api/src/services/garmin-backfill.test.ts
@@ -1,0 +1,130 @@
+// Mock fetch + logger before importing the module under test.
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock('../lib/logger', () => ({
+  logError: jest.fn(),
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { triggerGarminBackfillChunks, extractMinStartDate } from './garmin-backfill';
+
+const ok202 = { status: 202, ok: true };
+
+describe('extractMinStartDate', () => {
+  it('parses Garmin\'s min-start error message', () => {
+    const dt = extractMinStartDate(
+      JSON.stringify({
+        errorMessage:
+          'summaryStartTimeInSeconds must be greater than or equal to min start time of 2023-01-15T00:00:00Z',
+      })
+    );
+    expect(dt?.toISOString()).toBe('2023-01-15T00:00:00.000Z');
+  });
+
+  it('returns null for unrelated or unparseable text', () => {
+    expect(extractMinStartDate('not json')).toBeNull();
+    expect(extractMinStartDate(JSON.stringify({ errorMessage: 'something else' }))).toBeNull();
+  });
+});
+
+describe('triggerGarminBackfillChunks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockResolvedValue(ok202);
+  });
+
+  it('chunks the range into 30-day windows and counts accepted chunks', async () => {
+    // 45 days → two chunks (30 + 15).
+    const startDate = new Date('2026-05-01T00:00:00Z');
+    const endDate = new Date('2026-06-15T00:00:00Z');
+
+    const result = await triggerGarminBackfillChunks({
+      accessToken: 'tok',
+      startDate,
+      endDate,
+      apiBase: 'https://garmin.test/wellness-api',
+    });
+
+    expect(result.totalChunks).toBe(2);
+    expect(result.allDuplicates).toBe(false);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // First chunk starts at startDate and requests via the backfill endpoint.
+    const firstUrl = mockFetch.mock.calls[0][0] as string;
+    expect(firstUrl).toContain('https://garmin.test/wellness-api/rest/backfill/activities');
+    expect(firstUrl).toContain(`summaryStartTimeInSeconds=${Math.floor(startDate.getTime() / 1000)}`);
+    // Auth header is passed through.
+    expect(mockFetch.mock.calls[0][1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: 'Bearer tok' }),
+    });
+  });
+
+  it('flags allDuplicates when every chunk returns 409', async () => {
+    mockFetch.mockResolvedValue({ status: 409, ok: false });
+
+    const result = await triggerGarminBackfillChunks({
+      accessToken: 'tok',
+      startDate: new Date('2026-05-01T00:00:00Z'),
+      endDate: new Date('2026-05-20T00:00:00Z'),
+    });
+
+    expect(result.totalChunks).toBe(0);
+    expect(result.allDuplicates).toBe(true);
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it('adjusts the start date and retries when Garmin reports a min start time', async () => {
+    const startDate = new Date('2020-01-01T00:00:00Z'); // too old
+    const endDate = new Date('2020-02-15T00:00:00Z');
+    mockFetch
+      .mockResolvedValueOnce({
+        status: 400,
+        ok: false,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              errorMessage:
+                'summaryStartTimeInSeconds must be greater than or equal to min start time of 2020-02-01T00:00:00Z',
+            })
+          ),
+      })
+      .mockResolvedValue(ok202);
+
+    const result = await triggerGarminBackfillChunks({ accessToken: 'tok', startDate, endDate });
+
+    // Retried from the adjusted min start rather than failing the whole range.
+    expect(mockFetch.mock.calls.length).toBeGreaterThan(1);
+    expect(result.totalChunks).toBeGreaterThanOrEqual(1);
+    expect(result.errors.some((e) => e.includes('Adjusted start date'))).toBe(true);
+  });
+
+  it('still fires every chunk when a per-chunk throttle delay is set', async () => {
+    // 45 days → 2 chunks; a real (short) delay is inserted between them.
+    const start = Date.now();
+    const result = await triggerGarminBackfillChunks({
+      accessToken: 'tok',
+      startDate: new Date('2026-05-01T00:00:00Z'),
+      endDate: new Date('2026-06-15T00:00:00Z'),
+      delayBetweenChunksMs: 20,
+    });
+
+    expect(result.totalChunks).toBe(2);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // One inter-chunk delay of ~20ms should have elapsed (allow scheduler slack).
+    expect(Date.now() - start).toBeGreaterThanOrEqual(15);
+  });
+
+  it('collects an error note for non-2xx chunk failures without throwing', async () => {
+    mockFetch.mockResolvedValue({ status: 500, ok: false, text: () => Promise.resolve('boom') });
+
+    const result = await triggerGarminBackfillChunks({
+      accessToken: 'tok',
+      startDate: new Date('2026-05-01T00:00:00Z'),
+      endDate: new Date('2026-05-10T00:00:00Z'),
+    });
+
+    expect(result.totalChunks).toBe(0);
+    expect(result.errors[0]).toContain('500');
+    expect(result.allDuplicates).toBe(false);
+  });
+});

--- a/apps/api/src/services/garmin-backfill.ts
+++ b/apps/api/src/services/garmin-backfill.ts
@@ -1,0 +1,165 @@
+// Shared Garmin backfill trigger.
+//
+// Garmin's Wellness API doesn't allow arbitrary re-reads of historical activity
+// data — the compliant way to re-fetch a date range is the async backfill
+// endpoint (`/rest/backfill/activities`). Garmin then re-delivers each activity
+// via the activities-ping webhook, which runs processGarminCallback. That
+// callback path upserts the ride (extracting coords via extractGarminStartCoords
+// and enqueueing weather), so a backfill is also how we repair already-imported
+// rides that are missing coordinates.
+//
+// This module owns the chunked-trigger loop shared by the user-facing backfill
+// route and the coord-repair maintenance script, so the 30-day chunking and
+// 202/409/400 handling live in exactly one place.
+import { logError, logger } from '../lib/logger';
+
+// Garmin's backfill endpoint accepts at most a 30-day window per request.
+const CHUNK_DAYS = 30;
+
+const resolveApiBase = (override?: string): string =>
+  override ?? process.env.GARMIN_API_BASE ?? 'https://apis.garmin.com/wellness-api';
+
+export type GarminBackfillTriggerResult = {
+  /** Chunks Garmin accepted (HTTP 202). */
+  totalChunks: number;
+  /** Human-readable notes for skipped/failed chunks (duplicates, errors). */
+  errors: string[];
+  /** True when every chunk was a 409 duplicate — the range was already backfilled. */
+  allDuplicates: boolean;
+};
+
+/**
+ * Extract the minimum start date from a Garmin 400 error. When a backfill
+ * request reaches too far into the past, Garmin replies with e.g.
+ * "summaryStartTimeInSeconds must be greater than or equal to min start time of
+ * 2023-01-15T00:00:00Z". We parse that so the caller can retry from the allowed
+ * boundary instead of failing the whole backfill.
+ */
+export function extractMinStartDate(errorText: string): Date | null {
+  try {
+    const parsed = JSON.parse(errorText);
+    const message =
+      typeof parsed?.errorMessage === 'string' ? parsed.errorMessage : String(parsed ?? '');
+    const match = message.match(/min start time of ([0-9T:.-]+Z)/i);
+    if (match && match[1]) {
+      const dt = new Date(match[1]);
+      if (!Number.isNaN(dt.getTime())) {
+        return dt;
+      }
+    }
+  } catch {
+    // ignore JSON parse errors and fall through
+  }
+  return null;
+}
+
+/**
+ * Trigger Garmin's async backfill for [startDate, endDate) in 30-day chunks.
+ * Fire-and-forget from Garmin's side: on success (202) the activities arrive
+ * later via webhooks. Never throws for per-chunk failures — they're collected
+ * in `errors` so the caller can decide how to surface them.
+ */
+export async function triggerGarminBackfillChunks(opts: {
+  accessToken: string;
+  startDate: Date;
+  endDate: Date;
+  apiBase?: string;
+  /**
+   * Delay inserted before every request after the first. Garmin rate-limits
+   * backfill per user (~100/min), so background callers (the coord-repair
+   * worker) pace themselves; the interactive route leaves this at 0.
+   */
+  delayBetweenChunksMs?: number;
+}): Promise<GarminBackfillTriggerResult> {
+  const apiBase = resolveApiBase(opts.apiBase);
+  const { accessToken, endDate } = opts;
+  const delayMs = opts.delayBetweenChunksMs ?? 0;
+
+  let currentStartDate = new Date(opts.startDate);
+  let totalChunks = 0;
+  let requestsMade = 0;
+  const errors: string[] = [];
+
+  while (currentStartDate < endDate) {
+    // Throttle: pause before each request after the first to stay under
+    // Garmin's per-user rate limit.
+    if (delayMs > 0 && requestsMade > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+
+    // Chunk end is 30 days out, clamped to the overall end date.
+    const chunkEndDate = new Date(currentStartDate);
+    chunkEndDate.setDate(chunkEndDate.getDate() + CHUNK_DAYS);
+    const actualChunkEndDate = chunkEndDate > endDate ? endDate : chunkEndDate;
+
+    const chunkStartSeconds = Math.floor(currentStartDate.getTime() / 1000);
+    const chunkEndSeconds = Math.floor(actualChunkEndDate.getTime() / 1000);
+
+    const url = `${apiBase}/rest/backfill/activities?summaryStartTimeInSeconds=${chunkStartSeconds}&summaryEndTimeInSeconds=${chunkEndSeconds}`;
+
+    // Advance to the next chunk unless a min-start rejection tells us to retry
+    // this chunk from an adjusted (later) start date.
+    let advanceToNextChunk = true;
+
+    try {
+      const backfillRes = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: 'application/json',
+        },
+      });
+
+      if (backfillRes.status === 202) {
+        logger.info({ chunk: totalChunks + 1 }, 'Garmin backfill request accepted');
+        totalChunks++;
+      } else if (backfillRes.status === 409) {
+        // Garmin already fulfilled this range; it won't re-send the activities.
+        logger.warn(
+          { startDate: currentStartDate.toISOString().split('T')[0] },
+          'Garmin backfill already completed for this time period'
+        );
+        errors.push(`Duplicate request for period ${currentStartDate.toISOString().split('T')[0]}`);
+      } else if (backfillRes.status === 400) {
+        const text = await backfillRes.text();
+        const minStartDate = extractMinStartDate(text);
+        if (minStartDate && minStartDate > currentStartDate) {
+          logger.warn(
+            { originalStart: currentStartDate.toISOString(), adjustedStart: minStartDate.toISOString() },
+            'Garmin backfill chunk rejected, adjusting to minimum start date and retrying'
+          );
+          errors.push(
+            `Adjusted start date to ${minStartDate.toISOString()} due to Garmin min start restriction`
+          );
+          const alignedMinStart = new Date(Math.ceil(minStartDate.getTime() / 1000) * 1000);
+          currentStartDate = alignedMinStart;
+          advanceToNextChunk = false; // Retry with the adjusted date
+        } else {
+          logger.error({ status: backfillRes.status, response: text }, 'Garmin backfill chunk failed');
+          errors.push(
+            `Failed for period ${currentStartDate.toISOString().split('T')[0]}: ${backfillRes.status}`
+          );
+        }
+      } else {
+        const text = await backfillRes.text();
+        logger.error({ status: backfillRes.status, response: text }, 'Garmin backfill chunk failed');
+        errors.push(`Failed for period ${currentStartDate.toISOString().split('T')[0]}: ${backfillRes.status}`);
+      }
+    } catch (error) {
+      logError('Garmin Backfill chunk', error);
+      errors.push(`Error for period ${currentStartDate.toISOString().split('T')[0]}`);
+    }
+
+    requestsMade++;
+
+    // Next chunk starts where this one ended (1-second overlap; Garmin dedupes
+    // by activity ID) unless we're retrying with an adjusted start date.
+    if (advanceToNextChunk) {
+      currentStartDate = new Date(actualChunkEndDate);
+    }
+  }
+
+  const duplicateErrors = errors.filter((e) => e.includes('Duplicate request'));
+  const allDuplicates = duplicateErrors.length === errors.length && errors.length > 0;
+
+  return { totalChunks, errors, allDuplicates };
+}

--- a/apps/api/src/workers/backfill.worker.test.ts
+++ b/apps/api/src/workers/backfill.worker.test.ts
@@ -28,6 +28,7 @@ jest.mock('../lib/prisma', () => {
       findUnique: jest.fn(),
       upsert: jest.fn(),
       create: jest.fn(),
+      aggregate: jest.fn(),
     },
     importSession: {
       findFirst: jest.fn(),
@@ -225,8 +226,9 @@ describe('processBackfillJob (via worker processor)', () => {
             distanceInMeters: 50000,
             totalElevationGainInMeters: 500,
             averageHeartRateInBeatsPerMinute: 145,
-            startLatitudeInDegrees: 37.7749,
-            startLongitudeInDegrees: -122.4194,
+            // Garmin's real Activity Summary field names (with "ing").
+            startingLatitudeInDegrees: 37.7749,
+            startingLongitudeInDegrees: -122.4194,
           },
         ]),
       } as Response);
@@ -258,6 +260,10 @@ describe('processBackfillJob (via worker processor)', () => {
             userId: 'user-123',
             garminActivityId: 'activity-123',
             rideType: 'cycling',
+            // Coords must be parsed from Garmin's "starting…" fields and
+            // persisted — without them the weather worker skips the ride.
+            startLat: 37.7749,
+            startLng: -122.4194,
           }),
         })
       );
@@ -531,6 +537,67 @@ describe('processBackfillJob (via worker processor)', () => {
       });
 
       expect(mockPrisma.importSession.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('repairGarminCoords job', () => {
+    const aggregate = () => mockPrisma.ride.aggregate as jest.Mock;
+
+    it('triggers a throttled Garmin backfill over the null-coord ride span', async () => {
+      aggregate().mockResolvedValue({
+        _count: { _all: 5 },
+        _min: { startTime: new Date('2026-05-01T00:00:00Z') },
+        _max: { startTime: new Date('2026-05-20T00:00:00Z') },
+      });
+      mockGetValidGarminToken.mockResolvedValue('valid-token');
+      (global.fetch as jest.Mock).mockResolvedValue({ status: 202, ok: true });
+
+      await processBackfillJob({
+        name: 'repairGarminCoords',
+        id: 'job-repair',
+        data: { userId: 'user-123', provider: 'garmin' },
+      });
+
+      // Hit Garmin's backfill endpoint for the affected span.
+      expect(global.fetch).toHaveBeenCalled();
+      const url = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      expect(url).toContain('/rest/backfill/activities');
+    });
+
+    it('does nothing when the user has no null-coord Garmin rides', async () => {
+      aggregate().mockResolvedValue({
+        _count: { _all: 0 },
+        _min: { startTime: null },
+        _max: { startTime: null },
+      });
+
+      await processBackfillJob({
+        name: 'repairGarminCoords',
+        id: 'job-repair',
+        data: { userId: 'user-123', provider: 'garmin' },
+      });
+
+      expect(mockGetValidGarminToken).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('skips (no throw) when the user has no valid Garmin token', async () => {
+      aggregate().mockResolvedValue({
+        _count: { _all: 3 },
+        _min: { startTime: new Date('2026-05-01T00:00:00Z') },
+        _max: { startTime: new Date('2026-05-10T00:00:00Z') },
+      });
+      mockGetValidGarminToken.mockResolvedValue(null);
+
+      await expect(
+        processBackfillJob({
+          name: 'repairGarminCoords',
+          id: 'job-repair',
+          data: { userId: 'user-123', provider: 'garmin' },
+        })
+      ).resolves.toBeUndefined();
+
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -7,10 +7,12 @@ import { prisma } from '../lib/prisma';
 import { getValidGarminToken } from '../lib/garmin-token';
 import { getValidSuuntoToken } from '../lib/suunto-token';
 import { deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
+import { extractGarminStartCoords } from '../lib/garmin-coords';
 import { logError, logger } from '../lib/logger';
 import { config } from '../config/env';
 import type { BackfillJobData, BackfillJobName } from '../lib/queue/backfill.queue';
 import { enqueueWeatherJob } from '../lib/queue';
+import { triggerGarminBackfillChunks } from '../services/garmin-backfill';
 import { captureServerEvent } from '../lib/posthog';
 import { incrementBikeComponentHours, syncBikeComponentHours } from '../lib/component-hours';
 import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
@@ -71,10 +73,10 @@ type GarminActivityDetail = {
   averageHeartRateInBeatsPerMinute?: number;
   maxHeartRateInBeatsPerMinute?: number;
   locationName?: string;
-  startLatitudeInDegrees?: number;
-  startLongitudeInDegrees?: number;
-  beginLatitude?: number;
-  beginLongitude?: number;
+  // Garmin's Activity Summary spells these with "ing"; coords are read via
+  // extractGarminStartCoords, which also tolerates legacy/misspelled variants.
+  startingLatitudeInDegrees?: number;
+  startingLongitudeInDegrees?: number;
   [key: string]: unknown;
 };
 
@@ -82,8 +84,79 @@ type GarminActivityDetail = {
  * Process a backfill job.
  * Handles both backfillYear (triggers Garmin API) and processCallback (processes callback URL).
  */
+// Throttle between Garmin backfill chunk requests to respect the per-user
+// ~100/min rate limit. A repair spans a few months → a handful of 30-day
+// chunks, so ~1s spacing stays well under the ceiling.
+const COORD_REPAIR_CHUNK_DELAY_MS = 1_000;
+
+/**
+ * Re-backfill a user's Garmin rides that are missing start coordinates.
+ *
+ * The ingestion field-name bug stored null lat/lng for Garmin rides (see
+ * lib/garmin-coords.ts), so they never got weather. Re-triggering Garmin's
+ * backfill over the span of the affected rides makes Garmin re-deliver them via
+ * webhooks; the now-fixed processGarminCallback re-upserts each with coords and
+ * enqueues weather. Best-effort: on a missing token or rate-limit exhaustion it
+ * logs and returns rather than throwing — the user can re-run from Settings.
+ */
+async function processGarminCoordRepair(userId: string): Promise<void> {
+  const agg = await prisma.ride.aggregate({
+    where: { userId, garminActivityId: { not: null }, startLat: null },
+    _count: { _all: true },
+    _min: { startTime: true },
+    _max: { startTime: true },
+  });
+
+  const count = agg._count._all;
+  const minStart = agg._min.startTime;
+  const maxStart = agg._max.startTime;
+
+  if (count === 0 || !minStart || !maxStart) {
+    logger.info({ userId }, '[BackfillWorker] No Garmin rides missing coords — nothing to repair');
+    return;
+  }
+
+  const accessToken = await getValidGarminToken(userId);
+  if (!accessToken) {
+    logger.warn({ userId }, '[BackfillWorker] Garmin coord-repair skipped: no valid token');
+    return;
+  }
+
+  // End one day past the last affected ride so its 30-day chunk is fully covered.
+  const startDate = minStart;
+  const endDate = new Date(maxStart.getTime() + 24 * 60 * 60 * 1000);
+
+  logger.info(
+    { userId, count, startDate: startDate.toISOString(), endDate: endDate.toISOString() },
+    '[BackfillWorker] Triggering Garmin coord-repair backfill'
+  );
+
+  const result = await triggerGarminBackfillChunks({
+    accessToken,
+    startDate,
+    endDate,
+    delayBetweenChunksMs: COORD_REPAIR_CHUNK_DELAY_MS,
+  });
+
+  logger.info(
+    {
+      userId,
+      totalChunks: result.totalChunks,
+      allDuplicates: result.allDuplicates,
+      errorCount: result.errors.length,
+    },
+    '[BackfillWorker] Garmin coord-repair backfill triggered'
+  );
+}
+
 async function processBackfillJob(job: Job<BackfillJobData, void, BackfillJobName>): Promise<void> {
   const { userId, provider, year, callbackURL } = job.data;
+
+  // Handle Garmin coord-repair job type
+  if (job.name === 'repairGarminCoords') {
+    await processGarminCoordRepair(userId);
+    return;
+  }
 
   // Handle processCallback job type
   if (job.name === 'processCallback' && callbackURL) {
@@ -644,12 +717,26 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
 
     const startTime = new Date(activity.startTimeInSeconds * 1000);
 
+    // Start coords drive both reverse-geocoded location and weather
+    // enrichment. Read them once (correct Garmin field names) and reuse below.
+    const { lat: startLat, lng: startLng } = extractGarminStartCoords(activity);
+    if (startLat == null || startLng == null) {
+      logger.warn(
+        {
+          event: 'garmin_missing_coords',
+          summaryId: activity.summaryId,
+          activityType: activity.activityType,
+        },
+        '[BackfillWorker] Garmin cycling activity has no start coordinates — weather will be skipped'
+      );
+    }
+
     const autoLocation = await deriveLocationAsync({
       city: activity.locationName ?? null,
       state: null,
       country: null,
-      lat: activity.startLatitudeInDegrees ?? activity.beginLatitude ?? null,
-      lon: activity.startLongitudeInDegrees ?? activity.beginLongitude ?? null,
+      lat: startLat,
+      lon: startLng,
     });
 
     const existingRide = await prisma.ride.findUnique({
@@ -661,9 +748,6 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
       existingRide?.location ?? null,
       autoLocation?.title ?? null
     );
-
-    const startLat = activity.startLatitudeInDegrees ?? activity.beginLatitude ?? null;
-    const startLng = activity.startLongitudeInDegrees ?? activity.beginLongitude ?? null;
 
     // Upsert the ride + sync component hours together so callback-delivered
     // rides match the behavior of webhook-delivered ones (see sync.worker.ts

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -9,6 +9,7 @@ import { getValidGarminToken } from '../lib/garmin-token';
 import { getValidWhoopToken } from '../lib/whoop-token';
 import { getValidSuuntoToken } from '../lib/suunto-token';
 import { deriveLocation, deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
+import { extractGarminStartCoords } from '../lib/garmin-coords';
 import { syncBikeComponentHours } from '../lib/component-hours';
 import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { logger } from '../lib/logger';
@@ -108,10 +109,10 @@ type GarminActivity = {
   averageHeartRateInBeatsPerMinute?: number;
   maxHeartRateInBeatsPerMinute?: number;
   locationName?: string;
-  startLatitudeInDegrees?: number;
-  startLongitudeInDegrees?: number;
-  beginLatitude?: number;
-  beginLongitude?: number;
+  // Garmin's Activity Summary spells these with "ing"; coords are read via
+  // extractGarminStartCoords, which also tolerates legacy/misspelled variants.
+  startingLatitudeInDegrees?: number;
+  startingLongitudeInDegrees?: number;
   [key: string]: unknown;
 };
 
@@ -555,13 +556,27 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
 
   const startTime = new Date(activity.startTimeInSeconds * 1000);
 
+  // Start coords drive both reverse-geocoded location and weather enrichment.
+  // Read them once here (correct Garmin field names) and reuse below.
+  const { lat: startLat, lng: startLng } = extractGarminStartCoords(activity);
+  if (startLat == null || startLng == null) {
+    logger.warn(
+      {
+        event: 'garmin_missing_coords',
+        summaryId: activity.summaryId,
+        activityType: activity.activityType,
+      },
+      '[SyncWorker] Garmin cycling activity has no start coordinates — weather will be skipped'
+    );
+  }
+
   // Use async version for reverse geocoding (matching webhook behavior)
   const autoLocation = await deriveLocationAsync({
     city: activity.locationName ?? null,
     state: null,
     country: null,
-    lat: activity.startLatitudeInDegrees ?? activity.beginLatitude ?? null,
-    lon: activity.startLongitudeInDegrees ?? activity.beginLongitude ?? null,
+    lat: startLat,
+    lon: startLng,
   });
 
   const existing = await prisma.ride.findUnique({
@@ -592,9 +607,6 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
     where: { userId, provider: 'garmin', status: 'running' },
     select: { id: true },
   });
-
-  const startLat = activity.startLatitudeInDegrees ?? activity.beginLatitude ?? null;
-  const startLng = activity.startLongitudeInDegrees ?? activity.beginLongitude ?? null;
 
   // Upsert ride first — this is the primary data, must not be lost
   const ride = await prisma.ride.upsert({

--- a/apps/web/src/components/GarminWeatherRepairSection.tsx
+++ b/apps/web/src/components/GarminWeatherRepairSection.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+import { useApolloClient, useMutation, useQuery } from '@apollo/client';
+import { useNavigate } from 'react-router-dom';
+import { Mountain, Lock } from 'lucide-react';
+import { useUserTier } from '../hooks/useUserTier';
+import {
+  BACKFILL_GARMIN_WEATHER,
+  GARMIN_RIDES_MISSING_COORDS,
+} from '../graphql/backfillGarminWeather';
+import { RIDES } from '../graphql/rides';
+
+const apiBase =
+  (import.meta.env.VITE_API_URL ?? '').replace(/\/$/, '') ||
+  (import.meta.env.DEV ? 'http://localhost:4000' : '');
+
+type BackfillStatus =
+  | 'STARTED'
+  | 'ALREADY_RUNNING'
+  | 'NEEDS_RECONNECT'
+  | 'NOT_CONNECTED'
+  | 'NOTHING_TO_DO';
+
+// Garmin rides imported before the coordinate fix have no location data, so
+// they never got weather. This prompt lets the user re-import them from Garmin
+// (server-side throttled); Garmin re-delivers the activities and weather fills
+// in as they process.
+export default function GarminWeatherRepairSection() {
+  const { isPro } = useUserTier();
+  const apolloClient = useApolloClient();
+  const navigate = useNavigate();
+  const { data } = useQuery<{ me: { id: string; garminRidesMissingCoords: number } | null }>(
+    GARMIN_RIDES_MISSING_COORDS,
+    { fetchPolicy: 'cache-and-network' }
+  );
+  const [status, setStatus] = useState<BackfillStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [backfill, { loading }] = useMutation(BACKFILL_GARMIN_WEATHER, {
+    refetchQueries: [{ query: GARMIN_RIDES_MISSING_COORDS }],
+  });
+
+  const missing = data?.me?.garminRidesMissingCoords ?? 0;
+
+  // Nothing to repair and nothing to report → render nothing.
+  if (missing === 0 && status === null) return null;
+
+  const onClick = async () => {
+    if (!isPro) {
+      navigate('/pricing');
+      return;
+    }
+    setError(null);
+    try {
+      const { data: res } = await backfill();
+      const next = (res?.backfillGarminWeather?.status ?? null) as BackfillStatus | null;
+      setStatus(next);
+      // Rides trickle back via Garmin webhooks; refetch the list a bit later so
+      // the new weather tiles show up without a manual reload.
+      if (next === 'STARTED' || next === 'ALREADY_RUNNING') {
+        setTimeout(() => {
+          apolloClient.refetchQueries({ include: [RIDES] }).catch(() => {});
+        }, 30_000);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    }
+  };
+
+  const inProgress = status === 'STARTED' || status === 'ALREADY_RUNNING';
+  const needsReconnect = status === 'NEEDS_RECONNECT';
+
+  const message = (() => {
+    switch (status) {
+      case 'STARTED':
+      case 'ALREADY_RUNNING':
+        return "Re-importing from Garmin. Weather will appear as your rides come back — this can take a few minutes.";
+      case 'NEEDS_RECONNECT':
+        return 'Reconnect Garmin to grant permission for importing historical data, then try again.';
+      case 'NOT_CONNECTED':
+        return 'Connect your Garmin account to import weather for past rides.';
+      case 'NOTHING_TO_DO':
+        return 'All your Garmin rides already have location data.';
+      default:
+        return `${missing} Garmin ride${missing === 1 ? '' : 's'} imported without location data, so ${missing === 1 ? 'it has' : 'they have'} no weather. Re-import from Garmin to fix.`;
+    }
+  })();
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-medium text-white">Garmin Weather</h3>
+      <div className="rounded-2xl border border-app/60 bg-surface-2 p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <Mountain className="h-5 w-5 text-muted" />
+            <div>
+              <p className="text-sm font-medium text-white">Weather for past Garmin rides</p>
+              <p className="text-xs text-muted">{message}</p>
+            </div>
+          </div>
+          {needsReconnect ? (
+            <a
+              href={`${apiBase}/auth/garmin/start`}
+              className="flex items-center gap-1.5 rounded-lg border border-[#11A9ED]/50 bg-[#11A9ED]/20 px-3 py-1.5 text-xs font-medium text-[#11A9ED] no-underline transition hover:bg-[#11A9ED]/30"
+            >
+              <Mountain className="h-3 w-3" />
+              Reconnect Garmin
+            </a>
+          ) : isPro ? (
+            <button
+              onClick={onClick}
+              disabled={loading || inProgress || status === 'NOTHING_TO_DO'}
+              className="flex items-center gap-1.5 rounded-lg border border-white/20 px-3 py-1.5 text-xs font-medium text-white/80 transition hover:bg-white/10 disabled:opacity-50"
+            >
+              {loading ? 'Starting…' : inProgress ? 'Importing…' : 'Re-import'}
+            </button>
+          ) : (
+            <button
+              onClick={onClick}
+              className="flex items-center gap-1.5 rounded-lg border border-mint/30 bg-mint/15 px-3 py-1.5 text-xs font-medium text-mint transition hover:bg-mint/25"
+            >
+              <Lock className="h-3 w-3" />
+              Pro feature
+            </button>
+          )}
+        </div>
+        {error && <p className="mt-2 text-sm text-red-400">{error}</p>}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/graphql/backfillGarminWeather.ts
+++ b/apps/web/src/graphql/backfillGarminWeather.ts
@@ -1,0 +1,23 @@
+import { gql } from '@apollo/client';
+
+// Count of the viewer's Garmin rides missing coordinates (and therefore
+// weather). Drives whether the repair prompt is shown.
+export const GARMIN_RIDES_MISSING_COORDS = gql`
+  query GarminRidesMissingCoords {
+    me {
+      id
+      garminRidesMissingCoords
+    }
+  }
+`;
+
+// Trigger a throttled, server-side re-import of those rides from Garmin.
+// status: STARTED | ALREADY_RUNNING | NEEDS_RECONNECT | NOT_CONNECTED | NOTHING_TO_DO
+export const BACKFILL_GARMIN_WEATHER = gql`
+  mutation BackfillGarminWeather {
+    backfillGarminWeather {
+      status
+      ridesToRepair
+    }
+  }
+`;

--- a/apps/web/src/pages/Settings/sections/DataSourcesSection.tsx
+++ b/apps/web/src/pages/Settings/sections/DataSourcesSection.tsx
@@ -15,6 +15,7 @@ import StravaBikeMappingOverlay from '../../../components/StravaBikeMappingOverl
 import DataSourceSelector from '../../../components/DataSourceSelector';
 import DuplicateRidesModal from '../../../components/DuplicateRidesModal';
 import WeatherBackfillSection from '../../../components/WeatherBackfillSection';
+import GarminWeatherRepairSection from '../../../components/GarminWeatherRepairSection';
 import { UNMAPPED_STRAVA_GEARS } from '../../../graphql/stravaGear';
 import { useUserTier } from '../../../hooks/useUserTier';
 import { getAuthHeaders } from '@/lib/csrf';
@@ -265,6 +266,8 @@ export default function DataSourcesSection() {
       )}
 
       <WeatherBackfillSection />
+
+      <GarminWeatherRepairSection />
 
       {(garminAccount || stravaAccount) && (
         <div className="panel-spaced">


### PR DESCRIPTION
## Problem

Weather was effectively appearing only on Strava rides. Diagnosing against production found **two distinct bugs**, not one:

- **Garmin (all rides, 100% null coords):** the ingestion code read `startLatitudeInDegrees` / `beginLatitude`, but Garmin sends `startingLatitudeInDegrees`. The activity type's `[key: string]: unknown` index signature hid it — every Garmin ride was stored without coordinates, so it never got weather or reverse-geocoded location.
- **Suunto (all rides, coords present but no weather):** the real-time webhook (`processWorkoutCreated`) upserted coordinates but never enqueued a weather job — only the sync-worker/backfill paths did.

WHOOP is intentionally left as-is (no GPS).

## Fixes

**Ingestion (new rides going forward)**
- Shared `extractGarminStartCoords` helper reading Garmin's real field name (tolerant of casing + legacy fallbacks), wired into both the real-time sync and the callback/backfill paths, with a `garmin_missing_coords` warning when a cycling activity still yields no coords.
- Suunto webhook now enqueues weather when coordinates are present.

**Historical repair (existing null-coord Garmin rides)**
- Extracted the Garmin backfill-trigger loop into a shared `triggerGarminBackfillChunks` service (with an optional per-chunk throttle) — the route and the new repair job share one implementation.
- Self-service **`backfillGarminWeather`** mutation: Pro + rate-limit gated, pre-flights the Garmin connection (`NEEDS_RECONNECT` when the account lacks `HISTORICAL_DATA_EXPORT`, plus `NOT_CONNECTED` / `NOTHING_TO_DO`), then enqueues an idempotent, per-user, throttled `repairGarminCoords` job. Garmin re-delivers the activities and the fixed callback repopulates coords + weather.
- New `garminRidesMissingCoords` count field and a **Data Sources settings section** (web) with a reconnect CTA.
- Admin maintenance script (`scripts/backfill-garmin-coords.ts`, dry-run by default) as an operator fallback.

## Notes / context learned in prod
- Garmin's app **is** approved for historical export; the 412s are **per-user** — users who connected before the scope was requested must reconnect (the mutation + UI handle this).
- Garmin's 100/min backfill limit is **per-user**, which is why the repair job throttles itself.

## Testing
- Typecheck (API + web) and lint clean.
- 100 passing tests across the touched suites, including new coverage for the coord helper, the throttle, queue idempotency, and the worker repair paths. Route refactor is behavior-preserving (existing route tests unchanged).

## Follow-up
- Mobile button (loam-logger-mobile, separate repo) — a UI-only port of `GarminWeatherRepairSection` reusing the same mutation + count query on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)