### PR TITLE
feat(web): per-ride data source attribution in the component rides modal

### DIFF
--- a/apps/web/src/components/gear/ComponentRidesModal.test.tsx
+++ b/apps/web/src/components/gear/ComponentRidesModal.test.tsx
@@ -133,6 +133,68 @@ describe('ComponentRidesModal', () => {
     );
   });
 
+  it('attributes each ride to its data source, with the Garmin device model', () => {
+    mockComponentRidesQuery.mockReturnValue({
+      data: {
+        componentRides: {
+          ...basePayload.componentRides,
+          entries: [
+            {
+              counted: true,
+              adjustment: null,
+              beforeAnchor: false,
+              ride: {
+                id: 'r-garmin',
+                startTime: '2026-06-15T00:00:00.000Z',
+                durationSeconds: 3600,
+                location: 'Galbraith',
+                bikeId: 'bike-1',
+                garminActivityId: 'g-1',
+                garminDeviceName: 'edge_840',
+              },
+            },
+            {
+              counted: true,
+              adjustment: null,
+              beforeAnchor: false,
+              ride: {
+                id: 'r-strava',
+                startTime: '2026-06-14T00:00:00.000Z',
+                durationSeconds: 3600,
+                location: 'Chuckanut',
+                bikeId: 'bike-1',
+                stravaActivityId: 's-1',
+              },
+            },
+            {
+              counted: true,
+              adjustment: null,
+              beforeAnchor: false,
+              ride: {
+                id: 'r-manual',
+                startTime: '2026-06-13T00:00:00.000Z',
+                durationSeconds: 3600,
+                location: 'Sudden Valley',
+                bikeId: 'bike-1',
+              },
+            },
+          ],
+        },
+      },
+      loading: false,
+      fetchMore: vi.fn(),
+      refetch: vi.fn(),
+    });
+    renderModal();
+
+    // Garmin rides carry the sanctioned "Garmin [device model]" label, not a
+    // bare "Garmin".
+    expect(screen.getByTestId('component-ride-r-garmin')).toHaveTextContent('Garmin Edge 840');
+    expect(screen.getByTestId('component-ride-r-strava')).toHaveTextContent('Strava');
+    // A ride with no provider id falls back to a Manual badge.
+    expect(screen.getByTestId('component-ride-r-manual')).toHaveTextContent('Manual');
+  });
+
   it('flags dormant pre-anchor INCLUDEs instead of silently ignoring them', () => {
     mockComponentRidesQuery.mockReturnValue({
       data: {

--- a/apps/web/src/components/gear/ComponentRidesModal.tsx
+++ b/apps/web/src/components/gear/ComponentRidesModal.tsx
@@ -4,6 +4,7 @@ import { CircleMinus, CirclePlus, History, RotateCcw, TriangleAlert } from 'luci
 
 import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
+import RideSourceBadges from '../RideSourceBadges';
 import {
   COMPONENT_RIDES,
   SET_COMPONENT_RIDE_ADJUSTMENT,
@@ -26,6 +27,14 @@ type RideDto = {
   trailSystem?: string | null;
   rideType?: string | null;
   bikeId?: string | null;
+  // Provider ids + Garmin device model, so each row can attribute its data
+  // source. RideSourceBadges renders every contributing provider (a matched
+  // ride can carry more than one) with the Garmin device label where present.
+  garminActivityId?: string | null;
+  garminDeviceName?: string | null;
+  stravaActivityId?: string | null;
+  whoopWorkoutId?: string | null;
+  suuntoWorkoutId?: string | null;
 };
 
 type ComponentRideEntry = {
@@ -283,6 +292,12 @@ export function ComponentRidesModal({
                     <div className={`text-sm truncate ${entry.counted ? '' : 'text-muted line-through'}`}>
                       {rideTitle(ride)}
                     </div>
+                    {/* Data-source attribution, in the visible row (never a
+                        tooltip/collapsed container) as the Garmin guidelines
+                        require for the entries whose data came from a device. */}
+                    <div className="mt-1 flex flex-wrap items-center gap-1">
+                      <RideSourceBadges ride={ride} />
+                    </div>
                     <div className="text-xs text-muted">
                       {formatRideDate(ride.startTime)} · {formatDurationCompact(ride.durationSeconds)}
                       {entry.adjustment === 'INCLUDE' && ' · applied from another bike'}
@@ -407,6 +422,9 @@ export function ComponentRidesModal({
                 >
                   <div className="min-w-0">
                     <div className="text-sm truncate">{rideTitle(ride)}</div>
+                    <div className="mt-1 flex flex-wrap items-center gap-1">
+                      <RideSourceBadges ride={ride} />
+                    </div>
                     <div className="text-xs text-muted">
                       {formatRideDate(ride.startTime)} · {formatDurationCompact(ride.durationSeconds)}
                       {ride.bikeId == null && ' · unassigned'}

--- a/apps/web/src/graphql/componentRides.ts
+++ b/apps/web/src/graphql/componentRides.ts
@@ -25,11 +25,16 @@ export const COMPONENT_RIDES = gql`
           trailSystem
           rideType
           bikeId
-          # Needed to attribute Garmin-sourced rides in this list — the Garmin
-          # API Brand Guidelines require attribution on secondary/detail views,
-          # not just primary feeds.
+          # Provider ids drive the per-ride source badges. Garmin in particular
+          # must be attributed wherever its device-sourced data appears (the
+          # Garmin API Brand Guidelines require attribution on secondary/detail
+          # views, not just primary feeds), and garminDeviceName carries the
+          # sanctioned "Garmin [device model]" label.
           garminActivityId
           garminDeviceName
+          stravaActivityId
+          whoopWorkoutId
+          suuntoWorkoutId
         }
       }
     }


### PR DESCRIPTION
## What

The component "Rides" modal (opened from `/gear/:bikeId`) listed each ride with no indication of its data provider. This adds a source badge under every ride title, in **both** the Counted rides and Add rides lists.

Reuses the existing `RideSourceBadges` component, so attribution follows the rules already encoded in the codebase:

- **Garmin** rides render the sanctioned **"Garmin [device model]"** label (e.g. "Garmin Edge 840"), falling back to "Garmin" when the device is unknown, in the visible row (never a tooltip or collapsed container) as the Garmin API Brand Guidelines require for secondary/detail views.
- Cross-provider rides show **every** contributing source, so Garmin attribution is never dropped by source ranking.
- Strava / WHOOP / Suunto / Manual render their plain badges too.

## Why

Per-entry provider visibility for the ride list, with Garmin device-sourced data attributed wherever it appears.

## Changes

- `componentRides.ts` — the `COMPONENT_RIDES` query now also selects `stravaActivityId`, `whoopWorkoutId`, `suuntoWorkoutId` (the Garmin ids were already fetched).
- `ComponentRidesModal.tsx` — extended `RideDto` with the provider ids + `garminDeviceName`, and rendered `RideSourceBadges` in both ride lists.
- `ComponentRidesModal.test.tsx` — added a test asserting the Garmin device label, the Strava badge, and the Manual fallback.

## Test

- `npx vitest run ComponentRidesModal` → 14/14 pass.
- `tsc --noEmit -p tsconfig.app.json` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)