### PR TITLE
fix(garmin): stop activity details from creating a duplicate ride

### DIFF
--- a/apps/api/src/lib/garmin-ride-key.test.ts
+++ b/apps/api/src/lib/garmin-ride-key.test.ts
@@ -1,0 +1,29 @@
+import { garminRideKey } from './garmin-ride-key';
+
+describe('garminRideKey', () => {
+  it('passes a summary id through untouched', () => {
+    expect(garminRideKey('9876543210')).toBe('9876543210');
+  });
+
+  it('strips the details suffix so both deliveries share one key', () => {
+    expect(garminRideKey('9876543210-detail')).toBe('9876543210');
+  });
+
+  it('is idempotent, so it is safe on every read and write', () => {
+    expect(garminRideKey(garminRideKey('9876543210-detail'))).toBe('9876543210');
+  });
+
+  it('keeps a hyphen that is part of the id itself', () => {
+    // The dangerous failure is the opposite of a duplicate: a rule that kept
+    // only the leading segment would collapse these two distinct activities
+    // onto one row and silently lose a ride.
+    expect(garminRideKey('activity-123')).toBe('activity-123');
+    expect(garminRideKey('activity-456')).toBe('activity-456');
+    expect(garminRideKey('activity-123')).not.toBe(garminRideKey('activity-456'));
+  });
+
+  it('only strips the suffix at the end', () => {
+    expect(garminRideKey('9876543210-detail-2')).toBe('9876543210-detail-2');
+    expect(garminRideKey('detail-9876543210')).toBe('detail-9876543210');
+  });
+});

--- a/apps/api/src/lib/garmin-ride-key.ts
+++ b/apps/api/src/lib/garmin-ride-key.ts
@@ -1,0 +1,33 @@
+/**
+ * The stable ride key for a Garmin activity.
+ *
+ * Garmin delivers one ride under two summary types. The Activity Summary
+ * carries `summaryId: "9876543210"` and the stats. The Activity Details for the
+ * same ride carries `"9876543210-detail"`, the same stats nested under
+ * `summary`, and the `samples[]` that draw the map.
+ *
+ * Both describe one ride, so both must land on one row. Keying rides on the raw
+ * summaryId meant the details delivery looked up an id no row had, so it
+ * inserted a second ride and attached the GPS track to the copy: the rider saw
+ * their ride twice, once with a map and once without, and the duplicate's hours
+ * were counted against their components a second time.
+ *
+ * This is deliberately an exact suffix strip rather than "everything before the
+ * first hyphen". Garmin's ids are opaque, and a leading-segment rule would fuse
+ * two genuinely different activities into one row the moment an id carries a
+ * hyphen of its own. Silently losing a ride is worse than duplicating one, so
+ * the rule only removes the one suffix Garmin is known to append.
+ */
+const DETAILS_SUFFIX = '-detail';
+
+/**
+ * Normalize a Garmin summaryId to the id its ride is stored under.
+ *
+ * Idempotent: a summary id passes through untouched, so this is safe to apply
+ * at every read and write of `Ride.garminActivityId`.
+ */
+export function garminRideKey(summaryId: string): string {
+  return summaryId.endsWith(DETAILS_SUFFIX)
+    ? summaryId.slice(0, -DETAILS_SUFFIX.length)
+    : summaryId;
+}

--- a/apps/api/src/lib/garmin-ride-removal.ts
+++ b/apps/api/src/lib/garmin-ride-removal.ts
@@ -6,6 +6,7 @@ import {
   recomputeAdjustedComponentsForRides,
 } from './component-hours';
 import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
+import { garminRideKey } from './garmin-ride-key';
 
 /**
  * Remove the ride behind a Garmin activity that is no longer a bike ride.
@@ -29,8 +30,13 @@ import { invalidateBikePredictionsForBikes } from '../services/prediction/cache'
  */
 export async function removeGarminRideIfPresent(
   userId: string,
-  garminActivityId: string
+  summaryId: string
 ): Promise<boolean> {
+  // Normalized here rather than at the call sites: a retype can be announced by
+  // either summary type, and an "-detail" id would otherwise find no row and
+  // report that nothing was removed while the ride kept accruing hours.
+  const garminActivityId = garminRideKey(summaryId);
+
   // Removal and affected bikes are tracked separately: an unassigned ride is
   // still deleted but moves nobody's hours, so an empty bike list must not read
   // as "nothing happened".

--- a/apps/api/src/workers/backfill.worker.test.ts
+++ b/apps/api/src/workers/backfill.worker.test.ts
@@ -269,6 +269,59 @@ describe('processBackfillJob (via worker processor)', () => {
       );
     });
 
+    /**
+     * The same one-ride-two-deliveries case on the callback path, which is what
+     * a backfill answers on: the Activity Details entry carries the "-detail"
+     * id, the stats nested under `summary`, and the GPS samples. It has to land
+     * on the row the Activity Summary already created.
+     */
+    it('updates the existing ride when the details arrive, rather than inserting a duplicate', async () => {
+      (mockPrisma.ride.findUnique as jest.Mock).mockResolvedValue({
+        location: null,
+        bikeId: null,
+        durationSeconds: 3600,
+      });
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([
+          {
+            summaryId: 'activity-123-detail',
+            samples: [{ latitudeInDegree: 37.7749, longitudeInDegree: -122.4194 }],
+            summary: {
+              activityType: 'cycling',
+              activityName: 'Morning Ride',
+              startTimeInSeconds: 1706123456,
+              durationInSeconds: 3600,
+              distanceInMeters: 50000,
+              totalElevationGainInMeters: 500,
+              startingLatitudeInDegrees: 37.7749,
+              startingLongitudeInDegrees: -122.4194,
+            },
+          },
+        ]),
+      } as Response);
+
+      await processBackfillJob({
+        name: 'processCallback',
+        id: 'job-123',
+        data: {
+          userId: 'user-123',
+          provider: 'garmin',
+          callbackURL: 'https://apis.garmin.com/callback/xyz',
+        },
+      });
+
+      expect(mockPrisma.ride.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { garminActivityId: 'activity-123' } })
+      );
+
+      const keys = (mockPrisma.ride.upsert as jest.Mock).mock.calls.map(
+        ([args]) => args.where.garminActivityId
+      );
+      expect(keys).not.toContain('activity-123-detail');
+    });
+
     it('should fire fireRideNotifications after upserting a real-time callback ride (no active backfill session)', async () => {
       // No runningSession → isBackfill must be false so the user gets the
       // "Ride Synced" + bike-pick prompt push notifications. Regression

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -18,6 +18,7 @@ import type { BackfillJobData, BackfillJobName } from '../lib/queue/backfill.que
 import { enqueueWeatherJob, enqueueLiftDetectionJob } from '../lib/queue';
 import { triggerGarminBackfillChunks } from '../services/garmin-backfill';
 import { resolveGarminPeriodRange } from '../lib/garmin-backfill-periods';
+import { garminRideKey } from '../lib/garmin-ride-key';
 import { captureServerEvent } from '../lib/posthog';
 import { incrementBikeComponentHours, syncBikeComponentHours } from '../lib/component-hours';
 import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
@@ -832,8 +833,13 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
       lon: startLng,
     });
 
+    // One ride, two deliveries: the Activity Summary arrives as "123" and its
+    // Activity Details as "123-detail". Keying on the raw id made the details
+    // delivery miss the summary's row and insert a duplicate carrying the map.
+    const rideKey = garminRideKey(activity.summaryId);
+
     const existingRide = await prisma.ride.findUnique({
-      where: { garminActivityId: activity.summaryId },
+      where: { garminActivityId: rideKey },
       select: { location: true, bikeId: true, durationSeconds: true },
     });
 
@@ -849,10 +855,10 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
     let affectedBikeIds: string[] = [];
     const upsertedRide = await prisma.$transaction(async (tx) => {
       const ride = await tx.ride.upsert({
-        where: { garminActivityId: activity.summaryId },
+        where: { garminActivityId: rideKey },
         create: {
           userId,
-          garminActivityId: activity.summaryId,
+          garminActivityId: rideKey,
           startTime,
           durationSeconds: activity.durationInSeconds,
           distanceMeters,

--- a/apps/api/src/workers/sync.worker.test.ts
+++ b/apps/api/src/workers/sync.worker.test.ts
@@ -850,6 +850,49 @@ describe('processSyncJob (via worker processor)', () => {
         );
       });
 
+      /**
+       * One ride, two deliveries. Garmin sends the Activity Summary as
+       * "summary-456" and the Activity Details for the same ride as
+       * "summary-456-detail". Keying the row on the raw id sent the second
+       * delivery looking for a row that did not exist, so it inserted a
+       * duplicate: the rider saw the ride twice, the map was attached to the
+       * copy, and the copy's hours were counted against their components again.
+       */
+      it('updates the ride the summary created when its details arrive', async () => {
+        (mockPrisma.ride.findUnique as jest.Mock).mockResolvedValue({
+          id: 'ride-1',
+          location: null,
+          bikeId: null,
+          durationSeconds: 5340,
+        });
+        const samples = [{ latitudeInDegree: 48.75, longitudeInDegree: -122.48 }];
+
+        await processSyncJob({
+          name: 'syncActivity',
+          data: {
+            userId: 'user123',
+            provider: 'garmin',
+            activityId: 'summary-456-detail',
+            pushedActivity: { ...GARMIN_SUMMARY, summaryId: 'summary-456-detail', samples },
+          },
+        });
+
+        expect(mockPrisma.ride.upsert).toHaveBeenCalledWith(
+          expect.objectContaining({ where: { garminActivityId: 'summary-456' } })
+        );
+
+        const keys = (mockPrisma.ride.upsert as jest.Mock).mock.calls.map(
+          ([args]) => args.where.garminActivityId
+        );
+        expect(keys).not.toContain('summary-456-detail');
+
+        // The track belongs on the ride the rider already has.
+        expect(mockPersistGarminStream).toHaveBeenCalledWith(
+          'ride-1',
+          expect.objectContaining({ samples })
+        );
+      });
+
       // Verification mode blocks unprompted pulls. A push is not a pull, so it
       // must keep flowing or a reviewer sees no data at all.
       it('ingests a pushed activity during verification mode', async () => {

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -14,6 +14,7 @@ import { persistGarminStream } from '../lib/ride-stream-store';
 import { fetchGarminActivityFromCallback } from '../lib/garmin-activity-details';
 import { isGarminCyclingActivity } from '../types/garmin';
 import { removeGarminRideIfPresent } from '../lib/garmin-ride-removal';
+import { garminRideKey } from '../lib/garmin-ride-key';
 import { syncBikeComponentHours } from '../lib/component-hours';
 import { invalidateBikePredictionsForBikes } from '../services/prediction/cache';
 import { logger } from '../lib/logger';
@@ -620,6 +621,11 @@ async function syncGarminActivity(
 }
 
 async function upsertGarminActivity(userId: string, activity: GarminActivity): Promise<void> {
+  // One ride, two deliveries: the Activity Summary arrives as "123" and its
+  // Activity Details as "123-detail". Keying on the raw id made the details
+  // delivery miss the summary's row and insert a duplicate carrying the map.
+  const rideKey = garminRideKey(activity.summaryId);
+
   const distanceMeters = activity.distanceInMeters ?? 0;
 
   const elevationGainMeters =
@@ -651,7 +657,7 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
   });
 
   const existing = await prisma.ride.findUnique({
-    where: { garminActivityId: activity.summaryId },
+    where: { garminActivityId: rideKey },
     select: { id: true, location: true, bikeId: true, durationSeconds: true },
   });
 
@@ -681,10 +687,10 @@ async function upsertGarminActivity(userId: string, activity: GarminActivity): P
 
   // Upsert ride first — this is the primary data, must not be lost
   const ride = await prisma.ride.upsert({
-    where: { garminActivityId: activity.summaryId },
+    where: { garminActivityId: rideKey },
     create: {
       userId,
-      garminActivityId: activity.summaryId,
+      garminActivityId: rideKey,
       startTime,
       durationSeconds: activity.durationInSeconds,
       distanceMeters,


### PR DESCRIPTION
## The bug

Garmin delivers one ride under two summary types:

| delivery | `summaryId` | carries |
|---|---|---|
| Activity Summary | `9876543210` | the stats, flat |
| Activity Details | `9876543210-detail` | the same stats nested under `summary`, plus `samples[]` (the map) |

Both ingest paths keyed the row on the raw `summaryId`:

```ts
where: { garminActivityId: activity.summaryId }
```

So the details delivery looked up an id no row had, and the upsert took its `create` branch. The rider ends up with the ride twice, the GPS track attached to the copy rather than to the ride they already had, and the duplicate's hours counted against their components a second time.

The suffix was already known here: `garmin-activity-details.ts` documents it and `idsMatch` compensates for it when picking an entry out of a callback payload. Nothing normalized it before the database.

## The fix

`garminRideKey()` normalizes a summaryId to the id its ride is stored under, applied at every read and write of `Ride.garminActivityId` in both workers, and inside `removeGarminRideIfPresent` so a retype announced by either summary type still finds the ride instead of reporting nothing removed while it keeps accruing hours.

**An exact suffix strip, deliberately not "everything before the first hyphen."** Garmin's ids are opaque, and a leading-segment rule would fuse two genuinely different activities into one row the moment an id carries a hyphen of its own. Silently losing a ride is worse than duplicating one. This repo's own fixtures (`activity-123`, `summary-456`) are exactly the shape that rule would have destroyed, and there is a test pinning that.

A side benefit: `isNewRide` is now correct for a details delivery, so it no longer fires a second "Ride Synced" notification for the duplicate.

## Scope

The realtime path has had this since activity details were first requested. **#271 extended the same request to queued backfills**, which is what turned it from an occasional realtime duplicate into one per backfilled ride. That was my change, and this is the missing half of it.

## Testing

- 5 unit tests on the key rule, including the hyphen-in-id case that guards against the worse failure
- A regression test on each ingest path (realtime push in `sync.worker`, callback in `backfill.worker`) asserting the details delivery upserts onto the summary's row, never under the `-detail` id, and that the track lands on the existing ride
- **Verified the new tests fail against the unfixed workers** by stashing the source and re-running
- 129 tests pass across the workers and Garmin libs; `tsc --noEmit` clean

## Not included: cleaning up existing duplicates

Rides already inserted under a `-detail` id stay until something removes them. `duplicate-detector` will not surface them: it pairs a Garmin ride with a *non-Garmin* one, so a Garmin/Garmin pair is invisible to it. Those rows are also still crediting hours against components.

A cleanup wants to merge each `-detail` row into its base row (keeping the base ride's bike assignment and any manual edits, carrying over the stream, then recomputing component hours) rather than blind-deleting. Happy to write it as a follow-up admin route or script, but it is a data migration and deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
