### PR TITLE
feat(web): retain Garmin attribution on the bike history view

### DIFF
--- a/apps/web/src/pages/BikeHistory.test.tsx
+++ b/apps/web/src/pages/BikeHistory.test.tsx
@@ -358,6 +358,40 @@ describe('BikeHistory multi-select', () => {
     });
   });
 
+  describe('Garmin attribution', () => {
+    const withSources = (sources: string[] | undefined) => ({
+      bikeHistory: {
+        ...fixture.bikeHistory,
+        bike: { ...fixture.bikeHistory.bike, contributingSources: sources },
+      },
+    });
+
+    it('shows the Garmin derived-data note when Garmin contributed rides', () => {
+      mockUseQuery.mockReturnValue({
+        data: withSources(['strava', 'garmin']),
+        loading: false,
+        error: undefined,
+      });
+      renderPage();
+      expect(screen.getByText(/derived in part from Garmin/i)).toBeInTheDocument();
+    });
+
+    it('omits the note when Garmin did not contribute', () => {
+      mockUseQuery.mockReturnValue({
+        data: withSources(['strava']),
+        loading: false,
+        error: undefined,
+      });
+      renderPage();
+      expect(screen.queryByText(/derived in part from Garmin/i)).not.toBeInTheDocument();
+    });
+
+    it('omits the note when contributingSources is absent', () => {
+      renderPage();
+      expect(screen.queryByText(/derived in part from Garmin/i)).not.toBeInTheDocument();
+    });
+  });
+
   describe('handleBulkSetDate error path', () => {
     it('shows the mutation error inline and keeps selection mode active', async () => {
       mockBulkUpdate.mockRejectedValue(new Error('Removal date conflict'));

--- a/apps/web/src/pages/BikeHistory.tsx
+++ b/apps/web/src/pages/BikeHistory.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/lib/bikeHistory';
 import { useUserTier } from '@/hooks/useUserTier';
 import { UpsellCard } from '@/components/UpgradePrompt';
+import { GarminDerivedNote } from '@/components/attribution/GarminAttribution';
 
 const BikeHistoryPdfButton = lazy(() => import('@/components/history/BikeHistoryPdfButton'));
 
@@ -298,6 +299,17 @@ export default function BikeHistory() {
             <TotalChip label="Elevation" value={fmtElevation(payload.totals.totalElevationGainMeters, distanceUnit)} />
             <TotalChip label="Service events" value={(payload.totals.serviceEventCount + payload.totals.installEventCount).toLocaleString()} />
           </div>
+
+          {/* The totals above and the ride timeline below are derived from the
+              contributing providers' ride data, so any Garmin-sourced rides
+              have to be named as a source. Sits adjacent to the data and above
+              the fold, never behind a disclosure, as the Garmin API Brand
+              Guidelines require. Matches BikeDetail's Component Health note and
+              the PDF/shared-history attribution so it is retained across every
+              view of this history. */}
+          {payload.bike.contributingSources?.includes('garmin') && (
+            <GarminDerivedNote className="mb-4" />
+          )}
 
           <div className="flex flex-wrap items-center gap-2 mb-4">
             <label className="text-xs text-muted mr-1">Timeframe</label>


### PR DESCRIPTION
## What

The on-screen bike history view (`/gear/:bikeId/history`) showed no data-source attribution. This adds a `GarminDerivedNote` below the totals, gated on the bike's `contributingSources` including `garmin`.

## Why

The totals and the ride timeline on this page are derived from the contributing providers' ride data. Under the Garmin API Brand Guidelines, Garmin device-sourced data must be named wherever it appears (and never where it's absent). This view was the one surface missing it: the shared-history page, the PDF export, and BikeDetail's Component Health section already carry the same note.

"Retained across every view" was the goal, so this reuses the exact same component and gate as those siblings rather than inventing a new treatment.

## Details

- Reuses `GarminDerivedNote` (insight phrasing: "Insights derived in part from Garmin device-sourced data.").
- Gated on `payload.bike.contributingSources?.includes('garmin')`; the `bikeHistory` query already selects `contributingSources`, so no schema/query change was needed.
- Placed adjacent to the data and above the fold, never behind a disclosure.
- Authed in-app view, so it uses the derived note only (matching BikeDetail); the trademark notice remains scoped to the downstream/public surfaces (shared page + PDF), per the shared attribution module's contract.

## Test

Added three cases to `BikeHistory.test.tsx`: note present when Garmin contributed, absent when it didn't, absent when `contributingSources` is missing. 16/16 pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)