### PR TITLE
feat(garmin): offer 7, 14 and 30 day sync windows

### DIFF
--- a/apps/api/src/auth/tier-access.ts
+++ b/apps/api/src/auth/tier-access.ts
@@ -1,6 +1,7 @@
 import type { SubscriptionTier, UserRole } from '@prisma/client';
 import { GraphQLError } from 'graphql';
 import { TIER_LIMITS, TIER_DISPLAY_NAMES, BIKE_LIMIT_UPSELL_LINE } from '@loam/shared';
+import { parseGarminPeriodDays } from '../lib/garmin-backfill-periods';
 
 type TierUser = {
   subscriptionTier: SubscriptionTier;
@@ -36,13 +37,16 @@ export function canSeePredictions(user: TierUser): boolean {
 
 /**
  * Historical import depth is tier-gated: free users may backfill only the
- * current year ('ytd', an omitted year, or the current year number); Pro
- * unlocks any past season. Rolling `days` windows are not gated — they are
- * already capped at 365 days by the routes.
+ * current year ('ytd', an omitted year, the current year number, or one of the
+ * short rolling windows); Pro unlocks any past season. Rolling `days` windows
+ * are not gated — they are already capped at 365 days by the routes.
  */
 export function canBackfillYear(user: TierUser, yearParam: string | undefined): boolean {
   if (isProTier(user)) return true;
   if (yearParam === undefined || yearParam === 'ytd') return true;
+  // A '7d'/'14d'/'30d' window never reaches past the current season, so it is
+  // not the "past seasons" capability Pro is selling.
+  if (parseGarminPeriodDays(yearParam) !== null) return true;
   return parseInt(yearParam, 10) === new Date().getFullYear();
 }
 

--- a/apps/api/src/lib/garmin-backfill-periods.test.ts
+++ b/apps/api/src/lib/garmin-backfill-periods.test.ts
@@ -1,0 +1,83 @@
+import {
+  describeGarminPeriod,
+  isRollingGarminPeriod,
+  parseGarminPeriodDays,
+  resolveGarminPeriodRange,
+} from './garmin-backfill-periods';
+
+describe('parseGarminPeriodDays', () => {
+  it('reads the offered windows', () => {
+    expect(parseGarminPeriodDays('7d')).toBe(7);
+    expect(parseGarminPeriodDays('14d')).toBe(14);
+    expect(parseGarminPeriodDays('30d')).toBe(30);
+  });
+
+  it('rejects anything that is not an offered window', () => {
+    // Windows are an allow-list, not a pattern: an arbitrary '90d' would sail
+    // past Garmin's chunking rules and past the clients' labels.
+    expect(parseGarminPeriodDays('90d')).toBeNull();
+    expect(parseGarminPeriodDays('ytd')).toBeNull();
+    expect(parseGarminPeriodDays('2024')).toBeNull();
+    expect(parseGarminPeriodDays('')).toBeNull();
+  });
+
+  it('does not treat inherited Object properties as windows', () => {
+    expect(parseGarminPeriodDays('toString')).toBeNull();
+    expect(parseGarminPeriodDays('constructor')).toBeNull();
+  });
+});
+
+describe('isRollingGarminPeriod', () => {
+  it('counts the windows and ytd, since both keep moving', () => {
+    expect(isRollingGarminPeriod('7d')).toBe(true);
+    expect(isRollingGarminPeriod('ytd')).toBe(true);
+  });
+
+  it('excludes a calendar year, which is imported once and then done', () => {
+    expect(isRollingGarminPeriod('2024')).toBe(false);
+  });
+});
+
+describe('resolveGarminPeriodRange', () => {
+  it('measures the window back from now', () => {
+    const now = new Date('2026-07-30T12:00:00Z');
+
+    const range = resolveGarminPeriodRange('7d', now);
+
+    expect(range).not.toBeNull();
+    expect(range!.startDate.toISOString()).toBe('2026-07-23T12:00:00.000Z');
+    expect(range!.endDate.toISOString()).toBe('2026-07-30T12:00:00.000Z');
+  });
+
+  it('crosses a year boundary rather than clamping to Jan 1', () => {
+    const now = new Date('2026-01-05T00:00:00Z');
+
+    const range = resolveGarminPeriodRange('30d', now);
+
+    expect(range!.startDate.toISOString()).toBe('2025-12-06T00:00:00.000Z');
+  });
+
+  it('returns null for periods that are not windows', () => {
+    expect(resolveGarminPeriodRange('ytd', new Date())).toBeNull();
+    expect(resolveGarminPeriodRange('2024', new Date())).toBeNull();
+  });
+
+  it('does not hand back the caller their own Date to mutate', () => {
+    const now = new Date('2026-07-30T12:00:00Z');
+
+    const range = resolveGarminPeriodRange('14d', now);
+    range!.endDate.setFullYear(1999);
+
+    expect(now.toISOString()).toBe('2026-07-30T12:00:00.000Z');
+  });
+});
+
+describe('describeGarminPeriod', () => {
+  it('phrases a window for user-facing messages', () => {
+    expect(describeGarminPeriod('7d')).toBe('the last 7 days');
+  });
+
+  it('passes other periods through untouched', () => {
+    expect(describeGarminPeriod('2024')).toBe('2024');
+  });
+});

--- a/apps/api/src/lib/garmin-backfill-periods.ts
+++ b/apps/api/src/lib/garmin-backfill-periods.ts
@@ -1,0 +1,56 @@
+// Rolling day-window periods for Garmin imports.
+//
+// A Garmin import is tracked as a BackfillRequest whose `year` column holds one
+// of three things: a calendar year ('2024'), 'ytd', or one of the rolling
+// windows defined here ('7d'). The windows are what the clients offer. Garmin
+// re-delivers whatever range we request through webhooks, so a rider who only
+// wants this week's rides should not have to pull the whole season to get them.
+//
+// Deliberately dependency-free: the backfill route, the backfill worker and
+// tier-access all need the same answer to "what does this period mean", and
+// none of them should have to import the others to get it.
+
+/** Day windows the clients offer, shortest first. */
+export const GARMIN_PERIOD_DAYS = { '7d': 7, '14d': 14, '30d': 30 } as const;
+
+export type GarminPeriod = keyof typeof GARMIN_PERIOD_DAYS;
+
+/**
+ * Days in a rolling window, or null when `period` is not one ('ytd', '2024').
+ *
+ * `period` arrives from a query string or a request body, so the own-property
+ * check matters: a plain lookup would answer 'toString' with a function and
+ * send a NaN date range to Garmin.
+ */
+export function parseGarminPeriodDays(period: string): number | null {
+  if (!Object.prototype.hasOwnProperty.call(GARMIN_PERIOD_DAYS, period)) return null;
+  return GARMIN_PERIOD_DAYS[period as GarminPeriod];
+}
+
+/**
+ * Periods that name a moving window rather than a closed span. These can be
+ * re-run to pick up new rides, so only a request already in flight blocks
+ * another. A calendar year, once imported, is finished for good.
+ */
+export function isRollingGarminPeriod(period: string): boolean {
+  return period === 'ytd' || parseGarminPeriodDays(period) !== null;
+}
+
+/** `[now - N days, now]` for a rolling window, or null for any other period. */
+export function resolveGarminPeriodRange(
+  period: string,
+  now: Date = new Date()
+): { startDate: Date; endDate: Date } | null {
+  const days = parseGarminPeriodDays(period);
+  if (days === null) return null;
+
+  const startDate = new Date(now);
+  startDate.setDate(startDate.getDate() - days);
+  return { startDate, endDate: new Date(now) };
+}
+
+/** Phrase for user-facing messages, e.g. "the last 7 days". */
+export function describeGarminPeriod(period: string): string {
+  const days = parseGarminPeriodDays(period);
+  return days === null ? period : `the last ${days} days`;
+}

--- a/apps/api/src/routes/garmin.backfill.test.ts
+++ b/apps/api/src/routes/garmin.backfill.test.ts
@@ -6,6 +6,7 @@ global.fetch = mockFetch;
 
 // Mock Prisma
 const mockBackfillFindUnique = jest.fn();
+const mockBackfillFindMany = jest.fn();
 const mockBackfillUpsert = jest.fn();
 const mockBackfillUpdateMany = jest.fn();
 const mockRideFindMany = jest.fn();
@@ -19,6 +20,7 @@ jest.mock('../lib/prisma', () => ({
   prisma: {
     backfillRequest: {
       findUnique: mockBackfillFindUnique,
+      findMany: mockBackfillFindMany,
       upsert: mockBackfillUpsert,
       updateMany: mockBackfillUpdateMany,
     },
@@ -50,6 +52,12 @@ jest.mock('../lib/prisma', () => ({
 const mockGetValidGarminToken = jest.fn();
 jest.mock('../lib/garmin-token', () => ({
   getValidGarminToken: mockGetValidGarminToken,
+}));
+
+// Mock the background queue used by the batch route
+const mockEnqueueBackfillJob = jest.fn();
+jest.mock('../lib/queue/backfill.queue', () => ({
+  enqueueBackfillJob: mockEnqueueBackfillJob,
 }));
 
 // Mock logger
@@ -361,6 +369,81 @@ describe('GET /garmin/backfill/fetch', () => {
     });
   });
 
+  describe('Rolling Day Windows', () => {
+    it('should request exactly the last 7 days for a 7d window', async () => {
+      mockReq.query = { year: '7d' };
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(mockFetch).toHaveBeenCalled();
+      const fetchUrl = mockFetch.mock.calls[0][0] as string;
+      const start = Number(/summaryStartTimeInSeconds=(\d+)/.exec(fetchUrl)?.[1]);
+      const end = Number(/summaryEndTimeInSeconds=(\d+)/.exec(fetchUrl)?.[1]);
+      // Seven days apart, ending now (allow a second of clock drift)
+      expect(end - start).toBeCloseTo(7 * 24 * 60 * 60, -1);
+      expect(Math.abs(end - Math.floor(Date.now() / 1000))).toBeLessThanOrEqual(2);
+    });
+
+    it('should request the last 30 days for a 30d window rather than the year', async () => {
+      mockReq.query = { year: '30d' };
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      const fetchUrl = mockFetch.mock.calls[0][0] as string;
+      const start = Number(/summaryStartTimeInSeconds=(\d+)/.exec(fetchUrl)?.[1]);
+      const jan1Seconds = Math.floor(new Date(new Date().getFullYear(), 0, 1).getTime() / 1000);
+      const thirtyDaysAgo = Math.floor(Date.now() / 1000) - 30 * 24 * 60 * 60;
+      expect(Math.abs(start - thirtyDaysAgo)).toBeLessThanOrEqual(2);
+      // Guards the bug this replaced: '30 days' used to expand to Jan 1
+      expect(start).not.toBe(jan1Seconds);
+    });
+
+    it('should re-run a window whose previous request completed', async () => {
+      mockReq.query = { year: '14d' };
+      mockBackfillFindUnique.mockResolvedValue({
+        id: 'bf-1',
+        status: 'completed',
+        year: '14d',
+        backfilledUpTo: new Date('2026-07-01T00:00:00Z'),
+      });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(statusCode).not.toBe(409);
+      expect(mockFetch).toHaveBeenCalled();
+      // The window is measured from now, never from the last checkpoint
+      const fetchUrl = mockFetch.mock.calls[0][0] as string;
+      const start = Number(/summaryStartTimeInSeconds=(\d+)/.exec(fetchUrl)?.[1]);
+      const fourteenDaysAgo = Math.floor(Date.now() / 1000) - 14 * 24 * 60 * 60;
+      expect(Math.abs(start - fourteenDaysAgo)).toBeLessThanOrEqual(2);
+    });
+
+    it('should return 409 when the same window is already in progress', async () => {
+      mockReq.query = { year: '7d' };
+      mockBackfillFindUnique.mockResolvedValue({
+        id: 'bf-1',
+        status: 'in_progress',
+        year: '7d',
+        backfilledUpTo: null,
+      });
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      expect(statusCode).toBe(409);
+      expect(jsonResponse).toMatchObject({ error: 'Backfill already in progress' });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should not store backfilledUpTo for a window (only YTD is incremental)', async () => {
+      mockReq.query = { year: '30d' };
+
+      await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+      const updateCall = mockBackfillUpdateMany.mock.calls[0];
+      expect(updateCall[0].data.backfilledUpTo).toBeNull();
+    });
+  });
+
   describe('Days Parameter (Backward Compatibility)', () => {
     it('should default to 30 days when no parameters provided', async () => {
       mockReq.query = {};
@@ -501,6 +584,103 @@ describe('GET /garmin/backfill/fetch', () => {
 });
 
 // Test the extractMinStartDate helper function by testing its behavior through the API
+describe('POST /garmin/backfill/batch', () => {
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let handler: RequestHandler | undefined;
+  let jsonResponse: unknown;
+  let statusCode: number | undefined;
+
+  const queuedPeriods = () =>
+    mockEnqueueBackfillJob.mock.calls.map(([job]) => (job as { year: string }).year);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handler = getHandler('/garmin/backfill/batch', 'post');
+    jsonResponse = undefined;
+    statusCode = undefined;
+
+    mockReq = { sessionUser: { uid: 'user-123' }, body: {} };
+    mockRes = {
+      status: jest.fn().mockImplementation((code) => {
+        statusCode = code;
+        return mockRes;
+      }),
+      json: jest.fn().mockImplementation((data) => {
+        jsonResponse = data;
+        return mockRes;
+      }),
+    };
+
+    mockImportSessionFindFirst.mockResolvedValue(null);
+    mockImportSessionCreate.mockResolvedValue({ id: 'import-session-1' });
+    mockBackfillFindMany.mockResolvedValue([]);
+    mockBackfillFindUnique.mockResolvedValue(null);
+    mockBackfillUpsert.mockResolvedValue({});
+    mockEnqueueBackfillJob.mockResolvedValue({ status: 'queued', jobId: 'job-1' });
+  });
+
+  it('queues a rolling window', async () => {
+    mockReq.body = { years: ['7d'] };
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(queuedPeriods()).toEqual(['7d']);
+    expect(jsonResponse).toMatchObject({ success: true });
+  });
+
+  it('rejects a period that is neither a window, ytd, nor a valid year', async () => {
+    mockReq.body = { years: ['90d'] };
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(statusCode).toBe(400);
+    expect(mockEnqueueBackfillJob).not.toHaveBeenCalled();
+  });
+
+  it('re-queues a window whose previous run completed', async () => {
+    // Only in-flight rows come back from the rolling lookup, so a completed
+    // window looks exactly like a fresh one here.
+    mockBackfillFindMany.mockResolvedValue([]);
+    mockReq.body = { years: ['30d'] };
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(queuedPeriods()).toEqual(['30d']);
+  });
+
+  it('skips a window that is already in flight', async () => {
+    mockBackfillFindMany.mockResolvedValue([{ year: '30d', status: 'in_progress' }]);
+    mockReq.body = { years: ['30d'] };
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(statusCode).toBe(409);
+    expect(mockEnqueueBackfillJob).not.toHaveBeenCalled();
+  });
+
+  it('queues the free windows while skipping the one in flight', async () => {
+    mockBackfillFindMany.mockResolvedValue([{ year: '7d', status: 'in_progress' }]);
+    mockReq.body = { years: ['7d', '30d'] };
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(queuedPeriods()).toEqual(['30d']);
+    expect(jsonResponse).toMatchObject({ skipped: ['7d'] });
+  });
+
+  it('still treats an imported calendar year as finished', async () => {
+    const lastYear = String(new Date().getFullYear() - 1);
+    mockBackfillFindMany.mockResolvedValue([{ year: lastYear, status: 'completed' }]);
+    mockReq.body = { years: [lastYear] };
+
+    await invokeHandler(handler, mockReq as Request, mockRes as Response);
+
+    expect(statusCode).toBe(409);
+    expect(mockEnqueueBackfillJob).not.toHaveBeenCalled();
+  });
+});
+
 describe('extractMinStartDate behavior', () => {
   let mockReq: Partial<Request>;
   let mockRes: Partial<Response>;

--- a/apps/api/src/routes/garmin.backfill.ts
+++ b/apps/api/src/routes/garmin.backfill.ts
@@ -7,6 +7,11 @@ import { logError, logger } from '../lib/logger';
 import { enqueueBackfillJob } from '../lib/queue/backfill.queue';
 import { canBackfillYear } from '../auth/tier-access';
 import { triggerGarminBackfillChunks } from '../services/garmin-backfill';
+import {
+  describeGarminPeriod,
+  isRollingGarminPeriod,
+  resolveGarminPeriodRange,
+} from '../lib/garmin-backfill-periods';
 
 type Empty = Record<string, never>;
 const r: Router = createRouter();
@@ -65,8 +70,27 @@ r.get<Empty, void, Empty, { days?: string; year?: string }>(
       if (req.query.year) {
         const currentYear = new Date().getFullYear();
         const yearParam = req.query.year;
+        const rollingRange = resolveGarminPeriodRange(yearParam);
 
-        if (yearParam === 'ytd') {
+        if (rollingRange) {
+          // Short rolling window ('7d'/'14d'/'30d'). The window moves with the
+          // clock, so re-running it is how a rider picks up new rides; the only
+          // thing that blocks it is the same window still in flight.
+          const existingWindow = await prisma.backfillRequest.findUnique({
+            where: { userId_provider_year: { userId, provider: 'garmin', year: yearParam } },
+          });
+
+          if (existingWindow?.status === 'in_progress') {
+            return res.status(409).json({
+              error: 'Backfill already in progress',
+              message: `A backfill for ${describeGarminPeriod(yearParam)} is already in progress. Please wait for it to complete before requesting another.`,
+            });
+          }
+
+          startDate = rollingRange.startDate;
+          endDate = rollingRange.endDate;
+          periodDescription = describeGarminPeriod(yearParam);
+        } else if (yearParam === 'ytd') {
           // Check for existing YTD backfill to enable incremental fetching
           const existingYtd = await prisma.backfillRequest.findUnique({
             where: { userId_provider_year: { userId, provider: 'garmin', year: 'ytd' } },
@@ -281,8 +305,11 @@ r.get<Empty, void, Empty, { days?: string; year?: string }>(
 );
 
 /**
- * Queue multiple years for background backfill processing
- * Accepts an array of years and queues them as background jobs
+ * Queue Garmin backfills for background processing.
+ *
+ * The body field is still named `years` because shipped mobile builds send that
+ * name, but an entry is really a period: a rolling window ('7d'/'14d'/'30d'),
+ * 'ytd', or a calendar year. The clients now offer the rolling windows only.
  */
 r.post<Empty, void, { years: string[] }, Empty>(
   '/garmin/backfill/batch',
@@ -294,22 +321,25 @@ r.post<Empty, void, { years: string[] }, Empty>(
 
     const { years } = req.body;
     if (!Array.isArray(years) || years.length === 0) {
-      return sendBadRequest(res, 'At least one year is required');
+      return sendBadRequest(res, 'At least one time period is required');
     }
 
-    // Limit to 10 years max to prevent abuse
+    // Limit to 10 periods max to prevent abuse
     if (years.length > 10) {
-      return sendBadRequest(res, 'Maximum 10 years can be queued at once');
+      return sendBadRequest(res, 'Maximum 10 time periods can be queued at once');
     }
 
-    // Validate all years upfront (fail fast before any DB queries)
+    // Validate all periods upfront (fail fast before any DB queries)
     const currentYear = new Date().getFullYear();
     const minYear = currentYear - 4;
     for (const year of years) {
-      if (year !== 'ytd') {
+      if (!isRollingGarminPeriod(year)) {
         const yearNum = parseInt(year, 10);
         if (isNaN(yearNum) || yearNum < minYear || yearNum > currentYear) {
-          return sendBadRequest(res, `Invalid year: ${year}. Must be between ${minYear} and ${currentYear}, or 'ytd'`);
+          return sendBadRequest(
+            res,
+            `Invalid time period: ${year}. Must be '7d', '14d', '30d', 'ytd', or a year between ${minYear} and ${currentYear}`
+          );
         }
       }
     }
@@ -327,12 +357,17 @@ r.post<Empty, void, { years: string[] }, Empty>(
         });
       }
 
-      // Check for already backfilled years (non-YTD only, skip failed ones)
+      // A closed span (a calendar year) is imported once and is then done, so
+      // any non-failed record blocks it. A rolling window keeps moving, so
+      // re-running it is the whole point and only a run in flight blocks it.
+      const rollingPeriods = years.filter(isRollingGarminPeriod);
+      const fixedYears = years.filter(y => !isRollingGarminPeriod(y));
+
       const existingBackfills = await prisma.backfillRequest.findMany({
         where: {
           userId,
           provider: 'garmin',
-          year: { in: years.filter(y => y !== 'ytd') },
+          year: { in: fixedYears },
           status: { notIn: ['failed'] },
         },
         select: { year: true, status: true },
@@ -340,29 +375,28 @@ r.post<Empty, void, { years: string[] }, Empty>(
 
       const alreadyBackfilled = new Map(existingBackfills.map(b => [b.year, b.status]));
 
-      // Check if YTD is in progress
-      if (years.includes('ytd')) {
-        const ytdBackfill = await prisma.backfillRequest.findUnique({
-          where: { userId_provider_year: { userId, provider: 'garmin', year: 'ytd' } },
-          select: { status: true },
+      if (rollingPeriods.length > 0) {
+        const inFlight = await prisma.backfillRequest.findMany({
+          where: {
+            userId,
+            provider: 'garmin',
+            year: { in: rollingPeriods },
+            status: 'in_progress',
+          },
+          select: { year: true, status: true },
         });
-        if (ytdBackfill?.status === 'in_progress') {
-          alreadyBackfilled.set('ytd', 'in_progress');
+        for (const request of inFlight) {
+          alreadyBackfilled.set(request.year, request.status);
         }
       }
 
-      // Filter to years that can be processed
-      const yearsToProcess = years.filter(y => {
-        if (y === 'ytd') {
-          return alreadyBackfilled.get('ytd') !== 'in_progress';
-        }
-        return !alreadyBackfilled.has(y);
-      });
+      // Filter to periods that can be processed
+      const yearsToProcess = years.filter(y => !alreadyBackfilled.has(y));
 
       if (yearsToProcess.length === 0) {
         return res.status(409).json({
-          error: 'All years already backfilled or in progress',
-          message: 'All selected years have already been imported or are currently being processed.',
+          error: 'All time periods already backfilled or in progress',
+          message: 'All selected time periods have already been imported or are currently being processed.',
           skipped: years,
         });
       }

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -17,6 +17,7 @@ import { config } from '../config/env';
 import type { BackfillJobData, BackfillJobName } from '../lib/queue/backfill.queue';
 import { enqueueWeatherJob, enqueueLiftDetectionJob } from '../lib/queue';
 import { triggerGarminBackfillChunks } from '../services/garmin-backfill';
+import { resolveGarminPeriodRange } from '../lib/garmin-backfill-periods';
 import { captureServerEvent } from '../lib/posthog';
 import { incrementBikeComponentHours, syncBikeComponentHours } from '../lib/component-hours';
 import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
@@ -241,9 +242,9 @@ async function processBackfillJob(job: Job<BackfillJobData, void, BackfillJobNam
 }
 
 /**
- * Process Garmin backfill for a specific year.
- * Triggers the Garmin Wellness API backfill endpoint in 30-day chunks.
- * Activities are delivered asynchronously via webhooks.
+ * Process a Garmin backfill for one time period: a rolling window ('7d'), 'ytd',
+ * or a calendar year. Triggers the Garmin Wellness API backfill endpoint in
+ * 30-day chunks. Activities are delivered asynchronously via webhooks.
  */
 async function processGarminBackfill(userId: string, year: string): Promise<void> {
   const accessToken = await getValidGarminToken(userId);
@@ -257,7 +258,13 @@ async function processGarminBackfill(userId: string, year: string): Promise<void
   let startDate: Date;
   let endDate: Date;
 
-  if (year === 'ytd') {
+  const rollingRange = resolveGarminPeriodRange(year);
+
+  if (rollingRange) {
+    // Short rolling window: measured from now, never incremental. The rider
+    // asked for the last N days, so that is exactly the range we request.
+    ({ startDate, endDate } = rollingRange);
+  } else if (year === 'ytd') {
     // Check for existing YTD backfill to enable incremental fetching
     const existingYtd = await prisma.backfillRequest.findUnique({
       where: { userId_provider_year: { userId, provider: 'garmin', year: 'ytd' } },

--- a/apps/web/src/components/GarminImportModal.tsx
+++ b/apps/web/src/components/GarminImportModal.tsx
@@ -21,22 +21,31 @@ interface BackfillRequest {
   completedAt: string | null;
 }
 
-// Garmin's API only allows backfills for the past 30 days
-const GARMIN_YEAR_OPTIONS = [
-  { value: 'ytd', label: 'Last 30 Days' },
+// Rolling windows, shortest first. They nest (7 days is inside 30), so this is
+// a single choice rather than a multi-select. The API calls these periods and
+// still receives them under the legacy `years` body field.
+const GARMIN_PERIOD_OPTIONS = [
+  { value: '7d', label: 'Last 7 Days' },
+  { value: '14d', label: 'Last 14 Days' },
+  { value: '30d', label: 'Last 30 Days' },
 ];
+
+const DEFAULT_PERIOD = '30d';
+
+const periodLabel = (value: string) =>
+  GARMIN_PERIOD_OPTIONS.find((option) => option.value === value)?.label ?? value;
 
 export default function GarminImportModal({ open, onClose, onSuccess, onDuplicatesFound }: Props) {
   const [step, setStep] = useState<'period' | 'processing' | 'complete'>('period');
-  const [selectedYears, setSelectedYears] = useState<Set<string>>(new Set(['ytd']));
+  const [selectedPeriod, setSelectedPeriod] = useState<string>(DEFAULT_PERIOD);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [backfillHistory, setBackfillHistory] = useState<BackfillRequest[]>([]);
   const [historyLoading, setHistoryLoading] = useState(true);
   const [duplicatesFound, setDuplicatesFound] = useState(0);
 
-  // Get years that are in progress
-  const inProgressYears = useMemo(() => {
+  // Periods with a sync already queued or running
+  const inProgressPeriods = useMemo(() => {
     return new Set(
       backfillHistory
         .filter(
@@ -48,21 +57,7 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
     );
   }, [backfillHistory]);
 
-  // Toggle year selection
-  const toggleYearSelection = (year: string) => {
-    setSelectedYears((prev) => {
-      const next = new Set(prev);
-      if (next.has(year)) {
-        next.delete(year);
-      } else {
-        next.add(year);
-      }
-      return next;
-    });
-  };
-
-  // Get count of selectable years for button text
-  const selectableYearsCount = selectedYears.size;
+  const selectedIsInProgress = inProgressPeriods.has(selectedPeriod);
 
   // Fetch backfill history
   const fetchHistory = async () => {
@@ -89,7 +84,7 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
     } else {
       // Reset state when modal closes
       setStep('period');
-      setSelectedYears(new Set(['ytd']));
+      setSelectedPeriod(DEFAULT_PERIOD);
       setError(null);
       setSuccessMessage(null);
       setDuplicatesFound(0);
@@ -98,9 +93,8 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
   }, [open]);
 
   const handleTriggerBackfill = async () => {
-    const yearsArray = Array.from(selectedYears);
-    if (yearsArray.length === 0) {
-      setError('Please select at least one year');
+    if (!selectedPeriod) {
+      setError('Please select a time period');
       return;
     }
 
@@ -117,7 +111,9 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
             ...getAuthHeaders(),
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify({ years: yearsArray }),
+          // Legacy field name: shipped clients all post `years`, and the API
+          // reads each entry as a period key.
+          body: JSON.stringify({ years: [selectedPeriod] }),
         }
       );
 
@@ -126,7 +122,7 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
       if (!res.ok) {
         // Handle 409 Conflict (all years already backfilled)
         if (res.status === 409) {
-          setSuccessMessage(data.message || 'Selected years are already imported or in progress.');
+          setSuccessMessage(data.message || 'That time period is already syncing.');
           setStep('complete');
           await fetchHistory();
           return;
@@ -135,11 +131,8 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
         throw new Error(data.message || data.error || 'Failed to trigger backfill');
       }
 
-      const queuedCount = data.queued?.length || 0;
-      const skippedCount = data.skipped?.length || 0;
       setSuccessMessage(
-        data.message ||
-        `Queued ${queuedCount} year${queuedCount !== 1 ? 's' : ''} for import.${skippedCount > 0 ? ` ${skippedCount} already imported.` : ''}`
+        data.message || `Queued the ${periodLabel(selectedPeriod).toLowerCase()} for import.`
       );
       setStep('complete');
 
@@ -195,9 +188,9 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
               </div>
             ) : (
               <div className="space-y-3">
-                {GARMIN_YEAR_OPTIONS.map((option) => {
-                  const isInProgress = inProgressYears.has(option.value);
-                  const isSelected = selectedYears.has(option.value);
+                {GARMIN_PERIOD_OPTIONS.map((option) => {
+                  const isInProgress = inProgressPeriods.has(option.value);
+                  const isSelected = selectedPeriod === option.value;
 
                   return (
                     <label
@@ -211,11 +204,13 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
                       `}
                     >
                       <input
-                        type="checkbox"
+                        type="radio"
+                        name="garmin-import-period"
+                        value={option.value}
                         checked={isSelected}
                         disabled={isInProgress}
-                        onChange={() => !isInProgress && toggleYearSelection(option.value)}
-                        className="w-4 h-4 text-accent border-gray-500 focus:ring-accent rounded"
+                        onChange={() => !isInProgress && setSelectedPeriod(option.value)}
+                        className="w-4 h-4 text-accent border-gray-500 focus:ring-accent"
                       />
                       <span className={`flex-1 text-sm ${isInProgress ? 'text-muted' : 'text-primary'}`}>
                         {option.label}
@@ -226,14 +221,12 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
                     </label>
                   );
                 })}
-                <p className="text-xs text-muted mt-2">
-                  Garmin limits historical data access to the past 30 days. New rides sync automatically going forward.
-                </p>
               </div>
             )}
 
             <p className="text-xs text-muted mt-2">
-              Year to Date can be run multiple times to fetch new rides since your last import.
+              Garmin sends the rides in the window you pick. New rides keep syncing automatically, and you
+              can run this again anytime to catch anything missed.
             </p>
           </div>
 
@@ -250,11 +243,11 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
             <Button
               variant="primary"
               onClick={handleTriggerBackfill}
-              disabled={selectableYearsCount === 0 || historyLoading}
+              disabled={!selectedPeriod || selectedIsInProgress || historyLoading}
             >
-              {selectableYearsCount === 0
-                ? 'Select years to import'
-                : `Import ${selectableYearsCount} ${selectableYearsCount === 1 ? 'Year' : 'Years'}`}
+              {selectedIsInProgress
+                ? 'Sync In Progress'
+                : `Import ${periodLabel(selectedPeriod)}`}
             </Button>
           </div>
         </div>

--- a/apps/web/src/components/onboarding/ImportRidesForm.test.tsx
+++ b/apps/web/src/components/onboarding/ImportRidesForm.test.tsx
@@ -184,7 +184,7 @@ describe('ImportRidesForm', () => {
       });
     });
 
-    it('shows Garmin restriction note', async () => {
+    it('shows the Garmin sync-window note', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({ success: true, requests: [] }),
@@ -195,16 +195,55 @@ describe('ImportRidesForm', () => {
       fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
 
       await waitFor(() => {
-        expect(screen.getByText(/Garmin limits historical data access/i)).toBeInTheDocument();
+        expect(screen.getByText(/Garmin sends the rides in the window you pick/i)).toBeInTheDocument();
       });
     });
   });
 
-  describe('Garmin Last 30 Days', () => {
-    it('shows Last 30 Days as the only Garmin option', async () => {
+  describe('Garmin rolling windows', () => {
+    const emptyHistory = () => ({
+      ok: true,
+      json: () => Promise.resolve({ success: true, requests: [] }),
+    });
+
+    it('offers 7, 14 and 30 day windows, defaulting to 30', async () => {
+      mockFetch.mockResolvedValue(emptyHistory());
+
+      render(<ImportRidesForm connectedProviders={['garmin']} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('radio', { name: /Last 7 Days/i })).toBeInTheDocument();
+      });
+      expect(screen.getByRole('radio', { name: /Last 14 Days/i })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /Last 30 Days/i })).toBeChecked();
+
+      // Windows nest, so no calendar years are offered
+      expect(screen.queryByRole('radio', { name: /2024/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('radio', { name: /2025/i })).not.toBeInTheDocument();
+    });
+
+    it('names the selected window on the confirm button', async () => {
+      mockFetch.mockResolvedValue(emptyHistory());
+
+      render(<ImportRidesForm connectedProviders={['garmin']} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Import Last 30 Days/i })).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('radio', { name: /Last 7 Days/i }));
+
+      expect(screen.getByRole('button', { name: /Import Last 7 Days/i })).toBeInTheDocument();
+    });
+
+    it('posts the selected window to the batch endpoint', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ success: true, requests: [] }),
+        json: () => Promise.resolve({ success: true, requests: [], queued: [] }),
       });
 
       render(<ImportRidesForm connectedProviders={['garmin']} />);
@@ -212,22 +251,28 @@ describe('ImportRidesForm', () => {
       fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
 
       await waitFor(() => {
-        const checkbox = screen.getByRole('checkbox', { name: /Last 30 Days/i });
-        expect(checkbox).toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: /Last 14 Days/i })).toBeInTheDocument();
       });
 
-      // Should not have year checkboxes
-      expect(screen.queryByRole('checkbox', { name: /2024/i })).not.toBeInTheDocument();
-      expect(screen.queryByRole('checkbox', { name: /2025/i })).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole('radio', { name: /Last 14 Days/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Import Last 14 Days/i }));
+
+      await waitFor(() => {
+        const batchCall = mockFetch.mock.calls.find(([url]) =>
+          String(url).includes('/api/garmin/backfill/batch')
+        );
+        expect(batchCall).toBeDefined();
+        expect(JSON.parse(batchCall![1].body)).toEqual({ years: ['14d'] });
+      });
     });
 
-    it('disables Last 30 Days checkbox when in progress', async () => {
+    it('disables a window that is already syncing', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({
           success: true,
           requests: [
-            { id: '1', provider: 'garmin', year: 'ytd', status: 'in_progress', ridesFound: null },
+            { id: '1', provider: 'garmin', year: '30d', status: 'in_progress', ridesFound: null },
           ],
         }),
       });
@@ -237,18 +282,20 @@ describe('ImportRidesForm', () => {
       fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
 
       await waitFor(() => {
-        const checkbox = screen.getByRole('checkbox', { name: /Last 30 Days/i });
-        expect(checkbox).toBeDisabled();
+        expect(screen.getByRole('radio', { name: /Last 30 Days/i })).toBeDisabled();
       });
+      // A rolling window is nested, not exclusive: the shorter ones stay open
+      expect(screen.getByRole('radio', { name: /Last 7 Days/i })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: /Import In Progress/i })).toBeDisabled();
     });
 
-    it('enables Last 30 Days checkbox when not in progress', async () => {
+    it('leaves a completed window selectable so new rides can be picked up', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({
           success: true,
           requests: [
-            { id: '1', provider: 'garmin', year: 'ytd', status: 'completed', ridesFound: 50 },
+            { id: '1', provider: 'garmin', year: '30d', status: 'completed', ridesFound: 50 },
           ],
         }),
       });
@@ -258,8 +305,7 @@ describe('ImportRidesForm', () => {
       fireEvent.click(screen.getByRole('button', { name: /Import past rides/i }));
 
       await waitFor(() => {
-        const checkbox = screen.getByRole('checkbox', { name: /Last 30 Days/i });
-        expect(checkbox).not.toBeDisabled();
+        expect(screen.getByRole('radio', { name: /Last 30 Days/i })).not.toBeDisabled();
       });
     });
   });
@@ -368,7 +414,7 @@ describe('ImportRidesForm', () => {
         expect(screen.queryByText('Loading history...')).not.toBeInTheDocument();
       });
 
-      const importButton = screen.getByRole('button', { name: /Start Import/i });
+      const importButton = screen.getByRole('button', { name: /Import Last 30 Days/i });
       fireEvent.click(importButton);
 
       await waitFor(() => {
@@ -399,7 +445,7 @@ describe('ImportRidesForm', () => {
         expect(screen.queryByText('Loading history...')).not.toBeInTheDocument();
       });
 
-      const importButton = screen.getByRole('button', { name: /Start Import/i });
+      const importButton = screen.getByRole('button', { name: /Import Last 30 Days/i });
       fireEvent.click(importButton);
 
       await waitFor(() => {
@@ -427,7 +473,7 @@ describe('ImportRidesForm', () => {
         expect(screen.queryByText('Loading history...')).not.toBeInTheDocument();
       });
 
-      const importButton = screen.getByRole('button', { name: /Start Import/i });
+      const importButton = screen.getByRole('button', { name: /Import Last 30 Days/i });
       fireEvent.click(importButton);
 
       await waitFor(() => {

--- a/apps/web/src/components/onboarding/ImportRidesForm.tsx
+++ b/apps/web/src/components/onboarding/ImportRidesForm.tsx
@@ -38,10 +38,26 @@ const STRAVA_YEAR_OPTIONS = [
   })),
 ];
 
-// Garmin limits historical data access to the past 30 days
-const GARMIN_YEAR_OPTIONS = [
-  { value: 'ytd', label: 'Last 30 Days' },
+// Garmin imports are rolling windows, shortest first. They nest (7 days is
+// inside 30), so this is a single choice rather than a multi-select.
+const GARMIN_PERIOD_OPTIONS = [
+  { value: '7d', label: 'Last 7 Days' },
+  { value: '14d', label: 'Last 14 Days' },
+  { value: '30d', label: 'Last 30 Days' },
 ];
+
+const DEFAULT_GARMIN_PERIOD = '30d';
+
+const garminPeriodLabel = (value: string) =>
+  GARMIN_PERIOD_OPTIONS.find((option) => option.value === value)?.label ?? value;
+
+// Past requests are keyed the same way, so a chip may be a window ('7d'), a
+// year, or 'ytd' left over from an earlier import.
+const historyPeriodLabel = (value: string) => {
+  if (value === 'ytd') return 'YTD';
+  const window = GARMIN_PERIOD_OPTIONS.find((option) => option.value === value);
+  return window ? window.label.replace('Last ', '') : value;
+};
 
 // Suunto allows historical backfills back to 2015 (same as Strava)
 const SUUNTO_YEAR_OPTIONS = [
@@ -62,16 +78,16 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
   const { isPro } = useUserTier();
   const [expanded, setExpanded] = useState(false);
   const [selectedProvider, setSelectedProvider] = useState<'strava' | 'garmin' | 'suunto' | ''>('');
-  const [selectedYear, setSelectedYear] = useState<string>('ytd'); // For Strava/Suunto (single select)
-  const [selectedYears, setSelectedYears] = useState<Set<string>>(new Set(['ytd'])); // For Garmin (multi-select)
+  const [selectedYear, setSelectedYear] = useState<string>('ytd'); // For Strava/Suunto
+  const [selectedGarminPeriod, setSelectedGarminPeriod] = useState<string>(DEFAULT_GARMIN_PERIOD);
   const [importState, setImportState] = useState<'idle' | 'loading' | 'done'>('idle');
   const [importStats, setImportStats] = useState<ImportStats | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [backfillHistory, setBackfillHistory] = useState<BackfillRequest[]>([]);
   const [historyLoading, setHistoryLoading] = useState(true);
 
-  // Get years that are in progress for Garmin
-  const garminInProgressYears = useMemo(() => {
+  // Garmin periods with a sync already queued or running
+  const garminInProgressPeriods = useMemo(() => {
     return new Set(
       backfillHistory
         .filter(
@@ -83,29 +99,9 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
     );
   }, [backfillHistory]);
 
-  // Check if YTD is currently in progress (Garmin only - blocks re-triggering)
-  const isYtdInProgress = useMemo(() => {
-    if (selectedProvider !== 'garmin' || selectedYear !== 'ytd') return false;
-    return backfillHistory.some(
-      (req) => req.provider === 'garmin' && req.year === 'ytd' && req.status === 'in_progress'
-    );
-  }, [backfillHistory, selectedProvider, selectedYear]);
-
-  // Toggle year selection for Garmin multi-select
-  const toggleYearSelection = (year: string) => {
-    setSelectedYears((prev) => {
-      const next = new Set(prev);
-      if (next.has(year)) {
-        next.delete(year);
-      } else {
-        next.add(year);
-      }
-      return next;
-    });
-  };
-
-  // Get count of selectable years for button text
-  const selectableYearsCount = selectedYears.size;
+  // A window already syncing can't be re-triggered until it finishes
+  const isGarminPeriodInProgress =
+    selectedProvider === 'garmin' && garminInProgressPeriods.has(selectedGarminPeriod);
 
   // Auto-select provider if only one is connected
   useEffect(() => {
@@ -166,10 +162,10 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
       const baseUrl = import.meta.env.VITE_API_URL;
 
       if (selectedProvider === 'garmin') {
-        // Garmin uses batch endpoint for multi-year selection
-        const yearsArray = Array.from(selectedYears);
-        if (yearsArray.length === 0) {
-          setError('Please select at least one year');
+        // Garmin queues in the background; the API reads each `years` entry as
+        // a period key, which for us is always one rolling window.
+        if (!selectedGarminPeriod) {
+          setError('Please select a time period');
           setImportState('idle');
           return;
         }
@@ -181,14 +177,14 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
             ...getAuthHeaders(),
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify({ years: yearsArray }),
+          body: JSON.stringify({ years: [selectedGarminPeriod] }),
         });
 
         const data = await response.json();
 
         if (!response.ok) {
           if (response.status === 409) {
-            setError(data.message || 'Selected years are already imported or in progress.');
+            setError(data.message || 'That time period is already syncing.');
             setImportState('idle');
             return;
           }
@@ -346,12 +342,12 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
             </label>
 
             {selectedProvider === 'garmin' ? (
-              // Garmin: restricted to last 30 days
+              // Garmin: one rolling window, since the windows nest
               <div className="space-y-3">
-                {GARMIN_YEAR_OPTIONS.map((option) => {
-                  const isInProgress = garminInProgressYears.has(option.value);
+                {GARMIN_PERIOD_OPTIONS.map((option) => {
+                  const isInProgress = garminInProgressPeriods.has(option.value);
                   const isDisabled = isInProgress || importState === 'loading';
-                  const isSelected = selectedYears.has(option.value);
+                  const isSelected = selectedGarminPeriod === option.value;
 
                   return (
                     <label
@@ -365,11 +361,13 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
                       `}
                     >
                       <input
-                        type="checkbox"
+                        type="radio"
+                        name="garmin-import-period"
+                        value={option.value}
                         checked={isSelected}
                         disabled={isDisabled}
-                        onChange={() => !isDisabled && toggleYearSelection(option.value)}
-                        className="w-4 h-4 text-accent border-gray-500 focus:ring-accent rounded"
+                        onChange={() => !isDisabled && setSelectedGarminPeriod(option.value)}
+                        className="w-4 h-4 text-accent border-gray-500 focus:ring-accent"
                       />
                       <span className={`flex-1 text-sm ${isDisabled ? 'text-muted' : 'text-primary'}`}>
                         {option.label}
@@ -381,7 +379,8 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
                   );
                 })}
                 <p className="text-xs text-muted">
-                  Garmin limits historical data access to the past 30 days. New rides sync automatically going forward.
+                  Garmin sends the rides in the window you pick. New rides keep syncing automatically, and you
+                  can run this again anytime.
                 </p>
               </div>
             ) : (
@@ -438,7 +437,7 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
                       `}
                       title={`${req.status}${req.ridesFound ? ` - ${req.ridesFound} rides` : ''}`}
                     >
-                      {req.year === 'ytd' ? 'YTD' : req.year}
+                      {historyPeriodLabel(req.year)}
                       {req.status === 'completed' && req.ridesFound !== null && (
                         <span className="ml-1 opacity-75">({req.ridesFound})</span>
                       )}
@@ -478,15 +477,13 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
             disabled={
               !selectedProvider ||
               importState === 'loading' ||
-              (selectedProvider === 'garmin' && selectableYearsCount === 0) ||
-              (selectedProvider === 'strava' && isYtdInProgress)
+              (selectedProvider === 'garmin' && (!selectedGarminPeriod || isGarminPeriodInProgress))
             }
             className={`
               w-full py-3 px-4 rounded-lg text-sm font-medium transition-all
               ${!selectedProvider ||
                 importState === 'loading' ||
-                (selectedProvider === 'garmin' && selectableYearsCount === 0) ||
-                (selectedProvider === 'strava' && isYtdInProgress)
+                (selectedProvider === 'garmin' && (!selectedGarminPeriod || isGarminPeriodInProgress))
                 ? 'bg-gray-300 dark:bg-gray-700 text-gray-500 cursor-not-allowed'
                 : 'bg-accent text-white hover:bg-accent-hover'}
             `}
@@ -494,12 +491,10 @@ export function ImportRidesForm({ connectedProviders }: ImportRidesFormProps) {
             {importState === 'loading'
               ? 'Importing...'
               : selectedProvider === 'garmin'
-                ? selectableYearsCount === 0
-                  ? 'Select a period to import'
-                  : 'Start Import'
-                : isYtdInProgress
+                ? isGarminPeriodInProgress
                   ? 'Import In Progress'
-                  : 'Start Import'}
+                  : `Import ${garminPeriodLabel(selectedGarminPeriod)}`
+                : 'Start Import'}
           </button>
         </div>
       )}


### PR DESCRIPTION
## The problem

The Garmin import offered exactly one choice, labeled **Last 30 Days**, whose value was `ytd`. Both the backfill route and the worker expanded `ytd` to **Jan 1 through now**, so picking "30 days" pulled the whole season, and the confirm button honestly read `Import 1 Year`. The label was the thing that was wrong.

The old note claimed Garmin caps history at 30 days. That was never the constraint: 30 days is Garmin's per-request chunk size, which is why the code chunks a full year into 30-day requests.

## The fix

`7d` / `14d` / `30d` become real rolling windows. A new dependency-free lib, `apps/api/src/lib/garmin-backfill-periods.ts`, defines them as an allow-list and resolves each to `[now - N days, now]`. The route, the worker and tier-access all read period meaning from that one place instead of each parsing period strings their own way.

- **Route** (`garmin.backfill.ts`): windows accepted on both the sync fetch route and the batch queue route.
- **Worker** (`backfill.worker.ts`): computes the rolling range for queued jobs, which is the path the UI actually uses.
- **Tier access**: windows are free, since none of them reach past the current season.
- **Re-run semantics**: a rolling window is repeatable, so only a run in flight blocks another; a calendar year stays one-and-done. That repeatability used to be hard-coded to `ytd` alone.
- **UI** (Settings modal and the onboarding step): the three windows as a single choice, because the windows nest, defaulting to 30 days. The confirm button names the choice: `Import Last 7 Days`.

## Compatibility

`ytd` and calendar years are still accepted, so shipped mobile builds and existing `BackfillRequest` rows keep working. No migration. The batch body field stays `years`; the API reads each entry as a period key.

The mobile half is a separate PR in `loam-logger-mobile`.

## Worth a look

A test caught a real hole: `parseGarminPeriodDays('toString')` returned a function through prototype inheritance, which would have sent a NaN date range to Garmin from a query string. Fixed with an own-property check, covered by a test.

## Testing

- API `npm run typecheck` clean, `npm run lint` clean (3 pre-existing warnings, none in touched files)
- API suite: 1789 tests pass, including 11 new unit tests for the period lib, 5 new route tests for the windows, and 6 new tests for the batch endpoint, which had no coverage before
- Web suite: 927 tests pass, with the onboarding Garmin tests rewritten for the new options
- Verified after rebasing onto current `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
