### PR TITLE
fix(brand): stop masking the Garmin Connect tile's corners

### DIFF
--- a/apps/web/src/components/attribution/GarminConnectMark.tsx
+++ b/apps/web/src/components/attribution/GarminConnectMark.tsx
@@ -38,9 +38,12 @@ export default function GarminConnectMark({
       aria-hidden="true"
       width={size}
       height={size}
-      // The tile ships with its own rounded-square shape; the radius here only
-      // matches it so it does not read as a raw square on our surfaces.
-      className={`rounded-[22%] ${className}`.trim()}
+      // No corner rounding. The tile ships with its own rounded corners already
+      // cut into the artwork as transparency, measured at 14.9% of its width.
+      // The rounded-[22%] that used to be here was LARGER than that, so rather
+      // than tracing the existing edge it clipped into Garmin's visible mark.
+      // The asset renders as a rounded square untouched.
+      className={className}
       style={{ width: size, height: size }}
     />
   );


### PR DESCRIPTION
Removes the `rounded-[22%]` applied to the Garmin Connect tile image.

Found by review on the mobile mirror ([loam-logger-mobile#50](https://github.com/ryanlecours/loam-logger-mobile/pull/50)), which carried the same treatment. Fixed in both.

## Why it is wrong

The tile already has its own rounded corners cut into the artwork as transparency. Measured from the asset:

```
first opaque px along top edge:  x=634 of 4267  (14.86% of width)
=> artwork corner radius ≈ 14.9%
=> mask applied              22%
```

A 22% radius is **larger** than the 14.9% shape it was meant to trace, so instead of following the existing edge it clips into Garmin's visible mark. My original comment claimed the radius "only matches" the artwork. It did not, and I never measured it.

Small in absolute pixels at the 20 to 32px sizes we render, but it is a modification of a partner's trademark on the exact surfaces Garmin's brand review inspects, in a component whose entire purpose is exact-guideline compliance. It also contradicted the component's own docstring ("never recolored, cropped, rotated or animated") and the unaltered-mark claim in the submission.

Removing the mask makes both statements true. The asset renders as a rounded square on its own.

## Verification

Corner geometry measured with sharp against the shipped PNG. Typecheck clean; the 11 attribution tests still pass.

Worth an eye on the Settings and onboarding connect rows before submission screenshots are captured, since this is a visual change, though the expected difference is the corners becoming slightly squarer and matching Garmin's own artwork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
