### PR TITLE
fix(web): name Garmin Connect in full on the disconnect overlay

### DIFF
--- a/apps/web/src/pages/Settings/providers.ts
+++ b/apps/web/src/pages/Settings/providers.ts
@@ -1,9 +1,11 @@
+import { GARMIN_CONNECT_APP_NAME } from '@loam/shared';
+
 export type DataSource = 'garmin' | 'strava' | 'whoop' | 'suunto';
 
 export const DATA_SOURCES: readonly DataSource[] = ['garmin', 'strava', 'whoop', 'suunto'];
 
 export const PROVIDER_LABELS: Record<DataSource, string> = {
-  garmin: 'Garmin',
+  garmin: GARMIN_CONNECT_APP_NAME,
   strava: 'Strava',
   whoop: 'WHOOP',
   suunto: 'Suunto',


### PR DESCRIPTION
## What

The Settings disconnect confirmation dialog titled itself "Disconnect Garmin?". Its title is built from `PROVIDER_LABELS[provider]`, whose `garmin` entry was the bare string `"Garmin"`. This points that entry at the shared `GARMIN_CONNECT_APP_NAME` constant (`"Garmin Connect™"`), so the overlay now reads **"Disconnect Garmin Connect™?"**.

Because the disconnect toast and the delete-rides dialog read from the same label, they now name the app in full too.

## Why

DESIGN.md requires naming a partner app in full ("Garmin Connect™", never "Garmin" alone) wherever the connection or app is named. Reusing the existing `GARMIN_CONNECT_APP_NAME` constant keeps this in step with the attribution system already on `main` (which fixed the provider tile and clear-rides label) and avoids a drifting literal.

Device attribution (`libs/shared/src/garmin/attribution.ts`) is unaffected, so bare "Garmin" for device names still applies where the rules allow it.

## Test

`npx tsc --noEmit` passes. No tests asserted on the old label text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)