### PR TITLE
Drop the Garmin plaintext-token fallbacks

### DIFF
--- a/apps/api/src/lib/garmin-token.test.ts
+++ b/apps/api/src/lib/garmin-token.test.ts
@@ -355,72 +355,51 @@ describe('garmin-token', () => {
   // Users who linked Garmin before UserIntegration existed have a plaintext
   // OauthToken row and no encrypted counterpart. Reading only the encrypted
   // store would silently disconnect them.
-  describe('legacy plaintext adoption', () => {
-    const legacyRow = {
-      accessToken: 'legacy-access-token',
-      refreshToken: 'legacy-refresh-token',
-      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
-      createdAt: new Date('2026-01-01'),
-    };
-
-    it('adopts a pre-encryption connection and returns its token', async () => {
+  /**
+   * The plaintext OauthToken fallback is gone.
+   *
+   * Garmin tokens were dual-written to OauthToken (plaintext) and
+   * UserIntegration (AES-256-GCM) during the migration. An adopt-on-read path
+   * encrypted a straggler the first time it was used; once the migration drained
+   * the Garmin rows it was dead code holding open a route to a credential store
+   * nothing else reads.
+   *
+   * These pin the shape it left behind: the encrypted store is the only place
+   * looked at, so revoked and undecryptable both resolve to "no connection" with
+   * no second opinion available. Re-adding a fallback would have to defeat the
+   * last assertion in each of these deliberately.
+   */
+  describe('encrypted store is authoritative', () => {
+    it('never reads the legacy plaintext table', async () => {
       mockIntegrationFindUnique.mockResolvedValue(null);
-      mockLegacyFindUnique.mockResolvedValue(legacyRow);
-      mockAccountFindFirst.mockResolvedValue({ providerUserId: 'garmin-user-1' });
 
-      const result = await getValidGarminToken('user-123');
+      expect(await getValidGarminToken('user-123')).toBeNull();
+      expect(mockLegacyFindUnique).not.toHaveBeenCalled();
+    });
 
-      expect(result).toBe('legacy-access-token');
+    // The case the old fallback had to guard explicitly: adopting whenever the
+    // encrypted read came back empty would resurrect a revoked connection from
+    // its stale plaintext row, handing out credentials for a user who withdrew
+    // consent. With no fallback there is nothing to get backwards.
+    it('reports no connection when the integration is revoked', async () => {
+      mockIntegrationFindUnique.mockResolvedValue(integrationRow({ revokedAt: new Date() }));
 
-      // Encrypted on the way in…
-      const upsert = mockIntegrationUpsert.mock.calls[0][0];
-      expect(decrypt(upsert.create.accessTokenEnc)).toBe('legacy-access-token');
-      expect(decrypt(upsert.create.refreshTokenEnc)).toBe('legacy-refresh-token');
-      expect(upsert.create.externalUserId).toBe('garmin-user-1');
+      expect(await getValidGarminToken('user-123')).toBeNull();
+      expect(mockIntegrationUpsert).not.toHaveBeenCalled();
+      expect(mockLegacyFindUnique).not.toHaveBeenCalled();
+    });
 
-      // …and the plaintext row is destroyed in the same transaction.
-      expect(mockLegacyDeleteMany).toHaveBeenCalledWith({
-        where: { userId: 'user-123', provider: 'garmin' },
+    it('reports no connection when the ciphertext will not decrypt', async () => {
+      mockIntegrationFindUnique.mockResolvedValue({
+        accessTokenEnc: 'corrupt',
+        refreshTokenEnc: null,
+        expiresAt: new Date(Date.now() + 3600_000),
+        revokedAt: null,
       });
-    });
-
-    // The dangerous case. If adoption ran whenever the encrypted read came back
-    // empty, a revoked connection would be resurrected from its stale plaintext
-    // row — handing out credentials for a user who withdrew consent.
-    it('does NOT adopt when the integration exists but is revoked', async () => {
-      mockIntegrationFindUnique
-        // getIntegrationTokens: revoked → null
-        .mockResolvedValueOnce(integrationRow({ revokedAt: new Date() }))
-        // existence probe: row is present
-        .mockResolvedValueOnce({ id: 'integration-1' });
-      mockLegacyFindUnique.mockResolvedValue(legacyRow);
 
       expect(await getValidGarminToken('user-123')).toBeNull();
       expect(mockIntegrationUpsert).not.toHaveBeenCalled();
-      expect(mockLegacyDeleteMany).not.toHaveBeenCalled();
-    });
-
-    it('does NOT adopt when the integration exists but failed to decrypt', async () => {
-      mockIntegrationFindUnique
-        .mockResolvedValueOnce({
-          accessTokenEnc: 'corrupt',
-          refreshTokenEnc: null,
-          expiresAt: new Date(Date.now() + 3600_000),
-          revokedAt: null,
-        })
-        .mockResolvedValueOnce({ id: 'integration-1' });
-      mockLegacyFindUnique.mockResolvedValue(legacyRow);
-
-      expect(await getValidGarminToken('user-123')).toBeNull();
-      expect(mockIntegrationUpsert).not.toHaveBeenCalled();
-    });
-
-    it('returns null when neither store has a connection', async () => {
-      mockIntegrationFindUnique.mockResolvedValue(null);
-      mockLegacyFindUnique.mockResolvedValue(null);
-
-      expect(await getValidGarminToken('user-123')).toBeNull();
-      expect(mockIntegrationUpsert).not.toHaveBeenCalled();
+      expect(mockLegacyFindUnique).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/lib/garmin-token.ts
+++ b/apps/api/src/lib/garmin-token.ts
@@ -1,13 +1,15 @@
 /**
  * Garmin token lifecycle. All reads and writes go through the encrypted
- * `UserIntegration` store (see ./integration-tokens); nothing here touches the
- * legacy plaintext `OauthToken` table except `adoptLegacyPlaintextTokens`,
- * which exists only to migrate stragglers off it.
+ * `UserIntegration` store (see ./integration-tokens).
+ *
+ * Nothing here touches the legacy plaintext `OauthToken` table. It used to,
+ * via an adopt-on-read fallback that encrypted a pre-encryption connection the
+ * first time it was used; that path is gone now the migration has drained the
+ * Garmin rows. The table itself remains, because Google, Strava, WHOOP and
+ * Suunto still store their tokens there.
  */
-import { prisma } from './prisma';
 import { addSeconds } from 'date-fns';
 import { createLogger } from './logger';
-import { encrypt } from './crypto';
 import {
   getIntegrationTokens,
   saveIntegrationTokens,
@@ -114,86 +116,15 @@ export async function revokeGarminTokenForUser(userId: string): Promise<boolean>
   }
 }
 
-/**
- * One-time adoption of a pre-encryption Garmin connection.
- *
- * Users who linked Garmin before `UserIntegration` existed have a plaintext
- * `OauthToken` row and no encrypted counterpart. Reading only the encrypted
- * store would silently disconnect them, so on first access we encrypt what we
- * find, write it to `UserIntegration`, and delete the plaintext row.
- *
- * This is the only remaining read of plaintext Garmin tokens. It is
- * self-limiting: every path that touches a token calls through here, so the
- * legacy rows drain as users sync. `scripts/migrate-garmin-tokens.ts` does the
- * same thing eagerly for accounts that never sync, after which this function
- * and the OauthToken Garmin rows can both be deleted.
- */
-async function adoptLegacyPlaintextTokens(
-  userId: string
-): Promise<IntegrationTokens | null> {
-  const legacy = await prisma.oauthToken.findUnique({
-    where: { userId_provider: { userId, provider: 'garmin' } },
-  });
-
-  if (!legacy) return null;
-
-  const account = await prisma.userAccount.findFirst({
-    where: { userId, provider: 'garmin' },
-    select: { providerUserId: true },
-  });
-
-  log.warn(
-    { userId },
-    'Adopting pre-encryption Garmin tokens into the encrypted store'
-  );
-
-  await prisma.$transaction(async (tx) => {
-    await tx.userIntegration.upsert({
-      where: { userId_provider: { userId, provider: 'GARMIN' } },
-      create: {
-        userId,
-        provider: 'GARMIN',
-        externalUserId: account?.providerUserId ?? null,
-        accessTokenEnc: encrypt(legacy.accessToken),
-        refreshTokenEnc: legacy.refreshToken ? encrypt(legacy.refreshToken) : null,
-        expiresAt: legacy.expiresAt,
-        connectedAt: legacy.createdAt,
-      },
-      // An integration row that exists but was unreadable (decrypt failure)
-      // should not be clobbered by an older plaintext value; only fill gaps.
-      update: {},
-    });
-
-    await tx.oauthToken.deleteMany({ where: { userId, provider: 'garmin' } });
-  });
-
-  return {
-    accessToken: legacy.accessToken,
-    refreshToken: legacy.refreshToken,
-    expiresAt: legacy.expiresAt,
-  };
-}
 
 /**
- * Read this user's Garmin tokens, migrating a legacy plaintext row if that is
- * all we have. Returns null when the user has no live Garmin connection.
+ * Read this user's Garmin tokens. Returns null when the user has no live
+ * Garmin connection, which now includes a connection that was revoked or whose
+ * ciphertext will not decrypt: both are states the encrypted store answers on
+ * its own, with no second place to look.
  */
 async function readGarminTokens(userId: string): Promise<IntegrationTokens | null> {
-  const tokens = await getIntegrationTokens(userId, 'GARMIN');
-  if (tokens) return tokens;
-
-  // Adopt ONLY when no integration row exists at all. A row that exists but
-  // yielded no tokens is revoked or undecryptable, and reviving it from a stale
-  // plaintext row would undo a revocation — handing out credentials for a user
-  // who withdrew consent. Getting this backwards is the whole risk of keeping a
-  // fallback path, so it is checked explicitly rather than inferred.
-  const existing = await prisma.userIntegration.findUnique({
-    where: { userId_provider: { userId, provider: 'GARMIN' } },
-    select: { id: true },
-  });
-  if (existing) return null;
-
-  return adoptLegacyPlaintextTokens(userId);
+  return getIntegrationTokens(userId, 'GARMIN');
 }
 
 /**

--- a/apps/api/src/routes/auth.garmin.ts
+++ b/apps/api/src/routes/auth.garmin.ts
@@ -383,29 +383,6 @@ r.get('/garmin/status', async (req: Request, res: Response) => {
       });
     }
 
-    // Pre-encryption connections still living in the legacy plaintext table
-    // read as connected here. They are adopted into UserIntegration the next
-    // time a token is actually used (garmin-token.ts), or eagerly by
-    // scripts/migrate-garmin-tokens.ts. This branch goes away with the table.
-    //
-    // Deliberately below the UserIntegration check: a revoked integration must
-    // report disconnected even if a stale plaintext row is still present.
-    if (!integration) {
-      const legacy = await prisma.oauthToken.findUnique({
-        where: { userId_provider: { userId, provider: 'garmin' } },
-      });
-
-      if (legacy) {
-        return sendSuccess(res, {
-          connected: true,
-          connectedAt: legacy.createdAt.toISOString(),
-          revokedAt: null,
-          lastSyncAt: null,
-          scopes: null,
-        });
-      }
-    }
-
     return sendSuccess(res, { connected: false });
   } catch (err) {
     log.error({ err, userId }, 'Failed to get Garmin status');


### PR DESCRIPTION
The migration has drained the Garmin rows out of `OauthToken`, so the two paths that existed to cover stragglers are dead code holding open a route to a credential store nothing else reads.

**Removed:**
- `adoptLegacyPlaintextTokens` in `lib/garmin-token.ts` — encrypted a pre-encryption connection the first time it was used
- The `GET /garmin/status` fallback that reported `connected: true` from a plaintext row when no `UserIntegration` existed

Both carried a guard that only adopted when *no* integration row existed, because a row that exists but yields no tokens is revoked or undecryptable, and reviving it from stale plaintext would undo a revocation. With the fallbacks gone there is nothing to get backwards: revoked and undecryptable both resolve to "no connection" from the encrypted store alone.

The tests pin that shape, including that the legacy table is **never read at all**, so re-adding a fallback has to defeat those assertions deliberately.

`readGarminTokens` collapses to a call through to `getIntegrationTokens`, and the `prisma` and `encrypt` imports go with it. Net −113 lines.

## Two corrections to what the code claimed

**The table is not going anywhere.** The comment on the status fallback said "This branch goes away with the table". Google, Strava, WHOOP and Suunto all still store their tokens in `OauthToken`. Only the Garmin branches go, and the file header now says so.

**The `oauthToken.deleteMany` calls on disconnect and deregistration stay.** They are no-ops now, but they cost one query on a rare path and they are what stops a plaintext row lingering if one ever reappears from a restore.

## Precondition

Ryan confirmed there are no Garmin tokens left to migrate. Worth restating that this is only safe against a drained **production** database: if any plaintext Garmin row survived, this change silently disconnects that user. `getValidGarminToken` returns null so syncing stops, and `/garmin/status` reports disconnected, with nothing erroring.

Verify with `SELECT count(*) FROM "OauthToken" WHERE provider = 'garmin'` before deploying.

## Testing

1740 API tests pass, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
