### PR TITLE
chore(web): clear npm audit findings, incl. react-router v8

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,10 +28,9 @@
     "lucide-react": "^1.6.0",
     "motion": "^12.38.0",
     "posthog-js": "^1.203.0",
-    "react": "19.2.4",
-    "react-dom": "19.2.4",
-    "react-router": "^7.13.2",
-    "react-router-dom": "^7.13.2",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "react-router": "^8.3.0",
     "recharts": "^3.8.0",
     "sonner": "^2.0.7"
   },

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
 ﻿import { lazy, Suspense, type ReactNode } from 'react';
-import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 
 import MarketingLanding from './pages/MarketingLanding';

--- a/apps/web/src/components/AddRideForm.tsx
+++ b/apps/web/src/components/AddRideForm.tsx
@@ -1,6 +1,6 @@
 // src/components/AddRideForm.tsx
 import { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useMutation, useQuery } from '@apollo/client';
 import { ADD_RIDE } from '../graphql/addRide';
 import { BIKES } from '../graphql/bikes';

--- a/apps/web/src/components/AuthGate.tsx
+++ b/apps/web/src/components/AuthGate.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { Navigate, useLocation } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router'
 import { useQuery } from '@apollo/client'
 import { ME_QUERY } from '../graphql/me'
 import { useSentryUser } from '../hooks/useSentryUser'

--- a/apps/web/src/components/BikeHealthHero/index.tsx
+++ b/apps/web/src/components/BikeHealthHero/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { motion } from 'motion/react';
 import { BikeHealthCard } from './BikeHealthCard';
 import { Button } from '../ui';

--- a/apps/web/src/components/BillingSection.tsx
+++ b/apps/web/src/components/BillingSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { gql, useMutation } from '@apollo/client';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { CreditCard, ExternalLink } from 'lucide-react';
 import { useUserTier } from '../hooks/useUserTier';
 import { Modal } from './ui/Modal';

--- a/apps/web/src/components/GarminWeatherRepairSection.tsx
+++ b/apps/web/src/components/GarminWeatherRepairSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useApolloClient, useMutation, useQuery } from '@apollo/client';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Mountain, Lock } from 'lucide-react';
 import { useUserTier } from '../hooks/useUserTier';
 import {

--- a/apps/web/src/components/LandingNavbar.tsx
+++ b/apps/web/src/components/LandingNavbar.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 

--- a/apps/web/src/components/NavBar.tsx
+++ b/apps/web/src/components/NavBar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { NavLink, useNavigate } from "react-router-dom";
+import { NavLink, useNavigate } from "react-router";
 import { useApolloClient } from "@apollo/client";
 import { motion, AnimatePresence } from "motion/react";
 import { clearCsrfToken } from "@/lib/csrf";

--- a/apps/web/src/components/OnboardingGate.tsx
+++ b/apps/web/src/components/OnboardingGate.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { useCurrentUser } from '../hooks/useCurrentUser';
 
 export default function OnboardingGate({ children }: { children: ReactNode }) {

--- a/apps/web/src/components/SetPasswordModal.test.tsx
+++ b/apps/web/src/components/SetPasswordModal.test.tsx
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import SetPasswordModal from './SetPasswordModal';
 
-// Mock react-router-dom navigate
+// Mock react-router navigate
 const mockNavigate = vi.fn();
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/apps/web/src/components/SetPasswordModal.tsx
+++ b/apps/web/src/components/SetPasswordModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 import { Modal, Button } from './ui';
 import { validatePassword, PASSWORD_RULES } from '@loam/shared';

--- a/apps/web/src/components/TermsGate.test.tsx
+++ b/apps/web/src/components/TermsGate.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import TermsGate from './TermsGate';
 
 // Mock the useCurrentUser hook

--- a/apps/web/src/components/TermsGate.tsx
+++ b/apps/web/src/components/TermsGate.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { useCurrentUser } from '../hooks/useCurrentUser';
 
 export default function TermsGate({ children }: { children: ReactNode }) {

--- a/apps/web/src/components/WeatherBackfillSection.test.tsx
+++ b/apps/web/src/components/WeatherBackfillSection.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import WeatherBackfillSection from './WeatherBackfillSection';
 
 const mockBackfill = vi.fn();
@@ -16,9 +16,9 @@ vi.mock('@apollo/client', () => ({
   gql: vi.fn((strings: TemplateStringsArray) => strings[0]),
 }));
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>(
-    'react-router-dom'
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>(
+    'react-router'
   );
   return {
     ...actual,

--- a/apps/web/src/components/WeatherBackfillSection.tsx
+++ b/apps/web/src/components/WeatherBackfillSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useApolloClient, useMutation, useQuery } from '@apollo/client';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { CloudSun, Lock } from 'lucide-react';
 import { useUserTier } from '../hooks/useUserTier';
 import {

--- a/apps/web/src/components/dashboard/BikeSwitcherRow.test.tsx
+++ b/apps/web/src/components/dashboard/BikeSwitcherRow.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { BikeSwitcherRow } from './BikeSwitcherRow';
 import type { BikeWithPredictions } from '../../hooks/usePriorityBike';
 

--- a/apps/web/src/components/dashboard/BikeSwitcherRow.tsx
+++ b/apps/web/src/components/dashboard/BikeSwitcherRow.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Plus, GripHorizontal, Loader2 } from 'lucide-react';
 import { useMutation } from '@apollo/client';
 import {

--- a/apps/web/src/components/dashboard/PriorityBikeHero.tsx
+++ b/apps/web/src/components/dashboard/PriorityBikeHero.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { motion, AnimatePresence } from 'motion/react';
 import { Wrench, Settings, Bike, ChevronUp, ChevronDown } from 'lucide-react';
 import { StravaIcon } from '../icons/BrandIcons';

--- a/apps/web/src/components/dashboard/RecentRidesCard.tsx
+++ b/apps/web/src/components/dashboard/RecentRidesCard.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Route } from 'lucide-react';
 import { CompactRideRow } from './CompactRideRow';
 import { getBikeName } from '../../utils/formatters';

--- a/apps/web/src/components/dashboard/RideStatsCompact.tsx
+++ b/apps/web/src/components/dashboard/RideStatsCompact.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { TrendingUp } from 'lucide-react';
 import {
   getTimeframeStartDate,

--- a/apps/web/src/components/gear/BikeOverviewCard.test.tsx
+++ b/apps/web/src/components/gear/BikeOverviewCard.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { BikeOverviewCard } from './BikeOverviewCard';
 import type { PredictionStatus, ComponentType, ConfidenceLevel, ComponentLocation } from '../../types/prediction';
 

--- a/apps/web/src/components/gear/BikeOverviewCard.tsx
+++ b/apps/web/src/components/gear/BikeOverviewCard.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'motion/react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Bike, Wrench, Pencil, Trash2, ExternalLink } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { KebabMenu, type KebabMenuItem } from './KebabMenu';

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { NavLink, useNavigate } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router';
 import { useApolloClient } from '@apollo/client';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import type { ReactNode } from 'react';

--- a/apps/web/src/components/layout/Footer.tsx
+++ b/apps/web/src/components/layout/Footer.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 const productLinks = [
     { label: 'Dashboard', path: '/dashboard' },

--- a/apps/web/src/hooks/usePostHogPageviews.ts
+++ b/apps/web/src/hooks/usePostHogPageviews.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { posthog } from '@/lib/posthog';
 
 /**

--- a/apps/web/src/instrument.ts
+++ b/apps/web/src/instrument.ts
@@ -5,7 +5,7 @@ import {
   useNavigationType,
   createRoutesFromChildren,
   matchRoutes,
-} from "react-router-dom";
+} from "react-router";
 import { scrubKnownSecrets } from "./lib/sentry-scrub";
 
 Sentry.init({

--- a/apps/web/src/pages/About.tsx
+++ b/apps/web/src/pages/About.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { motion } from 'motion/react';
 import { Card } from '../components/ui';
 

--- a/apps/web/src/pages/Admin/index.test.tsx
+++ b/apps/web/src/pages/Admin/index.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import Admin from './index';
 
 // Mock the section components — we're testing the role gate + section
@@ -43,10 +43,10 @@ vi.mock('../../hooks/useCurrentUser', () => ({
   useCurrentUser: () => mockUseCurrentUser(),
 }));
 
-// react-router-dom <Navigate> renders a sentinel marker so we can assert
+// react-router <Navigate> renders a sentinel marker so we can assert
 // the redirect was issued without actually navigating.
-vi.mock('react-router-dom', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('react-router-dom')>();
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
   return {
     ...actual,
     Navigate: ({ to }: { to: string }) => <div data-testid="navigate" data-to={to} />,

--- a/apps/web/src/pages/Admin/index.tsx
+++ b/apps/web/src/pages/Admin/index.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
 import AdminShell from './AdminShell';
 import { OverviewSection } from './sections/OverviewSection';

--- a/apps/web/src/pages/Admin/useAdminSection.test.tsx
+++ b/apps/web/src/pages/Admin/useAdminSection.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ReactNode } from 'react';
 import { useAdminSection } from './useAdminSection';
 

--- a/apps/web/src/pages/Admin/useAdminSection.ts
+++ b/apps/web/src/pages/Admin/useAdminSection.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useCallback } from 'react';
 
 export type AdminSectionId = 'overview' | 'users' | 'email';

--- a/apps/web/src/pages/AuthComplete.tsx
+++ b/apps/web/src/pages/AuthComplete.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useApolloClient } from '@apollo/client';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { motion } from 'motion/react';
 import { Card } from '../components/ui';
 import { CircleCheck } from 'lucide-react';

--- a/apps/web/src/pages/BikeDetail.test.tsx
+++ b/apps/web/src/pages/BikeDetail.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import BikeDetail from './BikeDetail';
 import type { PredictionStatus } from '@/types/prediction';
 

--- a/apps/web/src/pages/BikeDetail.tsx
+++ b/apps/web/src/pages/BikeDetail.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router';
 import { useQuery, useMutation } from '@apollo/client';
 import { motion, AnimatePresence } from 'motion/react';
 import {

--- a/apps/web/src/pages/BikeHistory.test.tsx
+++ b/apps/web/src/pages/BikeHistory.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import BikeHistory from './BikeHistory';
 
 // Apollo — useQuery returns the fixed fixture below; useMutation returns
@@ -14,9 +14,9 @@ vi.mock('@apollo/client', () => ({
 }));
 
 // Pin the bikeId so the query fixture is reachable.
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>(
-    'react-router-dom'
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>(
+    'react-router'
   );
   return {
     ...actual,

--- a/apps/web/src/pages/BikeHistory.tsx
+++ b/apps/web/src/pages/BikeHistory.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy, useMemo, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { gql, useMutation, useQuery } from '@apollo/client';
 import { ArrowLeft, Bike as BikeIcon, CalendarClock, Check, FileDown, Link2, MinusCircle, PlusCircle, TriangleAlert, Wrench } from 'lucide-react';
 

--- a/apps/web/src/pages/ChangePassword.tsx
+++ b/apps/web/src/pages/ChangePassword.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { motion } from 'motion/react';
 import { Button } from '@/components/ui';
 import { validatePassword, PASSWORD_RULES } from '@loam/shared';

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 // src/pages/Dashboard.tsx
 import { useCallback, useEffect, useState, useMemo, useRef } from 'react';
 import { useQuery } from '@apollo/client';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { RIDES } from '../graphql/rides';
 import { BIKES, BIKES_LIGHT, BIKES_ADVISOR } from '../graphql/bikes';
 import { UNMAPPED_STRAVA_GEARS } from '../graphql/stravaGear';

--- a/apps/web/src/pages/Disclaimer.tsx
+++ b/apps/web/src/pages/Disclaimer.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { motion } from 'motion/react';
 import { Card } from '../components/ui';
 

--- a/apps/web/src/pages/ForgotPassword.tsx
+++ b/apps/web/src/pages/ForgotPassword.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { motion } from 'motion/react';
 import { Button } from '@/components/ui';
 

--- a/apps/web/src/pages/Gear.tsx
+++ b/apps/web/src/pages/Gear.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useMutation, useQuery } from '@apollo/client';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Bike } from 'lucide-react';
 import { Modal } from '@/components/ui/Modal';
 import { BikeForm } from '@/components/BikeForm';

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import AboutAppModal from '../components/AboutAppModal';
 import { Button } from '../components/ui';
 

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,7 +1,7 @@
 ﻿import { useState, useEffect } from 'react';
 import { useApolloClient } from '@apollo/client';
 import { GoogleLogin, type CredentialResponse } from '@react-oauth/google';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { motion } from 'motion/react';
 import { ME_QUERY } from '../graphql/me';
 import { useRedirectFrom } from '../utils/loginUtils';

--- a/apps/web/src/pages/Onboarding.test.tsx
+++ b/apps/web/src/pages/Onboarding.test.tsx
@@ -2,7 +2,7 @@ import { GARMIN_CONNECT_APP_NAME } from '@loam/shared';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import Onboarding from './Onboarding';
 
 // Mock Apollo Client
@@ -19,8 +19,8 @@ vi.mock('@apollo/client', () => ({
 
 // Mock useNavigate
 const mockNavigate = vi.fn();
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,
@@ -115,8 +115,8 @@ describe('Onboarding', () => {
 
   const renderOnboarding = (initialStep = 1) => {
     // Override useSearchParams for specific step
-    vi.doMock('react-router-dom', async () => {
-      const actual = await vi.importActual('react-router-dom');
+    vi.doMock('react-router', async () => {
+      const actual = await vi.importActual('react-router');
       return {
         ...actual,
         useNavigate: () => mockNavigate,

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { useApolloClient, useQuery, gql } from '@apollo/client';
 import { Settings, Check, ChevronDown, ChevronUp, Clock } from 'lucide-react';
 import GarminConnectMark from '@/components/attribution/GarminConnectMark';

--- a/apps/web/src/pages/PrivacyPolicy.tsx
+++ b/apps/web/src/pages/PrivacyPolicy.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { motion } from 'motion/react';
 import { Card } from '../components/ui';
 

--- a/apps/web/src/pages/ResetPassword.tsx
+++ b/apps/web/src/pages/ResetPassword.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { motion } from 'motion/react';
 import { Button } from '@/components/ui';
 import { validatePassword, PASSWORD_RULES } from '@loam/shared';

--- a/apps/web/src/pages/Rides.tsx
+++ b/apps/web/src/pages/Rides.tsx
@@ -1,6 +1,6 @@
 // src/pages/Rides.tsx
 import { useQuery } from "@apollo/client";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useState } from "react";
 import AddRideForm from "../components/AddRideForm";
 import RideCard from "../components/RideCard";

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactElement } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useApolloClient } from '@apollo/client';
 import { toast } from 'sonner';
 import SettingsShell from './SettingsShell';

--- a/apps/web/src/pages/Settings/sections/AccountSection.tsx
+++ b/apps/web/src/pages/Settings/sections/AccountSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQuery, gql } from '@apollo/client';
 import { useCurrentUser } from '../../../hooks/useCurrentUser';
 import SetPasswordModal from '../../../components/SetPasswordModal';

--- a/apps/web/src/pages/Settings/sections/MaintenanceSection.tsx
+++ b/apps/web/src/pages/Settings/sections/MaintenanceSection.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 import { useResetCalibration } from '../../../graphql/calibration';
 import SettingsSectionHeader from '../SettingsSectionHeader';

--- a/apps/web/src/pages/Settings/sections/PreferencesSection.tsx
+++ b/apps/web/src/pages/Settings/sections/PreferencesSection.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useMutation } from '@apollo/client';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useCurrentUser } from '../../../hooks/useCurrentUser';
 import { usePreferences } from '../../../hooks/usePreferences';
 import { useUserTier } from '../../../hooks/useUserTier';

--- a/apps/web/src/pages/Settings/useSettingsSection.ts
+++ b/apps/web/src/pages/Settings/useSettingsSection.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useCallback } from 'react';
 
 export type SettingsSectionId =

--- a/apps/web/src/pages/SharedBikeHistory.tsx
+++ b/apps/web/src/pages/SharedBikeHistory.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { gql, useQuery } from '@apollo/client';
 import { Bike as BikeIcon, Wrench, ArrowUpDown } from 'lucide-react';
 import { fmtDistance, fmtDuration, fmtDateTime } from '@/lib/format';

--- a/apps/web/src/pages/Signup.tsx
+++ b/apps/web/src/pages/Signup.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'motion/react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useApolloClient } from '@apollo/client';
 import { GoogleLogin, type CredentialResponse } from '@react-oauth/google';
 import { ME_QUERY } from '../graphql/me';

--- a/apps/web/src/pages/Support.tsx
+++ b/apps/web/src/pages/Support.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { motion } from 'motion/react';
 import { Card } from '../components/ui';
 

--- a/apps/web/src/pages/Terms.tsx
+++ b/apps/web/src/pages/Terms.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { motion } from 'motion/react';
 import { Card } from '../components/ui';
 import { TERMS_TEXT, TERMS_LAST_UPDATED } from '../legal/terms';

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import { render, type RenderOptions } from '@testing-library/react';
 import { MockedProvider, type MockedResponse } from '@apollo/client/testing';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { PreferencesProvider } from '../providers/PreferencesProvider';
 import type { ReactElement, ReactNode } from 'react';
 

--- a/apps/web/src/utils/loginUtils.ts
+++ b/apps/web/src/utils/loginUtils.ts
@@ -1,4 +1,4 @@
-import { useLocation, useSearchParams } from 'react-router-dom'
+import { useLocation, useSearchParams } from 'react-router'
 
 export function useRedirectFrom(defaultPath = '/dashboard') {
   const location = useLocation()

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
       "dependencies": {
         "leaflet": "^1.9.4",
         "lru-cache": "^11.5.2",
-        "react": "19.2.3",
-        "react-dom": "19.2.3",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
         "react-leaflet": "^5.0.0"
       },
       "devDependencies": {
@@ -159,10 +159,9 @@
         "lucide-react": "^1.6.0",
         "motion": "^12.38.0",
         "posthog-js": "^1.203.0",
-        "react": "19.2.4",
-        "react-dom": "19.2.4",
-        "react-router": "^7.13.2",
-        "react-router-dom": "^7.13.2",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
+        "react-router": "^8.3.0",
         "recharts": "^3.8.0",
         "sonner": "^2.0.7"
       },
@@ -290,21 +289,25 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "apps/web/node_modules/react": {
-      "version": "19.2.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "apps/web/node_modules/react-dom": {
-      "version": "19.2.4",
+    "apps/web/node_modules/react-router": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.27.0"
+        "cookie-es": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "apps/web/node_modules/typescript": {
@@ -3669,9 +3672,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3767,9 +3770,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6397,9 +6400,9 @@
       "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6719,24 +6722,24 @@
       "link": true
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.8.0.tgz",
-      "integrity": "sha512-7AaaiE4YOXFb+st6xlVDK65aNKZYR9S9ykH0q2mkHAHTgquXciAjypS8JuhmKn7Lob/2rkplMOc4YsGxG3Ng9Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.8.1.tgz",
+      "integrity": "sha512-w/+d+OjtzT6sa0b3elBcCw6uw+6l8JDOtMIyWzx1lNNuV9IPhq2pgSLXEVEHdIo77r4zgQAktm9kUfCzjO0VrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.8.0"
+        "@module-federation/sdk": "2.8.1"
       }
     },
     "node_modules/@module-federation/cli": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.8.0.tgz",
-      "integrity": "sha512-yTxdWkCJPPo+IGASz+NqdW13cw3DhjSBEn9r85aYn1ahckDwB1WcZe0OjDWMqCcR6yi0BMLedk0SWrUeUj0fWw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.8.1.tgz",
+      "integrity": "sha512-DZo0f3gTN7bKoqw/KM5Kj4qIKeF3bfQwCq7fgf2Gnd+jfZPY4otVy7nbRxFmtdienEhqzcmFFWJUPH/cOkyMqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.8.0",
-        "@module-federation/sdk": "2.8.0",
+        "@module-federation/dts-plugin": "2.8.1",
+        "@module-federation/sdk": "2.8.1",
         "commander": "11.1.0",
         "jiti": "2.4.2"
       },
@@ -6748,17 +6751,17 @@
       }
     },
     "node_modules/@module-federation/dts-plugin": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.8.0.tgz",
-      "integrity": "sha512-defjq4jOWMEfeejezPWLP5sc8kw0O6FqTT7/E5rbZPEVyjB1A0U3ynhW6GDE5/6hk9/TzdbWS+fBNi4MqUOY6Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.8.1.tgz",
+      "integrity": "sha512-JM8g76KzhhH44kHvM2JPJ5FIlQDwUNzw0vvq5EDSo/znNUmUEuSrfTssukCKg1nqnBGWLohjIV0LOOhLdCknoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.8.0",
-        "@module-federation/managers": "2.8.0",
-        "@module-federation/sdk": "2.8.0",
-        "@module-federation/third-party-dts-extractor": "2.8.0",
-        "adm-zip": "0.5.10",
+        "@module-federation/error-codes": "2.8.1",
+        "@module-federation/managers": "2.8.1",
+        "@module-federation/sdk": "2.8.1",
+        "@module-federation/third-party-dts-extractor": "2.8.1",
+        "adm-zip": "0.6.0",
         "isomorphic-ws": "5.0.0",
         "undici": "7.28.0",
         "ws": "8.21.0"
@@ -6796,23 +6799,23 @@
       }
     },
     "node_modules/@module-federation/enhanced": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.8.0.tgz",
-      "integrity": "sha512-h8vkLdhK7tlcSPmyYNGfGyt0pSzfDB0tYVYdyUt2tXwQRfaJAi3bsIpujMXElw3MXtOfSHESa6M/hPKrtWTHBw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.8.1.tgz",
+      "integrity": "sha512-QHlvm+poXVPkIPK0C8Ras36peZA9CxRp43deSQcArBZ6uEsZTGGm07ohDxRLzVO7kYXR6dE56gIAN9fqa9Fhgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "2.8.0",
-        "@module-federation/cli": "2.8.0",
-        "@module-federation/dts-plugin": "2.8.0",
-        "@module-federation/error-codes": "2.8.0",
-        "@module-federation/inject-external-runtime-core-plugin": "2.8.0",
-        "@module-federation/managers": "2.8.0",
-        "@module-federation/manifest": "2.8.0",
-        "@module-federation/rspack": "2.8.0",
-        "@module-federation/runtime-tools": "2.8.0",
-        "@module-federation/sdk": "2.8.0",
-        "@module-federation/webpack-bundler-runtime": "2.8.0",
+        "@module-federation/bridge-react-webpack-plugin": "2.8.1",
+        "@module-federation/cli": "2.8.1",
+        "@module-federation/dts-plugin": "2.8.1",
+        "@module-federation/error-codes": "2.8.1",
+        "@module-federation/inject-external-runtime-core-plugin": "2.8.1",
+        "@module-federation/managers": "2.8.1",
+        "@module-federation/manifest": "2.8.1",
+        "@module-federation/rspack": "2.8.1",
+        "@module-federation/runtime-tools": "2.8.1",
+        "@module-federation/sdk": "2.8.1",
+        "@module-federation/webpack-bundler-runtime": "2.8.1",
         "schema-utils": "4.3.0",
         "tapable": "2.3.0"
       },
@@ -6837,54 +6840,54 @@
       }
     },
     "node_modules/@module-federation/error-codes": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.8.0.tgz",
-      "integrity": "sha512-Gaog9904EmxYOQV0hli3XQ7jXeFaADfh5bnBtTCtbZ37Qd/Sz9kQfd+gYQRyIj7RGmkv9DPiN/SsmrTMrTymKw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.8.1.tgz",
+      "integrity": "sha512-0mQ+bWt1LRCZyURx3g2b8G+aAlvk8iXIgrp3Jit/75blrlVda/eVqnHz1L+YOxwkP3xSrdbUb4423AoWti31ZQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.8.0.tgz",
-      "integrity": "sha512-fW3jD1ZVds6r/Ul8TtUA42RsB0LfT1yjo5KjqgirH9QrmEMH21x44e3e6BC6IN820XKawRDSmz2kFA5YHIQp7Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.8.1.tgz",
+      "integrity": "sha512-xpqjWaLw4KbPW4CMRDRiGjH08/ABdPc9z4fRuPiFYA4loNYrjFWALRe2QA6W90SAew/d5RQ6QchO/wuhrzy3dw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@module-federation/runtime-tools": "2.8.0"
+        "@module-federation/runtime-tools": "2.8.1"
       }
     },
     "node_modules/@module-federation/managers": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.8.0.tgz",
-      "integrity": "sha512-SnVBCwmi962WGg6hLFElxZUCnrRJdR6glE2ZKPBY/iK07AHUN2ZxuaBCBsVzyws+xLZGHZxBHmVstijTh8dSUA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.8.1.tgz",
+      "integrity": "sha512-bHRooIgplIFNLH42eM3g21b2apM/a7lMG1EwifUxT4A4AobS42H08KGdYITdKJcrgowx3D7PhYndiwtHFI03zQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.8.0"
+        "@module-federation/sdk": "2.8.1"
       }
     },
     "node_modules/@module-federation/manifest": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.8.0.tgz",
-      "integrity": "sha512-wfVeBXc4/C2F70nRFSPqJhkcwbDgo+wQyEn3jbjJTDoUqxxhYBfHFs1ACBYOk3Qm97L7hHclHGtUG0/nvDEfAA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.8.1.tgz",
+      "integrity": "sha512-1NOd4J1sJrTpl7M1NYsdUtjSR2Eu3R//r+w51KC9XhAZkxWse0+uPphGdeiUqCOVgAAWjKreckY+xnEmG6Kqig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.8.0",
-        "@module-federation/managers": "2.8.0",
-        "@module-federation/sdk": "2.8.0"
+        "@module-federation/dts-plugin": "2.8.1",
+        "@module-federation/managers": "2.8.1",
+        "@module-federation/sdk": "2.8.1"
       }
     },
     "node_modules/@module-federation/node": {
-      "version": "2.7.47",
-      "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.7.47.tgz",
-      "integrity": "sha512-mifMvCjWmLl53GS+badQws0j2bsu1ICpdGzCbez4I6kSpaYA8v86L6dwcHtVHIZtkUC6cjAZBDcgpxs4fK3nFQ==",
+      "version": "2.7.48",
+      "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.7.48.tgz",
+      "integrity": "sha512-jeRj0ylawSFFt5EqTcNDVMq60kE3/3gY8vg8XiLiFSSpglgezWeR/5OOxBmRn+8UdS5545Nko+HQWe5e08S7NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/enhanced": "2.8.0",
-        "@module-federation/runtime": "2.8.0",
-        "@module-federation/sdk": "2.8.0",
+        "@module-federation/enhanced": "2.8.1",
+        "@module-federation/runtime": "2.8.1",
+        "@module-federation/sdk": "2.8.1",
         "encoding": "0.1.13",
         "node-fetch": "2.7.0",
         "tapable": "2.3.0"
@@ -6920,19 +6923,19 @@
       }
     },
     "node_modules/@module-federation/rspack": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.8.0.tgz",
-      "integrity": "sha512-TPcrkHpaZgL25Vx3c8oSNwyv7/KktC7uo6HTQdVWlFzbq5RSoMMGkWoir5pY5124isae2/p6v5xAuqICi4r0Zg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.8.1.tgz",
+      "integrity": "sha512-jJYkARn1U1M92CbiLyoaP7+tNKh8YzzOTMSGzbdj6okTtWK0Z9ImyVoKEnAnjnLP1nbQjkPEaojkR2D2IQFhLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "2.8.0",
-        "@module-federation/dts-plugin": "2.8.0",
-        "@module-federation/inject-external-runtime-core-plugin": "2.8.0",
-        "@module-federation/managers": "2.8.0",
-        "@module-federation/manifest": "2.8.0",
-        "@module-federation/runtime-tools": "2.8.0",
-        "@module-federation/sdk": "2.8.0"
+        "@module-federation/bridge-react-webpack-plugin": "2.8.1",
+        "@module-federation/dts-plugin": "2.8.1",
+        "@module-federation/inject-external-runtime-core-plugin": "2.8.1",
+        "@module-federation/managers": "2.8.1",
+        "@module-federation/manifest": "2.8.1",
+        "@module-federation/runtime-tools": "2.8.1",
+        "@module-federation/sdk": "2.8.1"
       },
       "peerDependencies": {
         "@rspack/core": "^0.7.0 || ^1.0.0 || ^2.0.0-0",
@@ -6949,63 +6952,63 @@
       }
     },
     "node_modules/@module-federation/runtime": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.8.0.tgz",
-      "integrity": "sha512-cGtUBQ1/TVy7KrXy6xPgy3FEmOGyIYkBA2T4iGH3ZH5PNPPTmqN9jF2AfneTSOj0RtBr7Pxq3CUt81E/UCvK1A==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.8.1.tgz",
+      "integrity": "sha512-+xpq/r6Om4plbGJisZp6/rl7usEUlQszz34E+JUKgl9uW3QIRzVgxwOAzGiF7U+dqOKxMqmiq+nTJwK2wAwteA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.8.0",
-        "@module-federation/runtime-core": "2.8.0",
-        "@module-federation/sdk": "2.8.0"
+        "@module-federation/error-codes": "2.8.1",
+        "@module-federation/runtime-core": "2.8.1",
+        "@module-federation/sdk": "2.8.1"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.8.0.tgz",
-      "integrity": "sha512-Tf98+epGGiPSHqmQHuXa2uXZMMvjGf1IqJDR1/FpXfmobv5ECN0mGZCjUHGNSyxvoDyXKIkKwJu7IwEoh0ouQA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.8.1.tgz",
+      "integrity": "sha512-Dif+3u7fvq6qBATFIv5qB7ay6Rgo2HNzhaNOt1yRfpVXjiJqQ3UPnHZ+TLP9znkXiZvg6Bg5W9EV2ZX4nH2S0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.8.0",
-        "@module-federation/sdk": "2.8.0"
+        "@module-federation/error-codes": "2.8.1",
+        "@module-federation/sdk": "2.8.1"
       }
     },
     "node_modules/@module-federation/runtime-tools": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.8.0.tgz",
-      "integrity": "sha512-3yOqjdSHXxX4HA3GhlXg3hghGAXW2RJUsnwXCcik2/lTxOHizKI8f3RM+GGCKPxDVqtw43IShe3tA12jNL5A/A==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.8.1.tgz",
+      "integrity": "sha512-CIQ9dPqWOiitXKCYqgHXfr0hehtxsZDfiuFaesJAJnXtqkM5+nVkkBNkY07cDV5wOi00/aiOhEWYoCcz+cRQtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "2.8.0",
-        "@module-federation/webpack-bundler-runtime": "2.8.0"
+        "@module-federation/runtime": "2.8.1",
+        "@module-federation/webpack-bundler-runtime": "2.8.1"
       }
     },
     "node_modules/@module-federation/sdk": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.8.0.tgz",
-      "integrity": "sha512-yBP+9+0Z8nlvKEXAZS3AsQVy7bFbZf8eMivGk4q4ZdwG3TsLMlsPjb1dQb2i7gcAG6ux9y2LWLkj/0LVk74cnQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.8.1.tgz",
+      "integrity": "sha512-3EVljiNilY2pFIG2RO4KNCC6gIPnYc9J+p5U6Nn8D5X3PtJeEcPyBvKGttxZnSLlXCi+YXQfgexBOfnkvEuzuQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.8.0.tgz",
-      "integrity": "sha512-nAMlr74OKIylkfRwlunOhytQbmsgb3gCqdXWnPQhG+ZtqWXGELLfMT4a1Q1ht3cS+sRpWj2SZRqK2M7GadI6tA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.8.1.tgz",
+      "integrity": "sha512-6ulu7vqv5wyM5YWwxjUHzZ+8Sg6e+/vn+gskiUBs6EPqe/w3XMdRoUrFjAI3EW62xi0e0xbWLsjbQs9jCAj8ig==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.8.0.tgz",
-      "integrity": "sha512-82fDy9v+7qV5fiN8TKVhOdrxhmAZnUIX/IKivYX5ulCt8aoOzVFTiwm/P1GQUDD8z6dqR48xgJdZdf0548Mc9w==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.8.1.tgz",
+      "integrity": "sha512-dGFlrTLimhxpHohysx/qPRuIRaAiutqFfX0xFzDchEkY0DXpS2sOhuJ2foNcCIQK/FKFJW1YeaaIUkZ5FWMcOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.8.0",
-        "@module-federation/runtime": "2.8.0",
-        "@module-federation/sdk": "2.8.0"
+        "@module-federation/error-codes": "2.8.1",
+        "@module-federation/runtime": "2.8.1",
+        "@module-federation/sdk": "2.8.1"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -7297,9 +7300,9 @@
       }
     },
     "node_modules/@nx/devkit": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.7.7.tgz",
-      "integrity": "sha512-XU9LZuqT4+/2DTrpKnGDuGFKjwe7LRr5kMfT6EOPiPYCYkmtwXriMGiaRZNabb6kliVG3L34L7+TEiMUWRPCDQ==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.7.8.tgz",
+      "integrity": "sha512-aQe6wSJY7eIsJXE+DSHEgCMf4UBLeRbW0o1WNoF2TlLxE7N3Navb6aWiebe2wv/eaQ2IDKJXLuNxdJJJK/6zCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7316,14 +7319,14 @@
       }
     },
     "node_modules/@nx/esbuild": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/esbuild/-/esbuild-22.7.7.tgz",
-      "integrity": "sha512-vqhhtTG5tdmKvNiHX4GygTTj3tZOefOFxBgUcbtsCAgkuWlI2+qJPiCDFOuuac1JO87k1EsIkJ9ENC5cQTgLPw==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/esbuild/-/esbuild-22.7.8.tgz",
+      "integrity": "sha512-Ppwm0IyFa+yhyS/2h7IOK86YzfKHk5+ywe8nwJjNIW8F6LWGzfJ13pR6NJnWZgdvXG+YssmmaDtoOIfK8FHDwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.7",
-        "@nx/js": "22.7.7",
+        "@nx/devkit": "22.7.8",
+        "@nx/js": "22.7.8",
         "picocolors": "^1.1.0",
         "tinyglobby": "^0.2.12",
         "tsconfig-paths": "^4.1.2",
@@ -7339,20 +7342,20 @@
       }
     },
     "node_modules/@nx/eslint": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-22.7.7.tgz",
-      "integrity": "sha512-mR4/EnzC8mR4tyH6jPbtaUq6dgq/dkpZrkm7WOlr8trvEhn8YoNPCnpIbsRmiJY0mZv8NX67IE8SpmBnzMpqnA==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-22.7.8.tgz",
+      "integrity": "sha512-b+KETcZnUOCV6Mb9mhI+SsWfkA+kkFSFY4mtIlDF2xpajA9H2yzoeLcoIDfEfjivrhCmPcpd4cmUyPySW3uNig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.7",
-        "@nx/js": "22.7.7",
+        "@nx/devkit": "22.7.8",
+        "@nx/js": "22.7.8",
         "semver": "^7.6.3",
         "tslib": "^2.3.0",
         "typescript": "~5.9.2"
       },
       "peerDependencies": {
-        "@nx/jest": "22.7.7",
+        "@nx/jest": "22.7.8",
         "@zkochan/js-yaml": "0.0.7",
         "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
       },
@@ -7380,9 +7383,9 @@
       }
     },
     "node_modules/@nx/js": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/js/-/js-22.7.7.tgz",
-      "integrity": "sha512-wjgr9LwT+ULkwjvX0CUMwK8BQ+wY53ipecGN/yCKptch5D5WXTOOBOx+YLrrrD8h+/amHy9jMqAg3ygryRkNhQ==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/js/-/js-22.7.8.tgz",
+      "integrity": "sha512-OBXoHIm1mMiyXyd/3xtEnOfaDzDrGtACvAqhhKAUUi+VXGlHyvUdXBQkAamIzvjCyxo+7p2JtdYG2ca8G4pKDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7393,8 +7396,8 @@
         "@babel/preset-env": "^7.23.2",
         "@babel/preset-typescript": "^7.22.5",
         "@babel/runtime": "^7.22.6",
-        "@nx/devkit": "22.7.7",
-        "@nx/workspace": "22.7.7",
+        "@nx/devkit": "22.7.8",
+        "@nx/workspace": "22.7.8",
         "@zkochan/js-yaml": "0.0.7",
         "babel-plugin-const-enum": "^1.0.1",
         "babel-plugin-macros": "^3.1.0",
@@ -7433,18 +7436,18 @@
       }
     },
     "node_modules/@nx/module-federation": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/module-federation/-/module-federation-22.7.7.tgz",
-      "integrity": "sha512-m1T4j/E3lbob5uo02r0SQf9eLJqyX14WGI8EEOqLJ2+uQjURLxVCrOfGZpHJAmopcKK5HRVK/1zC+UvZYsAwLw==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/module-federation/-/module-federation-22.7.8.tgz",
+      "integrity": "sha512-mAs4Acjjq3paxRL54UsbCLhbW0OdxSlD2QOWGCwVcZ6CASTHrykE166ByW8oDumQiYiptB3S6kUdGNsh+KsJXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/enhanced": "^2.3.3",
         "@module-federation/node": "^2.7.21",
         "@module-federation/sdk": "^2.1.0",
-        "@nx/devkit": "22.7.7",
-        "@nx/js": "22.7.7",
-        "@nx/web": "22.7.7",
+        "@nx/devkit": "22.7.8",
+        "@nx/js": "22.7.8",
+        "@nx/web": "22.7.8",
         "@rspack/core": "1.6.8",
         "express": "^4.21.2",
         "http-proxy-middleware": "^3.0.5",
@@ -7454,9 +7457,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.7.tgz",
-      "integrity": "sha512-HGu8Bc3DzmIFeKHzIEDBDScgI8/hOjVIj/EzJBE5289dUf+CQ5OSXc6kw2NL9SiCMAPKa0clqcJgLJLqP5t/DQ==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.8.tgz",
+      "integrity": "sha512-IM1geDyWPFsS565de9dByYNZ5I3j8FQZvNUp9LIYw1dNu70sCWbAT0glw0anholOwlAb7JWEscoUeV7ouRBW0A==",
       "cpu": [
         "arm64"
       ],
@@ -7468,9 +7471,9 @@
       ]
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.7.tgz",
-      "integrity": "sha512-J7z/Hh+bEKB9xvHdmtO5sK7YytFx8Ry6YpvYI2PoSl2/xDBca7q69fzHKTtm4S/8FvA1Qoi/m//JTIMQUB7cKA==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.8.tgz",
+      "integrity": "sha512-X/AyooJCmAwHyp9f//bspkAmtaPsv2lPEKe6OiOScsyxJITP4nw+rOfIAJ4Ar64WQcMAY8WLP+ys4ah0K6DZSw==",
       "cpu": [
         "x64"
       ],
@@ -7482,9 +7485,9 @@
       ]
     },
     "node_modules/@nx/nx-freebsd-x64": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.7.tgz",
-      "integrity": "sha512-9H4bbI3fBr8Ct+6xmF6dqDKEvER60XV3tanXTSVtUBxyAVw3cPmRh7aMAu5PNyN+ewzRAJvV6KI4Rx1kA+s9jw==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.8.tgz",
+      "integrity": "sha512-mgdqiFag8txon4XugDtNj+hq+X9Whn8LBMuqwJSez93L1fralzpQFSUip7XnE7ejQRr5Zewg3BFscGlsk8Cy3A==",
       "cpu": [
         "x64"
       ],
@@ -7496,9 +7499,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.7.tgz",
-      "integrity": "sha512-QsGaaZ7PI18c7rFgvUe0F0UYa5oErSKY6Yff6HVXy2zAAWluM4F/TXIRYbtXlvSq++CHhFXxk29Xb3+/zGR/rg==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.8.tgz",
+      "integrity": "sha512-g7ojIloHGFI7wuMnUdg7io42EL7C7ae4zAolNVj7eXZM54amn3qoNjwbyqaVbBQvUNRiAKJizGyn1IhKpzvG9A==",
       "cpu": [
         "arm"
       ],
@@ -7510,13 +7513,16 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.7.tgz",
-      "integrity": "sha512-CfzWaS+b32lI/inlYPv1ZAK9CWTWFHzT7TPThvOHML65nrgFl8cQ4Z4FeGdyCbHu2NoG3vR1E36O2tPI2/DLGg==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.8.tgz",
+      "integrity": "sha512-Kws8e7W4epfqpTWYaV7KLKaj33o+9JtJa2rErx/XFTtMXhfVzOs5hC4oIrZsYpgk1DuT0APp7UDvX06q2kdAVQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7524,13 +7530,16 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.7.tgz",
-      "integrity": "sha512-53QFuODMEHc1gobCT2WOmYz89DZtEIuLphirdIgnXkkPBTdrP77LPbJUXMRXCMKr90BQaSWhTX+J/ubANRE8og==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.8.tgz",
+      "integrity": "sha512-fpnyVFL+mSqLdKBPk8+n/rHUEXiem7Xwr9cIOd2Dd5zxQ5wcwj4qSYTNRsBPI2qDFo3esHliwaoFJZULbTHldw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7538,13 +7547,16 @@
       ]
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.7.tgz",
-      "integrity": "sha512-unzmqGIDXGzujo1ZtbrMj2e5D5ldQ1feZmqDPhvO4casK2d96jpT8LtgIILpVDUfhLjl+By185gb0ArrWTsyKw==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.8.tgz",
+      "integrity": "sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7552,13 +7564,16 @@
       ]
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.7.tgz",
-      "integrity": "sha512-oTjMGuM105ok8aH5rlg2YP0Kgkjg0VfUj1exwp49S70gGBJ0r8v5rEtJwOSdCf1WTHuEh0xi66Y/b1S0khF8dg==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.8.tgz",
+      "integrity": "sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7566,9 +7581,9 @@
       ]
     },
     "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.7.tgz",
-      "integrity": "sha512-K741meG/l48TPPeDqnhYTV7pP+1ljjZ+0DRJBxMrPFIu8qKE3Abko/7NKWmWRjcSXJvtxvYkgG3wZds4N2Bhow==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.8.tgz",
+      "integrity": "sha512-yYDu3pj7AXu7LtN/T/bA4TMWWWbmvEE4wa8UW8ZU5JeWYblyXQA7HyYpPAb4fLzCtHb/dIrNDghVBRIeAAcnSw==",
       "cpu": [
         "arm64"
       ],
@@ -7580,9 +7595,9 @@
       ]
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.7.tgz",
-      "integrity": "sha512-AHVjXkreXjVKAKpMNCsF5nQC/et6lpQcERRm8AYOCncI59hTjYOLpdCMBLrIHA3hgc6SUYU8n5+tMAbv7zXXiQ==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.8.tgz",
+      "integrity": "sha512-cSr0qMt/GgM2aOBFsapxllnIv55j0gAz/6eWvqEOx5sS8d3X1G0IgazZnPbjW2c8gfSYaBZ9UmYnfapWIO/jqg==",
       "cpu": [
         "x64"
       ],
@@ -7594,18 +7609,18 @@
       ]
     },
     "node_modules/@nx/react": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/react/-/react-22.7.7.tgz",
-      "integrity": "sha512-vw1r8TA1PrB7yHSKub9LZZ67x6AUTR7/d2BGheClUgI62gwMqZOnZaB2u7EnKnU7JjeKEGMZgie0/NznV9GuFg==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/react/-/react-22.7.8.tgz",
+      "integrity": "sha512-7wOPZYkI8nHWSuVhirP7X8iOHuzY0zKHTQ3R543sIqqC5yIP+zXPR7F+mM/D4E6V+41BWMJd1Au/XgShFTSyyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.7",
-        "@nx/eslint": "22.7.7",
-        "@nx/js": "22.7.7",
-        "@nx/module-federation": "22.7.7",
-        "@nx/rollup": "22.7.7",
-        "@nx/web": "22.7.7",
+        "@nx/devkit": "22.7.8",
+        "@nx/eslint": "22.7.8",
+        "@nx/js": "22.7.8",
+        "@nx/module-federation": "22.7.8",
+        "@nx/rollup": "22.7.8",
+        "@nx/web": "22.7.8",
         "@phenomnomnominal/tsquery": "~6.2.0",
         "@svgr/webpack": "^8.0.1",
         "express": "^4.21.2",
@@ -7616,18 +7631,18 @@
         "tslib": "^2.3.0"
       },
       "optionalDependencies": {
-        "@nx/vite": "22.7.7"
+        "@nx/vite": "22.7.8"
       }
     },
     "node_modules/@nx/rollup": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/rollup/-/rollup-22.7.7.tgz",
-      "integrity": "sha512-unS9+IR07ozRlWfoRO3PC/MiD+7i3/DUB/rPtfqZE4KmxgiBR5Dnj6MA5eElF9l2g8FCcb0b8B5C5fDU5Mcktg==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/rollup/-/rollup-22.7.8.tgz",
+      "integrity": "sha512-X6u4d8I4BlE1Ym1eTLYS4dosD73K4Jp+SdubaUMYe7UPPU8tB+kkLEb3i7QtuEg3fxM6Vw1jrZ2aKCsC3ObaDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.7",
-        "@nx/js": "22.7.7",
+        "@nx/devkit": "22.7.8",
+        "@nx/js": "22.7.8",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-image": "^3.0.3",
@@ -7646,15 +7661,15 @@
       }
     },
     "node_modules/@nx/vite": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/vite/-/vite-22.7.7.tgz",
-      "integrity": "sha512-t1zI8l1rzmaTA2jK2xsY26x6HZHvh53MSBHzqAnLDaxJgWcl/Gno2blAft7BaK7TORDMdF4Eo+kHzRk/mSHYWQ==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/vite/-/vite-22.7.8.tgz",
+      "integrity": "sha512-I56yrtx6llZKwA+ne1lv4TMo9XlYJU/MmOsxGy8/laa8oucysf1lhz/B/uk3kPjnX2Mk34jOOmdcNh5ZuGlb0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.7",
-        "@nx/js": "22.7.7",
-        "@nx/vitest": "22.7.7",
+        "@nx/devkit": "22.7.8",
+        "@nx/js": "22.7.8",
+        "@nx/vitest": "22.7.8",
         "@phenomnomnominal/tsquery": "~6.2.0",
         "ajv": "^8.0.0",
         "enquirer": "~2.3.6",
@@ -7669,20 +7684,20 @@
       }
     },
     "node_modules/@nx/vitest": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/vitest/-/vitest-22.7.7.tgz",
-      "integrity": "sha512-Xf4nTiwEYpjFmWP7Y6NuLIVOL8O2vs9JZWcQld0uyGoeyWnSHqbkwocOpt03kHpGKgzHnwA3QUG0avqksSaUZw==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/vitest/-/vitest-22.7.8.tgz",
+      "integrity": "sha512-LA9dJu9gmUZqtJPBxf96ZEwxHpOo9KIDW8sVrAHB4LC3rz/MjnTtxp7SwpIEf06cwJLsFMxWiyqVm8xB9NsL5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.7",
-        "@nx/js": "22.7.7",
+        "@nx/devkit": "22.7.8",
+        "@nx/js": "22.7.8",
         "@phenomnomnominal/tsquery": "~6.2.0",
         "semver": "^7.6.3",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@nx/eslint": "22.7.7",
+        "@nx/eslint": "22.7.8",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
       },
@@ -7699,26 +7714,26 @@
       }
     },
     "node_modules/@nx/web": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/web/-/web-22.7.7.tgz",
-      "integrity": "sha512-2XUG2IRhrPqxQvcNFxLytbslNT2sDPJvPnXE7EaZspRfD4bPt8rxVEnBzo5rm2hme5p3fht4HI4heHzcxQ4LfA==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/web/-/web-22.7.8.tgz",
+      "integrity": "sha512-j52F9u1s5nO/yCPcJX2a4bd93FUvf5blhrBdVs8nT4DpPzTMTi3lWE/0lNZdryTDa1Gll7KpFFt5Iy5dOJzSIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.7",
-        "@nx/js": "22.7.7",
+        "@nx/devkit": "22.7.8",
+        "@nx/js": "22.7.8",
         "detect-port": "^2.1.0",
         "http-server": "^14.1.0",
         "picocolors": "^1.1.0",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@nx/cypress": "22.7.7",
-        "@nx/eslint": "22.7.7",
-        "@nx/jest": "22.7.7",
-        "@nx/playwright": "22.7.7",
-        "@nx/vite": "22.7.7",
-        "@nx/webpack": "22.7.7"
+        "@nx/cypress": "22.7.8",
+        "@nx/eslint": "22.7.8",
+        "@nx/jest": "22.7.8",
+        "@nx/playwright": "22.7.8",
+        "@nx/vite": "22.7.8",
+        "@nx/webpack": "22.7.8"
       },
       "peerDependenciesMeta": {
         "@nx/cypress": {
@@ -7742,17 +7757,17 @@
       }
     },
     "node_modules/@nx/workspace": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-22.7.7.tgz",
-      "integrity": "sha512-tDSOWUEjTyEjoUKGSFyUGrFaCpScoFa8lRR0jorM169a3dA4iqwgkppcltR/uwklLw/aNSSW6J92DAzSRuOLnA==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-22.7.8.tgz",
+      "integrity": "sha512-VTe1hq+Bilm5LpjTiJK7eSNNRIn2/spy1vKOIVDKNox6VjygMVzZDrlobykbK7clLwL/1nAURsQWI1rC/i/zJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.7",
+        "@nx/devkit": "22.7.8",
         "@zkochan/js-yaml": "0.0.7",
         "chalk": "^4.1.0",
         "enquirer": "~2.3.6",
-        "nx": "22.7.7",
+        "nx": "22.7.8",
         "picomatch": "4.0.4",
         "semver": "^7.6.3",
         "tslib": "^2.3.0",
@@ -9569,6 +9584,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9583,6 +9601,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9597,6 +9618,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9611,6 +9635,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12423,19 +12450,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
-      }
-    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -12470,13 +12484,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
-      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -12839,14 +12853,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axios/node_modules/proxy-from-env": {
@@ -13221,21 +13261,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -13252,16 +13305,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -14112,6 +14165,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cookie-parser": {
       "version": "1.4.7",
@@ -15338,9 +15397,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
-      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15702,9 +15761,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16305,9 +16364,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -17002,9 +17061,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17770,9 +17829,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "dev": true,
       "license": "MIT"
     },
@@ -18715,9 +18774,9 @@
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19380,9 +19439,9 @@
       "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20562,20 +20621,6 @@
         }
       }
     },
-    "node_modules/loader-runner": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
-      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/loader-utils": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
@@ -20958,12 +21003,16 @@
       "license": "MIT"
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -21612,9 +21661,9 @@
       }
     },
     "node_modules/nx": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.7.tgz",
-      "integrity": "sha512-T4hq5PMAPXeqAmm0Y6Gr5ApeI2I+T8MflWEKN1cZ12R1Rnq2uEpfOgiwAZ74bHONmNgv6LRG9P9+x8SX2tDIlw==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.8.tgz",
+      "integrity": "sha512-ceEhmaGCvY7oi7L7G/Nm/UZSnbfwaJxU1XbDLro7CTmVcnrmxAnxExCp0J/Tpf1xQaMZtwxgV7QATdKA/7vLQw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -21627,16 +21676,17 @@
         "@tybys/wasm-util": "0.9.0",
         "@yarnpkg/lockfile": "1.1.0",
         "@zkochan/js-yaml": "0.0.7",
+        "agent-base": "6.0.2",
         "ansi-colors": "4.1.3",
         "ansi-regex": "5.0.1",
         "ansi-styles": "4.3.0",
         "argparse": "2.0.1",
         "asynckit": "0.4.0",
-        "axios": "1.16.0",
+        "axios": "1.18.1",
         "balanced-match": "4.0.3",
         "base64-js": "1.5.1",
         "bl": "4.1.0",
-        "brace-expansion": "5.0.6",
+        "brace-expansion": "5.0.8",
         "buffer": "5.7.1",
         "call-bind-apply-helpers": "1.0.2",
         "chalk": "4.1.2",
@@ -21647,6 +21697,7 @@
         "color-convert": "2.0.1",
         "color-name": "1.1.4",
         "combined-stream": "1.0.8",
+        "debug": "4.4.3",
         "defaults": "1.0.4",
         "define-lazy-prop": "2.0.0",
         "delayed-stream": "1.0.0",
@@ -21677,6 +21728,7 @@
         "has-symbols": "1.1.0",
         "has-tostringtag": "1.0.2",
         "hasown": "2.0.4",
+        "https-proxy-agent": "5.0.1",
         "ieee754": "1.2.1",
         "ignore": "7.0.5",
         "inherits": "2.0.4",
@@ -21695,6 +21747,7 @@
         "mimic-fn": "2.1.0",
         "minimatch": "10.2.5",
         "minimist": "1.2.8",
+        "ms": "2.1.3",
         "npm-run-path": "4.0.1",
         "once": "1.4.0",
         "onetime": "5.1.2",
@@ -21735,16 +21788,16 @@
         "nx-cloud": "dist/bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "22.7.7",
-        "@nx/nx-darwin-x64": "22.7.7",
-        "@nx/nx-freebsd-x64": "22.7.7",
-        "@nx/nx-linux-arm-gnueabihf": "22.7.7",
-        "@nx/nx-linux-arm64-gnu": "22.7.7",
-        "@nx/nx-linux-arm64-musl": "22.7.7",
-        "@nx/nx-linux-x64-gnu": "22.7.7",
-        "@nx/nx-linux-x64-musl": "22.7.7",
-        "@nx/nx-win32-arm64-msvc": "22.7.7",
-        "@nx/nx-win32-x64-msvc": "22.7.7"
+        "@nx/nx-darwin-arm64": "22.7.8",
+        "@nx/nx-darwin-x64": "22.7.8",
+        "@nx/nx-freebsd-x64": "22.7.8",
+        "@nx/nx-linux-arm-gnueabihf": "22.7.8",
+        "@nx/nx-linux-arm64-gnu": "22.7.8",
+        "@nx/nx-linux-arm64-musl": "22.7.8",
+        "@nx/nx-linux-x64-gnu": "22.7.8",
+        "@nx/nx-linux-x64-musl": "22.7.8",
+        "@nx/nx-win32-arm64-msvc": "22.7.8",
+        "@nx/nx-win32-x64-msvc": "22.7.8"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.11.1",
@@ -21822,6 +21875,19 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/nx/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/nx/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -21869,6 +21935,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/nx/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/nx/node_modules/ignore": {
@@ -23305,24 +23385,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-email": {
@@ -23737,44 +23817,6 @@
         "redux": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/readable-stream": {
@@ -24582,12 +24624,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
-    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -25332,9 +25368,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25518,9 +25554,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25997,17 +26033,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/type-is/node_modules/mime-db": {
@@ -26719,9 +26772,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.108.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.4.tgz",
-      "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
+      "version": "5.109.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
+      "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26731,22 +26784,20 @@
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.16.0",
-        "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.22.2",
+        "enhanced-resolve": "^5.24.4",
         "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "graceful-fs": "^4.2.11",
-        "loader-runner": "^4.3.2",
         "mime-db": "^1.54.0",
         "minimizer-webpack-plugin": "^5.6.1",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
         "watchpack": "^2.5.2",
-        "webpack-sources": "^3.5.0"
+        "webpack-sources": "^3.5.1"
       },
       "bin": {
         "webpack": "bin/webpack.js"

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   "dependencies": {
     "leaflet": "^1.9.4",
     "lru-cache": "^11.5.2",
-    "react": "19.2.3",
-    "react-dom": "19.2.3",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "react-leaflet": "^5.0.0"
   },
   "version": "1.0.0"


### PR DESCRIPTION
## Result

`npm audit` in `apps/web` reported **14 vulnerabilities (13 high, 1 low)**. This takes it to **4**, and none of the remaining four are the web app's own dependencies.

## react-router: forward, not backward

npm's suggested fix is a **downgrade** to 7.11.0, flagged as breaking. That is the wrong direction twice over: it drops seven minors of fixes, and since the range is a caret it would resolve straight back into the vulnerable window on the next install. The advisory covers `7.12.0 - 8.2.0`, so **8.3.0 is the patched release**.

- `react-router` 7.13.2 → **8.3.0**
- `react-router-dom` **removed**. There is no 8.x of it: v7 unified the two packages and v8 drops the alias. 60 files now import from `react-router`.
- `react` / `react-dom` 19.2.4 → 19.2.8 in web, to satisfy v8's `>=19.2.7` peer

Worth noting for risk assessment: the advisory is an **RSC-mode** CSRF bypass, and this app is a Vite SPA using `<BrowserRouter>` declaratively, so it was almost certainly not exploitable here. The upgrade is still the right resolution, and it is now on a supported line rather than pinned behind one.

## The React bump had to happen at the root

Raising React only in `apps/web` made things worse before better. The root pinned `19.2.3` and web pinned `19.2.4`, so npm nested a **second copy** of react and react-dom under `apps/web/node_modules`. Two React instances meant every hook inside a Router threw:

```
TypeError: Cannot read properties of null (reading 'useRef')
  at MemoryRouter (react-router/dist/development/lib/components.js)
```

149 tests across 11 files failed. That is the same hazard CI already works around by deleting `apps/*/node_modules/react` before building. Both pins are now exactly `19.2.8`, so a single hoisted copy serves the whole workspace, and all 927 tests pass. **The exact pins on both sides are deliberate**: a caret on either is how the second copy comes back.

## `npm audit fix` has to run at the root

Run inside `apps/web` it rewrote 613 lines of the lockfile and resolved **nothing** (14 before, 14 after). The lockfile and hoisted tree live at the root, so that is where it works. From there it cleared the nx toolchain, axios, brace-expansion and the rest.

## Verification

| check | result |
|---|---|
| web type-check | clean |
| web lint | clean |
| web tests | 927 passed |
| web build | built |
| api type-check | clean |
| api tests | 1802 passed |
| api build | built |

The API is included because the lockfile and the React pin are shared.

## What is left, and why it is not web's

| package | severity | actually comes from |
|---|---|---|
| next | high | `@react-email/preview-server`, the dev-only email preview CLI |
| postcss | high | nested under that `next` |
| sharp | high | nested under that `next` |
| esbuild | low | `vite` and `@nx/esbuild`; dev-server-only advisory |

`next` is attributed to the web workspace only because `@vercel/analytics` declares it as an **optional peer** (`peerDependenciesMeta.next.optional = true`) that the hoisted copy happens to satisfy. The app imports `inject` from `@vercel/analytics`, which needs no framework. Nothing from Next.js ships in the web bundle.

Clearing those three means a **major bump of `react-email` 5.x → 6.9.1** in the root and in `apps/api`. That is dev tooling (the API's runtime email path uses `@react-email/render` and `@react-email/components`, neither of which is affected), but it is outside the `apps/web` scope of this change and deserves its own verification of the preview script. Happy to do it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
