### PR TITLE
fix(garmin): name the connection "Garmin Connect™" across the import UI

### DIFF
--- a/apps/web/src/components/GarminImportModal.tsx
+++ b/apps/web/src/components/GarminImportModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { Modal, Button } from './ui';
 import { getAuthHeaders } from '@/lib/csrf';
+import { GARMIN_CONNECT_APP_NAME } from '@loam/shared';
 
 type Props = {
   open: boolean;
@@ -168,7 +169,7 @@ export default function GarminImportModal({ open, onClose, onSuccess, onDuplicat
     <Modal
       isOpen={open}
       onClose={onClose}
-      title="Import Garmin Rides"
+      title={`Import ${GARMIN_CONNECT_APP_NAME} Rides`}
       size="lg"
       preventClose={step === 'processing'}
     >

--- a/apps/web/src/components/onboarding/ImportRidesForm.test.tsx
+++ b/apps/web/src/components/onboarding/ImportRidesForm.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { GARMIN_CONNECT_APP_NAME } from '@loam/shared';
 import { ImportRidesForm } from './ImportRidesForm';
 
 // Mock fetch
@@ -74,7 +75,7 @@ describe('ImportRidesForm', () => {
 
       expect(screen.getByText('Import from')).toBeInTheDocument();
       expect(screen.getByText('Strava')).toBeInTheDocument();
-      expect(screen.getByText('Garmin Connect')).toBeInTheDocument();
+      expect(screen.getByText(GARMIN_CONNECT_APP_NAME)).toBeInTheDocument();
     });
 
     it('allows selecting a provider', () => {

--- a/apps/web/src/components/onboarding/ImportRidesForm.tsx
+++ b/apps/web/src/components/onboarding/ImportRidesForm.tsx
@@ -3,6 +3,7 @@ import { History, ChevronDown, ChevronUp, Check } from 'lucide-react';
 import { getAuthHeaders } from '@/lib/csrf';
 import { useUserTier } from '@/hooks/useUserTier';
 import { UpsellCard } from '@/components/UpgradePrompt';
+import { GARMIN_CONNECT_APP_NAME } from '@loam/shared';
 
 interface ImportRidesFormProps {
   connectedProviders: Array<'strava' | 'garmin' | 'suunto'>;
@@ -70,7 +71,9 @@ const SUUNTO_YEAR_OPTIONS = [
 
 const PROVIDER_LABELS: Record<string, string> = {
   strava: 'Strava',
-  garmin: 'Garmin Connect',
+  // The guidelines forbid abbreviating or stylizing the name, and that includes
+  // dropping the trademark mark, so this reads from the shared constant.
+  garmin: GARMIN_CONNECT_APP_NAME,
   suunto: 'Suunto',
 };
 

--- a/apps/web/src/pages/Settings/sections/DataSourcesSection.tsx
+++ b/apps/web/src/pages/Settings/sections/DataSourcesSection.tsx
@@ -201,7 +201,7 @@ export default function DataSourcesSection() {
                 showAdminClear={isAdmin}
                 onClearRides={() => setConfirmState({ kind: 'delete-rides', provider: 'garmin' })}
                 clearRidesLoading={garminDeleteLoading}
-                clearRidesLabel="Clear Garmin Rides"
+                clearRidesLabel={`Clear ${GARMIN_CONNECT_APP_NAME} Rides`}
               />
             ) : (
               <ConnectGarminLink />


### PR DESCRIPTION
## Why

Three web surfaces named the Garmin connection with the bare word, or with the name stripped of its trademark mark:

| where | was | now |
|---|---|---|
| Settings import modal title | `Import Garmin Rides` | `Import Garmin Connect™ Rides` |
| admin clear-rides control | `Clear Garmin Rides` | `Clear Garmin Connect™ Rides` |
| onboarding provider label | `Garmin Connect` (no ™) | `Garmin Connect™` |

The Garmin Developer API Brand Guidelines forbid abbreviating, truncating or stylizing the app name, and dropping the mark is stylizing it. This is the same rule the 1.0.10 mobile work applied to attribution.

## How

All three read from `GARMIN_CONNECT_APP_NAME` in `@loam/shared`, which already existed for exactly this and documents the rule on itself: use it where the *connection or app* is named, use `formatGarminSource()` for data-source attribution.

**Device attribution is untouched.** Rides still credit "Garmin Edge 840", or plain "Garmin" when the device is unknown, which the guidelines sanction as the fallback. Only the connection-naming contexts changed.

The onboarding test now asserts against the constant instead of a duplicated literal, so it moves with the source rather than pinning the old string.

## Companion

The mobile half is in `loam-logger-mobile` (on the import-sheet branch), where the sheet read "Sync Garmin Rides". Both apps had to move together: Garmin reviews the product as a whole, and the attribution strings are hand-mirrored between the repos.

## Testing

- Web suite: 927 tests pass; `tsc --noEmit` clean

## Worth checking

`docs/garmin/submission-checklist.md` row 14 covers "Garmin Connect™ naming through the import flow" as a secondary screen. If screenshots were already captured for submission, the modal title in them is now stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
