### PR TITLE
fix(garmin): request activity details for queued backfills

### DIFF
--- a/apps/api/src/workers/backfill.worker.test.ts
+++ b/apps/api/src/workers/backfill.worker.test.ts
@@ -831,6 +831,74 @@ describe('processBackfillJob (via worker processor)', () => {
         data: { backfilledUpTo: expect.any(Date), updatedAt: expect.any(Date) },
       });
     });
+
+    describe('activity details (ride maps)', () => {
+      const requestedUrls = () => mockFetch.mock.calls.map(([url]) => String(url));
+      const queryOf = (url: string) => url.slice(url.indexOf('?'));
+
+      it('requests activityDetails over the same range as the summaries', async () => {
+        mockFetch.mockResolvedValue({ status: 202, ok: true } as Response);
+
+        await processBackfillJob({
+          name: 'backfillYear',
+          id: 'job-123',
+          data: { userId: 'user-123', provider: 'garmin', year: '2024' },
+        });
+
+        const urls = requestedUrls();
+        const summaries = urls.find((u) => u.includes('/rest/backfill/activities'));
+        const details = urls.find((u) => u.includes('/rest/backfill/activityDetails'));
+
+        // Summaries carry no per-point GPS, so without this second request the
+        // imported rides can never draw a map.
+        expect(details).toBeDefined();
+        expect(queryOf(details!)).toBe(queryOf(summaries!));
+      });
+
+      it('requests activityDetails even when Garmin already fulfilled the summaries', async () => {
+        // The state a rider is in after a sync that came back mapless: Garmin
+        // 409s the summary range it already sent, but the details are new.
+        mockFetch.mockImplementation((url) =>
+          Promise.resolve(
+            String(url).includes('/rest/backfill/activityDetails')
+              ? ({ status: 202, ok: true } as Response)
+              : ({ status: 409, ok: false } as Response)
+          )
+        );
+
+        await processBackfillJob({
+          name: 'backfillYear',
+          id: 'job-123',
+          data: { userId: 'user-123', provider: 'garmin', year: '2024' },
+        });
+
+        expect(requestedUrls().some((u) => u.includes('/rest/backfill/activityDetails'))).toBe(true);
+      });
+
+      it('imports the rides even when the details request is rejected', async () => {
+        // No activityDetails scope on the app: tracks are missing, which is the
+        // status quo, but the ride history must still import.
+        mockFetch.mockImplementation((url) =>
+          Promise.resolve(
+            String(url).includes('/rest/backfill/activityDetails')
+              ? ({ status: 403, ok: false, text: () => Promise.resolve('Forbidden') } as Response)
+              : ({ status: 202, ok: true } as Response)
+          )
+        );
+
+        await expect(
+          processBackfillJob({
+            name: 'backfillYear',
+            id: 'job-123',
+            data: { userId: 'user-123', provider: 'garmin', year: '2024' },
+          })
+        ).resolves.toBeUndefined();
+
+        expect(mockPrisma.backfillRequest.updateMany).not.toHaveBeenCalledWith(
+          expect.objectContaining({ data: expect.objectContaining({ status: 'failed' }) })
+        );
+      });
+    });
   });
 });
 

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -359,6 +359,37 @@ async function processGarminBackfill(userId: string, year: string): Promise<void
     'Garmin backfill chunks processed'
   );
 
+  // Ask for the same range's Activity Details as well. Activity Summaries carry
+  // no per-point data, so a history imported only as `activities` yields rides
+  // that can never draw a map: processGarminCallback's persistGarminStream has
+  // nothing to store. The interactive route has always done this; this queued
+  // path, which is the one both clients actually use, never did.
+  //
+  // Deliberately above the allDuplicates check: Garmin tracks backfill requests
+  // per summary type, so a range whose activities it already fulfilled still
+  // needs its details requested. That is the only way an already-imported ride
+  // gets a track, and it is exactly the state a rider is in after a sync that
+  // came back mapless.
+  //
+  // Best effort, matching the route: if the activityDetails scope is not
+  // enabled for this app, the rides still import as before and only the tracks
+  // are missing, which is the status quo, not a regression.
+  try {
+    const details = await triggerGarminBackfillChunks({
+      accessToken,
+      startDate,
+      endDate,
+      apiBase: config.garminApiBase,
+      summaryType: 'activityDetails',
+    });
+    logger.info(
+      { totalChunks: details.totalChunks, errorCount: details.errors.length, year },
+      'Garmin activityDetails backfill requests triggered'
+    );
+  } catch (err) {
+    logger.warn({ err, year }, 'Garmin activityDetails backfill failed; rides import without tracks');
+  }
+
   // Check if ALL chunks returned 409 - means backfill was already completed
   const allDuplicates = duplicateChunks > 0 && totalChunks === 0 && errors.length === 0;
 


### PR DESCRIPTION
## The bug

Backfilled Garmin rides never draw a map, no matter how many times you sync previous rides.

Garmin's Activity Summaries carry no per-point GPS. The track only exists in the `activityDetails` summary type, which has to be requested as its own backfill. The interactive route has always asked for both (`garmin.backfill.ts`), but no client calls that route for Garmin. Everything goes through `POST /garmin/backfill/batch`, which queues a job, and the worker's chunk loop only ever requested `/rest/backfill/activities`.

So Garmin re-delivered summaries, `processGarminCallback` flattened them, and `persistGarminStream` found no `samples[]` to store. The map data was never asked for.

## The fix

Trigger the details pass in the worker too, reusing the shared `triggerGarminBackfillChunks` helper that the route uses.

It sits **above** the `allDuplicates` check on purpose. Garmin tracks backfill requests per summary type, so a range whose summaries it already fulfilled will 409 on the summaries while the details request is still new. That is the only way an already-imported ride gets a track, and it is exactly the state every affected rider is in right now: their next sync of the same window repairs the existing rides rather than doing nothing.

Best effort, matching the route. If the `activityDetails` scope is not enabled for the app, the rides still import as before and only the tracks are missing, which is the status quo rather than a regression.

## Testing

- Adds coverage to the queued backfill path, which had no test for what it actually asks Garmin for
- **Two of the three new tests fail against the unfixed worker** (verified by stashing the fix and re-running), so they pin the bug rather than the implementation
- API suite: 1770 tests pass; typecheck and lint clean

## Deploy note

This fixes new syncs. Existing mapless rides get their tracks once the rider re-runs a sync covering them, since the details request for that range has never been made. Worth knowing if you would rather backfill affected users rather than wait for them to click it.

Independent of #270 (the sync-window work) and touches a different part of the same function, so the two merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
