### PR TITLE
feat(whoop): add mobile OAuth routes so the app's connect button works

### DIFF
--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -104,8 +104,11 @@ export const MUTATION_RATE_LIMITS = {
   addPassword: { windowSeconds: 3600, maxRequests: 5 },
   /** changePassword: max 5 requests per hour per user (sensitive credential operation) */
   changePassword: { windowSeconds: 3600, maxRequests: 5 },
-  /** oauthStart: max 5 requests per 10 minutes per user (creates DB row each call) */
-  oauthStart: { windowSeconds: 600, maxRequests: 5 },
+  /** oauthStart: max 10 requests per 10 minutes per user (creates DB row each
+   *  call). The budget is per user, not per provider, and mobile onboarding
+   *  offers four connect buttons — at 5, a user connecting all four had a
+   *  single retry left before a 10-minute lockout. */
+  oauthStart: { windowSeconds: 600, maxRequests: 10 },
   /** updateUserPreferences: max 20 requests per minute per user */
   updateUserPreferences: { windowSeconds: 60, maxRequests: 20 },
   /** updateAnalyticsOptOut: max 10 toggles per hour per user. Users rarely flip

--- a/apps/api/src/routes/auth.whoop.test.ts
+++ b/apps/api/src/routes/auth.whoop.test.ts
@@ -9,6 +9,21 @@ jest.mock('../lib/whoop-token', () => ({
 const mockRandomString = jest.fn();
 jest.mock('../lib/pcke', () => ({
   randomString: mockRandomString,
+  sha256: jest.fn(),
+}));
+
+// Must be mocked: the real module pulls in ./redis, and isRedisReady() would
+// return false and silently take the in-memory path, making the 429 untestable.
+const mockCheckMutationRateLimit = jest.fn();
+jest.mock('../lib/rate-limit', () => ({
+  checkMutationRateLimit: (...args: unknown[]) => mockCheckMutationRateLimit(...args),
+}));
+
+const mockCreateOAuthAttempt = jest.fn();
+const mockConsumeOAuthAttempt = jest.fn();
+jest.mock('../lib/oauthState', () => ({
+  createOAuthAttempt: (...args: unknown[]) => mockCreateOAuthAttempt(...args),
+  consumeOAuthAttempt: (...args: unknown[]) => mockConsumeOAuthAttempt(...args),
 }));
 
 const mockFindUnique = jest.fn();
@@ -55,6 +70,7 @@ global.fetch = mockFetch;
 // Import router after mocks
 import router from './auth.whoop';
 import { Prisma } from '@prisma/client';
+import { WHOOP_API_BASE } from '../types/whoop';
 
 // Type for Express router layer internals
 interface RouteLayer {
@@ -92,6 +108,8 @@ describe('auth.whoop routes', () => {
     process.env.WHOOP_REDIRECT_URI = 'http://localhost:4000/auth/whoop/callback';
     process.env.APP_BASE_URL = 'http://localhost:5173';
     process.env.NODE_ENV = 'development';
+    delete process.env.MOBILE_DEEP_LINK_SCHEME;
+    mockCheckMutationRateLimit.mockResolvedValue({ allowed: true, redisAvailable: true });
   });
 
   describe('GET /whoop/start', () => {
@@ -218,6 +236,11 @@ describe('auth.whoop routes', () => {
           }),
         });
 
+      // Default: no DB attempt matches, so every test in this describe block
+      // exercises the WEB branch. That is deliberate — these are the regression
+      // guard for the pre-mobile behavior and must pass unchanged.
+      mockConsumeOAuthAttempt.mockResolvedValue(null);
+
       mockUpsert.mockResolvedValue({});
       mockUpdate.mockResolvedValue({});
       mockFindMany.mockResolvedValue([{ provider: 'whoop' }]);
@@ -277,12 +300,15 @@ describe('auth.whoop routes', () => {
     it('should fetch user profile', async () => {
       await invokeHandler(handler, mockReq as Request, mockRes as Response);
 
+      // Asserted against the constant, not a literal — pinning a literal here
+      // is exactly how this call stayed on v1 through the rest of the v2 migration.
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.prod.whoop.com/developer/v1/user/profile/basic',
+        `${WHOOP_API_BASE}/user/profile/basic`,
         expect.objectContaining({
           headers: { Authorization: 'Bearer new-access-token' },
         })
       );
+      expect(WHOOP_API_BASE).toContain('/developer/v2');
     });
 
     it('should store tokens in database', async () => {
@@ -404,6 +430,398 @@ describe('auth.whoop routes', () => {
       expect(mockRes.redirect).toHaveBeenCalledWith(
         expect.stringContaining('WHOOP%20connection%20failed')
       );
+    });
+  });
+
+  describe('POST /whoop/start (mobile)', () => {
+    let handler: RequestHandler | undefined;
+    let mockReq: Partial<Request>;
+    let mockRes: Partial<Response>;
+
+    beforeEach(() => {
+      handler = getHandler('/whoop/start', 'post');
+
+      mockReq = { sessionUser: { uid: 'user-123' } } as Partial<Request>;
+      mockRes = {
+        cookie: jest.fn().mockReturnThis(),
+        redirect: jest.fn().mockReturnThis(),
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+        setHeader: jest.fn().mockReturnThis(),
+      };
+
+      mockCreateOAuthAttempt.mockResolvedValue({
+        state: 'db-state-abc',
+        verifier: '',
+        attempt: { id: 'attempt-1' },
+      });
+    });
+
+    function authorizeUrl(): URL {
+      const call = (mockRes.json as jest.Mock).mock.calls[0][0];
+      return new URL(call.data.authorizeUrl);
+    }
+
+    it('should return 401 when sessionUser is missing', async () => {
+      mockReq.sessionUser = undefined;
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+      expect(mockCreateOAuthAttempt).not.toHaveBeenCalled();
+    });
+
+    it('should NOT fall back to req.user — mobile-only route', async () => {
+      mockReq.sessionUser = undefined;
+      mockReq.user = { id: 'web-user-999' } as Request['user'];
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+      expect(mockCreateOAuthAttempt).not.toHaveBeenCalled();
+    });
+
+    it('should return 429 with Retry-After when rate limited', async () => {
+      mockCheckMutationRateLimit.mockResolvedValue({ allowed: false, retryAfter: 120 });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(429);
+      expect(mockRes.setHeader).toHaveBeenCalledWith('Retry-After', '120');
+      expect(mockCreateOAuthAttempt).not.toHaveBeenCalled();
+    });
+
+    it.each(['WHOOP_CLIENT_ID', 'WHOOP_REDIRECT_URI'])(
+      'should return 500 when %s is missing, without creating an orphan attempt',
+      async (envVar) => {
+        delete process.env[envVar];
+
+        await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+        expect(mockRes.status).toHaveBeenCalledWith(500);
+        expect(mockCreateOAuthAttempt).not.toHaveBeenCalled();
+      }
+    );
+
+    it('should create a MOBILE attempt with no PKCE verifier', async () => {
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      // includeVerifier:false is the guard against someone flipping WHOOP to
+      // PKCE — WHOOP authenticates with a client secret, so a stored-but-unsent
+      // verifier would be a silent no-op.
+      expect(mockCreateOAuthAttempt).toHaveBeenCalledWith({
+        userId: 'user-123',
+        provider: 'WHOOP',
+        platform: 'MOBILE',
+        includeVerifier: false,
+      });
+    });
+
+    it('should return the authorize URL in the canonical envelope', async () => {
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        ok: true,
+        data: {
+          authorizeUrl: expect.stringContaining('https://api.prod.whoop.com/oauth/oauth2/auth'),
+        },
+      });
+
+      const url = authorizeUrl();
+      expect(url.searchParams.get('client_id')).toBe('test-client-id');
+      expect(url.searchParams.get('redirect_uri')).toBe('http://localhost:4000/auth/whoop/callback');
+      expect(url.searchParams.get('response_type')).toBe('code');
+      expect(url.searchParams.get('state')).toBe('db-state-abc');
+      expect(url.searchParams.get('scope')).toBe('read:workout read:profile offline');
+    });
+
+    it('should request the same scope and redirect_uri as the web start route', async () => {
+      // A drift in `scope` would drop `offline`, and WHOOP would return no
+      // refresh_token — the callback then writes undefined into a non-nullable
+      // column, but only on the mobile path. A drift in redirect_uri would break
+      // the token exchange, which sends exactly one registered value.
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+      const mobileUrl = authorizeUrl();
+
+      const webHandler = getHandler('/whoop/start', 'get');
+      const webRes = { cookie: jest.fn().mockReturnThis(), redirect: jest.fn().mockReturnThis() };
+      mockRandomString.mockReturnValue('web-state');
+      await invokeHandler(webHandler, {} as Request, webRes as unknown as Response);
+      const webUrl = new URL((webRes.redirect as jest.Mock).mock.calls[0][0]);
+
+      expect(mobileUrl.searchParams.get('scope')).toBe(webUrl.searchParams.get('scope'));
+      expect(mobileUrl.searchParams.get('redirect_uri')).toBe(webUrl.searchParams.get('redirect_uri'));
+    });
+
+    it('should not set a state cookie — the DB row is the only state carrier', async () => {
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.cookie).not.toHaveBeenCalled();
+    });
+
+    it('should return 500 when creating the attempt fails', async () => {
+      mockCreateOAuthAttempt.mockRejectedValue(new Error('db down'));
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('GET /whoop/callback (mobile flow)', () => {
+    let handler: RequestHandler | undefined;
+    let mockReq: Partial<Request>;
+    let mockRes: Partial<Response>;
+
+    beforeEach(() => {
+      handler = getHandler('/whoop/callback', 'get');
+
+      mockReq = {
+        query: { code: 'auth-code', state: 'valid-state' },
+        // Neither a cookie nor a session — this is what the external browser
+        // actually sends back on mobile.
+        cookies: {},
+        user: undefined,
+        sessionUser: undefined,
+      };
+
+      mockRes = {
+        clearCookie: jest.fn().mockReturnThis(),
+        redirect: jest.fn().mockReturnThis(),
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+        send: jest.fn().mockReturnThis(),
+      };
+
+      mockConsumeOAuthAttempt.mockResolvedValue({
+        attempt: { id: 'attempt-1', userId: 'mobile-user-1' },
+        verifier: '',
+      });
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            access_token: 'new-access-token',
+            refresh_token: 'new-refresh-token',
+            expires_in: 3600,
+            token_type: 'bearer',
+            scope: 'read:workout read:profile offline',
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            user_id: 12345,
+            email: 'test@example.com',
+            first_name: 'Test',
+            last_name: 'User',
+          }),
+        });
+
+      mockUpsert.mockResolvedValue({});
+      mockUpdate.mockResolvedValue({});
+      mockFindMany.mockResolvedValue([{ provider: 'whoop' }]);
+      mockFindUnique.mockResolvedValue({ onboardingCompleted: true });
+      mockTransaction.mockImplementation(async (fn: (tx: typeof mockPrisma) => Promise<void>) => {
+        await fn(mockPrisma);
+      });
+    });
+
+    it('should look up the attempt with the Prisma enum casing', async () => {
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      // oauthState filters on the IntegrationProvider enum — a lowercase
+      // value would silently never match.
+      expect(mockConsumeOAuthAttempt).toHaveBeenCalledWith({
+        state: 'valid-state',
+        provider: 'WHOOP',
+      });
+    });
+
+    it('should redirect to the mobile trampoline on success', async () => {
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.redirect).toHaveBeenCalledWith('/auth/whoop/mobile/complete?status=success');
+      expect(mockRes.clearCookie).not.toHaveBeenCalled();
+    });
+
+    it('should identify the user from the attempt, not the session', async () => {
+      // The whole point of the DB-state flow: this succeeds with no cookie and
+      // no session, and the *attempt's* user wins over any stale req.user.
+      mockReq.user = { id: 'web-user-999' } as Request['user'];
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId_provider: { userId: 'mobile-user-1', provider: 'whoop' } },
+        })
+      );
+    });
+
+    it('should skip the web-only redirect bookkeeping', async () => {
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockFindMany).not.toHaveBeenCalled();
+    });
+
+    it('should deep-link a token exchange failure instead of a 502', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 400, text: () => Promise.resolve('bad') });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.redirect).toHaveBeenCalledWith(
+        '/auth/whoop/mobile/complete?status=error&reason=token_exchange_failed'
+      );
+      expect(mockRes.status).not.toHaveBeenCalledWith(502);
+    });
+
+    it('should report a profile fetch failure as token_exchange_failed', async () => {
+      // The app has no profile_fetch_failed message; an unmapped reason would
+      // render a generic fallback.
+      mockFetch.mockReset();
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            access_token: 'a', refresh_token: 'b', expires_in: 3600, token_type: 'bearer', scope: '',
+          }),
+        })
+        .mockResolvedValueOnce({ ok: false, status: 401, text: () => Promise.resolve('nope') });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.redirect).toHaveBeenCalledWith(
+        '/auth/whoop/mobile/complete?status=error&reason=token_exchange_failed'
+      );
+      expect(mockRes.status).not.toHaveBeenCalledWith(502);
+    });
+
+    it('should deep-link account_already_linked on P2002', async () => {
+      mockTransaction.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+          code: 'P2002',
+          clientVersion: '5.0.0',
+          meta: { target: ['whoopUserId'] },
+        })
+      );
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.redirect).toHaveBeenCalledWith(
+        '/auth/whoop/mobile/complete?status=error&reason=account_already_linked'
+      );
+      expect(mockRes.redirect).not.toHaveBeenCalledWith(expect.stringContaining('localhost:5173'));
+    });
+
+    it('should deep-link internal_error on a generic failure', async () => {
+      mockTransaction.mockRejectedValue(new Error('Database connection lost'));
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.redirect).toHaveBeenCalledWith(
+        '/auth/whoop/mobile/complete?status=error&reason=internal_error'
+      );
+    });
+
+    it('should deep-link access_denied when the user declines consent', async () => {
+      mockReq.query = { error: 'access_denied', state: 'valid-state' };
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.redirect).toHaveBeenCalledWith(
+        '/auth/whoop/mobile/complete?status=error&reason=access_denied'
+      );
+    });
+
+    it('should leave a declined WEB consent on the legacy 400', async () => {
+      mockConsumeOAuthAttempt.mockResolvedValue(null);
+      mockReq.query = { error: 'access_denied', state: 'valid-state' };
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+    });
+
+    it('should fall through to the web branch when the attempt is expired or replayed', async () => {
+      // Known gap, shared with Strava and Suunto: past the 10-minute TTL the
+      // user sees a browser 400 rather than a deep link back into the app.
+      mockConsumeOAuthAttempt.mockResolvedValue(null);
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('GET /whoop/mobile/complete', () => {
+    let handler: RequestHandler | undefined;
+    let mockReq: Partial<Request>;
+    let mockRes: Partial<Response>;
+
+    beforeEach(() => {
+      handler = getHandler('/whoop/mobile/complete', 'get');
+      mockReq = { query: {} };
+      mockRes = {
+        setHeader: jest.fn().mockReturnThis(),
+        send: jest.fn().mockReturnThis(),
+      };
+    });
+
+    function body(): string {
+      return (mockRes.send as jest.Mock).mock.calls[0][0] as string;
+    }
+
+    it('should send uncacheable HTML', async () => {
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockRes.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+      expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html; charset=utf-8');
+    });
+
+    it('should deep-link to the whoop route the app registers', async () => {
+      mockReq.query = { status: 'success' };
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      // Path must stay `whoop` — app/oauth/whoop.tsx is what receives this.
+      expect(body()).toContain('loamlogger://oauth/whoop?status=success');
+    });
+
+    it('should pass a whitelisted reason through', async () => {
+      mockReq.query = { status: 'error', reason: 'token_exchange_failed' };
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(body()).toContain('loamlogger://oauth/whoop?status=error&amp;reason=token_exchange_failed');
+    });
+
+    it('should drop a non-whitelisted reason', async () => {
+      mockReq.query = { status: 'error', reason: '<script>alert(1)</script>' };
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(body()).not.toContain('<script>alert');
+      expect(body()).not.toContain('reason=');
+    });
+
+    it('should coerce an unknown status to error', async () => {
+      mockReq.query = { status: 'bogus' };
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(body()).toContain('loamlogger://oauth/whoop?status=error');
+    });
+
+    it('should honour MOBILE_DEEP_LINK_SCHEME', async () => {
+      process.env.MOBILE_DEEP_LINK_SCHEME = 'llstaging';
+      mockReq.query = { status: 'success' };
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(body()).toContain('llstaging://oauth/whoop?status=success');
     });
   });
 

--- a/apps/api/src/routes/auth.whoop.ts
+++ b/apps/api/src/routes/auth.whoop.ts
@@ -133,8 +133,13 @@ r.get<Empty, void, Empty, { code?: string; state?: string; scope?: string; error
     // failures keep the exact redirects this route has always emitted. Only
     // the failure sites *after* the state check can ever run with
     // isMobileFlow === true, so the web contract is untouched by construction.
+    //
+    // `access_denied` is deliberately NOT in this union. That path runs before
+    // isMobileFlow is set, so routing it through here would take the web branch
+    // and strand a mobile user on the web error page. It redirects directly
+    // instead; leaving it out makes the mistake a compile error.
     function failCallback(
-      reason: 'access_denied' | 'token_exchange_failed' | 'account_already_linked' | 'internal_error'
+      reason: 'token_exchange_failed' | 'account_already_linked' | 'internal_error'
     ) {
       if (isMobileFlow) {
         return res.redirect(`/auth/whoop/mobile/complete?status=error&reason=${encodeURIComponent(reason)}`);

--- a/apps/api/src/routes/auth.whoop.ts
+++ b/apps/api/src/routes/auth.whoop.ts
@@ -2,16 +2,25 @@ import { Router as createRouter, type Router, type Request, type Response } from
 import { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { randomString } from '../lib/pcke';
-import { sendBadRequest, sendSuccess, sendUnauthorized, sendInternalError } from '../lib/api-response';
+import { sendBadRequest, sendSuccess, sendUnauthorized, sendInternalError, sendTooManyRequests } from '../lib/api-response';
 import { createLogger } from '../lib/logger';
 import { revokeWhoopTokenForUser } from '../lib/whoop-token';
-import { WHOOP_AUTH_URL, WHOOP_TOKEN_URL, type WhoopUserProfile } from '../types/whoop';
+import { WHOOP_API_BASE, WHOOP_AUTH_URL, WHOOP_TOKEN_URL, type WhoopUserProfile } from '../types/whoop';
 import { captureServerEvent } from '../lib/posthog';
+import { checkMutationRateLimit } from '../lib/rate-limit';
+import { createOAuthAttempt, consumeOAuthAttempt } from '../lib/oauthState';
+import { renderOAuthCompletionPage } from '../lib/oauthCompletionPage';
 
 const log = createLogger('whoop-oauth');
 
 type Empty = Record<string, never>;
 const r: Router = createRouter();
+
+// Shared by both the web and mobile start routes. `offline` is what makes WHOOP
+// return a refresh_token; if only one of the two routes requested it, the
+// callback would write `refreshToken: undefined` into a non-nullable column on
+// whichever path drifted. One constant makes that divergence impossible.
+const SCOPE = 'read:workout read:profile offline';
 
 /**
  * 1) Start OAuth — redirect user to WHOOP's consent page with state
@@ -19,7 +28,6 @@ const r: Router = createRouter();
 r.get<Empty, void, Empty>('/whoop/start', async (_req: Request, res: Response) => {
   const CLIENT_ID = process.env.WHOOP_CLIENT_ID;
   const REDIRECT_URI = process.env.WHOOP_REDIRECT_URI;
-  const SCOPE = 'read:workout read:profile offline';
 
   if (!CLIENT_ID || !REDIRECT_URI) {
     const missing = [
@@ -56,12 +64,88 @@ r.get<Empty, void, Empty>('/whoop/start', async (_req: Request, res: Response) =
 });
 
 /**
- * 2) Callback — exchange code for tokens, store in DB
+ * 2) Mobile Start — returns the authorize URL as JSON.
+ *
+ * The mobile app has no cookie jar of its own, so state lives in an
+ * `OAuthAttempt` row keyed to the user instead of an httpOnly cookie. The
+ * callback then identifies the user by consuming that row. Mirrors
+ * auth.strava.ts and auth.suunto.ts.
  */
-r.get<Empty, void, Empty, { code?: string; state?: string; scope?: string }>(
+r.post<Empty, unknown, Empty>('/whoop/start', async (req: Request, res: Response) => {
+  const userId = req.sessionUser?.uid;
+  if (!userId) {
+    return sendUnauthorized(res, 'Not authenticated');
+  }
+
+  const rateLimit = await checkMutationRateLimit('oauthStart', userId);
+  if (!rateLimit.allowed) {
+    return sendTooManyRequests(res, 'Too many OAuth attempts. Please try again later.', rateLimit.retryAfter);
+  }
+
+  const CLIENT_ID = process.env.WHOOP_CLIENT_ID;
+  const REDIRECT_URI = process.env.WHOOP_REDIRECT_URI;
+
+  if (!CLIENT_ID || !REDIRECT_URI) {
+    const missing = [
+      !CLIENT_ID && 'WHOOP_CLIENT_ID',
+      !REDIRECT_URI && 'WHOOP_REDIRECT_URI',
+    ].filter(Boolean).join(', ');
+    log.error({ missing }, 'Missing env vars for WHOOP start (mobile)');
+    return sendInternalError(res, 'WHOOP OAuth is not configured');
+  }
+
+  try {
+    // WHOOP authenticates the token exchange with a client secret, not PKCE —
+    // same as Strava and Suunto, so no verifier is generated or stored.
+    const { state, attempt } = await createOAuthAttempt({
+      userId,
+      provider: 'WHOOP',
+      platform: 'MOBILE',
+      includeVerifier: false,
+    });
+
+    const url = new URL(WHOOP_AUTH_URL);
+    url.searchParams.set('client_id', CLIENT_ID);
+    url.searchParams.set('redirect_uri', REDIRECT_URI);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('scope', SCOPE);
+    url.searchParams.set('state', state);
+
+    log.info({ userId, attemptId: attempt.id, provider: 'WHOOP' }, 'WHOOP OAuth start (mobile)');
+    return sendSuccess(res, { authorizeUrl: url.toString() });
+  } catch (err) {
+    log.error({ err, userId }, 'Failed to create WHOOP OAuth attempt');
+    return sendInternalError(res);
+  }
+});
+
+/**
+ * 3) Callback — exchange code for tokens, store in DB
+ */
+r.get<Empty, void, Empty, { code?: string; state?: string; scope?: string; error?: string }>(
   '/whoop/callback',
-  async (req: Request<Empty, void, Empty, { code?: string; state?: string; scope?: string }>, res: Response) => {
+  async (req: Request<Empty, void, Empty, { code?: string; state?: string; scope?: string; error?: string }>, res: Response) => {
     let userId: string | undefined;
+    let isMobileFlow = false;
+    let attemptId: string | undefined;
+
+    // Mobile failures deep-link back into the app via the trampoline; web
+    // failures keep the exact redirects this route has always emitted. Only
+    // the failure sites *after* the state check can ever run with
+    // isMobileFlow === true, so the web contract is untouched by construction.
+    function failCallback(
+      reason: 'access_denied' | 'token_exchange_failed' | 'account_already_linked' | 'internal_error'
+    ) {
+      if (isMobileFlow) {
+        return res.redirect(`/auth/whoop/mobile/complete?status=error&reason=${encodeURIComponent(reason)}`);
+      }
+      const appBase = process.env.APP_BASE_URL ?? 'http://localhost:5173';
+      const message = reason === 'account_already_linked'
+        ? 'This WHOOP account is already linked to another user.'
+        : 'WHOOP connection failed. Please try again.';
+      return res.redirect(`${appBase}/auth/error?message=${encodeURIComponent(message)}`);
+    }
+
     try {
       const REDIRECT_URI = process.env.WHOOP_REDIRECT_URI;
       const CLIENT_ID = process.env.WHOOP_CLIENT_ID;
@@ -79,19 +163,45 @@ r.get<Empty, void, Empty, { code?: string; state?: string; scope?: string }>(
         return sendInternalError(res, 'WHOOP OAuth is not configured');
       }
 
-      const { code, state } = req.query;
-      const cookieState = req.cookies['ll_whoop_state'];
+      const { code, state, error: oauthError } = req.query;
 
-      log.debug({ hasCode: !!code, statesMatch: state === cookieState }, 'WHOOP callback state check');
+      // The user declined on WHOOP's consent screen: we get `error` and no
+      // `code`. Only acts when the state resolves to a mobile attempt, so the
+      // web path still falls through to the 400 below.
+      if (oauthError && state) {
+        const denied = await consumeOAuthAttempt({ state, provider: 'WHOOP' });
+        if (denied) {
+          log.info({ userId: denied.attempt.userId, oauthError }, 'WHOOP consent declined (mobile)');
+          return res.redirect('/auth/whoop/mobile/complete?status=error&reason=access_denied');
+        }
+      }
 
-      if (!code || !state || !cookieState || state !== cookieState) {
+      if (!code || !state) {
         return sendBadRequest(res, 'Invalid OAuth state');
       }
 
-      // Check for authenticated user
-      userId = req.user?.id || req.sessionUser?.uid;
-      if (!userId) {
-        return sendUnauthorized(res, 'No user - please log in first');
+      // Mobile flow first: DB-backed state, atomically consumed (replay-safe).
+      const dbAttempt = await consumeOAuthAttempt({ state, provider: 'WHOOP' });
+      if (dbAttempt) {
+        isMobileFlow = true;
+        userId = dbAttempt.attempt.userId;
+        attemptId = dbAttempt.attempt.id;
+        log.info({ userId, attemptId }, 'WHOOP callback: mobile flow (DB state)');
+      } else {
+        // Web flow: httpOnly cookie state plus an authenticated session.
+        const cookieState = req.cookies['ll_whoop_state'];
+
+        log.debug({ hasCode: !!code, statesMatch: state === cookieState }, 'WHOOP callback state check');
+
+        if (!cookieState || state !== cookieState) {
+          return sendBadRequest(res, 'Invalid OAuth state');
+        }
+
+        // Check for authenticated user
+        userId = req.user?.id || req.sessionUser?.uid;
+        if (!userId) {
+          return sendUnauthorized(res, 'No user - please log in first');
+        }
       }
 
       const authenticatedUserId = userId;
@@ -113,7 +223,8 @@ r.get<Empty, void, Empty, { code?: string; state?: string; scope?: string }>(
 
       if (!tokenRes.ok) {
         const text = await tokenRes.text();
-        log.error({ status: tokenRes.status, body: text.slice(0, 200) }, 'WHOOP token exchange failed');
+        log.error({ status: tokenRes.status, userId, attemptId, body: text.slice(0, 200) }, 'WHOOP token exchange failed');
+        if (isMobileFlow) return failCallback('token_exchange_failed');
         return res.status(502).send('Token exchange failed');
       }
 
@@ -131,7 +242,7 @@ r.get<Empty, void, Empty, { code?: string; state?: string; scope?: string }>(
       log.info({ expiresAt }, 'WHOOP token received');
 
       // Fetch user profile to get WHOOP user ID
-      const profileRes = await fetch('https://api.prod.whoop.com/developer/v1/user/profile/basic', {
+      const profileRes = await fetch(`${WHOOP_API_BASE}/user/profile/basic`, {
         headers: {
           Authorization: `Bearer ${t.access_token}`,
         },
@@ -139,7 +250,12 @@ r.get<Empty, void, Empty, { code?: string; state?: string; scope?: string }>(
 
       if (!profileRes.ok) {
         const text = await profileRes.text();
-        log.error({ status: profileRes.status, body: text.slice(0, 200) }, 'WHOOP profile fetch failed');
+        log.error({ status: profileRes.status, userId, attemptId, body: text.slice(0, 200) }, 'WHOOP profile fetch failed');
+        // Reported to mobile as token_exchange_failed on purpose: the app has
+        // no `profile_fetch_failed` entry in its ERROR_MESSAGES map, and an
+        // unmapped reason renders a generic fallback. "Could not complete
+        // authentication with the provider" is accurate for a failed profile read.
+        if (isMobileFlow) return failCallback('token_exchange_failed');
         return res.status(502).send('Profile fetch failed');
       }
 
@@ -202,6 +318,13 @@ r.get<Empty, void, Empty, { code?: string; state?: string; scope?: string }>(
 
       captureServerEvent(authenticatedUserId, 'provider_connected', { provider: 'whoop', isReconnect });
 
+      // Mobile stops here. Everything below only picks a web redirect path, and
+      // there is no cookie to clear — the attempt row was already consumed.
+      if (isMobileFlow) {
+        log.info({ userId, attemptId }, 'WHOOP OAuth callback success (mobile)');
+        return res.redirect('/auth/whoop/mobile/complete?status=success');
+      }
+
       // Check if user has multiple providers connected
       const userAccounts = await prisma.userAccount.findMany({
         where: { userId },
@@ -234,24 +357,56 @@ r.get<Empty, void, Empty, { code?: string; state?: string; scope?: string }>(
       log.info({ userId, redirectPath }, 'WHOOP OAuth callback success');
       return res.redirect(`${appBase.replace(/\/$/, '')}${redirectPath}`);
     } catch (error) {
-      const appBase = process.env.APP_BASE_URL ?? 'http://localhost:5173';
       if (
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === 'P2002' &&
         Array.isArray(error.meta?.target) && error.meta.target.includes('whoopUserId')
       ) {
-        log.warn({ userId }, 'WHOOP account already linked to another user');
-        return res.redirect(
-          `${appBase}/auth/error?message=${encodeURIComponent('This WHOOP account is already linked to another user.')}`
-        );
+        log.warn({ userId, attemptId }, 'WHOOP account already linked to another user');
+        return failCallback('account_already_linked');
       }
-      log.error({ err: error }, 'WHOOP callback error');
-      return res.redirect(
-        `${appBase}/auth/error?message=${encodeURIComponent('WHOOP connection failed. Please try again.')}`
-      );
+      log.error({ err: error, userId, attemptId }, 'WHOOP callback error');
+      return failCallback('internal_error');
     }
   }
 );
+
+// ---------------------------------------------------------------------------
+// 4) Mobile completion page — deep link trampoline
+// ---------------------------------------------------------------------------
+// The callback redirects here (relative, so it stays on the API origin) and
+// this page bounces the system browser back into the app. WHOOP never sees
+// this URL, so it does not need registering as a redirect URI.
+r.get('/whoop/mobile/complete', (req: Request, res: Response) => {
+  const VALID_STATUSES = ['success', 'error'] as const;
+  const VALID_REASONS = [
+    'invalid_state',
+    'access_denied',
+    'token_exchange_failed',
+    'account_already_linked',
+    'internal_error',
+  ] as const;
+
+  const rawStatus = req.query.status as string | undefined;
+  const rawReason = req.query.reason as string | undefined;
+
+  const status = (VALID_STATUSES as readonly string[]).includes(rawStatus!) ? rawStatus! : 'error';
+  const reason = (VALID_REASONS as readonly string[]).includes(rawReason!) ? rawReason! : undefined;
+  const scheme = process.env.MOBILE_DEEP_LINK_SCHEME || 'loamlogger';
+
+  log.debug({ status, reason }, 'Rendering WHOOP mobile completion page');
+
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+
+  res.send(renderOAuthCompletionPage({
+    provider: 'WHOOP',
+    status,
+    reason,
+    scheme,
+    brandColor: '#00a651',
+  }));
+});
 
 // ---------------------------------------------------------------------------
 // Auth strategy for the routes below
@@ -272,7 +427,7 @@ r.get<Empty, void, Empty, { code?: string; state?: string; scope?: string }>(
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// 3) Status — connection status for mobile UI
+// 5) Status — connection status for mobile UI
 // ---------------------------------------------------------------------------
 // WHOOP doesn't use the `UserIntegration` table (see comment in callback);
 // connection state lives in `oauthToken` keyed on (userId, provider='whoop').
@@ -318,7 +473,7 @@ r.get('/whoop/status', async (req: Request, res: Response) => {
 });
 
 // ---------------------------------------------------------------------------
-// 4/5) Disconnect — shared logic for POST (mobile) and DELETE (web)
+// 6/7) Disconnect — shared logic for POST (mobile) and DELETE (web)
 // ---------------------------------------------------------------------------
 async function handleWhoopDisconnect(userId: string): Promise<boolean> {
   // Revoke the token with WHOOP BEFORE deleting locally so the token is


### PR DESCRIPTION
## Why

The mobile app already ships a WHOOP row in Settings and onboarding, and it calls `POST /auth/whoop/start` exactly the way it does for Strava and Suunto. That route never existed, so the button was dead.

| route | strava | suunto | whoop (before) |
|---|---|---|---|
| `GET /start` (web, 302) | ✅ | ✅ | ✅ |
| `POST /start` (mobile, JSON) | ✅ | ✅ | ❌ |
| `GET /mobile/complete` (trampoline) | ✅ | ✅ | ❌ |

WHOOP's callback also identified the user from an httpOnly `ll_whoop_state` cookie **plus** a live session, neither of which survives the external-browser OAuth flow. Strava, Suunto and Garmin instead use a DB-backed `OAuthAttempt` row.

**No app release is needed** — the client already calls these endpoints. Deploying the API alone fixes the button.

## What changed

- **`POST /whoop/start`** returns the authorize URL as JSON and stores state in an `OAuthAttempt` row instead of a cookie. `includeVerifier: false`, matching Strava and Suunto, because WHOOP authenticates the token exchange with a client secret rather than PKCE.
- **Callback branches** on DB attempt vs cookie. Only failure sites *after* the state check can run with `isMobileFlow === true`, so the web contract is preserved by construction — including the pre-existing `appBase` trailing-slash asymmetry between the success and error redirects, which I deliberately left alone.
- **`GET /whoop/mobile/complete`** renders the trampoline to `loamlogger://oauth/whoop`, with a reason whitelist.
- **Declined consent** now emits `reason=access_denied` instead of rendering a raw 400 in the system browser. The app already had a message for it that no provider emitted.
- **`SCOPE` hoisted** to module scope so the two start routes can't drift on `offline` — the flag that makes WHOOP return a `refresh_token`, which the callback writes to a non-nullable column.
- **`oauthStart` rate limit 5 → 10.** The budget is keyed per user, not per provider, and mobile onboarding offers four connect buttons; connecting all four left one retry before a ten-minute lockout.

### Drive-by: last `/v1/` call moved to `WHOOP_API_BASE`

The profile fetch hardcoded `https://api.prod.whoop.com/developer/v1/user/profile/basic`, bypassing the constant the rest of the integration uses. **This is not a fix for a live break** — v1 still serves this endpoint and returns a body identical to v2 (verified against a real token: `{"user_id":824722,...}`, numeric as before). But it was the only v1 call left after the v2 migration, and it survived that migration precisely because its test pinned a string literal. The test now asserts against `WHOOP_API_BASE`.

## Testing

- **1767 tests pass** across 86 suites (`nx test api`), including `rate-limit.test.ts`, which iterates the config this PR changes.
- **All 38 pre-existing WHOOP tests pass** with exactly one edit — the profile-URL assertion above. The callback `beforeEach` now defaults `consumeOAuthAttempt` to `null` so every legacy test explicitly exercises the *web* branch; they are the regression guard for pre-mobile behavior.
- **27 new tests** (65 in the file). The load-bearing one: the mobile callback succeeds with neither cookie nor session, and the attempt's user wins over a stale `req.user`.
- `tsc --noEmit` clean; `nx lint api` 0 errors.

## Verification after deploy

1. `curl -X POST -H "Authorization: Bearer <jwt>" https://<api>/auth/whoop/start` → `{"ok":true,"data":{"authorizeUrl":"..."}}`
2. `curl 'https://<api>/auth/whoop/mobile/complete?status=success'` → HTML containing `loamlogger://oauth/whoop?status=success`
3. Device round trip: Settings → WHOOP → Connect → consent → trampoline → back in app, row flips to connected.
4. Decline the consent screen → app shows the access-denied alert, not a browser 400.
5. **Web regression:** connect and disconnect WHOOP from web Settings. The tests mock Prisma, so they cannot catch a real state-cookie regression.

No env var changes. The WHOOP developer-portal redirect URI must stay a **single** value — platform is discriminated after the redirect by whether `state` resolves to a DB row or a cookie, and the token exchange sends exactly one `redirect_uri`. The trampoline is reached via a relative redirect, so WHOOP never sees it.

## Known gaps left open

- **Expired mobile attempt shows a browser 400, not a deep link.** Past the 10-minute `OAuthAttempt` TTL the cookie branch finds no cookie and returns raw JSON. **Strava and Suunto have the identical hole** — fixing it needs a platform hint that survives the round trip, worth doing across all four providers at once. Covered by a test that pins the current behavior as intentional.
- **`multipleConnected` omits Suunto** (checks garmin/strava/whoop only), so a Suunto+WHOOP user isn't prompted to choose a data source. Pre-existing, web-only.
- **Garmin's trampoline emits a malformed deep link** — `auth.garmin.ts` passes `provider: 'Garmin Connect™'`, which lowercases into `loamlogger://oauth/garmin connect™?status=success`. Worth confirming whether Garmin mobile connect works today; separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
