### PR TITLE
Answer Garmin pings with their callbackURL, not our own request

### DIFF
--- a/apps/api/src/lib/garmin-activity-details.test.ts
+++ b/apps/api/src/lib/garmin-activity-details.test.ts
@@ -96,6 +96,37 @@ describe('fetchGarminActivityFromCallback', () => {
     );
   });
 
+  // Defence in depth. The webhook already screens the URL, but this function
+  // attaches a live Garmin bearer token, so it must refuse on its own rather
+  // than trusting that every future caller screened its input.
+  it('refuses to send the token to a non-Garmin origin', async () => {
+    const result = await fetchGarminActivityFromCallback({
+      accessToken: TOKEN,
+      summaryId: SUMMARY_ID,
+      callbackURL: 'https://attacker.example/steal',
+    });
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // An allowed origin must not be able to bounce the request, and its token,
+  // somewhere else.
+  it('refuses to follow redirects', async () => {
+    mockFetch.mockResolvedValue(ok([entry(SUMMARY_ID)]));
+
+    await fetchGarminActivityFromCallback({
+      accessToken: TOKEN,
+      summaryId: SUMMARY_ID,
+      callbackURL: CALLBACK_URL,
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      CALLBACK_URL,
+      expect.objectContaining({ redirect: 'error' })
+    );
+  });
+
   it('returns the entry whose summaryId matches', async () => {
     mockFetch.mockResolvedValue(
       ok([entry('1111111111'), entry(SUMMARY_ID, [{ latitudeInDegree: 48.75 }])])

--- a/apps/api/src/lib/garmin-activity-details.test.ts
+++ b/apps/api/src/lib/garmin-activity-details.test.ts
@@ -3,11 +3,12 @@ jest.mock('./logger', () => ({
   logError: jest.fn(),
 }));
 
-import { fetchGarminActivityDetails, flattenGarminActivity } from './garmin-activity-details';
+import { fetchGarminActivityFromCallback, flattenGarminActivity } from './garmin-activity-details';
 
-const API_BASE = 'https://garmin.test/wellness-api';
 const TOKEN = 'token-abc';
 const SUMMARY_ID = '9876543210';
+const CALLBACK_URL =
+  'https://apis.garmin.com/wellness-api/rest/activityDetails?uploadStartTimeInSeconds=1&uploadEndTimeInSeconds=2';
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch as unknown as typeof fetch;
@@ -19,7 +20,7 @@ const ok = (body: unknown) => ({
   text: async () => JSON.stringify(body),
 });
 
-const detailsFor = (summaryId: string, samples: unknown = [{ latitudeInDegree: 48.7 }]) => ({
+const entry = (summaryId: string, samples: unknown = [{ latitudeInDegree: 48.7 }]) => ({
   summaryId,
   activityType: 'MOUNTAIN_BIKING',
   samples,
@@ -73,120 +74,107 @@ describe('flattenGarminActivity', () => {
   });
 });
 
-describe('fetchGarminActivityDetails', () => {
-  describe('URL selection', () => {
-    // Garmin's ping already scoped the callbackURL to exactly the activities it
-    // is notifying about, so it needs no window arithmetic and cannot drift.
-    it('prefers the ping callbackURL when one was supplied', async () => {
-      mockFetch.mockResolvedValue(ok([detailsFor(SUMMARY_ID)]));
+describe('fetchGarminActivityFromCallback', () => {
+  // The entire point: Garmin's Partner Verification counts a pull as prompted
+  // only when it matches a URL Garmin issued. Composing our own request is an
+  // unprompted pull AND leaves the ping unanswered, failing two checks at once.
+  it('requests exactly the URL Garmin supplied, unmodified', async () => {
+    mockFetch.mockResolvedValue(ok([entry(SUMMARY_ID)]));
 
-      await fetchGarminActivityDetails({
-        accessToken: TOKEN,
-        summaryId: SUMMARY_ID,
-        callbackURL: 'https://garmin.test/callback/xyz',
-        uploadTimestampInSeconds: 1_700_000_000,
-        apiBase: API_BASE,
-      });
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://garmin.test/callback/xyz',
-        expect.objectContaining({
-          headers: expect.objectContaining({ Authorization: `Bearer ${TOKEN}` }),
-        })
-      );
+    await fetchGarminActivityFromCallback({
+      accessToken: TOKEN,
+      summaryId: SUMMARY_ID,
+      callbackURL: CALLBACK_URL,
     });
 
-    it('falls back to an upload window on the activityDetails endpoint', async () => {
-      mockFetch.mockResolvedValue(ok([detailsFor(SUMMARY_ID)]));
-
-      await fetchGarminActivityDetails({
-        accessToken: TOKEN,
-        summaryId: SUMMARY_ID,
-        uploadTimestampInSeconds: 1_700_000_000,
-        apiBase: API_BASE,
-      });
-
-      const [url] = mockFetch.mock.calls[0];
-      // Details, never /rest/activities. The summary endpoint is what carried
-      // no samples and left every Garmin ride without a map.
-      expect(url).toContain('/rest/activityDetails');
-      expect(url).toContain('uploadStartTimeInSeconds=1699999940');
-      expect(url).toContain('uploadEndTimeInSeconds=1700000060');
-    });
-
-    // Fabricating a window with nothing to anchor it to is the unprompted pull
-    // the Connect Developer Program forbids.
-    it('declines to fetch when neither a callbackURL nor a timestamp is known', async () => {
-      const result = await fetchGarminActivityDetails({
-        accessToken: TOKEN,
-        summaryId: SUMMARY_ID,
-        apiBase: API_BASE,
-      });
-
-      expect(result).toBeNull();
-      expect(mockFetch).not.toHaveBeenCalled();
-    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      CALLBACK_URL,
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: `Bearer ${TOKEN}` }),
+      })
+    );
   });
 
-  describe('matching', () => {
-    it('returns the entry whose summaryId matches', async () => {
-      mockFetch.mockResolvedValue(
-        ok([detailsFor('1111111111'), detailsFor(SUMMARY_ID, [{ latitudeInDegree: 48.75 }])])
-      );
+  it('returns the entry whose summaryId matches', async () => {
+    mockFetch.mockResolvedValue(
+      ok([entry('1111111111'), entry(SUMMARY_ID, [{ latitudeInDegree: 48.75 }])])
+    );
 
-      const result = await fetchGarminActivityDetails({
-        accessToken: TOKEN,
-        summaryId: SUMMARY_ID,
-        callbackURL: 'https://garmin.test/callback/xyz',
-      });
-
-      expect(result?.summaryId).toBe(SUMMARY_ID);
-      expect(result?.samples).toEqual([{ latitudeInDegree: 48.75 }]);
+    const result = await fetchGarminActivityFromCallback({
+      accessToken: TOKEN,
+      summaryId: SUMMARY_ID,
+      callbackURL: CALLBACK_URL,
     });
 
-    // Garmin suffixes the details id for some activity kinds.
-    it('matches a details id that carries a suffix', async () => {
-      mockFetch.mockResolvedValue(ok([detailsFor(`${SUMMARY_ID}-detail`)]));
+    expect(result?.summaryId).toBe(SUMMARY_ID);
+    expect(result?.samples).toEqual([{ latitudeInDegree: 48.75 }]);
+  });
 
-      const result = await fetchGarminActivityDetails({
-        accessToken: TOKEN,
-        summaryId: SUMMARY_ID,
-        callbackURL: 'https://garmin.test/callback/xyz',
-      });
+  // One prompted request has to yield both the stats and the track, otherwise
+  // we are back to needing a second call that verification would flag.
+  it('flattens a nested details payload so stats and samples arrive together', async () => {
+    mockFetch.mockResolvedValue(
+      ok([
+        {
+          summaryId: SUMMARY_ID,
+          samples: [{ latitudeInDegree: 48.75 }],
+          summary: { activityType: 'MOUNTAIN_BIKING', durationInSeconds: 5340 },
+        },
+      ])
+    );
 
-      expect(result?.summaryId).toBe(`${SUMMARY_ID}-detail`);
+    const result = await fetchGarminActivityFromCallback({
+      accessToken: TOKEN,
+      summaryId: SUMMARY_ID,
+      callbackURL: CALLBACK_URL,
     });
 
-    it('tolerates a bare object instead of an array', async () => {
-      mockFetch.mockResolvedValue(ok(detailsFor(SUMMARY_ID)));
+    expect(result?.activityType).toBe('MOUNTAIN_BIKING');
+    expect(result?.durationInSeconds).toBe(5340);
+    expect(result?.samples).toEqual([{ latitudeInDegree: 48.75 }]);
+  });
 
-      const result = await fetchGarminActivityDetails({
-        accessToken: TOKEN,
-        summaryId: SUMMARY_ID,
-        callbackURL: 'https://garmin.test/callback/xyz',
-      });
+  // Garmin suffixes the details id for some activity kinds.
+  it('matches a details id that carries a suffix', async () => {
+    mockFetch.mockResolvedValue(ok([entry(`${SUMMARY_ID}-detail`)]));
 
-      expect(result?.summaryId).toBe(SUMMARY_ID);
+    const result = await fetchGarminActivityFromCallback({
+      accessToken: TOKEN,
+      summaryId: SUMMARY_ID,
+      callbackURL: CALLBACK_URL,
     });
 
-    // A window pull can legitimately return several activities. Attaching
-    // another ride's GPS to this one is far worse than showing no map.
-    it('returns null rather than guessing when nothing matches', async () => {
-      mockFetch.mockResolvedValue(ok([detailsFor('2222222222'), detailsFor('3333333333')]));
+    expect(result?.summaryId).toBe(`${SUMMARY_ID}-detail`);
+  });
 
-      const result = await fetchGarminActivityDetails({
-        accessToken: TOKEN,
-        summaryId: SUMMARY_ID,
-        uploadTimestampInSeconds: 1_700_000_000,
-      });
+  it('tolerates a bare object instead of an array', async () => {
+    mockFetch.mockResolvedValue(ok(entry(SUMMARY_ID)));
 
-      expect(result).toBeNull();
+    const result = await fetchGarminActivityFromCallback({
+      accessToken: TOKEN,
+      summaryId: SUMMARY_ID,
+      callbackURL: CALLBACK_URL,
     });
+
+    expect(result?.summaryId).toBe(SUMMARY_ID);
+  });
+
+  // A callbackURL covers an upload window and can carry several activities.
+  // Attaching another ride's data to this one is worse than importing nothing.
+  it('returns null rather than guessing when nothing matches', async () => {
+    mockFetch.mockResolvedValue(ok([entry('2222222222'), entry('3333333333')]));
+
+    const result = await fetchGarminActivityFromCallback({
+      accessToken: TOKEN,
+      summaryId: SUMMARY_ID,
+      callbackURL: CALLBACK_URL,
+    });
+
+    expect(result).toBeNull();
   });
 
   describe('failure handling', () => {
-    // By the time this runs the ride and its component hours are committed.
-    // Losing a track costs a map; throwing would cost the ride.
     it('returns null on a non-ok response instead of throwing', async () => {
       mockFetch.mockResolvedValue({
         ok: false,
@@ -196,10 +184,10 @@ describe('fetchGarminActivityDetails', () => {
       });
 
       await expect(
-        fetchGarminActivityDetails({
+        fetchGarminActivityFromCallback({
           accessToken: TOKEN,
           summaryId: SUMMARY_ID,
-          callbackURL: 'https://garmin.test/callback/xyz',
+          callbackURL: CALLBACK_URL,
         })
       ).resolves.toBeNull();
     });
@@ -208,10 +196,10 @@ describe('fetchGarminActivityDetails', () => {
       mockFetch.mockRejectedValue(new Error('socket hang up'));
 
       await expect(
-        fetchGarminActivityDetails({
+        fetchGarminActivityFromCallback({
           accessToken: TOKEN,
           summaryId: SUMMARY_ID,
-          callbackURL: 'https://garmin.test/callback/xyz',
+          callbackURL: CALLBACK_URL,
         })
       ).resolves.toBeNull();
     });
@@ -227,10 +215,10 @@ describe('fetchGarminActivityDetails', () => {
       });
 
       await expect(
-        fetchGarminActivityDetails({
+        fetchGarminActivityFromCallback({
           accessToken: TOKEN,
           summaryId: SUMMARY_ID,
-          callbackURL: 'https://garmin.test/callback/xyz',
+          callbackURL: CALLBACK_URL,
         })
       ).resolves.toBeNull();
     });

--- a/apps/api/src/lib/garmin-activity-details.ts
+++ b/apps/api/src/lib/garmin-activity-details.ts
@@ -1,41 +1,34 @@
 import { logger } from './logger';
 
 /**
- * Fetcher for Garmin's Activity Details, the only endpoint that carries GPS.
+ * Reader for the payload behind a Garmin ping's callbackURL.
  *
- * Garmin splits one activity across two summary types. `/rest/activities`
- * returns the Activity Summary: duration, distance, elevation, HR, device,
- * start coords, and nothing per-point. The `samples[]` array with
- * latitude/longitude/elevation per second lives only in Activity Details,
- * `/rest/activityDetails`. Pulling the summary and looking for `samples` on it
- * therefore always finds nothing, which is why Garmin rides had no map: the
- * normalizer and the store were both correct and simply never fed.
+ * WHY THIS EXISTS, and why it is not a URL builder.
  *
- * COMPLIANCE: the Connect Developer Program forbids *unprompted* pulls. Every
- * call here is prompted. It happens in direct response to an activity ping,
- * using the callbackURL Garmin sent us or the upload window that ping named.
- * There is no polling path and no way to reach this from a user action.
- * `callbackURL` is preferred whenever Garmin supplied one: it is already scoped
- * to exactly the notified activities, so it needs no window arithmetic and
- * cannot drift.
+ * Garmin's PING service does not send activity data. It sends a notification
+ * carrying a `callbackURL`, and the integration is expected to GET exactly that
+ * URL. Partner Verification scores this: a pull is "prompted" only when it
+ * matches a callbackURL Garmin issued. Anything the integration composes for
+ * itself is an unprompted pull, and the ping it ignored is separately counted
+ * as unanswered. One self-built request therefore fails two checks at once,
+ * which is what the verification dashboard was showing.
+ *
+ * So this module never constructs a query. It takes the URL Garmin gave us and
+ * reads what comes back. An earlier version of this file built
+ * `/rest/activityDetails?uploadStartTimeInSeconds=...` as a fallback; that was
+ * itself an unprompted pull and has been removed rather than made conditional.
+ *
+ * The response doubles as the map fix: when the ping is for the activityDetails
+ * summary type, the payload carries `samples[]` alongside the stats, so one
+ * prompted request yields the ride and its GPS track together. No second call,
+ * prompted or otherwise, is needed.
  */
 
-const DEFAULT_API_BASE = 'https://apis.garmin.com/wellness-api';
-
-/**
- * Widening applied on each side of a ping's `uploadTimestampInSeconds` when no
- * callbackURL was supplied. Garmin filters this endpoint on UPLOAD time, not
- * start time, and the ping's timestamp is the upload instant, so the window
- * only has to absorb clock skew and the truncation to whole seconds rather
- * than the length of the ride.
- */
-const UPLOAD_WINDOW_PADDING_SECONDS = 60;
-
-/** One Activity Details entry. Only the fields we route on are named. */
-export type GarminActivityDetails = {
+/** One entry from a callbackURL payload. Only the fields we route on are named. */
+export type GarminActivityPayload = {
   summaryId?: string;
   activityId?: number | string;
-  /** Per-point array; normalized by lib/garmin-streams. Absent for indoor rides. */
+  /** Per-point array; normalized by lib/garmin-streams. Absent on summary-only payloads. */
   samples?: unknown;
   [key: string]: unknown;
 };
@@ -46,31 +39,25 @@ export type GarminActivityDetails = {
  * leading id segment matches both spellings without matching a different
  * activity, since the ids themselves are opaque and unique.
  */
-function idsMatch(detailsId: string | undefined, summaryId: string): boolean {
-  if (!detailsId) return false;
-  if (detailsId === summaryId) return true;
-  return detailsId.split('-')[0] === summaryId.split('-')[0];
-}
-
-function buildWindowUrl(apiBase: string, uploadTimestampInSeconds: number): string {
-  const start = uploadTimestampInSeconds - UPLOAD_WINDOW_PADDING_SECONDS;
-  const end = uploadTimestampInSeconds + UPLOAD_WINDOW_PADDING_SECONDS;
-  return `${apiBase}/rest/activityDetails?uploadStartTimeInSeconds=${start}&uploadEndTimeInSeconds=${end}`;
+function idsMatch(candidate: string | undefined, summaryId: string): boolean {
+  if (!candidate) return false;
+  if (candidate === summaryId) return true;
+  return candidate.split('-')[0] === summaryId.split('-')[0];
 }
 
 /**
- * Lift an Activity Details entry's nested `summary` onto the top level.
+ * Lift an entry's nested `summary` onto the top level.
  *
- * The two summary types are NOT the same shape. `/rest/activities` returns the
- * stats flat: `activityType`, `startTimeInSeconds`, `distanceInMeters` are all
- * top-level keys. `/rest/activityDetails` nests exactly those fields under a
- * `summary` object and puts `samples` beside it. Every consumer here was
+ * The two summary types are NOT the same shape. An `activities` payload returns
+ * the stats flat: `activityType`, `startTimeInSeconds`, `distanceInMeters` are
+ * all top-level keys. An `activityDetails` payload nests exactly those fields
+ * under a `summary` object and puts `samples` beside it. Every consumer here was
  * written against the flat shape, so a details payload reaching them reads
  * `activity.activityType` as undefined and throws on the first `.toLowerCase()`.
  *
  * Flattening at the boundary means the ingest code stays shape-blind and one
- * upsert path serves both summary and details callbacks. A flat payload passes
- * through untouched, so this is safe to apply to any Garmin callback batch.
+ * upsert path serves both. A flat payload passes through untouched, so this is
+ * safe to apply to any Garmin payload.
  */
 export function flattenGarminActivity<T extends Record<string, unknown>>(activity: T): T {
   const summary = activity.summary;
@@ -81,47 +68,28 @@ export function flattenGarminActivity<T extends Record<string, unknown>>(activit
 }
 
 /**
- * Resolve the Activity Details entry for one activity, or null.
+ * GET a ping's callbackURL and return the entry for one activity, flattened.
  *
- * Best-effort by contract, exactly like persistGarminStream downstream: by the
- * time this runs the ride and its component hours are the primary data and are
- * already safe. A details fetch that fails costs the rider a map; throwing here
- * would cost them the ride. Every failure path logs and returns null.
+ * Answering the ping is the point: this request is what Garmin's verification
+ * counts as prompted, and what stops the ping being logged as unanswered. The
+ * activity data is the by-product.
+ *
+ * Best-effort by contract. The caller decides what a null means, because at the
+ * ping stage there is no ride yet and failing loudly would just burn the job's
+ * retries against an endpoint that already answered.
  *
  * Returns null rather than guessing when nothing in the response matches the
- * summaryId. A window pull can legitimately return several activities, and
- * attaching another ride's GPS track to this one is far worse than no map.
+ * summaryId. A callbackURL covers an upload window and can legitimately carry
+ * several activities, and attaching another ride's data to this one is worse
+ * than importing nothing.
  */
-export async function fetchGarminActivityDetails(opts: {
+export async function fetchGarminActivityFromCallback(opts: {
   accessToken: string;
   summaryId: string;
-  /** From the ping, when Garmin supplied one. Preferred over the window. */
-  callbackURL?: string;
-  /** From the ping. Used to build a window when there is no callbackURL. */
-  uploadTimestampInSeconds?: number;
-  apiBase?: string;
-}): Promise<GarminActivityDetails | null> {
-  const apiBase = opts.apiBase ?? process.env.GARMIN_API_BASE ?? DEFAULT_API_BASE;
-
-  const url =
-    opts.callbackURL ??
-    (opts.uploadTimestampInSeconds != null
-      ? buildWindowUrl(apiBase, opts.uploadTimestampInSeconds)
-      : null);
-
-  // No callbackURL and no upload timestamp means nothing prompted this fetch.
-  // Inventing a window here would be exactly the unprompted pull the program
-  // rules forbid, so decline instead.
-  if (!url) {
-    logger.debug(
-      { summaryId: opts.summaryId },
-      '[GarminDetails] No callbackURL or upload timestamp; skipping details fetch'
-    );
-    return null;
-  }
-
+  callbackURL: string;
+}): Promise<GarminActivityPayload | null> {
   try {
-    const response = await fetch(url, {
+    const response = await fetch(opts.callbackURL, {
       headers: {
         Authorization: `Bearer ${opts.accessToken}`,
         Accept: 'application/json',
@@ -132,19 +100,18 @@ export async function fetchGarminActivityDetails(opts: {
       const text = await response.text().catch(() => '');
       logger.warn(
         {
-          event: 'garmin_details_fetch_failed',
+          event: 'garmin_callback_fetch_failed',
           summaryId: opts.summaryId,
           status: response.status,
-          usedCallbackUrl: opts.callbackURL != null,
           response: text.slice(0, 500),
         },
-        '[GarminDetails] Activity Details fetch failed; ride keeps its stats, loses its map'
+        '[GarminCallback] Ping callbackURL fetch failed'
       );
       return null;
     }
 
-    const body = (await response.json()) as GarminActivityDetails[] | GarminActivityDetails;
-    const entries = Array.isArray(body) ? body : [body];
+    const body = (await response.json()) as GarminActivityPayload[] | GarminActivityPayload;
+    const entries = (Array.isArray(body) ? body : [body]).map(flattenGarminActivity);
 
     const match = entries.find(
       (entry) =>
@@ -155,11 +122,11 @@ export async function fetchGarminActivityDetails(opts: {
     if (!match) {
       logger.info(
         {
-          event: 'garmin_details_no_match',
+          event: 'garmin_callback_no_match',
           summaryId: opts.summaryId,
           returned: entries.length,
         },
-        '[GarminDetails] No Activity Details entry matched this activity'
+        '[GarminCallback] No entry in the callback payload matched this activity'
       );
       return null;
     }
@@ -167,8 +134,8 @@ export async function fetchGarminActivityDetails(opts: {
     return match;
   } catch (err) {
     logger.warn(
-      { event: 'garmin_details_fetch_error', summaryId: opts.summaryId, err },
-      '[GarminDetails] Activity Details fetch threw; ride is unaffected'
+      { event: 'garmin_callback_fetch_error', summaryId: opts.summaryId, err },
+      '[GarminCallback] Ping callbackURL fetch threw'
     );
     return null;
   }

--- a/apps/api/src/lib/garmin-activity-details.ts
+++ b/apps/api/src/lib/garmin-activity-details.ts
@@ -1,4 +1,5 @@
 import { logger } from './logger';
+import { assertTrustedGarminCallbackUrl } from './garmin-callback-url';
 
 /**
  * Reader for the payload behind a Garmin ping's callbackURL.
@@ -88,12 +89,23 @@ export async function fetchGarminActivityFromCallback(opts: {
   summaryId: string;
   callbackURL: string;
 }): Promise<GarminActivityPayload | null> {
+  // The callbackURL arrives in an unauthenticated webhook body, and the request
+  // below carries the rider's live Garmin token. Anything outside Garmin's own
+  // origin is a forged notification trying to be handed that token.
+  if (!assertTrustedGarminCallbackUrl(opts.callbackURL, { summaryId: opts.summaryId })) {
+    return null;
+  }
+
   try {
     const response = await fetch(opts.callbackURL, {
       headers: {
         Authorization: `Bearer ${opts.accessToken}`,
         Accept: 'application/json',
       },
+      // An allowed origin must not be able to bounce this request, and its
+      // token, somewhere else. Garmin's callback endpoints return JSON
+      // directly, so a redirect here is never legitimate.
+      redirect: 'error',
     });
 
     if (!response.ok) {

--- a/apps/api/src/lib/garmin-callback-url.test.ts
+++ b/apps/api/src/lib/garmin-callback-url.test.ts
@@ -1,0 +1,123 @@
+jest.mock('./logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  logError: jest.fn(),
+}));
+
+import { isTrustedGarminCallbackUrl, assertTrustedGarminCallbackUrl } from './garmin-callback-url';
+import { logger } from './logger';
+
+const originalApiBase = process.env.GARMIN_API_BASE;
+
+afterEach(() => {
+  jest.clearAllMocks();
+  if (originalApiBase === undefined) {
+    delete process.env.GARMIN_API_BASE;
+  } else {
+    process.env.GARMIN_API_BASE = originalApiBase;
+  }
+});
+
+describe('isTrustedGarminCallbackUrl', () => {
+  it('accepts Garmin production callback URLs', () => {
+    expect(
+      isTrustedGarminCallbackUrl(
+        'https://apis.garmin.com/wellness-api/rest/activityDetails?uploadStartTimeInSeconds=1'
+      )
+    ).toBe(true);
+  });
+
+  /**
+   * The threat this exists for: the activities-ping webhook has no signature
+   * verification, so every field in the body is attacker-controlled, and
+   * whatever URL lands here gets fetched with the rider's live Garmin bearer
+   * token attached.
+   */
+  it('rejects an attacker-controlled origin', () => {
+    expect(isTrustedGarminCallbackUrl('https://attacker.example/steal')).toBe(false);
+  });
+
+  // new URL() resolves these to the real host, which is exactly why the check
+  // compares the parsed origin rather than doing string matching.
+  it.each([
+    ['credentials in the userinfo', 'https://apis.garmin.com@attacker.example/steal'],
+    ['the allowed host in the path', 'https://attacker.example/apis.garmin.com/steal'],
+    ['the allowed host in a query param', 'https://attacker.example/?x=apis.garmin.com'],
+    ['the allowed host in the fragment', 'https://attacker.example/#apis.garmin.com'],
+    ['a lookalike suffix', 'https://notapis.garmin.com.evil.example/steal'],
+    ['a subdomain of the allowed host', 'https://evil.apis.garmin.com/steal'],
+  ])('rejects %s', (_label, url) => {
+    expect(isTrustedGarminCallbackUrl(url)).toBe(false);
+  });
+
+  // Origin comparison covers scheme and port, not just the hostname.
+  it('rejects the right host on the wrong scheme or port', () => {
+    expect(isTrustedGarminCallbackUrl('http://apis.garmin.com/wellness-api/rest/activities')).toBe(
+      false
+    );
+    expect(isTrustedGarminCallbackUrl('https://apis.garmin.com:8443/wellness-api')).toBe(false);
+  });
+
+  it('rejects non-http schemes that could reach local resources', () => {
+    expect(isTrustedGarminCallbackUrl('file:///etc/passwd')).toBe(false);
+    expect(isTrustedGarminCallbackUrl('http://169.254.169.254/latest/meta-data/')).toBe(false);
+  });
+
+  it('rejects anything that is not a usable string', () => {
+    expect(isTrustedGarminCallbackUrl(undefined)).toBe(false);
+    expect(isTrustedGarminCallbackUrl(null)).toBe(false);
+    expect(isTrustedGarminCallbackUrl('')).toBe(false);
+    expect(isTrustedGarminCallbackUrl('not a url')).toBe(false);
+    expect(isTrustedGarminCallbackUrl({ href: 'https://apis.garmin.com' })).toBe(false);
+  });
+
+  // A sandbox base has to keep working without widening the allowlist to
+  // anything else.
+  it('also accepts the configured API base origin', () => {
+    process.env.GARMIN_API_BASE = 'https://apis-sandbox.garmin.com/wellness-api';
+
+    expect(isTrustedGarminCallbackUrl('https://apis-sandbox.garmin.com/rest/activities')).toBe(true);
+    // Production stays allowed, and nothing else is.
+    expect(isTrustedGarminCallbackUrl('https://apis.garmin.com/rest/activities')).toBe(true);
+    expect(isTrustedGarminCallbackUrl('https://attacker.example/steal')).toBe(false);
+  });
+
+  it('ignores a malformed API base rather than widening the allowlist', () => {
+    process.env.GARMIN_API_BASE = 'not-a-url';
+
+    expect(isTrustedGarminCallbackUrl('https://apis.garmin.com/rest/activities')).toBe(true);
+    expect(isTrustedGarminCallbackUrl('https://attacker.example/steal')).toBe(false);
+  });
+});
+
+describe('assertTrustedGarminCallbackUrl', () => {
+  it('passes a trusted URL through without noise', () => {
+    expect(assertTrustedGarminCallbackUrl('https://apis.garmin.com/rest/activities')).toBe(true);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  // A rejection is not a malformed Garmin payload, it is someone posting a
+  // forged notification, so it needs to be alertable.
+  it('logs an alertable error naming the target when it rejects', () => {
+    expect(assertTrustedGarminCallbackUrl('https://attacker.example/steal', { userId: 'u1' })).toBe(
+      false
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'garmin_untrusted_callback_url',
+        userId: 'u1',
+        callbackURL: 'https://attacker.example/steal',
+      }),
+      expect.stringContaining('Refusing to fetch')
+    );
+  });
+
+  it('truncates the logged URL so it cannot flood the log', () => {
+    const long = `https://attacker.example/${'a'.repeat(5000)}`;
+
+    assertTrustedGarminCallbackUrl(long);
+
+    const logged = (logger.error as jest.Mock).mock.calls[0][0] as { callbackURL: string };
+    expect(logged.callbackURL.length).toBeLessThanOrEqual(200);
+  });
+});

--- a/apps/api/src/lib/garmin-callback-url.ts
+++ b/apps/api/src/lib/garmin-callback-url.ts
@@ -1,0 +1,91 @@
+import { logger } from './logger';
+
+/**
+ * Origin allowlist for Garmin callbackURLs.
+ *
+ * THREAT: the activities-ping webhook has no signature or HMAC verification.
+ * The only gate is that the payload's `userId` matches a UserAccount row we
+ * already hold, which is an identifier an attacker can guess or learn rather
+ * than a secret. Every other field in that body is attacker-controlled,
+ * including `callbackURL`.
+ *
+ * Any code that fetches one of those URLs attaches the rider's live Garmin
+ * OAuth bearer token. Without this check, a forged ping carrying
+ * `callbackURL: "https://attacker.example/steal"` makes the server hand that
+ * rider's access token to the attacker, and the JSON they return is parsed and
+ * upserted into that rider's ride history. SSRF, credential exfiltration and
+ * data injection from one unauthenticated POST.
+ *
+ * Matching is on the full ORIGIN, not the hostname, so protocol and port have
+ * to agree too. `new URL()` resolves embedded credentials and other host
+ * confusion (`https://apis.garmin.com@evil.example/`) to the real host, so
+ * comparing its `origin` is not fooled by them.
+ *
+ * The configured API base is allowed alongside the production origin so a
+ * sandbox or local GARMIN_API_BASE keeps working without punching a hole for
+ * anything else.
+ */
+
+const GARMIN_PRODUCTION_ORIGIN = 'https://apis.garmin.com';
+
+function allowedOrigins(): string[] {
+  const origins = new Set<string>([GARMIN_PRODUCTION_ORIGIN]);
+
+  const configured = process.env.GARMIN_API_BASE;
+  if (configured) {
+    try {
+      origins.add(new URL(configured).origin);
+    } catch {
+      // A malformed GARMIN_API_BASE is a deployment problem, not a reason to
+      // widen the allowlist. Fall through with the production origin only.
+      logger.warn(
+        { configured },
+        '[GarminCallbackUrl] GARMIN_API_BASE is not a valid URL; ignoring it for the allowlist'
+      );
+    }
+  }
+
+  return [...origins];
+}
+
+/** Is this a URL we are willing to send a rider's Garmin token to? */
+export function isTrustedGarminCallbackUrl(callbackURL: unknown): callbackURL is string {
+  if (typeof callbackURL !== 'string' || callbackURL.length === 0) return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(callbackURL);
+  } catch {
+    return false;
+  }
+
+  return allowedOrigins().includes(parsed.origin);
+}
+
+/**
+ * Reject an untrusted callbackURL loudly.
+ *
+ * Emits a distinct, alertable event: a rejection here is not a bug in Garmin's
+ * payload, it is someone posting a forged notification at the webhook. The URL
+ * is logged so the target is visible, truncated so a huge string cannot be used
+ * to flood the log.
+ *
+ * @returns true when the URL is safe to fetch.
+ */
+export function assertTrustedGarminCallbackUrl(
+  callbackURL: unknown,
+  context: Record<string, unknown> = {}
+): callbackURL is string {
+  if (isTrustedGarminCallbackUrl(callbackURL)) return true;
+
+  logger.error(
+    {
+      event: 'garmin_untrusted_callback_url',
+      ...context,
+      callbackURL: typeof callbackURL === 'string' ? callbackURL.slice(0, 200) : typeof callbackURL,
+    },
+    '[GarminCallbackUrl] Refusing to fetch a callbackURL outside Garmin; possible forged notification'
+  );
+
+  return false;
+}

--- a/apps/api/src/lib/queue/sync.queue.ts
+++ b/apps/api/src/lib/queue/sync.queue.ts
@@ -32,6 +32,20 @@ export type SyncJobData = {
    * the same activity must still dedupe to one job.
    */
   callbackURL?: string;
+  /**
+   * Garmin only. The activity itself, when Garmin PUSHed it rather than pinging.
+   *
+   * Carrying the payload through the queue keeps the heavy work on the worker
+   * where every other ingest path already runs, and means the webhook can ACK
+   * inside Garmin's 30-second window without doing database work. When this is
+   * set the worker makes no outbound request at all, which is the entire point:
+   * a delivery we never answer cannot be scored as an unprompted pull.
+   *
+   * The tradeoff is that the payload lives in Redis until the job runs. A single
+   * ride's samples are a few MB at 1Hz, which is fine; the webhook filters to
+   * cycling first so a batch of runs never lands here.
+   */
+  pushedActivity?: unknown;
 };
 
 let syncQueue: Queue<SyncJobData, void, SyncJobName> | null = null;

--- a/apps/api/src/lib/queue/sync.queue.ts
+++ b/apps/api/src/lib/queue/sync.queue.ts
@@ -22,15 +22,16 @@ export type SyncJobData = {
   provider: SyncProvider;
   activityId?: string; // For syncActivity jobs
   /**
-   * Garmin only. The activityDetails callbackURL from the ping that triggered
-   * this job, forwarded so the worker can pull the GPS samples that the
-   * Activity Summary endpoint does not carry. Deliberately excluded from the
-   * job id (see buildSyncJobId): two pings for the same activity must still
-   * dedupe to one job.
+   * Garmin only. The callbackURL from the ping that triggered this job.
+   *
+   * Following it is what makes the resulting request a PROMPTED pull in
+   * Garmin's Partner Verification, and what marks the ping answered. Without
+   * it the worker has to compose its own request, which fails both checks.
+   *
+   * Deliberately excluded from the job id (see buildSyncJobId): two pings for
+   * the same activity must still dedupe to one job.
    */
-  detailsCallbackURL?: string;
-  /** Garmin only. Fallback for building a details window when no callbackURL came through. */
-  uploadTimestampInSeconds?: number;
+  callbackURL?: string;
 };
 
 let syncQueue: Queue<SyncJobData, void, SyncJobName> | null = null;

--- a/apps/api/src/routes/webhooks.garmin.test.ts
+++ b/apps/api/src/routes/webhooks.garmin.test.ts
@@ -523,6 +523,155 @@ describe('Garmin Webhooks', () => {
         });
       });
 
+      /**
+       * PUSH is the mode the integration targets: Garmin sends the activity
+       * itself and expects no answer, so there is no request that Partner
+       * Verification can score as an unprompted pull and no ping left
+       * unanswered.
+       */
+      describe('PUSH deliveries', () => {
+        const PUSHED_RIDE = {
+          userId: 'garmin-user-123',
+          summaryId: 'summary-456',
+          activityType: 'MOUNTAIN_BIKING',
+          startTimeInSeconds: 1706123456,
+          durationInSeconds: 5340,
+          distanceInMeters: 8368,
+          samples: [{ latitudeInDegree: 48.75, longitudeInDegree: -122.48 }],
+        };
+
+        beforeEach(() => {
+          (mockPrisma.userAccount.findUnique as jest.Mock).mockResolvedValue({
+            userId: 'internal-user-123',
+          });
+          mockEnqueueSyncJob.mockResolvedValue({ status: 'queued', jobId: 'job-1' });
+        });
+
+        it('carries a pushed activity to the worker instead of fetching it', async () => {
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({ activityDetails: [PUSHED_RIDE] });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          expect(mockEnqueueSyncJob).toHaveBeenCalledWith('syncActivity', {
+            userId: 'internal-user-123',
+            provider: 'garmin',
+            activityId: 'summary-456',
+            pushedActivity: expect.objectContaining({
+              summaryId: 'summary-456',
+              samples: PUSHED_RIDE.samples,
+            }),
+          });
+          // No callbackURL means nothing to follow, and nothing was queued for
+          // the callback processor either.
+          expect(mockEnqueueCallbackJob).not.toHaveBeenCalled();
+        });
+
+        // An activityDetails push nests its stats under `summary`; everything
+        // downstream reads the flat shape.
+        it('flattens a nested details push before queueing it', async () => {
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({
+              activityDetails: [
+                {
+                  userId: 'garmin-user-123',
+                  summaryId: 'summary-456',
+                  samples: PUSHED_RIDE.samples,
+                  summary: {
+                    activityType: 'MOUNTAIN_BIKING',
+                    startTimeInSeconds: 1706123456,
+                    durationInSeconds: 5340,
+                  },
+                },
+              ],
+            });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          expect(mockEnqueueSyncJob).toHaveBeenCalledWith(
+            'syncActivity',
+            expect.objectContaining({
+              pushedActivity: expect.objectContaining({
+                activityType: 'MOUNTAIN_BIKING',
+                durationInSeconds: 5340,
+                samples: PUSHED_RIDE.samples,
+              }),
+            })
+          );
+        });
+
+        // The activities summary type can be pushed too, not just pinged.
+        it('handles a push on the activities key', async () => {
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({ activities: [PUSHED_RIDE] });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          expect(mockEnqueueSyncJob).toHaveBeenCalledWith(
+            'syncActivity',
+            expect.objectContaining({ activityId: 'summary-456' })
+          );
+          expect(mockEnqueueCallbackJob).not.toHaveBeenCalled();
+        });
+
+        // A pushed payload carries its samples. Queueing a run's worth of them
+        // just to discard them on the worker would put megabytes through Redis
+        // for nothing.
+        it('drops a non-cycling push without queueing its samples', async () => {
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({
+              activityDetails: [{ ...PUSHED_RIDE, activityType: 'RUNNING' }],
+            });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          expect(mockEnqueueSyncJob).not.toHaveBeenCalled();
+        });
+
+        // Notifications must still route to the callbackURL paths untouched.
+        it('leaves a ping notification to the notification path', async () => {
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({
+              activityDetails: [
+                {
+                  userId: 'garmin-user-123',
+                  userAccessToken: 'token-xyz',
+                  summaryId: 'summary-456',
+                  uploadTimestampInSeconds: 1706123456,
+                  callbackURL: 'https://apis.garmin.com/wellness-api/rest/activities?x=1',
+                },
+              ],
+            });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          expect(mockEnqueueSyncJob).toHaveBeenCalledWith('syncActivity', {
+            userId: 'internal-user-123',
+            provider: 'garmin',
+            activityId: 'summary-456',
+            callbackURL: 'https://apis.garmin.com/wellness-api/rest/activities?x=1',
+          });
+        });
+
+        // Before this, such a delivery enqueued a callback job with no URL,
+        // which the worker rejected as a malformed backfill job.
+        it('skips an activities delivery with neither payload nor callbackURL', async () => {
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({ activities: [{ userId: 'garmin-user-123' }] });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          expect(mockEnqueueCallbackJob).not.toHaveBeenCalled();
+          expect(mockEnqueueSyncJob).not.toHaveBeenCalled();
+        });
+      });
+
       // A backfill of activityDetails answers on this same key with a
       // callbackURL covering a window and no single activity to name. Enqueuing
       // a syncActivity job for it would produce one with no activityId, which

--- a/apps/api/src/routes/webhooks.garmin.test.ts
+++ b/apps/api/src/routes/webhooks.garmin.test.ts
@@ -810,6 +810,45 @@ describe('Garmin Webhooks', () => {
           expect(mockEnqueueCallbackJob).not.toHaveBeenCalled();
           expect(mockEnqueueSyncJob).not.toHaveBeenCalled();
         });
+
+        /**
+         * The same hole on the sibling branch. It enqueued a job with
+         * activityId undefined, which the worker rejected from inside a
+         * fire-and-forget promise where the throw never reached this handler.
+         * Worse, buildSyncJobId falls back to `syncActivity_garmin_<userId>`
+         * without an activityId, so the first such entry poisoned that id and
+         * every later one came back 'already_queued' and vanished.
+         */
+        it('skips an activityDetails delivery naming no activity', async () => {
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({ activityDetails: [{ userId: 'garmin-user-123' }] });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          expect(mockEnqueueSyncJob).not.toHaveBeenCalled();
+          expect(mockEnqueueCallbackJob).not.toHaveBeenCalled();
+        });
+
+        // A summaryId with no callbackURL is still a legitimate notification:
+        // the worker can compose a request for that one activity. Only the
+        // entry naming nothing at all is dropped.
+        it('still enqueues a bare summaryId notification', async () => {
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({
+              activityDetails: [{ userId: 'garmin-user-123', summaryId: 'summary-456' }],
+            });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          expect(mockEnqueueSyncJob).toHaveBeenCalledWith('syncActivity', {
+            userId: 'internal-user-123',
+            provider: 'garmin',
+            activityId: 'summary-456',
+            callbackURL: undefined,
+          });
+        });
       });
 
       // A backfill of activityDetails answers on this same key with a

--- a/apps/api/src/routes/webhooks.garmin.test.ts
+++ b/apps/api/src/routes/webhooks.garmin.test.ts
@@ -717,6 +717,61 @@ describe('Garmin Webhooks', () => {
           expect(mockEnqueueSyncJob).not.toHaveBeenCalled();
         });
 
+        /**
+         * The one misclassification that would reproduce the original bug: a
+         * notification read as a push is never followed, so its ping is scored
+         * unanswered again. Some Garmin notifications carry summary metadata,
+         * and the live ping shape has not been observed, so a URL to follow
+         * always wins over data that happens to be present.
+         */
+        it('follows the URL when a delivery carries both a callbackURL and data', async () => {
+          const genuine = 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1';
+
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({
+              activityDetails: [{ ...PUSHED_RIDE, callbackURL: genuine }],
+            });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          // Routed as a notification: the URL rides along and nothing was
+          // treated as already-in-hand.
+          expect(mockEnqueueSyncJob).toHaveBeenCalledWith('syncActivity', {
+            userId: 'internal-user-123',
+            provider: 'garmin',
+            activityId: 'summary-456',
+            callbackURL: genuine,
+          });
+          expect(mockEnqueueSyncJob).not.toHaveBeenCalledWith(
+            'syncActivity',
+            expect.objectContaining({ pushedActivity: expect.anything() })
+          );
+        });
+
+        // That shape means the live ping differs from what this was written
+        // against, which is worth noticing rather than inferring from a drop in
+        // ride counts.
+        it('warns when a delivery is shaped like neither mode', async () => {
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({
+              activityDetails: [
+                {
+                  ...PUSHED_RIDE,
+                  callbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
+                },
+              ],
+            });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          expect(mockLogger.warn).toHaveBeenCalledWith(
+            expect.objectContaining({ event: 'garmin_delivery_shape_ambiguous' }),
+            expect.stringContaining('following the URL')
+          );
+        });
+
         // Notifications must still route to the callbackURL paths untouched.
         it('leaves a ping notification to the notification path', async () => {
           await request(app)

--- a/apps/api/src/routes/webhooks.garmin.test.ts
+++ b/apps/api/src/routes/webhooks.garmin.test.ts
@@ -487,16 +487,15 @@ describe('Garmin Webhooks', () => {
           userId: 'internal-user-123',
           provider: 'garmin',
           activityId: 'summary-456',
-          detailsCallbackURL: undefined,
-          uploadTimestampInSeconds: 1706123456,
+          callbackURL: undefined,
         });
       });
 
-      // The GPS samples that draw the ride map exist only on Garmin's
-      // activityDetails endpoint. Dropping the ping's pointers to it meant the
-      // worker re-pulled the summary, found no samples, and every Garmin ride
-      // came out with no track.
-      it('should forward the details callbackURL to the sync job', async () => {
+      // Following the ping's callbackURL is what makes the worker's request a
+      // PROMPTED pull in Garmin's Partner Verification and marks the ping
+      // answered. Dropping it meant the worker composed its own request, which
+      // failed both checks and left every Garmin ride without a track.
+      it('should forward the ping callbackURL to the sync job', async () => {
         (mockPrisma.userAccount.findUnique as jest.Mock).mockResolvedValue({
           userId: 'internal-user-123',
         });
@@ -520,8 +519,7 @@ describe('Garmin Webhooks', () => {
           userId: 'internal-user-123',
           provider: 'garmin',
           activityId: 'summary-456',
-          detailsCallbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
-          uploadTimestampInSeconds: 1706123456,
+          callbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
         });
       });
 

--- a/apps/api/src/routes/webhooks.garmin.test.ts
+++ b/apps/api/src/routes/webhooks.garmin.test.ts
@@ -524,6 +524,91 @@ describe('Garmin Webhooks', () => {
       });
 
       /**
+       * This endpoint has no signature verification, so every field in the body
+       * is attacker-controlled and `userId` is a guessable identifier rather
+       * than a secret. A callbackURL that reaches a fetch is handed the rider's
+       * live Garmin bearer token, so a forged notification pointing at an
+       * attacker host would exfiltrate that token and let the response be
+       * upserted into a real rider's history. None of these may reach a queue.
+       */
+      describe('forged callbackURL', () => {
+        const HOSTILE = 'https://attacker.example/steal';
+
+        beforeEach(() => {
+          (mockPrisma.userAccount.findUnique as jest.Mock).mockResolvedValue({
+            userId: 'internal-user-123',
+          });
+          mockEnqueueSyncJob.mockResolvedValue({ status: 'queued', jobId: 'job-1' });
+          mockEnqueueCallbackJob.mockResolvedValue({ status: 'queued', jobId: 'cb-1' });
+        });
+
+        it('does not queue a hostile URL from an activities delivery', async () => {
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({ activities: [{ userId: 'garmin-user-123', callbackURL: HOSTILE }] });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          expect(mockEnqueueCallbackJob).not.toHaveBeenCalled();
+        });
+
+        it('does not queue a hostile URL from a details backfill callback', async () => {
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({ activityDetails: [{ userId: 'garmin-user-123', callbackURL: HOSTILE }] });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          expect(mockEnqueueCallbackJob).not.toHaveBeenCalled();
+        });
+
+        // The activity is still worth importing; only the URL is untrusted. It
+        // is stripped so the worker cannot be instructed to fetch it.
+        it('strips a hostile URL but still syncs the named activity', async () => {
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({
+              activityDetails: [
+                {
+                  userId: 'garmin-user-123',
+                  summaryId: 'summary-456',
+                  uploadTimestampInSeconds: 1706123456,
+                  callbackURL: HOSTILE,
+                },
+              ],
+            });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          expect(mockEnqueueSyncJob).toHaveBeenCalledWith('syncActivity', {
+            userId: 'internal-user-123',
+            provider: 'garmin',
+            activityId: 'summary-456',
+            callbackURL: undefined,
+          });
+        });
+
+        it('still forwards a genuine Garmin callbackURL', async () => {
+          const genuine = 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1';
+
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({
+              activityDetails: [
+                { userId: 'garmin-user-123', summaryId: 'summary-456', callbackURL: genuine },
+              ],
+            });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          expect(mockEnqueueSyncJob).toHaveBeenCalledWith(
+            'syncActivity',
+            expect.objectContaining({ callbackURL: genuine })
+          );
+        });
+      });
+
+      /**
        * PUSH is the mode the integration targets: Garmin sends the activity
        * itself and expects no answer, so there is no request that Partner
        * Verification can score as an unprompted pull and no ping left

--- a/apps/api/src/routes/webhooks.garmin.test.ts
+++ b/apps/api/src/routes/webhooks.garmin.test.ts
@@ -653,6 +653,41 @@ describe('Garmin Webhooks', () => {
           expect(mockEnqueueCallbackJob).not.toHaveBeenCalled();
         });
 
+        /**
+         * The job lands in Redis in plaintext and this body is
+         * unauthenticated, so nothing beyond the activity fields may ride
+         * along. Garmin itself sends userAccessToken here: a credential the
+         * integration never uses, keeps out of logs, and encrypts at rest
+         * everywhere else.
+         */
+        it('never queues the access token or any other unlisted field', async () => {
+          await request(app)
+            .post('/webhooks/garmin/activities-ping')
+            .send({
+              activityDetails: [
+                {
+                  ...PUSHED_RIDE,
+                  userAccessToken: 'a-real-garmin-token',
+                  somethingNobodyAskedFor: 'x'.repeat(1000),
+                },
+              ],
+            });
+
+          await new Promise(resolve => setImmediate(resolve));
+
+          const queued = mockEnqueueSyncJob.mock.calls[0][1] as { pushedActivity: object };
+          expect(queued.pushedActivity).not.toHaveProperty('userAccessToken');
+          expect(queued.pushedActivity).not.toHaveProperty('somethingNobodyAskedFor');
+          expect(queued.pushedActivity).not.toHaveProperty('userId');
+          // The ride itself still made it through intact.
+          expect(queued.pushedActivity).toMatchObject({
+            summaryId: 'summary-456',
+            activityType: 'MOUNTAIN_BIKING',
+            durationInSeconds: 5340,
+            samples: PUSHED_RIDE.samples,
+          });
+        });
+
         // An activityDetails push nests its stats under `summary`; everything
         // downstream reads the flat shape.
         it('flattens a nested details push before queueing it', async () => {

--- a/apps/api/src/routes/webhooks.garmin.ts
+++ b/apps/api/src/routes/webhooks.garmin.ts
@@ -621,6 +621,25 @@ r.post<Empty, void, GarminPingPayload>(
             return { status: callbackResult.status, jobId: callbackResult.jobId };
           }
 
+          // Nothing was pushed, and the block above already returned for every
+          // entry that had a callbackURL without a summaryId, so reaching here
+          // without one means the delivery names no activity and offers no way
+          // to find it. Enqueueing anyway produced a job with activityId
+          // undefined that the worker rejected from inside a fire-and-forget
+          // promise, where the throw was invisible to this handler.
+          //
+          // It also collided: buildSyncJobId falls back to
+          // `syncActivity_garmin_<userId>` when there is no activityId, so the
+          // first malformed entry poisoned that id and every later one came
+          // back 'already_queued' and vanished silently.
+          if (!summaryId) {
+            logger.warn(
+              { requestId, garminUserId },
+              '[Garmin PING] activityDetails delivery had no pushed payload, callbackURL or summaryId'
+            );
+            return { status: 'skipped', reason: 'no_payload_or_callback' };
+          }
+
           // Enqueue sync job with deterministic ID for deduplication.
           // The callbackURL rides along because following it is what makes the
           // worker's request a prompted pull and marks this ping answered. It

--- a/apps/api/src/routes/webhooks.garmin.ts
+++ b/apps/api/src/routes/webhooks.garmin.ts
@@ -10,6 +10,7 @@ import { revokeIntegration } from '../lib/integration-tokens';
 import { flattenGarminActivity } from '../lib/garmin-activity-details';
 import { assertTrustedGarminCallbackUrl } from '../lib/garmin-callback-url';
 import {
+  isAmbiguousGarminDelivery,
   isGarminCyclingActivity,
   isPushedGarminActivity,
   type GarminDeliveryEntry,
@@ -324,6 +325,25 @@ async function handlePushedActivity(
   rawEntry: GarminDeliveryEntry
 ): Promise<PushOutcome> {
   const entry = flattenGarminActivity(rawEntry);
+
+  // A delivery carrying both a URL to follow and the measurements themselves is
+  // shaped like neither mode. It is handled as a notification, which is the
+  // safe reading, but it means the live ping differs from what this was written
+  // against, so it is logged loudly enough to notice rather than inferred from
+  // a drop in ride counts.
+  if (isAmbiguousGarminDelivery(entry)) {
+    logger.warn(
+      {
+        event: 'garmin_delivery_shape_ambiguous',
+        requestId,
+        summaryId: entry.summaryId,
+        activityType: entry.activityType,
+        hasSamples: Array.isArray(entry.samples) && entry.samples.length > 0,
+      },
+      '[Garmin] Delivery carried both a callbackURL and activity data; following the URL'
+    );
+  }
+
   if (!isPushedGarminActivity(entry)) return { handled: false };
 
   const summaryId = typeof entry.summaryId === 'string' ? entry.summaryId : undefined;

--- a/apps/api/src/routes/webhooks.garmin.ts
+++ b/apps/api/src/routes/webhooks.garmin.ts
@@ -267,9 +267,16 @@ r.post<Empty, void, { userPermissionsChange?: Array<{
  */
 type GarminActivityPing = {
   userId: string;
+  /**
+   * Garmin sends the rider's access token in the notification body. We never
+   * read it: every outbound call uses our own stored, encrypted credential, so
+   * trusting a token supplied by an unauthenticated request would be handing
+   * the caller a say in what we authenticate as. Declared so that stays a
+   * visible decision, and named in the logger's redaction list (lib/logger.ts)
+   * so it cannot reach logs on the debug body dump.
+   */
   userAccessToken: string;
   summaryId: string;
-  uploadTimestampInSeconds: number;
   /**
    * Present when Garmin pings for the activityDetails summary type. Points at
    * `/rest/activityDetails` already scoped to the notified activities, so it is

--- a/apps/api/src/routes/webhooks.garmin.ts
+++ b/apps/api/src/routes/webhooks.garmin.ts
@@ -8,6 +8,7 @@ import { isActiveSource } from '../lib/active-source';
 import { deleteRideStreamsForProvider } from '../lib/ride-stream-store';
 import { revokeIntegration } from '../lib/integration-tokens';
 import { flattenGarminActivity } from '../lib/garmin-activity-details';
+import { assertTrustedGarminCallbackUrl } from '../lib/garmin-callback-url';
 import {
   isGarminCyclingActivity,
   isPushedGarminActivity,
@@ -469,6 +470,13 @@ r.post<Empty, void, GarminPingPayload>(
             return { status: 'skipped', reason: 'no_payload_or_callback' };
           }
 
+          // Rejected at the boundary as well as at the fetch site: a forged URL
+          // should never reach the queue, where it would sit as a stored
+          // instruction to hand out a token.
+          if (!assertTrustedGarminCallbackUrl(callbackURL, { requestId, garminUserId })) {
+            return { status: 'skipped', reason: 'untrusted_callback_url' };
+          }
+
           const result = await enqueueCallbackJob({
             userId: userAccount.userId,
             provider: 'garmin',
@@ -575,6 +583,9 @@ r.post<Empty, void, GarminPingPayload>(
           // this they would enqueue a syncActivity job with no activityId,
           // which the worker rejects outright.
           if (!summaryId && callbackURL) {
+            if (!assertTrustedGarminCallbackUrl(callbackURL, { requestId, garminUserId })) {
+              return { status: 'skipped', reason: 'untrusted_callback_url' };
+            }
             const callbackResult = await enqueueCallbackJob({
               userId: userAccount.userId,
               provider: 'garmin',
@@ -594,11 +605,23 @@ r.post<Empty, void, GarminPingPayload>(
           // The callbackURL rides along because following it is what makes the
           // worker's request a prompted pull and marks this ping answered. It
           // is not part of the job id, so dedup still keys on the activity.
+          // Drop an untrusted URL rather than the whole delivery: the worker
+          // can still fall back to a composed request for this activity, which
+          // is a compliance problem rather than a security one.
+          // Only assert when there is something to assert about: a ping with no
+          // callbackURL at all is an ordinary shape, not a security event, and
+          // must not raise an alertable error.
+          const trustedCallbackURL =
+            callbackURL &&
+            assertTrustedGarminCallbackUrl(callbackURL, { requestId, garminUserId, summaryId })
+              ? callbackURL
+              : undefined;
+
           const result = await enqueueSyncJob('syncActivity', {
             userId: userAccount.userId,
             provider: 'garmin',
             activityId: summaryId,
-            callbackURL,
+            callbackURL: trustedCallbackURL,
           });
 
           logger.info({

--- a/apps/api/src/routes/webhooks.garmin.ts
+++ b/apps/api/src/routes/webhooks.garmin.ts
@@ -437,12 +437,7 @@ r.post<Empty, void, GarminPingPayload>(
 
         // Fire-and-forget: Enqueue jobs for background processing
         const enqueuePromises = activityDetails.map(async (notification) => {
-          const {
-            userId: garminUserId,
-            summaryId,
-            callbackURL,
-            uploadTimestampInSeconds,
-          } = notification;
+          const { userId: garminUserId, summaryId, callbackURL } = notification;
 
           // Fast indexed lookup for internal userId
           const userAccount = await prisma.userAccount.findUnique({
@@ -493,15 +488,14 @@ r.post<Empty, void, GarminPingPayload>(
           }
 
           // Enqueue sync job with deterministic ID for deduplication.
-          // The details pointers ride along so the worker can pull the GPS
-          // samples that only /rest/activityDetails carries. They are not part
-          // of the job id, so dedup still keys on the activity alone.
+          // The callbackURL rides along because following it is what makes the
+          // worker's request a prompted pull and marks this ping answered. It
+          // is not part of the job id, so dedup still keys on the activity.
           const result = await enqueueSyncJob('syncActivity', {
             userId: userAccount.userId,
             provider: 'garmin',
             activityId: summaryId,
-            detailsCallbackURL: callbackURL,
-            uploadTimestampInSeconds,
+            callbackURL,
           });
 
           logger.info({

--- a/apps/api/src/routes/webhooks.garmin.ts
+++ b/apps/api/src/routes/webhooks.garmin.ts
@@ -7,6 +7,12 @@ import { enqueueCallbackJob } from '../lib/queue/backfill.queue';
 import { isActiveSource } from '../lib/active-source';
 import { deleteRideStreamsForProvider } from '../lib/ride-stream-store';
 import { revokeIntegration } from '../lib/integration-tokens';
+import { flattenGarminActivity } from '../lib/garmin-activity-details';
+import {
+  isGarminCyclingActivity,
+  isPushedGarminActivity,
+  type GarminDeliveryEntry,
+} from '../types/garmin';
 
 type Empty = Record<string, never>;
 const r: Router = createRouter();
@@ -287,6 +293,80 @@ type GarminPingPayload = {
   activities?: GarminActivityCallback[];
 };
 
+/** What handlePushedActivity decided to do with one delivery entry. */
+type PushOutcome =
+  | { handled: false }
+  | { handled: true; status: string; summaryId?: string; jobId?: string; reason?: string };
+
+/**
+ * Take an activity Garmin PUSHed in the request body, if that is what this is.
+ *
+ * PUSH is the mode this integration targets. Garmin sends the whole activity
+ * and expects no answer, so there is no request to make and therefore nothing
+ * that can be scored as an unprompted pull or an unanswered ping. Both summary
+ * types can arrive this way, so both branches below run entries through here
+ * before falling back to the notification handling.
+ *
+ * The payload is flattened first because an activityDetails push nests its
+ * stats under `summary`, and everything downstream reads the flat shape.
+ *
+ * Non-cycling activities are dropped here rather than on the worker. A pushed
+ * payload carries its samples, and queueing a marathon's worth of them just to
+ * discard them on the other side would put megabytes through Redis for nothing.
+ *
+ * Returns `{ handled: false }` when the entry is a notification, so the caller
+ * can fall through to the callbackURL paths unchanged.
+ */
+async function handlePushedActivity(
+  requestId: string,
+  internalUserId: string,
+  rawEntry: GarminDeliveryEntry
+): Promise<PushOutcome> {
+  const entry = flattenGarminActivity(rawEntry);
+  if (!isPushedGarminActivity(entry)) return { handled: false };
+
+  const summaryId = typeof entry.summaryId === 'string' ? entry.summaryId : undefined;
+  if (!summaryId) {
+    // The job id is built from the activity id, so without one two deliveries
+    // of the same ride would queue twice and race each other's upsert.
+    logger.warn(
+      { requestId, activityType: entry.activityType },
+      '[Garmin PUSH] Pushed activity has no summaryId, skipping'
+    );
+    return { handled: true, status: 'skipped', reason: 'no_summary_id' };
+  }
+
+  if (!isGarminCyclingActivity(entry.activityType)) {
+    logger.debug(
+      { requestId, summaryId, activityType: entry.activityType },
+      '[Garmin PUSH] Skipping non-cycling pushed activity'
+    );
+    return { handled: true, status: 'skipped', summaryId, reason: 'not_cycling' };
+  }
+
+  const result = await enqueueSyncJob('syncActivity', {
+    userId: internalUserId,
+    provider: 'garmin',
+    activityId: summaryId,
+    pushedActivity: entry,
+  });
+
+  logger.info(
+    {
+      event: 'garmin_push_job_enqueued',
+      requestId,
+      jobId: result.jobId,
+      summaryId,
+      userId: internalUserId,
+      hasSamples: Array.isArray(entry.samples) && entry.samples.length > 0,
+      status: result.status,
+    },
+    '[Garmin PUSH] Enqueued sync job from pushed activity'
+  );
+
+  return { handled: true, status: result.status, summaryId, jobId: result.jobId };
+}
+
 r.post<Empty, void, GarminPingPayload>(
   '/webhooks/garmin/activities-ping',
   async (req: Request, res: Response) => {
@@ -369,6 +449,24 @@ r.post<Empty, void, GarminPingPayload>(
               '[Garmin PING] User active source is not Garmin, skipping callback'
             );
             return { status: 'skipped', reason: 'inactive_source' };
+          }
+
+          // PUSH first: the activities summary type can also be delivered as
+          // data rather than as a callbackURL pointer.
+          const pushed = await handlePushedActivity(requestId, userAccount.userId, notification);
+          if (pushed.handled) return pushed;
+
+          // Everything past here is a notification, which means a callbackURL
+          // to follow. Without one there is nothing to fetch and nothing was
+          // pushed, so the delivery is unusable; enqueueing anyway produced a
+          // callback job with no URL that the worker rejected as a malformed
+          // backfill.
+          if (!callbackURL) {
+            logger.warn(
+              { requestId, garminUserId },
+              '[Garmin PING] Activities delivery had neither a pushed payload nor a callbackURL'
+            );
+            return { status: 'skipped', reason: 'no_payload_or_callback' };
           }
 
           const result = await enqueueCallbackJob({
@@ -464,6 +562,11 @@ r.post<Empty, void, GarminPingPayload>(
             );
             return { status: 'skipped', summaryId, reason: 'inactive_source' };
           }
+
+          // PUSH first: if Garmin sent the activity itself there is nothing to
+          // fetch, and no request means nothing verification can score.
+          const pushed = await handlePushedActivity(requestId, userAccount.userId, notification);
+          if (pushed.handled) return pushed;
 
           // A backfill of activityDetails answers on this same key, but with a
           // callbackURL and no summaryId. There is no single activity to name

--- a/apps/api/src/routes/webhooks.garmin.ts
+++ b/apps/api/src/routes/webhooks.garmin.ts
@@ -13,6 +13,7 @@ import {
   isAmbiguousGarminDelivery,
   isGarminCyclingActivity,
   isPushedGarminActivity,
+  pickGarminActivityFields,
   type GarminDeliveryEntry,
 } from '../types/garmin';
 
@@ -372,11 +373,15 @@ async function handlePushedActivity(
     return { handled: true, status: 'skipped', summaryId, reason: 'not_cycling' };
   }
 
+  // Projected onto the fields the ingest path reads, never queued raw. This
+  // body is unauthenticated and the job lands in Redis in plaintext, and Garmin
+  // sends `userAccessToken` in it: a credential we never use, keep out of logs,
+  // and encrypt at rest everywhere else.
   const result = await enqueueSyncJob('syncActivity', {
     userId: internalUserId,
     provider: 'garmin',
     activityId: summaryId,
-    pushedActivity: entry,
+    pushedActivity: pickGarminActivityFields(entry),
   });
 
   logger.info(

--- a/apps/api/src/types/garmin.test.ts
+++ b/apps/api/src/types/garmin.test.ts
@@ -2,7 +2,9 @@ import {
   isAmbiguousGarminDelivery,
   isGarminCyclingActivity,
   isPushedGarminActivity,
+  pickGarminActivityFields,
 } from './garmin';
+import { extractGarminStartCoords } from '../lib/garmin-coords';
 
 describe('isGarminCyclingActivity', () => {
   // Garmin spells these inconsistently across payloads, so the comparison has
@@ -148,5 +150,101 @@ describe('isAmbiguousGarminDelivery', () => {
         durationInSeconds: 5340,
       })
     ).toBe(false);
+  });
+});
+
+describe('pickGarminActivityFields', () => {
+  /**
+   * A pushed entry arrives in an unauthenticated body and is then persisted
+   * into BullMQ job data, which lives in Redis in plaintext. Garmin puts the
+   * rider's access token in that body: a credential this integration never
+   * uses, keeps out of logs via lib/logger.ts redaction, and encrypts at rest
+   * everywhere it does store one. Queueing the raw entry undoes all three.
+   */
+  it('strips the access token Garmin sends in the body', () => {
+    const picked = pickGarminActivityFields({
+      summaryId: 'abc',
+      activityType: 'MOUNTAIN_BIKING',
+      durationInSeconds: 5340,
+      userAccessToken: 'a-real-garmin-token',
+    });
+
+    expect(picked).not.toHaveProperty('userAccessToken');
+    expect(picked.summaryId).toBe('abc');
+  });
+
+  // An allowlist rather than a denylist, because the entry type carries an
+  // index signature: what we want is knowable and small, what someone might
+  // send is not.
+  it('drops anything not on the allowlist', () => {
+    const picked = pickGarminActivityFields({
+      summaryId: 'abc',
+      activityType: 'MOUNTAIN_BIKING',
+      durationInSeconds: 5340,
+      userId: 'garmin-1',
+      callbackURL: 'https://apis.garmin.com/x',
+      somethingNobodyAskedFor: 'x'.repeat(1000),
+      __proto__: { polluted: true },
+    } as never);
+
+    expect(Object.keys(picked).sort()).toEqual(
+      ['activityType', 'durationInSeconds', 'summaryId'].sort()
+    );
+  });
+
+  it('keeps every stat the upsert reads, and the track', () => {
+    const full = {
+      summaryId: 'abc',
+      activityId: 12345,
+      activityType: 'MOUNTAIN_BIKING',
+      activityName: 'Galbraith',
+      startTimeInSeconds: 1706123456,
+      startTimeOffsetInSeconds: -28800,
+      durationInSeconds: 5340,
+      distanceInMeters: 8368,
+      elevationGainInMeters: 369,
+      totalElevationGainInMeters: 369,
+      averageHeartRateInBeatsPerMinute: 104,
+      maxHeartRateInBeatsPerMinute: 168,
+      locationName: 'Bellingham',
+      deviceName: 'fenix8',
+      samples: [{ latitudeInDegree: 48.75 }],
+    };
+
+    expect(pickGarminActivityFields(full)).toEqual(full);
+  });
+
+  /**
+   * The projection's real risk: dropping a coordinate spelling would silently
+   * cost a ride its start point, and with it weather enrichment. Garmin has
+   * shipped four spellings per axis, so this asserts against the extractor
+   * itself rather than trusting the allowlist to stay in step with it.
+   */
+  it.each([
+    ['startingLatitudeInDegrees', 'startingLongitudeInDegrees'],
+    ['startingLatitudeInDegree', 'startingLongitudeInDegree'],
+    ['startLatitudeInDegrees', 'startLongitudeInDegrees'],
+    ['beginLatitude', 'beginLongitude'],
+  ])('survives coordinates spelled %s / %s', (latKey, lngKey) => {
+    const picked = pickGarminActivityFields({
+      summaryId: 'abc',
+      activityType: 'MOUNTAIN_BIKING',
+      durationInSeconds: 5340,
+      [latKey]: 48.75,
+      [lngKey]: -122.48,
+    });
+
+    expect(extractGarminStartCoords(picked)).toEqual({ lat: 48.75, lng: -122.48 });
+  });
+
+  it('omits absent fields rather than writing undefined into the job', () => {
+    const picked = pickGarminActivityFields({
+      summaryId: 'abc',
+      activityType: 'MOUNTAIN_BIKING',
+      durationInSeconds: 5340,
+    });
+
+    expect('deviceName' in picked).toBe(false);
+    expect('samples' in picked).toBe(false);
   });
 });

--- a/apps/api/src/types/garmin.test.ts
+++ b/apps/api/src/types/garmin.test.ts
@@ -1,0 +1,78 @@
+import { isGarminCyclingActivity, isPushedGarminActivity } from './garmin';
+
+describe('isGarminCyclingActivity', () => {
+  // Garmin spells these inconsistently across payloads, so the comparison has
+  // to normalize rather than match the raw value.
+  it.each([
+    ['MOUNTAIN_BIKING', true],
+    ['Mountain Biking', true],
+    ['mountain_biking', true],
+    ['GRAVEL_CYCLING', true],
+    ['INDOOR_CYCLING', true],
+    ['RUNNING', false],
+    ['LAP_SWIMMING', false],
+  ])('%s -> %s', (activityType, expected) => {
+    expect(isGarminCyclingActivity(activityType)).toBe(expected);
+  });
+
+  it('is false for anything that is not a string', () => {
+    expect(isGarminCyclingActivity(undefined)).toBe(false);
+    expect(isGarminCyclingActivity(null)).toBe(false);
+    expect(isGarminCyclingActivity(42)).toBe(false);
+  });
+});
+
+describe('isPushedGarminActivity', () => {
+  // The distinction the whole PUSH path turns on: data we already hold versus a
+  // pointer to data we would have to go and request. Getting it wrong either
+  // discards a pushed activity or issues a pull Garmin never asked for.
+  it('recognizes a pushed activity carrying measurements', () => {
+    expect(
+      isPushedGarminActivity({
+        summaryId: 'abc',
+        activityType: 'MOUNTAIN_BIKING',
+        durationInSeconds: 5340,
+      })
+    ).toBe(true);
+  });
+
+  it('treats a ping notification as not pushed', () => {
+    expect(
+      isPushedGarminActivity({
+        userId: 'garmin-1',
+        summaryId: 'abc',
+        uploadTimestampInSeconds: 1706123456,
+        callbackURL: 'https://apis.garmin.com/wellness-api/rest/activities?x=1',
+      })
+    ).toBe(false);
+  });
+
+  it('treats a backfill callback as not pushed', () => {
+    expect(
+      isPushedGarminActivity({
+        userId: 'garmin-1',
+        callbackURL: 'https://apis.garmin.com/wellness-api/rest/activities?x=1',
+      })
+    ).toBe(false);
+  });
+
+  // An indoor ride is a complete activity that simply has no GPS. Keying the
+  // check on `samples` would send us fetching data Garmin had already sent.
+  it('recognizes a pushed indoor activity with no samples', () => {
+    expect(
+      isPushedGarminActivity({
+        summaryId: 'abc',
+        activityType: 'INDOOR_CYCLING',
+        durationInSeconds: 3600,
+      })
+    ).toBe(true);
+  });
+
+  // activityType alone is not enough: it must come with measurements, or a
+  // notification that happened to name the type would be mistaken for data.
+  it('is false for an activityType with no measurements', () => {
+    expect(isPushedGarminActivity({ summaryId: 'abc', activityType: 'MOUNTAIN_BIKING' })).toBe(
+      false
+    );
+  });
+});

--- a/apps/api/src/types/garmin.test.ts
+++ b/apps/api/src/types/garmin.test.ts
@@ -1,4 +1,8 @@
-import { isGarminCyclingActivity, isPushedGarminActivity } from './garmin';
+import {
+  isAmbiguousGarminDelivery,
+  isGarminCyclingActivity,
+  isPushedGarminActivity,
+} from './garmin';
 
 describe('isGarminCyclingActivity', () => {
   // Garmin spells these inconsistently across payloads, so the comparison has
@@ -74,5 +78,75 @@ describe('isPushedGarminActivity', () => {
     expect(isPushedGarminActivity({ summaryId: 'abc', activityType: 'MOUNTAIN_BIKING' })).toBe(
       false
     );
+  });
+
+  /**
+   * The one misclassification that reproduces the bug this whole change exists
+   * to fix. A notification read as a push is never followed, so its ping is
+   * scored unanswered again. Some Garmin notifications carry summary metadata,
+   * and the live ping shape has not been observed, so a URL to follow always
+   * wins over data that happens to be present.
+   *
+   * The invariant lives here rather than in the webhook's branch ordering
+   * precisely so that reordering those branches cannot resurrect the bug.
+   */
+  it('is false when a callbackURL is present, whatever else the entry carries', () => {
+    expect(
+      isPushedGarminActivity({
+        summaryId: 'abc',
+        activityType: 'MOUNTAIN_BIKING',
+        durationInSeconds: 5340,
+        startTimeInSeconds: 1706123456,
+        samples: [{ latitudeInDegree: 48.75 }],
+        callbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
+      })
+    ).toBe(false);
+  });
+
+  it('ignores an empty callbackURL rather than treating it as followable', () => {
+    expect(
+      isPushedGarminActivity({
+        summaryId: 'abc',
+        activityType: 'MOUNTAIN_BIKING',
+        durationInSeconds: 5340,
+        callbackURL: '',
+      })
+    ).toBe(true);
+  });
+});
+
+describe('isAmbiguousGarminDelivery', () => {
+  // Shaped like neither mode. Handled as a notification, but surfaced, because
+  // it would mean the live ping differs from what this was written against.
+  it('flags an entry carrying both a URL to follow and measurements', () => {
+    expect(
+      isAmbiguousGarminDelivery({
+        summaryId: 'abc',
+        activityType: 'MOUNTAIN_BIKING',
+        durationInSeconds: 5340,
+        callbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
+      })
+    ).toBe(true);
+  });
+
+  it('does not flag an ordinary notification', () => {
+    expect(
+      isAmbiguousGarminDelivery({
+        userId: 'garmin-1',
+        summaryId: 'abc',
+        uploadTimestampInSeconds: 1706123456,
+        callbackURL: 'https://apis.garmin.com/wellness-api/rest/activities?x=1',
+      })
+    ).toBe(false);
+  });
+
+  it('does not flag an ordinary push', () => {
+    expect(
+      isAmbiguousGarminDelivery({
+        summaryId: 'abc',
+        activityType: 'MOUNTAIN_BIKING',
+        durationInSeconds: 5340,
+      })
+    ).toBe(false);
   });
 });

--- a/apps/api/src/types/garmin.ts
+++ b/apps/api/src/types/garmin.ts
@@ -49,7 +49,6 @@ export type GarminDeliveryEntry = {
   userId?: string;
   summaryId?: string;
   callbackURL?: string;
-  uploadTimestampInSeconds?: number;
   activityType?: string;
   summary?: Record<string, unknown>;
   samples?: unknown;

--- a/apps/api/src/types/garmin.ts
+++ b/apps/api/src/types/garmin.ts
@@ -102,6 +102,72 @@ function hasCallbackUrl(entry: GarminDeliveryEntry): boolean {
   return typeof entry.callbackURL === 'string' && entry.callbackURL.length > 0;
 }
 
+/**
+ * Every key the ingest path actually reads off a Garmin activity.
+ *
+ * Grouped by who reads them so an addition has an obvious home:
+ *  - identity and stats: upsertGarminActivity in workers/sync.worker
+ *  - coordinates: extractGarminStartCoords in lib/garmin-coords, which accepts
+ *    four spellings per axis because Garmin has shipped all of them. Every one
+ *    has to survive the projection or a ride silently loses its start point,
+ *    and with it weather enrichment. garmin.test.ts asserts that per key rather
+ *    than trusting this list to stay in step.
+ *  - track: normalizeGarminSamples in lib/garmin-streams
+ */
+const GARMIN_ACTIVITY_FIELDS = [
+  'summaryId',
+  'activityId',
+  'activityType',
+  'activityName',
+  'startTimeInSeconds',
+  'startTimeOffsetInSeconds',
+  'durationInSeconds',
+  'distanceInMeters',
+  'elevationGainInMeters',
+  'totalElevationGainInMeters',
+  'averageHeartRateInBeatsPerMinute',
+  'maxHeartRateInBeatsPerMinute',
+  'locationName',
+  'deviceName',
+  'startingLatitudeInDegrees',
+  'startingLatitudeInDegree',
+  'startLatitudeInDegrees',
+  'beginLatitude',
+  'startingLongitudeInDegrees',
+  'startingLongitudeInDegree',
+  'startLongitudeInDegrees',
+  'beginLongitude',
+  'samples',
+] as const;
+
+/**
+ * Reduce a delivery entry to the activity fields, discarding everything else.
+ *
+ * A pushed entry arrives in an unauthenticated webhook body and is then
+ * persisted into BullMQ job data, which lives in Redis in plaintext. Passing
+ * the raw entry through would put whatever the caller sent in there, and Garmin
+ * itself sends `userAccessToken` in that body: a credential this integration
+ * deliberately never uses, is careful to keep out of logs (lib/logger.ts
+ * redaction), and encrypts at rest everywhere it does store one. Queueing it
+ * would undo all three.
+ *
+ * An allowlist rather than a denylist of known-bad keys, because the entry type
+ * carries an index signature: the set of fields we want is knowable and small,
+ * the set someone might send is not.
+ *
+ * `samples` passes through as-is. It is the one large field, its shape is the
+ * normalizer's business, and projecting thousands of points in the request
+ * handler would trade a real latency cost against a credential risk that does
+ * not apply inside it.
+ */
+export function pickGarminActivityFields(entry: GarminDeliveryEntry): Record<string, unknown> {
+  const picked: Record<string, unknown> = {};
+  for (const field of GARMIN_ACTIVITY_FIELDS) {
+    if (entry[field] !== undefined) picked[field] = entry[field];
+  }
+  return picked;
+}
+
 function isGarminActivityTypePresent(entry: GarminDeliveryEntry): boolean {
   return typeof entry.activityType === 'string' && entry.activityType.length > 0;
 }

--- a/apps/api/src/types/garmin.ts
+++ b/apps/api/src/types/garmin.ts
@@ -59,20 +59,48 @@ export type GarminDeliveryEntry = {
 /**
  * Does this entry carry the activity itself, rather than a pointer to it?
  *
- * A notification is small and structural: userId, summaryId, maybe a
- * callbackURL and an upload timestamp. A pushed activity carries the actual
- * measurements. `activityType` plus a duration is the cheapest thing that is
- * always present on real activity data and never on a notification, and it is
- * checked after flattening so an activityDetails payload (which nests those
- * fields under `summary`) reads the same as a flat activities payload.
+ * A pushed activity carries measurements. `activityType` plus a duration or a
+ * start time is the cheapest thing that is always present on real activity data,
+ * and it is checked after flattening so an activityDetails payload (which nests
+ * those fields under `summary`) reads the same as a flat activities payload.
  *
  * Deliberately not keyed on `samples`: an indoor ride pushes a full activity
  * with no GPS at all, and treating that as a notification would send us
  * fetching data Garmin had already handed us.
+ *
+ * A callbackURL DISQUALIFIES an entry, whatever else it carries. That rule is
+ * here rather than in the caller's branch ordering on purpose, because getting
+ * it wrong reproduces the exact bug this whole change exists to fix: an entry
+ * misread as pushed is never followed, so its ping is scored unanswered again.
+ * The real ping shape has not been observed yet, and some Garmin notifications
+ * carry summary metadata alongside the URL, so the safe reading is that
+ * anything offering a URL to follow is a notification.
+ *
+ * The asymmetry is deliberate. Misreading a push as a notification costs one
+ * prompted request, which no verification check objects to. Misreading a
+ * notification as a push costs an unanswered ping and a lost activity.
  */
 export function isPushedGarminActivity(entry: GarminDeliveryEntry): boolean {
+  if (hasCallbackUrl(entry)) return false;
   if (!isGarminActivityTypePresent(entry)) return false;
   return entry.durationInSeconds != null || entry.startTimeInSeconds != null;
+}
+
+/**
+ * An entry that carries BOTH a callbackURL and measurements.
+ *
+ * Treated as a notification (see above), but worth surfacing: it would mean the
+ * live ping shape differs from what this code was written against, and that is
+ * the assumption most worth checking once real payloads are in hand.
+ */
+export function isAmbiguousGarminDelivery(entry: GarminDeliveryEntry): boolean {
+  if (!hasCallbackUrl(entry)) return false;
+  if (!isGarminActivityTypePresent(entry)) return false;
+  return entry.durationInSeconds != null || entry.startTimeInSeconds != null;
+}
+
+function hasCallbackUrl(entry: GarminDeliveryEntry): boolean {
+  return typeof entry.callbackURL === 'string' && entry.callbackURL.length > 0;
 }
 
 function isGarminActivityTypePresent(entry: GarminDeliveryEntry): boolean {

--- a/apps/api/src/types/garmin.ts
+++ b/apps/api/src/types/garmin.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared shapes for Garmin Activity API deliveries.
+ *
+ * Garmin can deliver an activity three ways, and the same webhook endpoint
+ * receives all of them keyed by summary type:
+ *
+ *  - PUSH: the full payload arrives in the request body. Nothing to fetch.
+ *  - PING: a notification arrives carrying a `callbackURL` to GET.
+ *  - Backfill: a callbackURL covering a window, delivered the same way.
+ *
+ * PUSH is the mode this integration targets, because a delivery we never have
+ * to answer cannot be scored as an unprompted pull or an unanswered ping. The
+ * other two remain handled so a portal change, or a summary type still set to
+ * ping, degrades rather than breaks.
+ */
+
+/** Garmin activityType values that count as cycling for our purposes. */
+export const GARMIN_CYCLING_TYPES = [
+  'cycling',
+  'bmx',
+  'cyclocross',
+  'downhill_biking',
+  'e_bike_fitness',
+  'e_bike_mountain',
+  'e_enduro_mtb',
+  'enduro_mtb',
+  'gravel_cycling',
+  'indoor_cycling',
+  'mountain_biking',
+  'recumbent_cycling',
+  'road_biking',
+  'track_cycling',
+  'virtual_ride',
+  'handcycling',
+  'indoor_handcycling',
+];
+
+/**
+ * Garmin spells activity types inconsistently across payloads (`MOUNTAIN_BIKING`,
+ * `Mountain Biking`), so compare on a normalized form rather than the raw value.
+ */
+export function isGarminCyclingActivity(activityType: unknown): boolean {
+  if (typeof activityType !== 'string') return false;
+  return GARMIN_CYCLING_TYPES.includes(activityType.toLowerCase().replace(/\s+/g, '_'));
+}
+
+/** A delivery entry, before we know whether it is data or a pointer to data. */
+export type GarminDeliveryEntry = {
+  userId?: string;
+  summaryId?: string;
+  callbackURL?: string;
+  uploadTimestampInSeconds?: number;
+  activityType?: string;
+  summary?: Record<string, unknown>;
+  samples?: unknown;
+  [key: string]: unknown;
+};
+
+/**
+ * Does this entry carry the activity itself, rather than a pointer to it?
+ *
+ * A notification is small and structural: userId, summaryId, maybe a
+ * callbackURL and an upload timestamp. A pushed activity carries the actual
+ * measurements. `activityType` plus a duration is the cheapest thing that is
+ * always present on real activity data and never on a notification, and it is
+ * checked after flattening so an activityDetails payload (which nests those
+ * fields under `summary`) reads the same as a flat activities payload.
+ *
+ * Deliberately not keyed on `samples`: an indoor ride pushes a full activity
+ * with no GPS at all, and treating that as a notification would send us
+ * fetching data Garmin had already handed us.
+ */
+export function isPushedGarminActivity(entry: GarminDeliveryEntry): boolean {
+  if (!isGarminActivityTypePresent(entry)) return false;
+  return entry.durationInSeconds != null || entry.startTimeInSeconds != null;
+}
+
+function isGarminActivityTypePresent(entry: GarminDeliveryEntry): boolean {
+  return typeof entry.activityType === 'string' && entry.activityType.length > 0;
+}

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -10,6 +10,7 @@ import { deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
 import { extractGarminStartCoords } from '../lib/garmin-coords';
 import { persistGarminStream } from '../lib/ride-stream-store';
 import { flattenGarminActivity } from '../lib/garmin-activity-details';
+import { assertTrustedGarminCallbackUrl } from '../lib/garmin-callback-url';
 import { logError, logger } from '../lib/logger';
 import { config } from '../config/env';
 import type { BackfillJobData, BackfillJobName } from '../lib/queue/backfill.queue';
@@ -679,12 +680,24 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
     userId,
   }, '[BackfillWorker] Fetching from Garmin callback URL');
 
-  // Fetch activities from the callback URL
+  // Fetch activities from the callback URL.
+  //
+  // This URL came from the unauthenticated activities-ping webhook body and
+  // this request carries the rider's live Garmin token, so the origin has to be
+  // checked before it is trusted with either. Predates the ping-side callback
+  // path but is the same exposure, so it is closed here too.
+  if (!assertTrustedGarminCallbackUrl(callbackURL, { userId })) {
+    throw new Error('Refusing to fetch an untrusted Garmin callback URL');
+  }
+
   const callbackRes = await fetch(callbackURL, {
     headers: {
       'Authorization': `Bearer ${accessToken}`,
       'Accept': 'application/json',
     },
+    // An allowed origin must not be able to bounce this request, and its token,
+    // somewhere else.
+    redirect: 'error',
   });
 
   if (!callbackRes.ok) {

--- a/apps/api/src/workers/sync.worker.test.ts
+++ b/apps/api/src/workers/sync.worker.test.ts
@@ -53,7 +53,7 @@ jest.mock('../lib/garmin-token', () => ({
 }));
 
 jest.mock('../lib/garmin-activity-details', () => ({
-  fetchGarminActivityDetails: jest.fn().mockResolvedValue(null),
+  fetchGarminActivityFromCallback: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock('../lib/ride-stream-store', () => ({
@@ -99,7 +99,8 @@ import { acquireLock, releaseLock } from '../lib/rate-limit';
 import { prisma } from '../lib/prisma';
 import { getValidStravaToken } from '../lib/strava-token';
 import { getValidGarminToken } from '../lib/garmin-token';
-import { fetchGarminActivityDetails } from '../lib/garmin-activity-details';
+import { fetchGarminActivityFromCallback } from '../lib/garmin-activity-details';
+import { config } from '../config/env';
 import { persistGarminStream } from '../lib/ride-stream-store';
 import { getValidWhoopToken } from '../lib/whoop-token';
 import { getValidSuuntoToken } from '../lib/suunto-token';
@@ -111,9 +112,11 @@ const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockGetValidStravaToken = getValidStravaToken as jest.MockedFunction<typeof getValidStravaToken>;
 const mockGetValidWhoopToken = getValidWhoopToken as jest.MockedFunction<typeof getValidWhoopToken>;
 const mockGetValidGarminToken = getValidGarminToken as jest.MockedFunction<typeof getValidGarminToken>;
-const mockFetchGarminActivityDetails = fetchGarminActivityDetails as jest.MockedFunction<
-  typeof fetchGarminActivityDetails
+const mockFetchFromCallback = fetchGarminActivityFromCallback as jest.MockedFunction<
+  typeof fetchGarminActivityFromCallback
 >;
+// Mutable so the verification-mode cases can flip it; reset in beforeEach.
+const mockConfig = config as unknown as { garminVerificationMode: boolean };
 const mockPersistGarminStream = persistGarminStream as jest.MockedFunction<
   typeof persistGarminStream
 >;
@@ -208,6 +211,9 @@ describe('processSyncJob (via worker processor)', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // config is a module singleton, so a case that flips this would otherwise
+    // leak into every later describe.
+    mockConfig.garminVerificationMode = false;
 
     MockedWorker.mockImplementation((queueName, processor) => {
       processSyncJob = processor as typeof processSyncJob;
@@ -779,9 +785,10 @@ describe('processSyncJob (via worker processor)', () => {
           redisAvailable: true,
         });
         mockGetValidGarminToken.mockResolvedValue('valid-garmin-token');
-        // Fresh copy per call: the worker merges samples onto the object it
-        // parsed, and handing back one shared literal would let one test's
-        // merge leak into the next.
+        mockConfig.garminVerificationMode = false;
+        mockFetchFromCallback.mockResolvedValue(null);
+        // Fresh copy per call: the worker mutates the object it parsed, and
+        // handing back one shared literal would let one test leak into the next.
         mockFetch.mockResolvedValue({
           ok: true,
           json: () => Promise.resolve({ ...GARMIN_SUMMARY }),
@@ -795,33 +802,34 @@ describe('processSyncJob (via worker processor)', () => {
         });
       });
 
-      it('fetches Activity Details using the callbackURL from the ping', async () => {
+      const CALLBACK_URL = 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1';
+
+      // Garmin's Partner Verification counts a pull as prompted only when it
+      // matches a callbackURL Garmin issued, and counts a ping we did not
+      // follow as unanswered. Composing our own request fails both checks at
+      // once, which is what the verification dashboard was reporting.
+      it('answers the ping by following its callbackURL', async () => {
+        mockFetchFromCallback.mockResolvedValueOnce({ ...GARMIN_SUMMARY });
+
         await processSyncJob({
           name: 'syncActivity',
           data: {
             userId: 'user123',
             provider: 'garmin',
             activityId: 'summary-456',
-            detailsCallbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
-            uploadTimestampInSeconds: 1706123456,
+            callbackURL: CALLBACK_URL,
           },
         });
 
-        expect(mockFetchGarminActivityDetails).toHaveBeenCalledWith(
-          expect.objectContaining({
-            accessToken: 'valid-garmin-token',
-            summaryId: 'summary-456',
-            callbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
-          })
-        );
+        expect(mockFetchFromCallback).toHaveBeenCalledWith({
+          accessToken: 'valid-garmin-token',
+          summaryId: 'summary-456',
+          callbackURL: CALLBACK_URL,
+        });
       });
 
-      it('merges the fetched samples onto the activity so the stream can be stored', async () => {
-        const samples = [{ latitudeInDegree: 48.75, longitudeInDegree: -122.48 }];
-        mockFetchGarminActivityDetails.mockResolvedValueOnce({
-          summaryId: 'summary-456',
-          samples,
-        });
+      it('makes no self-composed request when the callback answered', async () => {
+        mockFetchFromCallback.mockResolvedValueOnce({ ...GARMIN_SUMMARY });
 
         await processSyncJob({
           name: 'syncActivity',
@@ -829,7 +837,26 @@ describe('processSyncJob (via worker processor)', () => {
             userId: 'user123',
             provider: 'garmin',
             activityId: 'summary-456',
-            detailsCallbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
+            callbackURL: CALLBACK_URL,
+          },
+        });
+
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      // One prompted request has to carry the stats and the GPS together,
+      // otherwise the map needs a second call that verification would flag.
+      it('stores the track from the same payload it got the ride from', async () => {
+        const samples = [{ latitudeInDegree: 48.75, longitudeInDegree: -122.48 }];
+        mockFetchFromCallback.mockResolvedValueOnce({ ...GARMIN_SUMMARY, samples });
+
+        await processSyncJob({
+          name: 'syncActivity',
+          data: {
+            userId: 'user123',
+            provider: 'garmin',
+            activityId: 'summary-456',
+            callbackURL: CALLBACK_URL,
           },
         });
 
@@ -839,10 +866,24 @@ describe('processSyncJob (via worker processor)', () => {
         );
       });
 
-      // Indoor and trainer rides genuinely have no GPS. The ride still imports;
-      // it just has no track.
-      it('still upserts the ride when no details are available', async () => {
-        mockFetchGarminActivityDetails.mockResolvedValueOnce(null);
+      // A ping without a usable callbackURL leaves no prompted route to the
+      // data. The ride still imports, but the request is unprompted, so it is
+      // logged as such rather than passing silently.
+      it('falls back to a self-composed request when there is no callbackURL', async () => {
+        await processSyncJob({
+          name: 'syncActivity',
+          data: { userId: 'user123', provider: 'garmin', activityId: 'summary-456' },
+        });
+
+        expect(mockFetchFromCallback).not.toHaveBeenCalled();
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/rest/activities/summary-456'),
+          expect.anything()
+        );
+      });
+
+      it('falls back the same way when the callback returns no match', async () => {
+        mockFetchFromCallback.mockResolvedValueOnce(null);
 
         await processSyncJob({
           name: 'syncActivity',
@@ -850,25 +891,50 @@ describe('processSyncJob (via worker processor)', () => {
             userId: 'user123',
             provider: 'garmin',
             activityId: 'summary-456',
-            detailsCallbackURL: 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1',
+            callbackURL: CALLBACK_URL,
           },
         });
 
-        expect(mockPersistGarminStream).toHaveBeenCalledWith(
-          expect.anything(),
-          expect.not.objectContaining({ samples: expect.anything() })
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/rest/activities/summary-456'),
+          expect.anything()
         );
       });
 
-      // Nothing prompted a details pull, so making one would be exactly the
-      // unprompted request the Connect Developer Program forbids.
-      it('does not fetch details when the job carries no pointers', async () => {
+      // docs/garmin/ticket-reply.md tells Garmin that unprompted pulls are
+      // blocked behind this flag. Before this it guarded manual sync and
+      // syncGarminLatest but left the ping path wide open, so a reviewer
+      // running verification still saw unprompted pulls next to that claim.
+      it('refuses the unprompted fallback during verification mode', async () => {
+        mockConfig.garminVerificationMode = true;
+
         await processSyncJob({
           name: 'syncActivity',
           data: { userId: 'user123', provider: 'garmin', activityId: 'summary-456' },
         });
 
-        expect(mockFetchGarminActivityDetails).not.toHaveBeenCalled();
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(mockPrisma.ride.upsert).not.toHaveBeenCalled();
+      });
+
+      // Verification mode must not block the compliant path, or a reviewer sees
+      // no data flowing at all.
+      it('still follows the callbackURL during verification mode', async () => {
+        mockConfig.garminVerificationMode = true;
+        mockFetchFromCallback.mockResolvedValueOnce({ ...GARMIN_SUMMARY });
+
+        await processSyncJob({
+          name: 'syncActivity',
+          data: {
+            userId: 'user123',
+            provider: 'garmin',
+            activityId: 'summary-456',
+            callbackURL: CALLBACK_URL,
+          },
+        });
+
+        expect(mockFetchFromCallback).toHaveBeenCalled();
+        expect(mockPrisma.ride.upsert).toHaveBeenCalled();
       });
     });
 

--- a/apps/api/src/workers/sync.worker.test.ts
+++ b/apps/api/src/workers/sync.worker.test.ts
@@ -804,6 +804,63 @@ describe('processSyncJob (via worker processor)', () => {
 
       const CALLBACK_URL = 'https://apis.garmin.com/wellness-api/rest/activityDetails?x=1';
 
+      // PUSH is the mode the integration targets. Garmin sent the activity, so
+      // there is nothing to request, and a delivery we never answer cannot be
+      // scored as an unprompted pull or an unanswered ping.
+      it('makes no request at all when the activity was pushed', async () => {
+        await processSyncJob({
+          name: 'syncActivity',
+          data: {
+            userId: 'user123',
+            provider: 'garmin',
+            activityId: 'summary-456',
+            pushedActivity: { ...GARMIN_SUMMARY },
+          },
+        });
+
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(mockFetchFromCallback).not.toHaveBeenCalled();
+        expect(mockPrisma.ride.upsert).toHaveBeenCalled();
+      });
+
+      it('stores the track that came with the pushed activity', async () => {
+        const samples = [{ latitudeInDegree: 48.75, longitudeInDegree: -122.48 }];
+
+        await processSyncJob({
+          name: 'syncActivity',
+          data: {
+            userId: 'user123',
+            provider: 'garmin',
+            activityId: 'summary-456',
+            pushedActivity: { ...GARMIN_SUMMARY, samples },
+          },
+        });
+
+        expect(mockPersistGarminStream).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ samples })
+        );
+      });
+
+      // Verification mode blocks unprompted pulls. A push is not a pull, so it
+      // must keep flowing or a reviewer sees no data at all.
+      it('ingests a pushed activity during verification mode', async () => {
+        mockConfig.garminVerificationMode = true;
+
+        await processSyncJob({
+          name: 'syncActivity',
+          data: {
+            userId: 'user123',
+            provider: 'garmin',
+            activityId: 'summary-456',
+            pushedActivity: { ...GARMIN_SUMMARY },
+          },
+        });
+
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(mockPrisma.ride.upsert).toHaveBeenCalled();
+      });
+
       // Garmin's Partner Verification counts a pull as prompted only when it
       // matches a callbackURL Garmin issued, and counts a ping we did not
       // follow as unanswered. Composing our own request fails both checks at

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -11,7 +11,7 @@ import { getValidSuuntoToken } from '../lib/suunto-token';
 import { deriveLocation, deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
 import { extractGarminStartCoords } from '../lib/garmin-coords';
 import { persistGarminStream } from '../lib/ride-stream-store';
-import { fetchGarminActivityDetails } from '../lib/garmin-activity-details';
+import { fetchGarminActivityFromCallback } from '../lib/garmin-activity-details';
 import { syncBikeComponentHours } from '../lib/component-hours';
 import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { logger } from '../lib/logger';
@@ -121,9 +121,10 @@ type GarminActivity = {
   // extractGarminStartCoords, which also tolerates legacy/misspelled variants.
   startingLatitudeInDegrees?: number;
   startingLongitudeInDegrees?: number;
-  // NOT returned by the summary endpoint. Merged in from Activity Details
-  // before the upsert, because persistGarminStream reads the track off this
-  // object. Absent for indoor/trainer rides, which genuinely have no GPS.
+  // Present when the ping's callbackURL pointed at the activityDetails summary
+  // type, which returns samples beside the stats. persistGarminStream reads the
+  // track off this object. Absent on summary-only payloads and on
+  // indoor/trainer rides, which genuinely have no GPS.
   samples?: unknown;
   [key: string]: unknown;
 };
@@ -157,8 +158,7 @@ async function processSyncJob(job: Job<SyncJobData, void, SyncJobName>): Promise
           throw new Error('syncActivity requires activityId');
         }
         await syncSingleActivity(userId, provider, job.data.activityId, {
-          detailsCallbackURL: job.data.detailsCallbackURL,
-          uploadTimestampInSeconds: job.data.uploadTimestampInSeconds,
+          callbackURL: job.data.callbackURL,
         });
         break;
       default:
@@ -494,14 +494,15 @@ async function syncGarminLatest(userId: string): Promise<void> {
 }
 
 /**
- * What the activityDetails ping told us about where to find this activity's
- * GPS samples. Both fields are optional: an older queued job, or a ping shaped
- * differently than expected, simply yields a ride with no track rather than a
- * failure.
+ * The callbackURL Garmin sent on the ping that triggered this job.
+ *
+ * Optional because an older queued job predates it, and because a ping could
+ * arrive shaped differently than expected. Its absence degrades to an
+ * unprompted pull, which is logged and is refused outright in verification
+ * mode.
  */
 type GarminDetailsHint = {
-  detailsCallbackURL?: string;
-  uploadTimestampInSeconds?: number;
+  callbackURL?: string;
 };
 
 async function syncGarminActivity(
@@ -528,30 +529,74 @@ async function syncGarminActivity(
   }
 
   try {
-    const response = await fetch(
-      `${config.garminApiBase}/rest/activities/${activityId}`,
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          Accept: 'application/json',
-        },
-      }
-    );
+    // Answering the ping with its own callbackURL is the whole game here.
+    // Garmin's Partner Verification counts a pull as prompted only when it
+    // matches a URL Garmin issued, and counts a ping we did not follow as
+    // unanswered, so composing our own request fails both checks at once.
+    //
+    // It is also the map fix: an activityDetails payload carries `samples[]`
+    // beside the stats, so this one prompted request yields the ride and its
+    // GPS track together. There is nothing left to fetch separately.
+    let activity: GarminActivity | null = null;
 
-    if (!response.ok) {
-      const text = await response.text();
-      logger.error({
-        event: 'garmin_pull_error',
-        userId,
-        activityId,
-        status: response.status,
-        response: text,
-      }, '[SyncWorker] Garmin API error');
-      throw new Error(`Garmin API error: ${response.status} ${text}`);
+    if (details?.callbackURL) {
+      activity = (await fetchGarminActivityFromCallback({
+        accessToken,
+        summaryId: activityId,
+        callbackURL: details.callbackURL,
+      })) as GarminActivity | null;
     }
 
-    const activity = (await response.json()) as GarminActivity;
-    const typeLower = activity.activityType.toLowerCase().replace(/\s+/g, '_');
+    if (!activity) {
+      // Composing `/rest/activities/{summaryId}` is an UNPROMPTED pull. It is
+      // kept only so an activity still imports when a ping arrives without a
+      // usable callbackURL, and it is suppressed outright during a verification
+      // window so the reviewer's dashboard stays clean. That suppression is
+      // what makes the claim in docs/garmin/ticket-reply.md true rather than
+      // aspirational: before this, verification mode guarded manual sync and
+      // syncGarminLatest but left this path wide open.
+      if (config.garminVerificationMode) {
+        logger.warn({
+          event: 'garmin_unprompted_pull_suppressed',
+          userId,
+          activityId,
+          hadCallbackUrl: details?.callbackURL != null,
+        }, '[SyncWorker] Skipping unprompted Garmin pull during verification mode');
+        return;
+      }
+
+      logger.warn({
+        event: 'garmin_unprompted_pull',
+        userId,
+        activityId,
+      }, '[SyncWorker] No usable callbackURL on the ping; falling back to an unprompted pull');
+
+      const response = await fetch(
+        `${config.garminApiBase}/rest/activities/${activityId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            Accept: 'application/json',
+          },
+        }
+      );
+
+      if (!response.ok) {
+        const text = await response.text();
+        logger.error({
+          event: 'garmin_pull_error',
+          userId,
+          activityId,
+          status: response.status,
+          response: text,
+        }, '[SyncWorker] Garmin API error');
+        throw new Error(`Garmin API error: ${response.status} ${text}`);
+      }
+
+      activity = (await response.json()) as GarminActivity;
+    }
+
+    const typeLower = (activity.activityType ?? '').toLowerCase().replace(/\s+/g, '_');
 
     if (!GARMIN_CYCLING_TYPES.includes(typeLower)) {
       logger.debug({
@@ -559,24 +604,6 @@ async function syncGarminActivity(
         activityType: activity.activityType,
       }, '[SyncWorker] Skipping non-cycling activity');
       return;
-    }
-
-    // The endpoint above is the Activity SUMMARY: stats, device, start coords,
-    // and no per-point data whatsoever. GPS lives only in Activity Details, so
-    // the samples have to be pulled separately and merged in before the ride is
-    // upserted, because persistGarminStream reads them off this same object. Skipped
-    // for non-cycling activities above, since we would only discard the result.
-    if (details?.detailsCallbackURL || details?.uploadTimestampInSeconds != null) {
-      const detailsPayload = await fetchGarminActivityDetails({
-        accessToken,
-        summaryId: activity.summaryId,
-        callbackURL: details.detailsCallbackURL,
-        uploadTimestampInSeconds: details.uploadTimestampInSeconds,
-        apiBase: config.garminApiBase,
-      });
-      if (detailsPayload?.samples) {
-        activity.samples = detailsPayload.samples;
-      }
     }
 
     await upsertGarminActivity(userId, activity);

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -12,6 +12,7 @@ import { deriveLocation, deriveLocationAsync, shouldApplyAutoLocation } from '..
 import { extractGarminStartCoords } from '../lib/garmin-coords';
 import { persistGarminStream } from '../lib/ride-stream-store';
 import { fetchGarminActivityFromCallback } from '../lib/garmin-activity-details';
+import { isGarminCyclingActivity } from '../types/garmin';
 import { syncBikeComponentHours } from '../lib/component-hours';
 import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { logger } from '../lib/logger';
@@ -53,27 +54,6 @@ const STRAVA_CYCLING_TYPES = [
   'EBikeRide',
   'EMountainBikeRide',
   'Handcycle',
-];
-
-// Cycling activity types for Garmin
-const GARMIN_CYCLING_TYPES = [
-  'cycling',
-  'bmx',
-  'cyclocross',
-  'downhill_biking',
-  'e_bike_fitness',
-  'e_bike_mountain',
-  'e_enduro_mtb',
-  'enduro_mtb',
-  'gravel_cycling',
-  'indoor_cycling',
-  'mountain_biking',
-  'recumbent_cycling',
-  'road_biking',
-  'track_cycling',
-  'virtual_ride',
-  'handcycling',
-  'indoor_handcycling',
 ];
 
 // Strava activity type
@@ -159,6 +139,7 @@ async function processSyncJob(job: Job<SyncJobData, void, SyncJobName>): Promise
         }
         await syncSingleActivity(userId, provider, job.data.activityId, {
           callbackURL: job.data.callbackURL,
+          pushedActivity: job.data.pushedActivity,
         });
         break;
       default:
@@ -479,10 +460,7 @@ async function syncGarminLatest(userId: string): Promise<void> {
   logger.debug({ count: activities.length }, '[SyncWorker] Fetched Garmin activities');
 
   // Filter to cycling activities
-  const cyclingActivities = activities.filter((a) => {
-    const typeLower = a.activityType.toLowerCase().replace(/\s+/g, '_');
-    return GARMIN_CYCLING_TYPES.includes(typeLower);
-  });
+  const cyclingActivities = activities.filter((a) => isGarminCyclingActivity(a.activityType));
 
   logger.debug({ count: cyclingActivities.length }, '[SyncWorker] Processing cycling activities');
 
@@ -503,6 +481,8 @@ async function syncGarminLatest(userId: string): Promise<void> {
  */
 type GarminDetailsHint = {
   callbackURL?: string;
+  /** The activity itself, when Garmin PUSHed it. Short-circuits every fetch. */
+  pushedActivity?: unknown;
 };
 
 async function syncGarminActivity(
@@ -539,7 +519,16 @@ async function syncGarminActivity(
     // GPS track together. There is nothing left to fetch separately.
     let activity: GarminActivity | null = null;
 
-    if (details?.callbackURL) {
+    // Garmin PUSHed the activity: it is already in hand and there is nothing to
+    // request. This is the mode the integration targets, because a delivery we
+    // never answer cannot be scored as an unprompted pull or an unanswered
+    // ping. The webhook flattened it, so an activityDetails push arrives with
+    // its stats hoisted and `samples` alongside, ready for persistGarminStream.
+    if (details?.pushedActivity) {
+      activity = details.pushedActivity as GarminActivity;
+    }
+
+    if (!activity && details?.callbackURL) {
       activity = (await fetchGarminActivityFromCallback({
         accessToken,
         summaryId: activityId,
@@ -596,9 +585,7 @@ async function syncGarminActivity(
       activity = (await response.json()) as GarminActivity;
     }
 
-    const typeLower = (activity.activityType ?? '').toLowerCase().replace(/\s+/g, '_');
-
-    if (!GARMIN_CYCLING_TYPES.includes(typeLower)) {
+    if (!isGarminCyclingActivity(activity.activityType)) {
       logger.debug({
         activityId,
         activityType: activity.activityType,


### PR DESCRIPTION
Partner Verification is reporting unanswered pings and unprompted pulls in equal numbers. They are two readings of one mistake.

## Cause

Garmin's PING service sends a notification carrying a `callbackURL` and expects that exact URL to be fetched. The webhook read `userId` and `summaryId` off the ping, discarded the rest, and the worker composed `GET /rest/activities/{summaryId}` instead. Garmin scores a pull as prompted only when it matches a URL it issued, so our request counted as unprompted, and the ping we never followed counted separately as unanswered.

The dashboard shows the pairing directly: ping `97904864710` at `03:14:49`, our pull `97904865032` at `03:14:50`, same user, same activity, and the pull's data window is exactly that one activity's upload time.

Backfill amplifies it rather than causing it. A backfill makes Garmin re-deliver activities, each delivery drives the same webhook, and each one issues another self-composed pull.

## Fix

Follow the ping's `callbackURL`. That single change makes the request prompted and marks the ping answered.

It also replaces the separate Activity Details fetch added earlier on this line of work. An `activityDetails` payload carries `samples[]` beside the stats, so **one prompted request now yields the ride and its GPS track together**. The window-building fallback is deleted rather than made conditional, because it composed its own `/rest/activityDetails` query, which was another unprompted pull.

A ping without a usable `callbackURL` still falls back to the composed request, since the alternative is dropping the ride. That path now logs `garmin_unprompted_pull` so it is observable, and is refused outright when `GARMIN_VERIFICATION_MODE` is on.

## This closes a gap between the code and what Garmin was told

`docs/garmin/ticket-reply.md` states "Manual/unprompted pulls are additionally blocked behind a verification-mode flag during your review", and `docs/garmin/submission-checklist.md` instructs setting that flag before any verification run.

The flag guarded the manual-sync mutation and `syncGarminLatest`, and left the ping path wide open. A reviewer following the checklist would still have seen unprompted pulls, next to a written claim that they could not happen. The flag now covers the only remaining path that can produce one.

## Testing

1653 API tests pass, typecheck and lint clean. The 3 remaining lint warnings are pre-existing in untouched files.

New coverage: the callbackURL is fetched unmodified; no self-composed request is made when the callback answers; stats and samples arrive from the same payload; both fallback paths (no callbackURL, and callback returned no match); verification mode refuses the fallback but still allows the compliant path.

## Not yet verified against a live ping

Whether your pings actually carry a `callbackURL`. Garmin's ping service normally includes one and "unanswered ping" is hard to explain otherwise, but the original type comment in `webhooks.garmin.ts` documents the ping as `{ userId, summaryId, userAccessToken, ... }` and attributes `callbackURL` only to backfill responses. If it turns out to be absent, this code takes the logged fallback and the remaining work is with Garmin rather than in this diff.

Note the raw body is logged at `debug` while production runs at `info`, so `LOG_LEVEL=debug` is needed briefly to see one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
