### PR TITLE
fix(garmin): stop idsMatch fusing activities that share a prefix

### DIFF
--- a/apps/api/src/lib/garmin-activity-details.test.ts
+++ b/apps/api/src/lib/garmin-activity-details.test.ts
@@ -179,6 +179,48 @@ describe('fetchGarminActivityFromCallback', () => {
     expect(result?.summaryId).toBe(`${SUMMARY_ID}-detail`);
   });
 
+  // The dangerous inverse of the suffix case. A callbackURL covers an upload
+  // window and can carry several activities; the old leading-segment rule made
+  // any two ids sharing a prefix segment "the same activity", which is how one
+  // ride's samples end up on another ride.
+  it('does not match a different activity that shares a leading segment', async () => {
+    mockFetch.mockResolvedValue(ok([entry('activity-999')]));
+
+    const result = await fetchGarminActivityFromCallback({
+      accessToken: TOKEN,
+      summaryId: 'activity-123',
+      callbackURL: CALLBACK_URL,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('picks the right entry when a payload carries prefix-sharing ids', async () => {
+    mockFetch.mockResolvedValue(ok([entry('activity-999'), entry('activity-123')]));
+
+    const result = await fetchGarminActivityFromCallback({
+      accessToken: TOKEN,
+      summaryId: 'activity-123',
+      callbackURL: CALLBACK_URL,
+    });
+
+    expect(result?.summaryId).toBe('activity-123');
+  });
+
+  // Only `-detail` is documented, but the rule holds for any suffix appended to
+  // the id we asked for, because the whole requested id must precede it.
+  it('matches an unfamiliar suffix on the requested id', async () => {
+    mockFetch.mockResolvedValue(ok([entry(`${SUMMARY_ID}-summary`)]));
+
+    const result = await fetchGarminActivityFromCallback({
+      accessToken: TOKEN,
+      summaryId: SUMMARY_ID,
+      callbackURL: CALLBACK_URL,
+    });
+
+    expect(result?.summaryId).toBe(`${SUMMARY_ID}-summary`);
+  });
+
   it('tolerates a bare object instead of an array', async () => {
     mockFetch.mockResolvedValue(ok(entry(SUMMARY_ID)));
 

--- a/apps/api/src/lib/garmin-activity-details.ts
+++ b/apps/api/src/lib/garmin-activity-details.ts
@@ -1,5 +1,6 @@
 import { logger } from './logger';
 import { assertTrustedGarminCallbackUrl } from './garmin-callback-url';
+import { garminRideKey } from './garmin-ride-key';
 
 /**
  * Reader for the payload behind a Garmin ping's callbackURL.
@@ -35,15 +36,31 @@ export type GarminActivityPayload = {
 };
 
 /**
+ * Does this payload entry describe the activity we asked for?
+ *
  * Garmin appends a suffix to the details summaryId for some activity kinds
- * (e.g. `12345678-detail`), so an exact match alone misses them. Comparing the
- * leading id segment matches both spellings without matching a different
- * activity, since the ids themselves are opaque and unique.
+ * (e.g. `12345678-detail`), so an exact match alone misses them.
+ *
+ * This used to compare the text before the first hyphen on both sides, which
+ * matched the suffixed spelling but also matched any two ids sharing a leading
+ * segment: `activity-999` and `activity-123` were "the same activity". A
+ * callbackURL covers an upload window and can carry several activities, so that
+ * is the shape that attaches one ride's samples to a different ride. Garmin's
+ * ids are opaque, and nothing guarantees the leading segment identifies
+ * anything on its own.
+ *
+ * The requested id now has to be the entire leading id, up to a hyphen
+ * boundary, rather than a fragment it happens to share. A miss is logged as
+ * garmin_callback_no_match and imports nothing, which this module already
+ * prefers to guessing.
  */
 function idsMatch(candidate: string | undefined, summaryId: string): boolean {
   if (!candidate) return false;
   if (candidate === summaryId) return true;
-  return candidate.split('-')[0] === summaryId.split('-')[0];
+  // The same ride under the other summary type: "123" and "123-detail".
+  if (garminRideKey(candidate) === garminRideKey(summaryId)) return true;
+  // Any other suffix Garmin appends to the id we asked for.
+  return candidate.startsWith(`${summaryId}-`);
 }
 
 /**


### PR DESCRIPTION
## Why

Raised in review on #273. That PR's doc comment argues leading-segment id matching is unsafe, while `idsMatch` in `garmin-activity-details.ts` was still doing exactly that:

```ts
return candidate.split('-')[0] === summaryId.split('-')[0];
```

`fetchGarminActivityFromCallback` uses it to pick one activity's entry out of a callback payload, and **a callbackURL covers an upload window and can carry several activities**. So `idsMatch('activity-999', 'activity-123')` returning `true` is the shape that attaches one ride's samples to a different ride. Garmin's ids are opaque; nothing guarantees the leading segment identifies anything on its own.

## The change

The requested id now has to be the **entire leading id, up to a hyphen boundary**, rather than a fragment it happens to share:

```ts
if (candidate === summaryId) return true;
if (garminRideKey(candidate) === garminRideKey(summaryId)) return true;  // "123" vs "123-detail"
return candidate.startsWith(`${summaryId}-`);                            // any other appended suffix
```

This reuses `garminRideKey` from #273, so the two places that reason about Garmin ids now agree on one rule instead of contradicting each other.

Matching stays permissive about *which* suffix Garmin appends. Only `-detail` is documented, and the third clause holds for any suffix because the whole requested id must precede it, so this does not trade the old rule's tolerance for safety.

## Failure direction

A miss logs `garmin_callback_no_match` and imports nothing. That is the tradeoff this module already states it prefers: "attaching another ride's data to this one is worse than importing nothing." The loose rule failed silently in the worse direction.

## Testing

- Two new tests pin the behavior change: a prefix-sharing id no longer matches, and the right entry is chosen when a payload carries both. **Both fail against the old rule** (verified by stashing the source).
- A third test guards the forward-compatible case (an unfamiliar suffix on the requested id). It passes under both rules, so it documents intent rather than a change.
- Full API suite: 1802 tests pass. `tsc --noEmit` clean.

## Stacked

Based on `fix/garmin-details-duplicate-ride` (#273), since it needs `garminRideKey`. GitHub will retarget this to `main` once #273 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
