### PR TITLE
chore: replace generic support@ with named contact address

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -10,7 +10,7 @@
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them via email to: security@loamlogger.com (or your preferred contact method)
+Instead, please report them via email to: security@loamlogger.app (or your preferred contact method)
 
 You should receive a response within 48 hours. If for some reason you do not, please follow up to ensure we received your original message.
 
@@ -88,7 +88,7 @@ If you're contributing to this project, please:
 ## Security Contacts
 
 For security-related questions or concerns, please contact:
-- **Email:** security@loamlogger.com
+- **Email:** security@loamlogger.app
 - **GitHub:** Create a private security advisory
 
 ## Acknowledgments

--- a/apps/web/src/components/layout/Footer.tsx
+++ b/apps/web/src/components/layout/Footer.tsx
@@ -104,10 +104,10 @@ export default function Footer() {
                             ))}
                             <li>
                                 <a
-                                    href="mailto:support@loamlogger.app"
+                                    href="mailto:ryan.lecours@loamlogger.app"
                                     className="text-sm text-concrete hover:text-mint transition-colors focus-visible:outline-none focus-visible:text-mint"
                                 >
-                                    support@loamlogger.app
+                                    ryan.lecours@loamlogger.app
                                 </a>
                             </li>
                         </ul>

--- a/apps/web/src/legal/terms.ts
+++ b/apps/web/src/legal/terms.ts
@@ -262,7 +262,7 @@ These Terms constitute the entire agreement between you and Loam Logger regardin
 For questions regarding these Terms, contact:
 
 **Loam Logger**  
-Email: support@loamlogger.app
+Email: ryan.lecours@loamlogger.app
 
 ---
 

--- a/apps/web/src/pages/About.tsx
+++ b/apps/web/src/pages/About.tsx
@@ -59,10 +59,10 @@ export default function About() {
                                     </p>
                                     <p className="body mt-2">
                                         <a
-                                            href="mailto:support@loamlogger.app"
+                                            href="mailto:ryan.lecours@loamlogger.app"
                                             className="text-mint hover:text-sage transition-colors underline"
                                         >
-                                            support@loamlogger.app
+                                            ryan.lecours@loamlogger.app
                                         </a>
                                     </p>
                                 </section>

--- a/docs/garmin/ticket-reply.md
+++ b/docs/garmin/ticket-reply.md
@@ -192,10 +192,13 @@ first, because they are the most likely reason for another round trip:
 
 1. The developer-program contact of record is a `gmail.com` address. Move all
    developer-program access to named `@loamlogger.app` addresses before replying.
-2. `support@loamlogger.app` appears in the app's Terms and site footer. It is
-   fine as a user-facing support address, but it must not be an account on the
-   Garmin developer portal or a recipient of Garmin data.
+   (This is an account setting in the Garmin developer portal, not a code change;
+   the repo itself contains no freemail address.)
+2. Resolved: the generic `support@loamlogger.app` in the app's Terms, About page,
+   and site footer (web and mobile) has been replaced with the named
+   `ryan.lecours@loamlogger.app`, matching the address already used everywhere
+   else. No generic address remains in user-facing copy.
 
-Unrelated to Garmin but worth fixing while you are in there:
-`.github/SECURITY.md` lists `security@loamlogger.com` — the only `.com` in the
-repo, and almost certainly a typo for `.app`.
+Unrelated to Garmin but fixed while in here: `.github/SECURITY.md` previously
+listed `security@loamlogger.com` (the only `.com` in the repo, a typo). It now
+reads `security@loamlogger.app` in both places.


### PR DESCRIPTION
## What

- Replace `support@loamlogger.app` with `ryan.lecours@loamlogger.app` in the web **Terms** (contact section), **About** page, and **site footer**.
- Fix the `.com` typo in `.github/SECURITY.md`: `security@loamlogger.com` to `security@loamlogger.app` (both occurrences).
- Update the Garmin `ticket-reply.md` note to record these fixes.

## Why

`ryan.lecours@loamlogger.app` is already the contact used everywhere else (reply-to, all email templates, privacy policy, support page). This removes the last generic address from user-facing copy, which the Garmin Connect Developer Program restricts (generic addresses like support@/info@/contact@/dev@ are not permitted for the program or for sharing Garmin data).

## Terms version

The Terms body text changed, but `CURRENT_TERMS_VERSION` is **intentionally not bumped**. A support-contact correction is non-material and should not force every user to re-accept the Terms. The Privacy Policy is untouched, so no privacy version change and no Garmin pre-approval is triggered.

## Scope

Mobile has the same `support@` to named-address change; it ships as a separate PR in the `loam-logger-mobile` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)