### PR TITLE
Fix Garmin ride maps and report real overdue hours

### DIFF
--- a/apps/api/src/lib/garmin-activity-details.test.ts
+++ b/apps/api/src/lib/garmin-activity-details.test.ts
@@ -1,0 +1,238 @@
+jest.mock('./logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  logError: jest.fn(),
+}));
+
+import { fetchGarminActivityDetails, flattenGarminActivity } from './garmin-activity-details';
+
+const API_BASE = 'https://garmin.test/wellness-api';
+const TOKEN = 'token-abc';
+const SUMMARY_ID = '9876543210';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+const ok = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+  text: async () => JSON.stringify(body),
+});
+
+const detailsFor = (summaryId: string, samples: unknown = [{ latitudeInDegree: 48.7 }]) => ({
+  summaryId,
+  activityType: 'MOUNTAIN_BIKING',
+  samples,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('flattenGarminActivity', () => {
+  // The two Garmin summary types are not the same shape. Ingest code reads the
+  // flat one, so a details payload arriving unflattened has an undefined
+  // activityType and throws on the first .toLowerCase().
+  it('lifts a nested summary onto the top level', () => {
+    const flat = flattenGarminActivity({
+      summaryId: SUMMARY_ID,
+      samples: [{ latitudeInDegree: 48.75 }],
+      summary: {
+        activityType: 'MOUNTAIN_BIKING',
+        startTimeInSeconds: 1706123456,
+        distanceInMeters: 8368,
+      },
+    });
+
+    expect(flat.activityType).toBe('MOUNTAIN_BIKING');
+    expect(flat.distanceInMeters).toBe(8368);
+    // The samples must survive the lift; they are the whole point.
+    expect(flat.samples).toEqual([{ latitudeInDegree: 48.75 }]);
+  });
+
+  // summaryId and userId are top-level identity and must not be shadowed by a
+  // same-named key inside the nested summary.
+  it('lets outer keys win over nested ones', () => {
+    const flat = flattenGarminActivity({
+      summaryId: 'outer',
+      summary: { summaryId: 'inner', activityType: 'ROAD_BIKING' },
+    });
+
+    expect(flat.summaryId).toBe('outer');
+    expect(flat.activityType).toBe('ROAD_BIKING');
+  });
+
+  it('passes an already-flat activities payload through untouched', () => {
+    const activity = { summaryId: SUMMARY_ID, activityType: 'MOUNTAIN_BIKING' };
+    expect(flattenGarminActivity(activity)).toEqual(activity);
+  });
+
+  it('ignores a summary that is not an object', () => {
+    const activity = { summaryId: SUMMARY_ID, summary: 'nonsense' };
+    expect(flattenGarminActivity(activity)).toEqual(activity);
+  });
+});
+
+describe('fetchGarminActivityDetails', () => {
+  describe('URL selection', () => {
+    // Garmin's ping already scoped the callbackURL to exactly the activities it
+    // is notifying about, so it needs no window arithmetic and cannot drift.
+    it('prefers the ping callbackURL when one was supplied', async () => {
+      mockFetch.mockResolvedValue(ok([detailsFor(SUMMARY_ID)]));
+
+      await fetchGarminActivityDetails({
+        accessToken: TOKEN,
+        summaryId: SUMMARY_ID,
+        callbackURL: 'https://garmin.test/callback/xyz',
+        uploadTimestampInSeconds: 1_700_000_000,
+        apiBase: API_BASE,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://garmin.test/callback/xyz',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: `Bearer ${TOKEN}` }),
+        })
+      );
+    });
+
+    it('falls back to an upload window on the activityDetails endpoint', async () => {
+      mockFetch.mockResolvedValue(ok([detailsFor(SUMMARY_ID)]));
+
+      await fetchGarminActivityDetails({
+        accessToken: TOKEN,
+        summaryId: SUMMARY_ID,
+        uploadTimestampInSeconds: 1_700_000_000,
+        apiBase: API_BASE,
+      });
+
+      const [url] = mockFetch.mock.calls[0];
+      // Details, never /rest/activities. The summary endpoint is what carried
+      // no samples and left every Garmin ride without a map.
+      expect(url).toContain('/rest/activityDetails');
+      expect(url).toContain('uploadStartTimeInSeconds=1699999940');
+      expect(url).toContain('uploadEndTimeInSeconds=1700000060');
+    });
+
+    // Fabricating a window with nothing to anchor it to is the unprompted pull
+    // the Connect Developer Program forbids.
+    it('declines to fetch when neither a callbackURL nor a timestamp is known', async () => {
+      const result = await fetchGarminActivityDetails({
+        accessToken: TOKEN,
+        summaryId: SUMMARY_ID,
+        apiBase: API_BASE,
+      });
+
+      expect(result).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('matching', () => {
+    it('returns the entry whose summaryId matches', async () => {
+      mockFetch.mockResolvedValue(
+        ok([detailsFor('1111111111'), detailsFor(SUMMARY_ID, [{ latitudeInDegree: 48.75 }])])
+      );
+
+      const result = await fetchGarminActivityDetails({
+        accessToken: TOKEN,
+        summaryId: SUMMARY_ID,
+        callbackURL: 'https://garmin.test/callback/xyz',
+      });
+
+      expect(result?.summaryId).toBe(SUMMARY_ID);
+      expect(result?.samples).toEqual([{ latitudeInDegree: 48.75 }]);
+    });
+
+    // Garmin suffixes the details id for some activity kinds.
+    it('matches a details id that carries a suffix', async () => {
+      mockFetch.mockResolvedValue(ok([detailsFor(`${SUMMARY_ID}-detail`)]));
+
+      const result = await fetchGarminActivityDetails({
+        accessToken: TOKEN,
+        summaryId: SUMMARY_ID,
+        callbackURL: 'https://garmin.test/callback/xyz',
+      });
+
+      expect(result?.summaryId).toBe(`${SUMMARY_ID}-detail`);
+    });
+
+    it('tolerates a bare object instead of an array', async () => {
+      mockFetch.mockResolvedValue(ok(detailsFor(SUMMARY_ID)));
+
+      const result = await fetchGarminActivityDetails({
+        accessToken: TOKEN,
+        summaryId: SUMMARY_ID,
+        callbackURL: 'https://garmin.test/callback/xyz',
+      });
+
+      expect(result?.summaryId).toBe(SUMMARY_ID);
+    });
+
+    // A window pull can legitimately return several activities. Attaching
+    // another ride's GPS to this one is far worse than showing no map.
+    it('returns null rather than guessing when nothing matches', async () => {
+      mockFetch.mockResolvedValue(ok([detailsFor('2222222222'), detailsFor('3333333333')]));
+
+      const result = await fetchGarminActivityDetails({
+        accessToken: TOKEN,
+        summaryId: SUMMARY_ID,
+        uploadTimestampInSeconds: 1_700_000_000,
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('failure handling', () => {
+    // By the time this runs the ride and its component hours are committed.
+    // Losing a track costs a map; throwing would cost the ride.
+    it('returns null on a non-ok response instead of throwing', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: async () => 'Forbidden',
+        json: async () => ({}),
+      });
+
+      await expect(
+        fetchGarminActivityDetails({
+          accessToken: TOKEN,
+          summaryId: SUMMARY_ID,
+          callbackURL: 'https://garmin.test/callback/xyz',
+        })
+      ).resolves.toBeNull();
+    });
+
+    it('returns null when the request throws', async () => {
+      mockFetch.mockRejectedValue(new Error('socket hang up'));
+
+      await expect(
+        fetchGarminActivityDetails({
+          accessToken: TOKEN,
+          summaryId: SUMMARY_ID,
+          callbackURL: 'https://garmin.test/callback/xyz',
+        })
+      ).resolves.toBeNull();
+    });
+
+    it('returns null when the body is not JSON', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new Error('Unexpected token');
+        },
+        text: async () => 'not json',
+      });
+
+      await expect(
+        fetchGarminActivityDetails({
+          accessToken: TOKEN,
+          summaryId: SUMMARY_ID,
+          callbackURL: 'https://garmin.test/callback/xyz',
+        })
+      ).resolves.toBeNull();
+    });
+  });
+});

--- a/apps/api/src/lib/garmin-activity-details.ts
+++ b/apps/api/src/lib/garmin-activity-details.ts
@@ -1,0 +1,175 @@
+import { logger } from './logger';
+
+/**
+ * Fetcher for Garmin's Activity Details, the only endpoint that carries GPS.
+ *
+ * Garmin splits one activity across two summary types. `/rest/activities`
+ * returns the Activity Summary: duration, distance, elevation, HR, device,
+ * start coords, and nothing per-point. The `samples[]` array with
+ * latitude/longitude/elevation per second lives only in Activity Details,
+ * `/rest/activityDetails`. Pulling the summary and looking for `samples` on it
+ * therefore always finds nothing, which is why Garmin rides had no map: the
+ * normalizer and the store were both correct and simply never fed.
+ *
+ * COMPLIANCE: the Connect Developer Program forbids *unprompted* pulls. Every
+ * call here is prompted. It happens in direct response to an activity ping,
+ * using the callbackURL Garmin sent us or the upload window that ping named.
+ * There is no polling path and no way to reach this from a user action.
+ * `callbackURL` is preferred whenever Garmin supplied one: it is already scoped
+ * to exactly the notified activities, so it needs no window arithmetic and
+ * cannot drift.
+ */
+
+const DEFAULT_API_BASE = 'https://apis.garmin.com/wellness-api';
+
+/**
+ * Widening applied on each side of a ping's `uploadTimestampInSeconds` when no
+ * callbackURL was supplied. Garmin filters this endpoint on UPLOAD time, not
+ * start time, and the ping's timestamp is the upload instant, so the window
+ * only has to absorb clock skew and the truncation to whole seconds rather
+ * than the length of the ride.
+ */
+const UPLOAD_WINDOW_PADDING_SECONDS = 60;
+
+/** One Activity Details entry. Only the fields we route on are named. */
+export type GarminActivityDetails = {
+  summaryId?: string;
+  activityId?: number | string;
+  /** Per-point array; normalized by lib/garmin-streams. Absent for indoor rides. */
+  samples?: unknown;
+  [key: string]: unknown;
+};
+
+/**
+ * Garmin appends a suffix to the details summaryId for some activity kinds
+ * (e.g. `12345678-detail`), so an exact match alone misses them. Comparing the
+ * leading id segment matches both spellings without matching a different
+ * activity, since the ids themselves are opaque and unique.
+ */
+function idsMatch(detailsId: string | undefined, summaryId: string): boolean {
+  if (!detailsId) return false;
+  if (detailsId === summaryId) return true;
+  return detailsId.split('-')[0] === summaryId.split('-')[0];
+}
+
+function buildWindowUrl(apiBase: string, uploadTimestampInSeconds: number): string {
+  const start = uploadTimestampInSeconds - UPLOAD_WINDOW_PADDING_SECONDS;
+  const end = uploadTimestampInSeconds + UPLOAD_WINDOW_PADDING_SECONDS;
+  return `${apiBase}/rest/activityDetails?uploadStartTimeInSeconds=${start}&uploadEndTimeInSeconds=${end}`;
+}
+
+/**
+ * Lift an Activity Details entry's nested `summary` onto the top level.
+ *
+ * The two summary types are NOT the same shape. `/rest/activities` returns the
+ * stats flat: `activityType`, `startTimeInSeconds`, `distanceInMeters` are all
+ * top-level keys. `/rest/activityDetails` nests exactly those fields under a
+ * `summary` object and puts `samples` beside it. Every consumer here was
+ * written against the flat shape, so a details payload reaching them reads
+ * `activity.activityType` as undefined and throws on the first `.toLowerCase()`.
+ *
+ * Flattening at the boundary means the ingest code stays shape-blind and one
+ * upsert path serves both summary and details callbacks. A flat payload passes
+ * through untouched, so this is safe to apply to any Garmin callback batch.
+ */
+export function flattenGarminActivity<T extends Record<string, unknown>>(activity: T): T {
+  const summary = activity.summary;
+  if (!summary || typeof summary !== 'object' || Array.isArray(summary)) return activity;
+  // Outer keys win: summaryId and userId live at the top level and must not be
+  // shadowed by anything of the same name inside the nested summary.
+  return { ...(summary as Record<string, unknown>), ...activity } as T;
+}
+
+/**
+ * Resolve the Activity Details entry for one activity, or null.
+ *
+ * Best-effort by contract, exactly like persistGarminStream downstream: by the
+ * time this runs the ride and its component hours are the primary data and are
+ * already safe. A details fetch that fails costs the rider a map; throwing here
+ * would cost them the ride. Every failure path logs and returns null.
+ *
+ * Returns null rather than guessing when nothing in the response matches the
+ * summaryId. A window pull can legitimately return several activities, and
+ * attaching another ride's GPS track to this one is far worse than no map.
+ */
+export async function fetchGarminActivityDetails(opts: {
+  accessToken: string;
+  summaryId: string;
+  /** From the ping, when Garmin supplied one. Preferred over the window. */
+  callbackURL?: string;
+  /** From the ping. Used to build a window when there is no callbackURL. */
+  uploadTimestampInSeconds?: number;
+  apiBase?: string;
+}): Promise<GarminActivityDetails | null> {
+  const apiBase = opts.apiBase ?? process.env.GARMIN_API_BASE ?? DEFAULT_API_BASE;
+
+  const url =
+    opts.callbackURL ??
+    (opts.uploadTimestampInSeconds != null
+      ? buildWindowUrl(apiBase, opts.uploadTimestampInSeconds)
+      : null);
+
+  // No callbackURL and no upload timestamp means nothing prompted this fetch.
+  // Inventing a window here would be exactly the unprompted pull the program
+  // rules forbid, so decline instead.
+  if (!url) {
+    logger.debug(
+      { summaryId: opts.summaryId },
+      '[GarminDetails] No callbackURL or upload timestamp; skipping details fetch'
+    );
+    return null;
+  }
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${opts.accessToken}`,
+        Accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      logger.warn(
+        {
+          event: 'garmin_details_fetch_failed',
+          summaryId: opts.summaryId,
+          status: response.status,
+          usedCallbackUrl: opts.callbackURL != null,
+          response: text.slice(0, 500),
+        },
+        '[GarminDetails] Activity Details fetch failed; ride keeps its stats, loses its map'
+      );
+      return null;
+    }
+
+    const body = (await response.json()) as GarminActivityDetails[] | GarminActivityDetails;
+    const entries = Array.isArray(body) ? body : [body];
+
+    const match = entries.find(
+      (entry) =>
+        idsMatch(entry.summaryId, opts.summaryId) ||
+        idsMatch(entry.activityId != null ? String(entry.activityId) : undefined, opts.summaryId)
+    );
+
+    if (!match) {
+      logger.info(
+        {
+          event: 'garmin_details_no_match',
+          summaryId: opts.summaryId,
+          returned: entries.length,
+        },
+        '[GarminDetails] No Activity Details entry matched this activity'
+      );
+      return null;
+    }
+
+    return match;
+  } catch (err) {
+    logger.warn(
+      { event: 'garmin_details_fetch_error', summaryId: opts.summaryId, err },
+      '[GarminDetails] Activity Details fetch threw; ride is unaffected'
+    );
+    return null;
+  }
+}

--- a/apps/api/src/lib/garmin-streams.ts
+++ b/apps/api/src/lib/garmin-streams.ts
@@ -4,14 +4,24 @@ import type { NormalizedStreams, RideStreamsResult } from './ride-streams';
 /**
  * Normalizer for Garmin Activity Details `samples[]`.
  *
- * Unlike Strava, this module makes NO network call. Garmin delivers samples in
- * the Activity Details payload we already receive through the PUSH/PING
- * pipeline, so there is nothing to fetch — and adding a pull path would work
- * against the Connect Developer Program's "PULL-ONLY requests not allowed"
- * requirement. If a Garmin ride has no samples, it simply has no track.
+ * This module makes NO network call: it is handed samples and returns arrays.
+ *
+ * Where those samples come from used to be misdescribed here, and the mistake
+ * cost every Garmin ride its map. The claim was that samples arrive with the
+ * activity through the PING pipeline, so there was nothing to fetch. They do
+ * not. An activityDetails PING carries only a notification: a summaryId and a
+ * callbackURL, and the worker was pulling `/rest/activities`, the Activity
+ * SUMMARY, which has no per-point data at all. So `samples` was always
+ * undefined, persistGarminStream always returned false, and every Garmin ride
+ * resolved to UNAVAILABLE.
+ *
+ * The pull now happens in ./garmin-activity-details, against
+ * `/rest/activityDetails`. That is not the "PULL-ONLY requests not allowed"
+ * case the Connect Developer Program forbids: it is prompted by Garmin's own
+ * ping and scoped by the callbackURL Garmin sent.
  *
  * See ./ride-streams for the shared output contract, and ./strava-streams for
- * the provider that does fetch.
+ * the other provider fetcher.
  */
 
 /**

--- a/apps/api/src/lib/queue/sync.queue.ts
+++ b/apps/api/src/lib/queue/sync.queue.ts
@@ -21,6 +21,16 @@ export type SyncJobData = {
   userId: string;
   provider: SyncProvider;
   activityId?: string; // For syncActivity jobs
+  /**
+   * Garmin only. The activityDetails callbackURL from the ping that triggered
+   * this job, forwarded so the worker can pull the GPS samples that the
+   * Activity Summary endpoint does not carry. Deliberately excluded from the
+   * job id (see buildSyncJobId): two pings for the same activity must still
+   * dedupe to one job.
+   */
+  detailsCallbackURL?: string;
+  /** Garmin only. Fallback for building a details window when no callbackURL came through. */
+  uploadTimestampInSeconds?: number;
 };
 
 let syncQueue: Queue<SyncJobData, void, SyncJobName> | null = null;

--- a/apps/api/src/lib/ride-stream-store.ts
+++ b/apps/api/src/lib/ride-stream-store.ts
@@ -58,10 +58,12 @@ export async function deleteRideStreamsForProvider(
  * Store the per-point track for a Garmin activity, if its payload carried
  * Activity Details samples.
  *
- * Unlike Strava there is nothing to fetch — Garmin pushes samples with the
- * activity, or the ride simply has no track. Adding a pull path here would
- * also work against the Connect Developer Program's "PULL-ONLY requests not
- * allowed" requirement.
+ * The caller is responsible for putting them there. Garmin's Activity Summary
+ * endpoint carries no per-point data, so `samples` only exists on this object
+ * once the sync worker has merged in a fetch from `/rest/activityDetails` (see
+ * lib/garmin-activity-details). A ride reaching here with no samples is an
+ * indoor/trainer ride, or one whose details fetch failed. Either way it has no
+ * track and that is not an error.
  *
  * Deliberately swallows its own errors. By the time this runs the ride and its
  * component hours are committed and Garmin will not resend the activity, so

--- a/apps/api/src/routes/garmin.backfill.ts
+++ b/apps/api/src/routes/garmin.backfill.ts
@@ -154,6 +154,28 @@ r.get<Empty, void, Empty, { days?: string; year?: string }>(
 
       logger.info({ totalChunks }, 'Garmin backfill requests triggered');
 
+      // Ask for the same range's Activity Details as well. Summaries carry no
+      // per-point data, so a history imported only as `activities` yields rides
+      // that can never draw a map. Deliberately not folded into the result
+      // above: this is the map, not the ride. If Garmin has not enabled the
+      // activityDetails scope for this app, or the range was already
+      // backfilled, the rides still import exactly as before and only the
+      // tracks are missing, which is the status quo, not a regression.
+      try {
+        const details = await triggerGarminBackfillChunks({
+          accessToken,
+          startDate,
+          endDate,
+          summaryType: 'activityDetails',
+        });
+        logger.info(
+          { totalChunks: details.totalChunks, errorCount: details.errors.length },
+          'Garmin activityDetails backfill requests triggered'
+        );
+      } catch (err) {
+        logger.warn({ err }, 'Garmin activityDetails backfill failed; rides import without tracks');
+      }
+
       // Track backfill request in database (only for year-based requests)
       // Uses atomic conditional update to prevent race condition with webhook completion
       const yearKey = req.query.year || null;

--- a/apps/api/src/routes/webhooks.garmin.test.ts
+++ b/apps/api/src/routes/webhooks.garmin.test.ts
@@ -487,7 +487,73 @@ describe('Garmin Webhooks', () => {
           userId: 'internal-user-123',
           provider: 'garmin',
           activityId: 'summary-456',
+          detailsCallbackURL: undefined,
+          uploadTimestampInSeconds: 1706123456,
         });
+      });
+
+      // The GPS samples that draw the ride map exist only on Garmin's
+      // activityDetails endpoint. Dropping the ping's pointers to it meant the
+      // worker re-pulled the summary, found no samples, and every Garmin ride
+      // came out with no track.
+      it('should forward the details callbackURL to the sync job', async () => {
+        (mockPrisma.userAccount.findUnique as jest.Mock).mockResolvedValue({
+          userId: 'internal-user-123',
+        });
+        mockEnqueueSyncJob.mockResolvedValue({ status: 'queued', jobId: 'job-1' });
+
+        await request(app)
+          .post('/webhooks/garmin/activities-ping')
+          .send({
+            activityDetails: [{
+              userId: 'garmin-user-123',
+              userAccessToken: 'token-xyz',
+              summaryId: 'summary-456',
+              uploadTimestampInSeconds: 1706123456,
+              callbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
+            }],
+          });
+
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(mockEnqueueSyncJob).toHaveBeenCalledWith('syncActivity', {
+          userId: 'internal-user-123',
+          provider: 'garmin',
+          activityId: 'summary-456',
+          detailsCallbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
+          uploadTimestampInSeconds: 1706123456,
+        });
+      });
+
+      // A backfill of activityDetails answers on this same key with a
+      // callbackURL covering a window and no single activity to name. Enqueuing
+      // a syncActivity job for it would produce one with no activityId, which
+      // the worker rejects.
+      it('should route a summaryId-less details callback to the callback queue', async () => {
+        (mockPrisma.userAccount.findUnique as jest.Mock).mockResolvedValue({
+          userId: 'internal-user-123',
+        });
+        mockEnqueueCallbackJob.mockResolvedValue({ status: 'queued', jobId: 'cb-1' });
+
+        const response = await request(app)
+          .post('/webhooks/garmin/activities-ping')
+          .send({
+            activityDetails: [{
+              userId: 'garmin-user-123',
+              userAccessToken: 'token-xyz',
+              callbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?window=1',
+            }],
+          });
+
+        expect(response.status).toBe(200);
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(mockEnqueueCallbackJob).toHaveBeenCalledWith({
+          userId: 'internal-user-123',
+          provider: 'garmin',
+          callbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?window=1',
+        });
+        expect(mockEnqueueSyncJob).not.toHaveBeenCalled();
       });
 
       it('should return 200 and skip unknown users', async () => {

--- a/apps/api/src/routes/webhooks.garmin.ts
+++ b/apps/api/src/routes/webhooks.garmin.ts
@@ -262,6 +262,15 @@ type GarminActivityPing = {
   userAccessToken: string;
   summaryId: string;
   uploadTimestampInSeconds: number;
+  /**
+   * Present when Garmin pings for the activityDetails summary type. Points at
+   * `/rest/activityDetails` already scoped to the notified activities, so it is
+   * the shortest route to the `samples[]` array that draws the ride map. This
+   * was being dropped on the floor, which is why Garmin rides had no track: the
+   * worker re-pulled the *summary* endpoint instead, and summaries carry no
+   * per-point data.
+   */
+  callbackURL?: string;
   [key: string]: unknown;
 };
 
@@ -428,7 +437,12 @@ r.post<Empty, void, GarminPingPayload>(
 
         // Fire-and-forget: Enqueue jobs for background processing
         const enqueuePromises = activityDetails.map(async (notification) => {
-          const { userId: garminUserId, summaryId } = notification;
+          const {
+            userId: garminUserId,
+            summaryId,
+            callbackURL,
+            uploadTimestampInSeconds,
+          } = notification;
 
           // Fast indexed lookup for internal userId
           const userAccount = await prisma.userAccount.findUnique({
@@ -456,11 +470,38 @@ r.post<Empty, void, GarminPingPayload>(
             return { status: 'skipped', summaryId, reason: 'inactive_source' };
           }
 
-          // Enqueue sync job with deterministic ID for deduplication
+          // A backfill of activityDetails answers on this same key, but with a
+          // callbackURL and no summaryId. There is no single activity to name
+          // because the URL covers a whole window. Route those to the callback
+          // processor, which fetches the batch and upserts each entry. Without
+          // this they would enqueue a syncActivity job with no activityId,
+          // which the worker rejects outright.
+          if (!summaryId && callbackURL) {
+            const callbackResult = await enqueueCallbackJob({
+              userId: userAccount.userId,
+              provider: 'garmin',
+              callbackURL,
+            });
+            logger.info({
+              event: 'garmin_details_callback_enqueued',
+              requestId,
+              jobId: callbackResult.jobId,
+              userId: userAccount.userId,
+              status: callbackResult.status,
+            }, '[Garmin PING] Enqueued activityDetails callback job');
+            return { status: callbackResult.status, jobId: callbackResult.jobId };
+          }
+
+          // Enqueue sync job with deterministic ID for deduplication.
+          // The details pointers ride along so the worker can pull the GPS
+          // samples that only /rest/activityDetails carries. They are not part
+          // of the job id, so dedup still keys on the activity alone.
           const result = await enqueueSyncJob('syncActivity', {
             userId: userAccount.userId,
             provider: 'garmin',
             activityId: summaryId,
+            detailsCallbackURL: callbackURL,
+            uploadTimestampInSeconds,
           });
 
           logger.info({

--- a/apps/api/src/services/advisor/summarize.ts
+++ b/apps/api/src/services/advisor/summarize.ts
@@ -13,7 +13,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { logError, logger } from '../../lib/logger';
-import type { BikePredictionSummary } from '../prediction/types';
+import type { BikePredictionSummary, ComponentPrediction } from '../prediction/types';
 
 export const DEFAULT_ADVISOR_MODEL = 'claude-haiku-4-5-20251001';
 const MAX_TOKENS = 300;
@@ -103,8 +103,32 @@ export async function generateSummary(
   // these user-typed fields — that would leak rider-chosen strings into a
   // surface the original data-flow disclosure didn't cover. The PostHog
   // event in the resolver deliberately logs only metrics, never text.
+  //
+  // The engine reports overdue components as NEGATIVE hoursRemaining so the
+  // apps can render real overdue magnitude. The sign is dropped here, at the
+  // payload boundary, rather than in the prompt: SUMMARY_SYSTEM_PROMPT is a
+  // verbatim copy of the Python eval harness's string and cannot drift without
+  // landing the same change there, and a raw -42.3 in the payload invites the
+  // model to write "-42 hours remaining". The prompt already asks for overdue
+  // phrasing, which it derives from hoursSinceService and serviceIntervalHours
+  // without needing the negative. If the magnitude is ever wanted in the prose,
+  // add a derived hoursOverdue field and land the prompt line in
+  // loam-agent-evals first.
+  const dropSign = (c: ComponentPrediction): ComponentPrediction => ({
+    ...c,
+    hoursRemaining: Math.max(0, c.hoursRemaining),
+  });
+  // priorityComponent is a second copy of one of the components above and is
+  // serialized alongside them, so it needs the same treatment.
+  const advisorPredictions: BikePredictionSummary = {
+    ...predictions,
+    components: predictions.components.map(dropSign),
+    priorityComponent: predictions.priorityComponent
+      ? dropSign(predictions.priorityComponent)
+      : null,
+  };
   const userContent =
-    'Bike predictions payload:\n\n' + JSON.stringify(predictions, null, 2);
+    'Bike predictions payload:\n\n' + JSON.stringify(advisorPredictions, null, 2);
 
   const start = Date.now();
   try {

--- a/apps/api/src/services/garmin-backfill.test.ts
+++ b/apps/api/src/services/garmin-backfill.test.ts
@@ -59,6 +59,36 @@ describe('triggerGarminBackfillChunks', () => {
     });
   });
 
+  // Activity Summaries carry no per-point data, so a history imported only as
+  // `activities` produces rides that can never draw a map. The GPS samples come
+  // back only from the activityDetails summary type.
+  it('requests the activityDetails summary type when asked', async () => {
+    await triggerGarminBackfillChunks({
+      accessToken: 'tok',
+      startDate: new Date('2026-05-01T00:00:00Z'),
+      endDate: new Date('2026-05-20T00:00:00Z'),
+      apiBase: 'https://garmin.test/wellness-api',
+      summaryType: 'activityDetails',
+    });
+
+    expect(mockFetch.mock.calls[0][0]).toContain(
+      'https://garmin.test/wellness-api/rest/backfill/activityDetails'
+    );
+  });
+
+  // Every existing caller (the interactive route, the coord-repair script)
+  // omits summaryType and must keep hitting the summaries endpoint.
+  it('defaults to the activities summary type', async () => {
+    await triggerGarminBackfillChunks({
+      accessToken: 'tok',
+      startDate: new Date('2026-05-01T00:00:00Z'),
+      endDate: new Date('2026-05-20T00:00:00Z'),
+      apiBase: 'https://garmin.test/wellness-api',
+    });
+
+    expect(mockFetch.mock.calls[0][0]).toContain('/rest/backfill/activities?');
+  });
+
   it('flags allDuplicates when every chunk returns 409', async () => {
     mockFetch.mockResolvedValue({ status: 409, ok: false });
 

--- a/apps/api/src/services/garmin-backfill.ts
+++ b/apps/api/src/services/garmin-backfill.ts
@@ -16,6 +16,18 @@ import { logError, logger } from '../lib/logger';
 // Garmin's backfill endpoint accepts at most a 30-day window per request.
 const CHUNK_DAYS = 30;
 
+/**
+ * Which Garmin summary type a backfill asks for.
+ *
+ * `activities` re-delivers Activity Summaries: stats, device, start coords. It
+ * is what repairs a ride's numbers.
+ *
+ * `activityDetails` re-delivers the same activities WITH their `samples[]`, the
+ * per-point GPS that draws the ride map. Summaries carry none, so a history
+ * backfilled only as `activities` produces rides that can never have a track.
+ */
+export type GarminBackfillSummaryType = 'activities' | 'activityDetails';
+
 const resolveApiBase = (override?: string): string =>
   override ?? process.env.GARMIN_API_BASE ?? 'https://apis.garmin.com/wellness-api';
 
@@ -70,8 +82,15 @@ export async function triggerGarminBackfillChunks(opts: {
    * worker) pace themselves; the interactive route leaves this at 0.
    */
   delayBetweenChunksMs?: number;
+  /**
+   * Defaults to `activities` so existing callers (the coord-repair script, the
+   * interactive route) keep their exact behavior. Pass `activityDetails` to
+   * request the same range's GPS samples.
+   */
+  summaryType?: GarminBackfillSummaryType;
 }): Promise<GarminBackfillTriggerResult> {
   const apiBase = resolveApiBase(opts.apiBase);
+  const summaryType = opts.summaryType ?? 'activities';
   const { accessToken, endDate } = opts;
   const delayMs = opts.delayBetweenChunksMs ?? 0;
 
@@ -95,7 +114,7 @@ export async function triggerGarminBackfillChunks(opts: {
     const chunkStartSeconds = Math.floor(currentStartDate.getTime() / 1000);
     const chunkEndSeconds = Math.floor(actualChunkEndDate.getTime() / 1000);
 
-    const url = `${apiBase}/rest/backfill/activities?summaryStartTimeInSeconds=${chunkStartSeconds}&summaryEndTimeInSeconds=${chunkEndSeconds}`;
+    const url = `${apiBase}/rest/backfill/${summaryType}?summaryStartTimeInSeconds=${chunkStartSeconds}&summaryEndTimeInSeconds=${chunkEndSeconds}`;
 
     // Advance to the next chunk unless a min-start rejection tells us to retry
     // this chunk from an adjusted (later) start date.
@@ -110,7 +129,7 @@ export async function triggerGarminBackfillChunks(opts: {
       });
 
       if (backfillRes.status === 202) {
-        logger.info({ chunk: totalChunks + 1 }, 'Garmin backfill request accepted');
+        logger.info({ chunk: totalChunks + 1, summaryType }, 'Garmin backfill request accepted');
         totalChunks++;
       } else if (backfillRes.status === 409) {
         // Garmin already fulfilled this range; it won't re-send the activities.

--- a/apps/api/src/services/notification.service.test.ts
+++ b/apps/api/src/services/notification.service.test.ts
@@ -254,6 +254,34 @@ describe('notification.service', () => {
       ]);
     });
 
+    // The engine reports overdue components as negative hours so the apps can
+    // show how far past due a part is. A push notification has no room to
+    // explain a minus sign, and "-12h left" reads as a bug.
+    it('should say overdue rather than negative hours left (HOURS_BEFORE mode)', async () => {
+      (mockPrisma.bikeNotificationPreference.findUnique as jest.Mock).mockResolvedValue({
+        serviceNotificationsEnabled: true,
+        serviceNotificationMode: 'HOURS_BEFORE',
+        serviceNotificationThreshold: 10,
+      });
+
+      const overduePredictions = [
+        { ...basePredictions[0], status: 'OVERDUE', hoursRemaining: -12 },
+      ];
+
+      await checkAndNotifyServiceDue({ ...baseParams, predictions: overduePredictions });
+
+      expect(mockSendPushNotificationsAsync).toHaveBeenCalledWith([
+        expect.objectContaining({
+          body: expect.stringContaining('overdue'),
+        }),
+      ]);
+      expect(mockSendPushNotificationsAsync).not.toHaveBeenCalledWith([
+        expect.objectContaining({
+          body: expect.stringContaining('-12'),
+        }),
+      ]);
+    });
+
     it('should only notify for DUE_NOW/OVERDUE in AT_SERVICE mode', async () => {
       (mockPrisma.bikeNotificationPreference.findUnique as jest.Mock).mockResolvedValue({
         serviceNotificationsEnabled: true,

--- a/apps/api/src/services/notification.service.ts
+++ b/apps/api/src/services/notification.service.ts
@@ -203,7 +203,12 @@ export async function checkAndNotifyServiceDue(params: {
       case 'RIDES_BEFORE':
         return `${c.ridesRemainingEstimate} rides left`;
       case 'HOURS_BEFORE':
-        return `${Math.round(c.hoursRemaining)}h left`;
+        // hoursRemaining goes negative once a component is past due, and
+        // "-42h left" is not a sentence. The magnitude belongs in the app,
+        // where the row can say "42h overdue"; a push notification only has to
+        // say the part needs attention. The trigger above is unaffected: it
+        // already fired at zero, so this only renames what was reaching it.
+        return c.hoursRemaining <= 0 ? 'overdue' : `${Math.round(c.hoursRemaining)}h left`;
       case 'AT_SERVICE':
         return c.status === 'OVERDUE' ? 'overdue' : 'due now';
     }

--- a/apps/api/src/services/prediction/__tests__/engine.test.ts
+++ b/apps/api/src/services/prediction/__tests__/engine.test.ts
@@ -119,7 +119,7 @@ describe('prediction engine', () => {
       expect(result.bikeId).toBe('bike-123');
       expect(result.bikeName).toBe('Trail Slayer');
       expect(result.components).toHaveLength(2);
-      expect(result.algoVersion).toBe('v2');
+      expect(result.algoVersion).toBe('v3');
     });
 
     it('should throw for unauthorized bike access', async () => {
@@ -338,6 +338,64 @@ describe('prediction engine', () => {
 
       // Fork should be priority (DUE_NOW with 2h remaining)
       expect(result.priorityComponent?.componentId).toBe('comp-2');
+    });
+
+    // While hoursRemaining was clamped at 0, every OVERDUE component tied and
+    // the reduce kept whichever it saw first, so the array order decided which
+    // part the advisor and the push notification led with. comp-1 is listed
+    // first here precisely so a regression to the clamp fails this test.
+    it('should pick the furthest past due among several overdue components', async () => {
+      // Both components share the same 90h of riding since service; only their
+      // intervals differ, so comp-1 lands at -10 and comp-2 at -40.
+      const components = [
+        {
+          id: 'comp-1',
+          type: 'CHAIN',
+          location: 'NONE',
+          brand: 'SRAM',
+          model: 'XX1',
+          hoursUsed: 90,
+          serviceDueAtHours: 80,
+        },
+        {
+          id: 'comp-2',
+          type: 'FORK',
+          location: 'NONE',
+          brand: 'Fox',
+          model: '36',
+          hoursUsed: 90,
+          serviceDueAtHours: 50,
+        },
+      ];
+
+      // hoursSinceService comes from ride duration, not from hoursUsed, so the
+      // overdue state has to be built out of real rides.
+      const rides: RideMetrics[] = Array.from({ length: 9 }, (_, i) => ({
+        durationSeconds: 10 * 3600,
+        distanceMeters: 16093,
+        elevationGainMeters: 457,
+        startTime: new Date(`2024-01-${String(15 - i).padStart(2, '0')}`),
+      }));
+
+      (prisma.bike.findUnique as jest.Mock).mockResolvedValue({
+        ...mockBike,
+        components,
+      });
+      (prisma.ride.findMany as jest.Mock).mockResolvedValue(rides);
+      (prisma.serviceLog.findFirst as jest.Mock).mockResolvedValue(null);
+      (prisma.serviceLog.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.ride.findFirst as jest.Mock).mockResolvedValue({
+        startTime: new Date('2023-12-01'),
+      });
+
+      const result = await generateBikePredictions({
+        userId: 'user-123',
+        bikeId: 'bike-123',
+        userRole: 'FREE',
+      });
+
+      expect(result.priorityComponent?.componentId).toBe('comp-2');
+      expect(result.priorityComponent?.hoursRemaining).toBe(-40);
     });
   });
 
@@ -798,7 +856,7 @@ describe('prediction engine', () => {
       });
 
       it('should return OVERDUE when hoursRemaining <= 0', async () => {
-        // 6h interval, 7h ridden => clamped to 0 => OVERDUE
+        // 6h interval, 7h ridden => -1 => OVERDUE
         setupSingleComponentTest(6, 7);
 
         const result = await generateBikePredictions({
@@ -808,7 +866,39 @@ describe('prediction engine', () => {
         });
 
         expect(result.components[0].status).toBe('OVERDUE');
-        expect(result.components[0].hoursRemaining).toBe(0);
+        expect(result.components[0].hoursRemaining).toBe(-1);
+      });
+
+      // The value used to be clamped to 0, which made every overdue component
+      // report the same "0h" no matter how far past due it was. Clients render
+      // this as `Math.abs(x)h overdue`, so the clamp collapsed a whole list of
+      // parts into one indistinguishable string. The magnitude is the signal.
+      it('should report how far past due a strongly overdue component is', async () => {
+        // 6h interval, 30h ridden => -24
+        setupSingleComponentTest(6, 30);
+
+        const result = await generateBikePredictions({
+          userId: 'user-123',
+          bikeId: 'bike-123',
+          userRole: 'FREE',
+        });
+
+        expect(result.components[0].status).toBe('OVERDUE');
+        expect(result.components[0].hoursRemaining).toBe(-24);
+      });
+
+      // Negative hours must not turn into a negative ride countdown. The guard
+      // in estimateRidesRemaining short-circuits before the division.
+      it('should not estimate negative rides remaining when overdue', async () => {
+        setupSingleComponentTest(6, 30);
+
+        const result = await generateBikePredictions({
+          userId: 'user-123',
+          bikeId: 'bike-123',
+          userRole: 'FREE',
+        });
+
+        expect(result.components[0].ridesRemainingEstimate).toBe(0);
       });
     });
 

--- a/apps/api/src/services/prediction/config.ts
+++ b/apps/api/src/services/prediction/config.ts
@@ -1,11 +1,16 @@
 import type { ComponentType, ComponentLocation } from '@prisma/client';
 import type { ComponentWearWeights } from './types';
 
-/** Algorithm version for cache keys. v2: the since-service window anchors
- * on component.installedAt when no service log exists (parity with the
- * canonical hoursUsed anchor in lib/component-hours.ts) — bumped so cached
- * v1 predictions computed with the old bike-level anchor can't linger. */
-export const ALGO_VERSION = 'v2';
+/** Algorithm version for cache keys. v3: hoursRemaining is no longer clamped
+ * at zero, so an overdue component reports how far past due it is instead of
+ * a flat 0. Bumped so cached v2 predictions computed with the clamp cannot
+ * linger and keep serving "0h overdue" after deploy.
+ *
+ * v2: the since-service window anchors on component.installedAt when no
+ * service log exists (parity with the canonical hoursUsed anchor in
+ * lib/component-hours.ts) — bumped so cached v1 predictions computed with the
+ * old bike-level anchor can't linger. */
+export const ALGO_VERSION = 'v3';
 
 /** Default cache TTL in seconds (30 minutes) */
 export const DEFAULT_CACHE_TTL_SECONDS = 30 * 60;

--- a/apps/api/src/services/prediction/engine.ts
+++ b/apps/api/src/services/prediction/engine.ts
@@ -282,10 +282,13 @@ function predictComponent(
     } else {
       hoursRemaining = wearRemaining / recentWearPerHour;
     }
-    hoursRemaining = Math.max(0, hoursRemaining);
+    // Deliberately unclamped. A negative value is the magnitude a component is
+    // PAST due, and every client renders it as `Math.abs(x)h overdue`. Clamping
+    // here is why ten consecutive overdue rows on the mobile dashboard all read
+    // "0h overdue": the sign was thrown away before it reached the string.
   } else {
     // FREE tier OR LOW confidence: Deterministic prediction using base intervals
-    hoursRemaining = Math.max(0, baseInterval - hoursSinceService);
+    hoursRemaining = baseInterval - hoursSinceService;
   }
 
   // Determine status
@@ -368,7 +371,12 @@ function findPriorityComponent(
     // More urgent status wins
     if (currentIndex < priorityIndex) return current;
 
-    // Same status: lower hours remaining wins
+    // Same status: lower hours remaining wins. For two OVERDUE components this
+    // now compares negatives, so the one furthest past due leads. While
+    // hoursRemaining was clamped, every OVERDUE peer tied at 0 and whichever
+    // was encountered first won, which is why the advisor and push
+    // notifications sometimes led with the least urgent of several overdue
+    // parts.
     if (currentIndex === priorityIndex && current.hoursRemaining < priority.hoursRemaining) {
       return current;
     }

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -9,6 +9,7 @@ import { getValidSuuntoToken } from '../lib/suunto-token';
 import { deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
 import { extractGarminStartCoords } from '../lib/garmin-coords';
 import { persistGarminStream } from '../lib/ride-stream-store';
+import { flattenGarminActivity } from '../lib/garmin-activity-details';
 import { logError, logger } from '../lib/logger';
 import { config } from '../config/env';
 import type { BackfillJobData, BackfillJobName } from '../lib/queue/backfill.queue';
@@ -59,11 +60,21 @@ const GARMIN_CYCLING_TYPES = [
   'indoor_handcycling',
 ];
 
-// Garmin activity type from callback URL response
+// Garmin activity from a callback URL response.
+//
+// Covers both summary types: an `activities` callback carries these fields
+// flat, while an `activityDetails` callback nests them under `summary` and adds
+// `samples`. flattenGarminActivity lifts the nested form onto this shape before
+// anything reads it, so `activityType` is optional only to describe a malformed
+// payload, not a normal one.
 type GarminActivityDetail = {
   summaryId: string;
   activityId?: number;
-  activityType: string;
+  activityType?: string;
+  /** Present on activityDetails payloads; the per-point GPS that draws the map. */
+  samples?: unknown;
+  /** Pre-flatten nesting. Never read directly; see flattenGarminActivity. */
+  summary?: Record<string, unknown>;
   activityName?: string;
   startTimeInSeconds: number;
   startTimeOffsetInSeconds?: number;
@@ -679,16 +690,22 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
     throw new Error(`Garmin callback fetch failed: ${callbackRes.status}`);
   }
 
-  const activities = (await callbackRes.json()) as GarminActivityDetail[];
+  const payload = (await callbackRes.json()) as GarminActivityDetail[];
 
-  if (!Array.isArray(activities)) {
+  if (!Array.isArray(payload)) {
     logger.error({
       event: 'garmin_callback_error',
       userId,
-      response: activities,
+      response: payload,
     }, '[BackfillWorker] Unexpected response format from callback URL');
     throw new Error('Unexpected response format from callback URL');
   }
+
+  // An activityDetails backfill answers through this same callback mechanism,
+  // but nests the stats under `summary` and adds the `samples` that draw the
+  // ride map. Flattening here lets the loop below read one shape; a plain
+  // activities callback passes through untouched.
+  const activities = payload.map(flattenGarminActivity);
 
   logger.info({
     event: 'garmin_callback_activities_fetched',
@@ -705,8 +722,12 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
   let processedActivityCount = 0;
 
   for (const activity of activities) {
-    const activityTypeLower = activity.activityType.toLowerCase().replace(/\s+/g, '_');
-    if (!GARMIN_CYCLING_TYPES.includes(activityTypeLower)) {
+    // A payload with no activityType even after flattening is malformed. Skip
+    // it rather than throwing: one bad entry must not abandon the rest of the
+    // batch, which is the rider's ride history.
+    const activityType = activity.activityType;
+    const activityTypeLower = activityType?.toLowerCase().replace(/\s+/g, '_') ?? '';
+    if (!activityType || !GARMIN_CYCLING_TYPES.includes(activityTypeLower)) {
       logger.debug({
         activityType: activity.activityType,
         summaryId: activity.summaryId,
@@ -770,7 +791,7 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
           distanceMeters,
           elevationGainMeters,
           averageHr: activity.averageHeartRateInBeatsPerMinute ?? null,
-          rideType: activity.activityType,
+          rideType: activityType,
           notes: activity.activityName ?? null,
           location: autoLocation?.title ?? null,
           importSessionId: runningSession?.id ?? null,
@@ -784,7 +805,7 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
           distanceMeters,
           elevationGainMeters,
           averageHr: activity.averageHeartRateInBeatsPerMinute ?? null,
-          rideType: activity.activityType,
+          rideType: activityType,
           notes: activity.activityName ?? null,
           // Only written when present, never cleared — see sync.worker.ts.
           ...(activity.deviceName ? { garminDeviceName: activity.deviceName } : {}),

--- a/apps/api/src/workers/sync.worker.test.ts
+++ b/apps/api/src/workers/sync.worker.test.ts
@@ -38,6 +38,8 @@ jest.mock('../lib/prisma', () => ({
     bike: { findMany: jest.fn() },
     ride: { findUnique: jest.fn(), upsert: jest.fn() },
     component: { updateMany: jest.fn() },
+    // The Garmin upsert path looks for a running import session to stamp.
+    importSession: { findFirst: jest.fn().mockResolvedValue(null), update: jest.fn() },
     $transaction: jest.fn(),
   },
 }));
@@ -48,6 +50,14 @@ jest.mock('../lib/strava-token', () => ({
 
 jest.mock('../lib/garmin-token', () => ({
   getValidGarminToken: jest.fn(),
+}));
+
+jest.mock('../lib/garmin-activity-details', () => ({
+  fetchGarminActivityDetails: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../lib/ride-stream-store', () => ({
+  persistGarminStream: jest.fn().mockResolvedValue(false),
 }));
 
 jest.mock('../lib/whoop-token', () => ({
@@ -68,6 +78,8 @@ jest.mock('../services/notification.service', () => ({
 
 jest.mock('../lib/location', () => ({
   deriveLocation: jest.fn().mockReturnValue('Derived Location'),
+  // The Garmin upsert path reverse-geocodes through the async variant.
+  deriveLocationAsync: jest.fn().mockResolvedValue('Derived Location'),
   shouldApplyAutoLocation: jest.fn().mockReturnValue(undefined),
 }));
 
@@ -87,6 +99,8 @@ import { acquireLock, releaseLock } from '../lib/rate-limit';
 import { prisma } from '../lib/prisma';
 import { getValidStravaToken } from '../lib/strava-token';
 import { getValidGarminToken } from '../lib/garmin-token';
+import { fetchGarminActivityDetails } from '../lib/garmin-activity-details';
+import { persistGarminStream } from '../lib/ride-stream-store';
 import { getValidWhoopToken } from '../lib/whoop-token';
 import { getValidSuuntoToken } from '../lib/suunto-token';
 
@@ -97,6 +111,12 @@ const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockGetValidStravaToken = getValidStravaToken as jest.MockedFunction<typeof getValidStravaToken>;
 const mockGetValidWhoopToken = getValidWhoopToken as jest.MockedFunction<typeof getValidWhoopToken>;
 const mockGetValidGarminToken = getValidGarminToken as jest.MockedFunction<typeof getValidGarminToken>;
+const mockFetchGarminActivityDetails = fetchGarminActivityDetails as jest.MockedFunction<
+  typeof fetchGarminActivityDetails
+>;
+const mockPersistGarminStream = persistGarminStream as jest.MockedFunction<
+  typeof persistGarminStream
+>;
 const mockGetValidSuuntoToken = getValidSuuntoToken as jest.MockedFunction<typeof getValidSuuntoToken>;
 const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
 
@@ -731,7 +751,129 @@ describe('processSyncJob (via worker processor)', () => {
     });
   });
 
+    /**
+     * Regression pins for the bug that left every Garmin ride without a map.
+     *
+     * `/rest/activities` is the Activity SUMMARY: stats, device, start coords,
+     * and no per-point data at all. GPS lives only in Activity Details. The
+     * worker pulled the summary and handed it straight to persistGarminStream,
+     * which looks for `samples`, so the check always failed, no RideStream was
+     * ever written, and rideTrack resolved UNAVAILABLE for every Garmin ride.
+     */
+    describe('Garmin activity details', () => {
+      const GARMIN_SUMMARY = {
+        summaryId: 'summary-456',
+        activityType: 'MOUNTAIN_BIKING',
+        startTimeInSeconds: 1706123456,
+        durationInSeconds: 5340,
+        distanceInMeters: 8368,
+        startingLatitudeInDegrees: 48.75,
+        startingLongitudeInDegrees: -122.48,
+      };
+
+      beforeEach(() => {
+        mockAcquireLock.mockResolvedValue({
+          acquired: true,
+          lockKey: 'lock:garmin:user123',
+          lockValue: 'value123',
+          redisAvailable: true,
+        });
+        mockGetValidGarminToken.mockResolvedValue('valid-garmin-token');
+        // Fresh copy per call: the worker merges samples onto the object it
+        // parsed, and handing back one shared literal would let one test's
+        // merge leak into the next.
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ ...GARMIN_SUMMARY }),
+        } as Response);
+        (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([]);
+        (mockPrisma.ride.findUnique as jest.Mock).mockResolvedValue(null);
+        (mockPrisma.ride.upsert as jest.Mock).mockResolvedValue({
+          id: 'ride-1',
+          bikeId: null,
+          durationSeconds: 5340,
+        });
+      });
+
+      it('fetches Activity Details using the callbackURL from the ping', async () => {
+        await processSyncJob({
+          name: 'syncActivity',
+          data: {
+            userId: 'user123',
+            provider: 'garmin',
+            activityId: 'summary-456',
+            detailsCallbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
+            uploadTimestampInSeconds: 1706123456,
+          },
+        });
+
+        expect(mockFetchGarminActivityDetails).toHaveBeenCalledWith(
+          expect.objectContaining({
+            accessToken: 'valid-garmin-token',
+            summaryId: 'summary-456',
+            callbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
+          })
+        );
+      });
+
+      it('merges the fetched samples onto the activity so the stream can be stored', async () => {
+        const samples = [{ latitudeInDegree: 48.75, longitudeInDegree: -122.48 }];
+        mockFetchGarminActivityDetails.mockResolvedValueOnce({
+          summaryId: 'summary-456',
+          samples,
+        });
+
+        await processSyncJob({
+          name: 'syncActivity',
+          data: {
+            userId: 'user123',
+            provider: 'garmin',
+            activityId: 'summary-456',
+            detailsCallbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
+          },
+        });
+
+        expect(mockPersistGarminStream).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ samples })
+        );
+      });
+
+      // Indoor and trainer rides genuinely have no GPS. The ride still imports;
+      // it just has no track.
+      it('still upserts the ride when no details are available', async () => {
+        mockFetchGarminActivityDetails.mockResolvedValueOnce(null);
+
+        await processSyncJob({
+          name: 'syncActivity',
+          data: {
+            userId: 'user123',
+            provider: 'garmin',
+            activityId: 'summary-456',
+            detailsCallbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
+          },
+        });
+
+        expect(mockPersistGarminStream).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.not.objectContaining({ samples: expect.anything() })
+        );
+      });
+
+      // Nothing prompted a details pull, so making one would be exactly the
+      // unprompted request the Connect Developer Program forbids.
+      it('does not fetch details when the job carries no pointers', async () => {
+        await processSyncJob({
+          name: 'syncActivity',
+          data: { userId: 'user123', provider: 'garmin', activityId: 'summary-456' },
+        });
+
+        expect(mockFetchGarminActivityDetails).not.toHaveBeenCalled();
+      });
+    });
+
   describe('unknown job type', () => {
+
     it('should throw for unknown job type', async () => {
       mockAcquireLock.mockResolvedValue({
         acquired: true,

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -11,6 +11,7 @@ import { getValidSuuntoToken } from '../lib/suunto-token';
 import { deriveLocation, deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
 import { extractGarminStartCoords } from '../lib/garmin-coords';
 import { persistGarminStream } from '../lib/ride-stream-store';
+import { fetchGarminActivityDetails } from '../lib/garmin-activity-details';
 import { syncBikeComponentHours } from '../lib/component-hours';
 import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { logger } from '../lib/logger';
@@ -120,6 +121,10 @@ type GarminActivity = {
   // extractGarminStartCoords, which also tolerates legacy/misspelled variants.
   startingLatitudeInDegrees?: number;
   startingLongitudeInDegrees?: number;
+  // NOT returned by the summary endpoint. Merged in from Activity Details
+  // before the upsert, because persistGarminStream reads the track off this
+  // object. Absent for indoor/trainer rides, which genuinely have no GPS.
+  samples?: unknown;
   [key: string]: unknown;
 };
 
@@ -151,7 +156,10 @@ async function processSyncJob(job: Job<SyncJobData, void, SyncJobName>): Promise
         if (!job.data.activityId) {
           throw new Error('syncActivity requires activityId');
         }
-        await syncSingleActivity(userId, provider, job.data.activityId);
+        await syncSingleActivity(userId, provider, job.data.activityId, {
+          detailsCallbackURL: job.data.detailsCallbackURL,
+          uploadTimestampInSeconds: job.data.uploadTimestampInSeconds,
+        });
         break;
       default:
         throw new Error(`Unknown sync job type: ${jobName}`);
@@ -194,7 +202,9 @@ async function syncLatestActivities(userId: string, provider: SyncProvider): Pro
 async function syncSingleActivity(
   userId: string,
   provider: SyncProvider,
-  activityId: string
+  activityId: string,
+  /** Garmin-only pointers to the Activity Details payload; see GarminDetailsHint. */
+  garminDetails?: GarminDetailsHint
 ): Promise<void> {
   logger.info({ activityId, provider }, '[SyncWorker] Syncing single activity');
 
@@ -203,7 +213,7 @@ async function syncSingleActivity(
       await syncStravaActivity(userId, activityId);
       break;
     case 'garmin':
-      await syncGarminActivity(userId, activityId);
+      await syncGarminActivity(userId, activityId, garminDetails);
       break;
     case 'whoop':
       await syncWhoopActivity(userId, activityId);
@@ -483,7 +493,22 @@ async function syncGarminLatest(userId: string): Promise<void> {
   logger.info({ userId, count: cyclingActivities.length }, '[SyncWorker] Garmin sync complete');
 }
 
-async function syncGarminActivity(userId: string, activityId: string): Promise<void> {
+/**
+ * What the activityDetails ping told us about where to find this activity's
+ * GPS samples. Both fields are optional: an older queued job, or a ping shaped
+ * differently than expected, simply yields a ride with no track rather than a
+ * failure.
+ */
+type GarminDetailsHint = {
+  detailsCallbackURL?: string;
+  uploadTimestampInSeconds?: number;
+};
+
+async function syncGarminActivity(
+  userId: string,
+  activityId: string,
+  details?: GarminDetailsHint
+): Promise<void> {
   logger.info({
     event: 'garmin_pull_start',
     userId,
@@ -534,6 +559,24 @@ async function syncGarminActivity(userId: string, activityId: string): Promise<v
         activityType: activity.activityType,
       }, '[SyncWorker] Skipping non-cycling activity');
       return;
+    }
+
+    // The endpoint above is the Activity SUMMARY: stats, device, start coords,
+    // and no per-point data whatsoever. GPS lives only in Activity Details, so
+    // the samples have to be pulled separately and merged in before the ride is
+    // upserted, because persistGarminStream reads them off this same object. Skipped
+    // for non-cycling activities above, since we would only discard the result.
+    if (details?.detailsCallbackURL || details?.uploadTimestampInSeconds != null) {
+      const detailsPayload = await fetchGarminActivityDetails({
+        accessToken,
+        summaryId: activity.summaryId,
+        callbackURL: details.detailsCallbackURL,
+        uploadTimestampInSeconds: details.uploadTimestampInSeconds,
+        apiBase: config.garminApiBase,
+      });
+      if (detailsPayload?.samples) {
+        activity.samples = detailsPayload.samples;
+      }
     }
 
     await upsertGarminActivity(userId, activity);

--- a/apps/web/src/components/dashboard/BikeSwitcherTile.tsx
+++ b/apps/web/src/components/dashboard/BikeSwitcherTile.tsx
@@ -50,7 +50,10 @@ export function BikeSwitcherTile({ bike, isSelected, onClick }: BikeSwitcherTile
         <span className="bike-tile-hours">
           {hoursDisplay === 'total' || priorityComp.hoursRemaining == null
             ? `${(priorityComp.hoursSinceService ?? 0).toFixed(1)}/${priorityComp.serviceIntervalHours}h`
-            : `${priorityComp.hoursRemaining.toFixed(1)} hrs`}
+            : /* Clamped: hoursRemaining is negative for a component past due,
+                 and the tile has no room to explain a minus sign. Overdue is
+                 already carried by bike-tile-status. */
+              `${Math.max(0, priorityComp.hoursRemaining).toFixed(1)} hrs`}
         </span>
       )}
       {advisorText && (

--- a/apps/web/src/components/dashboard/LogServiceModal.tsx
+++ b/apps/web/src/components/dashboard/LogServiceModal.tsx
@@ -166,7 +166,11 @@ export function LogServiceModal({
                   </span>
                   <span className="log-service-item-hours">
                     {component.hoursRemaining != null
-                      ? `${component.hoursRemaining.toFixed(1)} hrs`
+                      ? /* Clamped: hoursRemaining is negative for a component
+                           past due. This is a pick-list for logging service, so
+                           the row only has to identify the part; its status is
+                           carried by the StatusDot above. */
+                        `${Math.max(0, component.hoursRemaining).toFixed(1)} hrs`
                       : `${component.hoursSinceService.toFixed(1)}h since service`}
                   </span>
                 </div>

--- a/apps/web/src/components/dashboard/MiniComponentList.tsx
+++ b/apps/web/src/components/dashboard/MiniComponentList.tsx
@@ -34,7 +34,11 @@ export function MiniComponentList({ components, className = '' }: MiniComponentL
           <span className="mini-component-hours">
             {hoursDisplay === 'total' || component.hoursRemaining == null
               ? `${component.hoursSinceService.toFixed(1)}/${component.serviceIntervalHours}h`
-              : `${component.hoursRemaining.toFixed(1)} hrs`}
+              : /* Clamped: hoursRemaining goes negative once a component is past
+                   due, and "-42.0 hrs" reads as a rendering fault in a one-line
+                   tile. The overdue magnitude is carried by the status dot and
+                   by the total-mode string beside it. */
+                `${Math.max(0, component.hoursRemaining).toFixed(1)} hrs`}
           </span>
           <span className="mini-component-rides">
             {component.ridesRemainingEstimate != null

--- a/apps/web/src/components/dashboard/SortableBikeTile.test.tsx
+++ b/apps/web/src/components/dashboard/SortableBikeTile.test.tsx
@@ -184,6 +184,19 @@ describe('SortableBikeTile', () => {
       expect(screen.getByText('5.8 hrs')).toBeInTheDocument();
     });
 
+    // The engine reports overdue components as negative hours. The tile has no
+    // room to explain a minus sign, so it floors at zero and lets the status
+    // dot carry the overdue state.
+    it('clamps negative hours remaining to zero', () => {
+      const bike = createBike({
+        predictions: createPrediction('OVERDUE', -42.3),
+      });
+      render(<SortableBikeTile {...defaultProps} bike={bike} />);
+
+      expect(screen.getByText('0.0 hrs')).toBeInTheDocument();
+      expect(screen.queryByText(/-42/)).not.toBeInTheDocument();
+    });
+
     it('hides hours when priorityComponent is null', () => {
       const bike = createBike({
         predictions: {

--- a/apps/web/src/components/dashboard/SortableBikeTile.tsx
+++ b/apps/web/src/components/dashboard/SortableBikeTile.tsx
@@ -69,7 +69,10 @@ export function SortableBikeTile({ bike, isSelected, onClick, disabled }: Sortab
         <span className="bike-tile-hours">
           {hoursDisplay === 'total' || priorityComp.hoursRemaining == null
             ? `${(priorityComp.hoursSinceService ?? 0).toFixed(1)}/${priorityComp.serviceIntervalHours}h`
-            : `${priorityComp.hoursRemaining.toFixed(1)} hrs`}
+            : /* Clamped: hoursRemaining is negative for a component past due,
+                 and the tile has no room to explain a minus sign. Overdue is
+                 already carried by bike-tile-status. */
+              `${Math.max(0, priorityComp.hoursRemaining).toFixed(1)} hrs`}
         </span>
       )}
     </button>


### PR DESCRIPTION
Two independent API fixes, both surfaced while reworking the mobile dashboard.

## 1. Garmin rides never had a map

Garmin splits an activity across two summary types. `/rest/activities` is the Activity Summary: stats, device, start coords, no per-point data. GPS lives only in `/rest/activityDetails`, as a `samples[]` array.

The `activityDetails` ping was read for `userId` and `summaryId`, the rest discarded. The worker then pulled the **summary** endpoint and handed that object to `persistGarminStream`, which looks for `samples`. That guard always failed, no `RideStream` row was ever written, and `ride-track.ts` classified every Garmin ride `UNAVAILABLE`. `RideTrackMap` renders `null` for anything that is not `AVAILABLE`, so the ride detail screen showed no map, no message, no explanation.

This was never specific to one ride. **No Garmin ride could ever have had a map.** The normalizer and the store were correct all along and simply never fed. A comment in `garmin-streams.ts` claimed samples arrive with the activity through the ping pipeline, which is what hid the gap; it is corrected here.

- New `lib/garmin-activity-details.ts` owns the fetch. Prefers Garmin's `callbackURL`, falls back to a ±60s upload window, returns `null` rather than guessing when nothing matches the summaryId.
- Every failure path returns `null`. By then the ride and its component hours are committed, so losing a track costs a map while throwing would cost the ride.
- Not the unprompted pull the Connect Developer Program forbids: it only runs in response to Garmin's own ping.
- Historical rides covered by requesting `activityDetails` alongside `activities` in the backfill.
- `flattenGarminActivity` handles the nested `summary` shape details payloads use, which would otherwise throw on `activityType.toLowerCase()`.

## 2. Every overdue component reported "0h overdue"

The engine clamped `hoursRemaining` at zero on both branches, so it was never negative, and clients render `Math.abs(hoursRemaining)h overdue`. The sign was thrown away before it reached the string.

- Clamp removed. `ALGO_VERSION` bumped to v3, which is **not optional**: it is baked into every prediction cache key, so without it warm Redis entries keep serving clamped values for 30 minutes after deploy.
- `findPriorityComponent` changes behavior. While every `OVERDUE` peer tied at 0 the reduce kept whichever it saw first, so array order decided which part the advisor and push notifications led with. It now picks the furthest past due. Correct, but it will look like an unrelated regression to anyone who did not read the commit.
- Four display sites floored: the `HOURS_BEFORE` push body says "overdue" rather than "-12h left", plus three web tiles and the log-service picker.
- The advisor payload is clamped at the boundary, not in the prompt, because that string is a verbatim copy of `loam-agent-evals/summarize_prompt.py`.

## Testing

1646 API tests pass (18 new), typecheck and lint clean. The 3 remaining lint warnings are pre-existing in untouched files.

**Not verified against Garmin's live API.** Two assumptions worth confirming before trusting the map fix end to end:

- That the ping actually carries `callbackURL`. The webhook already logs the full body at debug; grep for `[Garmin PING Webhook] Incoming request`. If absent, the window fallback covers it.
- That the Garmin app is approved for the `activityDetails` scope. If not, the fetch logs `garmin_details_fetch_failed` and rides import exactly as they do today. No regression, just still no map.

To repair existing rides: `GET /api/garmin/backfill/fetch?days=N`. The `days` form is not tracked in `BackfillRequest` so it re-runs freely, and `activityDetails` is a distinct summary type on Garmin's side so it should not 409 against an earlier `activities` backfill.

Pairs with the mobile dashboard PR in loam-logger-mobile, which is where the overdue hours become visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
