### PR TITLE
chore(ts): drop baseUrl ahead of its removal in TypeScript 7

### DIFF
--- a/apps/api/tsconfig.app.json
+++ b/apps/api/tsconfig.app.json
@@ -5,8 +5,7 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "types": ["node"],
-    "baseUrl": ".",
-    "paths": { "@/*": ["src/*"] },
+    "paths": { "@/*": ["./src/*"] },
     "outDir": "../../dist/apps/api",
     "jsx": "react-jsx"
   },

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -14,7 +14,6 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@loam/shared": ["../../libs/shared/src/index.ts"]

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -6,9 +6,8 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
-    "baseUrl": "./src",
     "paths": {
-      "@/*": ["*"]
+      "@/*": ["./src/*"]
     }
   }
 }

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -12,7 +12,6 @@
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,10 +4,9 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
-    "baseUrl": ".",
     "paths": {
-      "@loam/graphql": ["libs/graphql/src/index.ts"],
-      "@loam/shared": ["libs/shared/src/index.ts"]
+      "@loam/graphql": ["./libs/graphql/src/index.ts"],
+      "@loam/shared": ["./libs/shared/src/index.ts"]
     }
   }
 }


### PR DESCRIPTION
## Why

TypeScript deprecated `baseUrl` in 6.0 and removes it in 7.0. Newer editors already flag it as an error against these configs:

```
Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

The repo's own tsc is 5.8.3, which still accepts it, so nothing is failing in CI today. This is forward work, not a fix for a live break.

**Migrating rather than silencing.** The suggested `"ignoreDeprecations": "6.0"` only defers the same edit to the version that stops honouring the option, and adds a second thing to remember to remove.

## What changed

`paths` has not needed `baseUrl` for some time: entries resolve relative to the config file that declares them. Every mapping is now explicitly relative, so resolution is byte-for-byte the same.

| file | before | after |
|---|---|---|
| `tsconfig.base.json` | `baseUrl: "."`, `libs/…/index.ts` | `./libs/…/index.ts` |
| `apps/api/tsconfig.app.json` | `baseUrl: "."`, `@/*: ["src/*"]` | `@/*: ["./src/*"]` |
| `apps/web/tsconfig.json` | `baseUrl: "./src"`, `@/*: ["*"]` | `@/*: ["./src/*"]` |
| `apps/web/tsconfig.app.json` | `baseUrl: "."`, paths already relative | `baseUrl` removed |
| `apps/web/tsconfig.node.json` | `baseUrl: "."`, paths already relative | `baseUrl` removed |

Inherited mappings still resolve against `tsconfig.base.json`'s own directory, which is where they were already pointing.

## Why this is safe

**Nothing relied on `baseUrl` for bare-specifier resolution.** No source file imports `"src/…"` or `"libs/…"`; every alias in use (`@/…` in 40 web files and 1 api file, `@loam/shared`, `@loam/graphql`) goes through an explicit `paths` entry or the npm workspace link.

**Vite reads these paths too**, which was the real risk rather than tsc. The build log names `nx-vite-ts-paths`, so tsconfig paths feed the bundler in addition to the explicit `@` alias in `vite.config.ts`. That is why I verified with real builds rather than type-checks alone.

## Verification

| check | result |
|---|---|
| `type-check` web / api | clean |
| `libs/shared`, `libs/graphql` | clean |
| API tests | 1802 passed |
| Web tests | 927 passed |
| `apps/web` build (`tsc -b && vite build`) | built |
| `apps/api` build (vite + esbuild) | built |

The web app project still resolves the same 321 files it did before the change.

## Relation to #276

Independent. That PR touches CI and package.json scripts; this touches only tsconfigs, so the two merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
