### PR TITLE
Fix Garmin weather backfill reconnect loop

### DIFF
--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -5809,22 +5809,20 @@ export const resolvers = {
         );
       }
 
-      // Garmin's backfill API requires the HISTORICAL_DATA_EXPORT scope. Users
-      // who connected before we requested it get a 412 from Garmin, so surface
-      // a reconnect prompt instead of silently enqueueing doomed work.
+      // Require a live Garmin connection. We intentionally do NOT gate on a
+      // HISTORICAL_DATA_EXPORT scope string: that permission is granted at the
+      // Garmin app level, not returned in the per-user OAuth token's `scope`,
+      // so the stored `scopes` never contains it. Checking for it produced a
+      // permanent false-positive reconnect loop. Historical export is enabled
+      // for the app, so we just attempt the backfill; a genuine per-user 412
+      // is handled best-effort in the worker.
       const integration = await prisma.userIntegration.findUnique({
         where: { userId_provider: { userId, provider: 'GARMIN' } },
-        select: { revokedAt: true, scopes: true },
+        select: { revokedAt: true },
       });
 
       if (!integration || integration.revokedAt) {
         return { status: 'NOT_CONNECTED', ridesToRepair: 0 };
-      }
-      // Only block when scopes are recorded AND clearly lack the permission.
-      // A null scopes string is unknown, not proof of absence — let the worker
-      // attempt it rather than false-positive a reconnect.
-      if (integration.scopes && !integration.scopes.includes('HISTORICAL_DATA_EXPORT')) {
-        return { status: 'NEEDS_RECONNECT', ridesToRepair: 0 };
       }
 
       const ridesToRepair = await prisma.ride.count({

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -226,9 +226,10 @@ export const typeDefs = gql`
   # status is one of:
   #   STARTED         — a repair job was enqueued
   #   ALREADY_RUNNING — a repair for this user is already in flight
-  #   NEEDS_RECONNECT — Garmin connected but lacks HISTORICAL_DATA_EXPORT scope
   #   NOT_CONNECTED   — no active Garmin connection
   #   NOTHING_TO_DO   — no Garmin rides are missing coordinates
+  # (NEEDS_RECONNECT is retained as a value for client compatibility but is no
+  #  longer returned — see the resolver for why the scope pre-flight was dropped.)
   type GarminWeatherBackfillResult {
     status: String!
     ridesToRepair: Int!


### PR DESCRIPTION
## Problem

Clicking **Re-import** in the Garmin weather section returned `NEEDS_RECONNECT` every time; reconnecting Garmin didn't help — an infinite loop.

## Cause

The `backfillGarminWeather` mutation gated on the stored Garmin `scopes` string containing `HISTORICAL_DATA_EXPORT`. But that permission is granted at the **Garmin app level** and is **not** returned in the per-user OAuth token's `scope` — so the stored scopes never contain it. The check always failed, and reconnecting just rewrote the same scope string, so the user could never get past it.

## Fix

Drop the scope-string pre-flight. The app is approved for historical export, so the mutation now just requires a live Garmin connection (`NOT_CONNECTED` otherwise) and enqueues the throttled repair job. A genuine per-user Garmin 412 is already handled best-effort in the worker (logs and returns). `NEEDS_RECONNECT` stays in the schema as a value for client compatibility but is no longer returned, so the existing web/mobile branches are harmless dead paths.

Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)