### PR TITLE
feat(garmin): attribute Strava rides recorded on a Garmin device

### DIFF
--- a/apps/api/prisma/migrations/20260803120000_add_ride_strava_device_name/migration.sql
+++ b/apps/api/prisma/migrations/20260803120000_add_ride_strava_device_name/migration.sql
@@ -1,0 +1,13 @@
+-- Strava's reported recording device (detailed-activity "device_name", e.g.
+-- "Garmin Edge 840"), stored raw. Captured so a ride recorded on a Garmin unit
+-- and imported via Strava can still be attributed to Garmin, which the Garmin
+-- Developer API Brand Guidelines require wherever Garmin device-sourced data is
+-- present ("If strava data originated from Garmin device, it must be identified
+-- as well").
+--
+-- Nullable and NOT backfilled by this migration. Strava does not always report
+-- a device, and only Strava's detailed-activity endpoint carries device_name;
+-- rides imported before this column existed are filled in opportunistically on
+-- their next detailed sync. Garmin origin is derived from this value via
+-- isGarminDevice() in @loam/shared, so this is not a Garmin-only column.
+ALTER TABLE "Ride" ADD COLUMN "stravaDeviceName" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -130,6 +130,14 @@ model Ride {
   garminDeviceName        String?
   stravaActivityId        String?                   @unique
   stravaGearId            String?
+  // Strava's reported recording device (detailed-activity `device_name`, e.g.
+  // "Garmin Edge 840"). Captured so a ride recorded on a Garmin unit and
+  // imported via Strava can still be attributed to Garmin, which the Garmin API
+  // Brand Guidelines require wherever Garmin device-sourced data is present.
+  // NULL is expected: Strava does not always report a device, and only the
+  // detailed endpoint carries it. Garmin origin is derived from this via
+  // isGarminDevice() in @loam/shared; it is not a Garmin-only column.
+  stravaDeviceName        String?
   whoopWorkoutId          String?                   @unique
   suuntoWorkoutId         String?                   @unique
   importSessionId         String?

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -155,6 +155,13 @@ export const typeDefs = gql`
     whoopWorkoutId: String
     suuntoWorkoutId: String
     stravaGearId: String
+    """
+    Strava's reported recording device (e.g. "Garmin Edge 840"). When it names a
+    Garmin device, this ride carries Garmin device-sourced data and clients must
+    render Garmin attribution even though it arrived via Strava (isGarminDevice /
+    garminSourceDevice in @loam/shared). Null when Strava reported no device.
+    """
+    stravaDeviceName: String
     startTime: String!
     durationSeconds: Int!
     distanceMeters: Float!

--- a/apps/api/src/lib/strava-device.test.ts
+++ b/apps/api/src/lib/strava-device.test.ts
@@ -1,0 +1,45 @@
+import { fetchStravaDeviceName } from './strava-device';
+
+// The rest of the Strava-attribution feature calls this unconditionally and
+// treats null as "no device", so its "swallow everything, never throw" contract
+// is what keeps it safe to call in hot paths (backfill loop, latest-sync).
+describe('fetchStravaDeviceName', () => {
+  const realFetch = global.fetch;
+  const mockFetch = jest.fn();
+
+  beforeEach(() => {
+    global.fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+  });
+
+  afterAll(() => {
+    global.fetch = realFetch;
+  });
+
+  it('returns device_name from a 200 response', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ device_name: 'Garmin Edge 840' }) });
+    await expect(fetchStravaDeviceName('token', 123)).resolves.toBe('Garmin Edge 840');
+  });
+
+  it('returns null when the 200 response has no device_name', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+    await expect(fetchStravaDeviceName('token', 123)).resolves.toBeNull();
+  });
+
+  it('returns null on a non-ok response instead of throwing', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 429, text: async () => 'Too Many Requests' });
+    await expect(fetchStravaDeviceName('token', 123)).resolves.toBeNull();
+  });
+
+  it('returns null when fetch rejects (network error / abort / timeout)', async () => {
+    mockFetch.mockRejectedValue(new Error('aborted'));
+    await expect(fetchStravaDeviceName('token', 123)).resolves.toBeNull();
+  });
+
+  it('passes an abort signal so the request can time out', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ device_name: 'Wahoo ELEMNT' }) });
+    await fetchStravaDeviceName('token', 123);
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/apps/api/src/lib/strava-device.ts
+++ b/apps/api/src/lib/strava-device.ts
@@ -1,0 +1,28 @@
+/**
+ * Fetch just the recording device for a Strava activity.
+ *
+ * Strava's activity list and backfill endpoints omit `device_name`; only the
+ * detailed activity (GET /activities/{id}) carries it. We capture it so a ride
+ * recorded on a Garmin device and imported via Strava can still be attributed to
+ * Garmin, which the Garmin Developer API Brand Guidelines require wherever
+ * Garmin device-sourced data is present.
+ *
+ * Best-effort by design: a rate-limited or failed lookup returns null and the
+ * ride still imports, falling back to no Garmin attribution until a later sync
+ * (webhook delivery or latest-sync) fills it in.
+ */
+export async function fetchStravaDeviceName(
+  accessToken: string,
+  activityId: number | string
+): Promise<string | null> {
+  try {
+    const res = await fetch(`https://www.strava.com/api/v3/activities/${activityId}`, {
+      headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' },
+    });
+    if (!res.ok) return null;
+    const detail = (await res.json()) as { device_name?: string | null };
+    return detail.device_name ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/lib/strava-device.ts
+++ b/apps/api/src/lib/strava-device.ts
@@ -7,22 +7,44 @@
  * Garmin, which the Garmin Developer API Brand Guidelines require wherever
  * Garmin device-sourced data is present.
  *
- * Best-effort by design: a rate-limited or failed lookup returns null and the
- * ride still imports, falling back to no Garmin attribution until a later sync
- * (webhook delivery or latest-sync) fills it in.
+ * Best-effort by design: a rate-limited, failed, slow, or malformed lookup
+ * returns null and the ride still imports, falling back to no Garmin attribution
+ * until a later sync (webhook delivery or latest-sync) fills it in.
+ *
+ * QUOTA TRADEOFF (deliberate): callers invoke this once per NEW activity only,
+ * both the backfill route and latest-sync skip already-imported rides, so no ride
+ * is re-fetched. A large first-time backfill can still issue hundreds of these
+ * sequentially, and Strava's rate limit is enforced per-application (shared
+ * across all users), so a burst of big backfills eats into the shared 15-minute
+ * and daily quotas. That is an accepted cost for attributing imported history;
+ * the timeout below bounds per-call latency, and the null fallback keeps a
+ * throttled lookup from failing the import. If this pressure becomes a problem,
+ * the next step is to batch/throttle here (or drop backfill capture and rely on
+ * the webhook path, which already has the detail in hand for free).
  */
+
+// Bounds a single lookup so a stalled Strava endpoint can't hold a backfill
+// request or a sync-worker job open for the HTTP client's (long) default.
+const STRAVA_DEVICE_FETCH_TIMEOUT_MS = 5000;
+
 export async function fetchStravaDeviceName(
   accessToken: string,
   activityId: number | string
 ): Promise<string | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), STRAVA_DEVICE_FETCH_TIMEOUT_MS);
   try {
     const res = await fetch(`https://www.strava.com/api/v3/activities/${activityId}`, {
       headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' },
+      signal: controller.signal,
     });
     if (!res.ok) return null;
     const detail = (await res.json()) as { device_name?: string | null };
     return detail.device_name ?? null;
   } catch {
+    // Network error, abort/timeout, or bad JSON — never block or fail the caller.
     return null;
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/apps/api/src/routes/strava.backfill.ts
+++ b/apps/api/src/routes/strava.backfill.ts
@@ -1,5 +1,6 @@
 import { Router as createRouter, type Router, type Request, type Response } from 'express';
 import { getValidStravaToken } from '../lib/strava-token';
+import { fetchStravaDeviceName } from '../lib/strava-device';
 import { subDays } from 'date-fns';
 import { prisma } from '../lib/prisma';
 import { formatLatLon, reverseGeocode } from '../lib/location';
@@ -235,12 +236,18 @@ r.get<Empty, void, Empty, { year?: string }>(
           }
         }
 
+        // The list endpoint omits device_name; fetch it best-effort so a ride
+        // recorded on a Garmin device and imported via Strava can still be
+        // attributed to Garmin. A rate-limited lookup just leaves it null.
+        const stravaDeviceName = await fetchStravaDeviceName(accessToken, activity.id);
+
         const ride = await prisma.$transaction(async (tx) => {
           const createdRide = await tx.ride.create({
             data: {
               userId,
               stravaActivityId: activity.id.toString(),
               stravaGearId: activity.gear_id ?? null,
+              stravaDeviceName,
               startTime,
               durationSeconds: activity.moving_time,
               distanceMeters,

--- a/apps/api/src/routes/webhooks.strava.ts
+++ b/apps/api/src/routes/webhooks.strava.ts
@@ -75,6 +75,7 @@ type StravaActivityDetail = {
   distance: number; // meters
   total_elevation_gain: number; // meters
   gear_id?: string | null; // Strava bike/gear ID
+  device_name?: string | null; // recording device, e.g. "Garmin Edge 840"
   average_heartrate?: number;
   max_heartrate?: number;
   average_speed?: number; // m/s
@@ -366,6 +367,7 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
             userId: userAccount.userId,
             stravaActivityId: activityId.toString(),
             stravaGearId: activity.gear_id ?? null,
+            stravaDeviceName: activity.device_name ?? null,
             startTime,
             durationSeconds: activity.moving_time,
             distanceMeters,
@@ -381,6 +383,8 @@ async function processActivityEvent(event: StravaWebhookEvent): Promise<void> {
           update: {
             startTime,
             stravaGearId: activity.gear_id ?? null,
+            // Only written when present, never blanked (see sync.worker.ts).
+            ...(activity.device_name ? { stravaDeviceName: activity.device_name } : {}),
             durationSeconds: activity.moving_time,
             distanceMeters,
             elevationGainMeters,

--- a/apps/api/src/workers/sync.worker.test.ts
+++ b/apps/api/src/workers/sync.worker.test.ts
@@ -410,6 +410,42 @@ describe('processSyncJob (via worker processor)', () => {
       );
     });
 
+    // The upsert's update block spreads stravaDeviceName only when present. A
+    // routine re-sync (existing ride, list has no device_name) must NOT put
+    // stravaDeviceName in the update — that omission is what stops a device
+    // captured earlier (e.g. a Garmin attribution) from being silently blanked.
+    it('omits stravaDeviceName from the update when Strava reports no device', async () => {
+      mockGetValidStravaToken.mockResolvedValue('valid-token');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve([
+            { id: 123, name: 'Ride', sport_type: 'Ride', start_date: '2024-01-01T10:00:00Z', moving_time: 3600, distance: 10000, total_elevation_gain: 100 },
+          ]),
+      } as Response);
+      (mockPrisma.ride.findMany as jest.Mock).mockResolvedValue([{ stravaActivityId: '123' }]); // existing → no device fetch
+
+      const upsertSpy = jest.fn().mockResolvedValue({ bikeId: null, durationSeconds: 3600 });
+      mockPrisma.$transaction.mockImplementation(async (cb) =>
+        cb({
+          ride: {
+            findUnique: jest.fn().mockResolvedValue({ id: 'ride-1', durationSeconds: 3600, bikeId: null, location: null }),
+            upsert: upsertSpy,
+          },
+          component: { updateMany: jest.fn() },
+        })
+      );
+      (mockPrisma.stravaGearMapping.findUnique as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([]);
+
+      await processSyncJob({ name: 'syncLatest', data: { userId: 'user123', provider: 'strava' } });
+
+      const [upsertArg] = upsertSpy.mock.calls[0];
+      expect('stravaDeviceName' in upsertArg.update).toBe(false);
+      // create still sets an explicit null (the column is never left unset).
+      expect(upsertArg.create.stravaDeviceName).toBeNull();
+    });
+
     it('should throw when Strava token is not available', async () => {
       mockGetValidStravaToken.mockResolvedValue(null);
 

--- a/apps/api/src/workers/sync.worker.test.ts
+++ b/apps/api/src/workers/sync.worker.test.ts
@@ -36,7 +36,7 @@ jest.mock('../lib/prisma', () => ({
   prisma: {
     stravaGearMapping: { findUnique: jest.fn() },
     bike: { findMany: jest.fn() },
-    ride: { findUnique: jest.fn(), upsert: jest.fn() },
+    ride: { findUnique: jest.fn(), findMany: jest.fn().mockResolvedValue([]), upsert: jest.fn() },
     component: { updateMany: jest.fn() },
     // The Garmin upsert path looks for a running import session to stamp.
     importSession: { findFirst: jest.fn().mockResolvedValue(null), update: jest.fn() },
@@ -345,6 +345,68 @@ describe('processSyncJob (via worker processor)', () => {
             Authorization: 'Bearer valid-token',
           }),
         })
+      );
+    });
+
+    // device_name is not on the list response, so a new ride needs one detailed
+    // lookup to capture the recording device (attributes Garmin-recorded rides).
+    it('fetches device_name once for a newly-imported Strava ride', async () => {
+      mockGetValidStravaToken.mockResolvedValue('valid-token');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve([
+            { id: 123, name: 'Ride', sport_type: 'Ride', start_date: '2024-01-01T10:00:00Z', moving_time: 3600, distance: 10000, total_elevation_gain: 100 },
+          ]),
+      } as Response);
+      (mockPrisma.ride.findMany as jest.Mock).mockResolvedValue([]); // none imported yet
+      mockPrisma.$transaction.mockImplementation(async (cb) =>
+        cb({
+          ride: { findUnique: jest.fn().mockResolvedValue(null), upsert: jest.fn().mockResolvedValue({ bikeId: null, durationSeconds: 3600 }) },
+          component: { updateMany: jest.fn() },
+        })
+      );
+      (mockPrisma.stravaGearMapping.findUnique as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([]);
+
+      await processSyncJob({ name: 'syncLatest', data: { userId: 'user123', provider: 'strava' } });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v3/activities/123'),
+        expect.anything()
+      );
+    });
+
+    // Regression: an already-imported ride must NOT trigger a per-activity
+    // detail call on every "sync now". device_name is never on the list, so an
+    // unconditional fetch would burn one Strava request per ride, every sync.
+    it('does not re-fetch device_name for an already-imported Strava ride', async () => {
+      mockGetValidStravaToken.mockResolvedValue('valid-token');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve([
+            { id: 123, name: 'Ride', sport_type: 'Ride', start_date: '2024-01-01T10:00:00Z', moving_time: 3600, distance: 10000, total_elevation_gain: 100 },
+          ]),
+      } as Response);
+      (mockPrisma.ride.findMany as jest.Mock).mockResolvedValue([{ stravaActivityId: '123' }]); // already imported
+      mockPrisma.$transaction.mockImplementation(async (cb) =>
+        cb({
+          ride: {
+            findUnique: jest.fn().mockResolvedValue({ id: 'ride-1', durationSeconds: 3600, bikeId: null, location: null }),
+            upsert: jest.fn().mockResolvedValue({ bikeId: null, durationSeconds: 3600 }),
+          },
+          component: { updateMany: jest.fn() },
+        })
+      );
+      (mockPrisma.stravaGearMapping.findUnique as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([]);
+
+      await processSyncJob({ name: 'syncLatest', data: { userId: 'user123', provider: 'strava' } });
+
+      expect(mockFetch).not.toHaveBeenCalledWith(
+        expect.stringContaining('/api/v3/activities/123'),
+        expect.anything()
       );
     });
 

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -10,6 +10,7 @@ import { getValidWhoopToken } from '../lib/whoop-token';
 import { getValidSuuntoToken } from '../lib/suunto-token';
 import { deriveLocation, deriveLocationAsync, shouldApplyAutoLocation } from '../lib/location';
 import { extractGarminStartCoords } from '../lib/garmin-coords';
+import { fetchStravaDeviceName } from '../lib/strava-device';
 import { persistGarminStream } from '../lib/ride-stream-store';
 import { fetchGarminActivityFromCallback } from '../lib/garmin-activity-details';
 import { isGarminCyclingActivity } from '../types/garmin';
@@ -70,6 +71,9 @@ type StravaActivity = {
   distance: number;
   total_elevation_gain: number;
   gear_id?: string | null;
+  // Only present on Strava's detailed-activity endpoint, e.g. "Garmin Edge 840".
+  // Used to attribute Strava rides that were recorded on a Garmin device.
+  device_name?: string | null;
   average_heartrate?: number;
   max_heartrate?: number;
   location_city?: string | null;
@@ -253,6 +257,12 @@ async function syncStravaLatest(userId: string): Promise<void> {
   logger.debug({ count: cyclingActivities.length }, '[SyncWorker] Processing cycling activities');
 
   for (const activity of cyclingActivities) {
+    // The list endpoint omits device_name; fetch it best-effort so a ride
+    // recorded on a Garmin device and imported via Strava can still be
+    // attributed to Garmin. A rate-limited lookup just leaves it null.
+    if (activity.device_name == null) {
+      activity.device_name = await fetchStravaDeviceName(accessToken, activity.id);
+    }
     await upsertStravaActivity(userId, activity);
   }
 
@@ -348,6 +358,7 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
         userId,
         stravaActivityId: activity.id.toString(),
         stravaGearId: activity.gear_id ?? null,
+        stravaDeviceName: activity.device_name ?? null,
         startTime,
         durationSeconds: activity.moving_time,
         distanceMeters,
@@ -363,6 +374,10 @@ async function upsertStravaActivity(userId: string, activity: StravaActivity): P
       update: {
         startTime,
         stravaGearId: activity.gear_id ?? null,
+        // Only written when present, never blanked — a re-sync via the list
+        // endpoint (which omits device_name) must not clear a device captured
+        // from a detailed fetch.
+        ...(activity.device_name ? { stravaDeviceName: activity.device_name } : {}),
         durationSeconds: activity.moving_time,
         distanceMeters,
         elevationGainMeters,

--- a/apps/api/src/workers/sync.worker.ts
+++ b/apps/api/src/workers/sync.worker.ts
@@ -256,11 +256,26 @@ async function syncStravaLatest(userId: string): Promise<void> {
 
   logger.debug({ count: cyclingActivities.length }, '[SyncWorker] Processing cycling activities');
 
+  // device_name is only on Strava's detailed activity, not this list, so
+  // capturing it costs one extra call per activity. Pay that only for rides we
+  // have not imported yet (mirrors the backfill route): an already-imported ride
+  // was fetched when it was first seen, so re-fetching on every user-triggered
+  // "sync now" would be pure Strava-quota burn. One batch lookup, not one query
+  // per activity.
+  const existingStravaIds = new Set(
+    (
+      await prisma.ride.findMany({
+        where: {
+          userId,
+          stravaActivityId: { in: cyclingActivities.map((a) => a.id.toString()) },
+        },
+        select: { stravaActivityId: true },
+      })
+    ).map((r) => r.stravaActivityId)
+  );
+
   for (const activity of cyclingActivities) {
-    // The list endpoint omits device_name; fetch it best-effort so a ride
-    // recorded on a Garmin device and imported via Strava can still be
-    // attributed to Garmin. A rate-limited lookup just leaves it null.
-    if (activity.device_name == null) {
+    if (!existingStravaIds.has(activity.id.toString())) {
       activity.device_name = await fetchStravaDeviceName(accessToken, activity.id);
     }
     await upsertStravaActivity(userId, activity);

--- a/apps/web/src/components/RideSourceBadges.tsx
+++ b/apps/web/src/components/RideSourceBadges.tsx
@@ -1,3 +1,4 @@
+import { stravaRecordingDevice } from '@loam/shared';
 import {
   getRideSources,
   getRideSourceLabel,
@@ -29,6 +30,10 @@ export default function RideSourceBadges({
   className?: string;
 }) {
   const sources = getRideSources(ride);
+  // A non-Garmin recording device (Wahoo, phone, ...) Strava reported. Garmin
+  // devices already appear as their own attribution badge, so this only fills
+  // the gap for everything else — shown muted, since it is info, not a badge.
+  const device = stravaRecordingDevice(ride);
 
   return (
     <>
@@ -47,6 +52,9 @@ export default function RideSourceBadges({
           {getRideSourceLabel(ride, source)}
         </span>
       ))}
+      {device && (
+        <span className={['source-device', className].filter(Boolean).join(' ')}>{device}</span>
+      )}
     </>
   );
 }

--- a/apps/web/src/graphql/componentRides.ts
+++ b/apps/web/src/graphql/componentRides.ts
@@ -29,10 +29,12 @@ export const COMPONENT_RIDES = gql`
           # must be attributed wherever its device-sourced data appears (the
           # Garmin API Brand Guidelines require attribution on secondary/detail
           # views, not just primary feeds), and garminDeviceName carries the
-          # sanctioned "Garmin [device model]" label.
+          # sanctioned "Garmin [device model]" label. stravaDeviceName lets a
+          # Strava ride recorded on a Garmin device be attributed to Garmin too.
           garminActivityId
           garminDeviceName
           stravaActivityId
+          stravaDeviceName
           whoopWorkoutId
           suuntoWorkoutId
         }

--- a/apps/web/src/graphql/rides.ts
+++ b/apps/web/src/graphql/rides.ts
@@ -25,6 +25,7 @@ export const RIDES = gql`
       garminActivityId
       garminDeviceName
       stravaActivityId
+      stravaDeviceName
       whoopWorkoutId
       suuntoWorkoutId
       startTime

--- a/apps/web/src/styles/pages/dashboard.css
+++ b/apps/web/src/styles/pages/dashboard.css
@@ -4604,6 +4604,18 @@
   color: #00FF87;
 }
 
+/* Recording device for a non-Garmin Strava ride (e.g. "Wahoo ELEMNT BOLT").
+   Informational, not a provider badge or a compliance attribution, so it reads
+   as muted plain text rather than a colored chip. Garmin devices are shown in
+   their own attribution badge instead. */
+.source-device {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.625rem;
+  letter-spacing: 0.01em;
+  color: var(--concrete);
+}
+
 /* Ride Stats Card Compact */
 .ride-stats-compact {
   flex: 1;

--- a/apps/web/src/utils/rideSource.test.ts
+++ b/apps/web/src/utils/rideSource.test.ts
@@ -142,6 +142,20 @@ describe('getRideSources', () => {
     expect(getRideSources({ suuntoWorkoutId: 'suunto-key' })).toEqual(['suunto']);
   });
 
+  // Garmin's cross-provider requirement: a Strava ride recorded on a Garmin
+  // device must carry a Garmin badge too, even with no garminActivityId.
+  it('adds a Garmin source to a Strava ride recorded on a Garmin device', () => {
+    expect(
+      getRideSources({ stravaActivityId: '123', stravaDeviceName: 'Garmin Edge 840' })
+    ).toEqual(['strava', 'garmin']);
+  });
+
+  it('does not add Garmin to a Strava ride recorded on non-Garmin hardware', () => {
+    expect(
+      getRideSources({ stravaActivityId: '123', stravaDeviceName: 'Wahoo ELEMNT' })
+    ).toEqual(['strava']);
+  });
+
   it('falls back to manual when no provider contributed', () => {
     expect(getRideSources({})).toEqual(['manual']);
     expect(getRideSources({ stravaActivityId: null, garminActivityId: null })).toEqual([
@@ -165,6 +179,14 @@ describe('getRideSourceLabel', () => {
     expect(
       getRideSourceLabel({ garminActivityId: 'abc123', garminDeviceName: null }, 'garmin')
     ).toBe('Garmin');
+  });
+
+  // A Strava-imported ride recorded on a Garmin device is attributed with the
+  // model Strava reported, even though it has no garminActivityId.
+  it('attributes a Garmin-recorded Strava ride with the Strava-reported model', () => {
+    expect(
+      getRideSourceLabel({ stravaActivityId: '1', stravaDeviceName: 'Garmin Edge 840' }, 'garmin')
+    ).toBe('Garmin Edge 840');
   });
 
   it('leaves other providers on their plain platform name', () => {

--- a/apps/web/src/utils/rideSource.ts
+++ b/apps/web/src/utils/rideSource.ts
@@ -2,14 +2,18 @@ import { formatGarminSource, garminSourceDevice, hasGarminData } from '@loam/sha
 
 export type RideSource = 'strava' | 'garmin' | 'whoop' | 'suunto' | 'manual';
 
-export interface RideWithSource {
+// A type alias, not an interface: hasGarminData/stravaRecordingDevice in
+// @loam/shared accept an index-signatured object, and an interface is not
+// assignable to that (it stays open to declaration merging) while a sealed type
+// alias is. See TS "index signature is missing in type" for the rationale.
+export type RideWithSource = {
   stravaActivityId?: string | null;
   garminActivityId?: string | null;
   whoopWorkoutId?: string | null;
   suuntoWorkoutId?: string | null;
   garminDeviceName?: string | null;
   stravaDeviceName?: string | null;
-}
+};
 
 /**
  * The single source to show when a UI can only show one.

--- a/apps/web/src/utils/rideSource.ts
+++ b/apps/web/src/utils/rideSource.ts
@@ -1,4 +1,4 @@
-import { formatGarminSource, hasGarminData } from '@loam/shared';
+import { formatGarminSource, garminSourceDevice, hasGarminData } from '@loam/shared';
 
 export type RideSource = 'strava' | 'garmin' | 'whoop' | 'suunto' | 'manual';
 
@@ -8,6 +8,7 @@ export interface RideWithSource {
   whoopWorkoutId?: string | null;
   suuntoWorkoutId?: string | null;
   garminDeviceName?: string | null;
+  stravaDeviceName?: string | null;
 }
 
 /**
@@ -35,7 +36,11 @@ export function getRideSource(ride: RideWithSource): RideSource {
 export function getRideSources(ride: RideWithSource): RideSource[] {
   const sources: RideSource[] = [];
   if (ride.stravaActivityId) sources.push('strava');
-  if (ride.garminActivityId) sources.push('garmin');
+  // Garmin is attributed wherever its device-sourced data is present, including
+  // a ride recorded on a Garmin device but imported via Strava (hasGarminData
+  // keys on garminActivityId OR a Garmin stravaDeviceName). A cross-provider
+  // ride therefore carries both a Strava and a Garmin badge.
+  if (hasGarminData(ride)) sources.push('garmin');
   if (ride.whoopWorkoutId) sources.push('whoop');
   if (ride.suuntoWorkoutId) sources.push('suunto');
   return sources.length ? sources : ['manual'];
@@ -47,7 +52,11 @@ export function getRideSources(ride: RideWithSource): RideSource[] {
  * uses its plain name.
  */
 export function getRideSourceLabel(ride: RideWithSource, source: RideSource): string {
-  if (source === 'garmin') return formatGarminSource(ride.garminDeviceName);
+  // Resolve the Garmin device from whichever source carries it: Garmin's own
+  // reported model for a native Garmin ride, or Strava's device_name for a ride
+  // recorded on a Garmin device and imported via Strava. Falls back to plain
+  // "Garmin" when no model is known.
+  if (source === 'garmin') return formatGarminSource(garminSourceDevice(ride));
   return SOURCE_LABELS[source];
 }
 

--- a/libs/graphql/src/generated/index.ts
+++ b/libs/graphql/src/generated/index.ts
@@ -138,6 +138,18 @@ export type Bike = {
   buildKind?: Maybe<Scalars['String']['output']>;
   category?: Maybe<Scalars['String']['output']>;
   components: Array<Component>;
+  /**
+   * Providers that contributed the rides behind this bike's component hours,
+   * e.g. ["garmin", "strava"]. Values match Ride source keys.
+   *
+   * Exists so clients can attribute derived data correctly: component wear,
+   * service predictions and the generated maintenance summary are all
+   * materially influenced by ride duration, and the Garmin API Brand
+   * Guidelines require Garmin to be named as a contributing source wherever
+   * that is true — and equally require Garmin branding NOT to appear where
+   * Garmin data is absent. Do not infer this from a single ride's source.
+   */
+  contributingSources: Array<Scalars['String']['output']>;
   createdAt: Scalars['String']['output'];
   family?: Maybe<Scalars['String']['output']>;
   fork?: Maybe<Component>;
@@ -1062,6 +1074,13 @@ export type Ride = {
   rideType: Scalars['String']['output'];
   startTime: Scalars['String']['output'];
   stravaActivityId?: Maybe<Scalars['String']['output']>;
+  /**
+   * Strava's reported recording device (e.g. "Garmin Edge 840"). When it names a
+   * Garmin device, this ride carries Garmin device-sourced data and clients must
+   * render Garmin attribution even though it arrived via Strava (isGarminDevice /
+   * garminSourceDevice in @loam/shared). Null when Strava reported no device.
+   */
+  stravaDeviceName?: Maybe<Scalars['String']['output']>;
   stravaGearId?: Maybe<Scalars['String']['output']>;
   suuntoWorkoutId?: Maybe<Scalars['String']['output']>;
   trailSystem?: Maybe<Scalars['String']['output']>;
@@ -1073,8 +1092,22 @@ export type Ride = {
 
 export type RideTrack = {
   __typename?: 'RideTrack';
+  /**
+   * Garmin device model behind this track, when source is "garmin". Drives the
+   * "Garmin [device model]" attribution the Garmin API Brand Guidelines require
+   * on visuals built from device data. Null for non-Garmin tracks, and for
+   * Garmin tracks where the device was not reported (attribute plain "Garmin").
+   */
+  garminDeviceName?: Maybe<Scalars['String']['output']>;
   points?: Maybe<Array<Array<Scalars['Float']['output']>>>;
   sampledFrom?: Maybe<Scalars['Int']['output']>;
+  /**
+   * Provider that recorded the stored stream ("strava" | "garmin"); null unless
+   * status is AVAILABLE. Lets the client attribute the rendered map to the right
+   * source — a cross-provider ride cannot be attributed from its activity ids
+   * alone, since only one provider's stream is actually persisted.
+   */
+  source?: Maybe<Scalars['String']['output']>;
   status: RideTrackStatus;
 };
 
@@ -1182,6 +1215,14 @@ export type SharedBike = {
 export type SharedBikeHistory = {
   __typename?: 'SharedBikeHistory';
   bike: SharedBike;
+  /**
+   * Providers whose rides contribute to the totals above, e.g. ["garmin"].
+   *
+   * This page is public and unauthenticated, which makes it "downstream data"
+   * under the Garmin API Brand Guidelines — attribution must travel with the
+   * data wherever it is shared. Contains no identifiers, only source names.
+   */
+  contributingSources: Array<Scalars['String']['output']>;
   installs: Array<SharedInstallEvent>;
   serviceEvents: Array<SharedServiceEvent>;
   totals: BikeHistoryTotals;
@@ -1669,7 +1710,7 @@ export type RidesQueryVariables = Exact<{
 }>;
 
 
-export type RidesQuery = { __typename?: 'Query', rides: Array<{ __typename?: 'Ride', id: string, garminActivityId?: string | null, garminDeviceName?: string | null, stravaActivityId?: string | null, whoopWorkoutId?: string | null, suuntoWorkoutId?: string | null, startTime: string, durationSeconds: number, distanceMeters: number, elevationGainMeters: number, averageHr?: number | null, rideType: string, bikeId?: string | null, notes?: string | null, trailSystem?: string | null, location?: string | null }> };
+export type RidesQuery = { __typename?: 'Query', rides: Array<{ __typename?: 'Ride', id: string, garminActivityId?: string | null, garminDeviceName?: string | null, stravaActivityId?: string | null, stravaDeviceName?: string | null, whoopWorkoutId?: string | null, suuntoWorkoutId?: string | null, startTime: string, durationSeconds: number, distanceMeters: number, elevationGainMeters: number, averageHr?: number | null, rideType: string, bikeId?: string | null, notes?: string | null, trailSystem?: string | null, location?: string | null }> };
 
 export type UnmappedStravaGearsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -2424,6 +2465,7 @@ export const RidesDocument = gql`
     garminActivityId
     garminDeviceName
     stravaActivityId
+    stravaDeviceName
     whoopWorkoutId
     suuntoWorkoutId
     startTime

--- a/libs/graphql/src/operations/rides.graphql
+++ b/libs/graphql/src/operations/rides.graphql
@@ -4,6 +4,7 @@ query Rides($take: Int, $after: ID, $filter: RidesFilterInput) {
     garminActivityId
     garminDeviceName
     stravaActivityId
+    stravaDeviceName
     whoopWorkoutId
     suuntoWorkoutId
     startTime

--- a/libs/shared/src/garmin/attribution.test.ts
+++ b/libs/shared/src/garmin/attribution.test.ts
@@ -131,6 +131,20 @@ describe('garminSourceDevice', () => {
     ).toBeUndefined();
   });
 
+  // Cross-provider edge case: native Garmin reported no model, but the same ride
+  // matched on Strava names a Garmin unit — use that specific model.
+  it('uses a matched Strava Garmin model when the native ride reported none', () => {
+    expect(
+      garminSourceDevice({ garminActivityId: 's1', garminDeviceName: null, stravaDeviceName: 'Garmin Edge 840' })
+    ).toBe('Garmin Edge 840');
+  });
+
+  it('stays undefined when the native ride has no model and Strava is non-Garmin', () => {
+    expect(
+      garminSourceDevice({ garminActivityId: 's1', garminDeviceName: null, stravaDeviceName: 'Wahoo ELEMNT' })
+    ).toBeUndefined();
+  });
+
   it('uses the Strava-reported model for a Garmin-recorded Strava ride', () => {
     expect(
       garminSourceDevice({ stravaDeviceName: 'Garmin Edge 840' })

--- a/libs/shared/src/garmin/attribution.test.ts
+++ b/libs/shared/src/garmin/attribution.test.ts
@@ -4,6 +4,7 @@ import {
   hasGarminData,
   isGarminDevice,
   garminSourceDevice,
+  stravaRecordingDevice,
   normalizeGarminDeviceName,
   GARMIN_SOURCE_FALLBACK,
   GARMIN_CHART_ATTRIBUTION,
@@ -141,6 +142,25 @@ describe('garminSourceDevice', () => {
 
   it('is undefined for a non-Garmin Strava ride', () => {
     expect(garminSourceDevice({ stravaDeviceName: 'Wahoo ELEMNT' })).toBeUndefined();
+  });
+});
+
+describe('stravaRecordingDevice', () => {
+  it('returns a non-Garmin device Strava reported, as-is', () => {
+    expect(stravaRecordingDevice({ stravaDeviceName: 'Wahoo ELEMNT BOLT' })).toBe('Wahoo ELEMNT BOLT');
+    expect(stravaRecordingDevice({ stravaDeviceName: '  iPhone 14  ' })).toBe('iPhone 14');
+  });
+
+  // Garmin devices are surfaced as their own attribution badge, not here, so
+  // this must not double them up.
+  it('is undefined for a Garmin device', () => {
+    expect(stravaRecordingDevice({ stravaDeviceName: 'Garmin Edge 840' })).toBeUndefined();
+  });
+
+  it('is undefined when Strava reported no device', () => {
+    for (const input of [null, undefined, '', '   ']) {
+      expect(stravaRecordingDevice({ stravaDeviceName: input })).toBeUndefined();
+    }
   });
 });
 

--- a/libs/shared/src/garmin/attribution.test.ts
+++ b/libs/shared/src/garmin/attribution.test.ts
@@ -2,6 +2,8 @@ import {
   formatGarminSource,
   humanizeGarminDevice,
   hasGarminData,
+  isGarminDevice,
+  garminSourceDevice,
   normalizeGarminDeviceName,
   GARMIN_SOURCE_FALLBACK,
   GARMIN_CHART_ATTRIBUTION,
@@ -94,9 +96,65 @@ describe('normalizeGarminDeviceName', () => {
   });
 });
 
+describe('isGarminDevice', () => {
+  // Strava reports the recorder as its full name, so a leading "Garmin" marks a
+  // ride that was recorded on Garmin hardware and reached us via Strava.
+  it('recognizes a Strava-reported Garmin device', () => {
+    expect(isGarminDevice('Garmin Edge 840')).toBe(true);
+    expect(isGarminDevice('garmin edge 1030')).toBe(true);
+  });
+
+  it('is false for non-Garmin devices and for blanks/sentinels', () => {
+    for (const input of ['Wahoo ELEMNT BOLT', 'iPhone', 'unknown', '', null, undefined]) {
+      expect(isGarminDevice(input)).toBe(false);
+    }
+  });
+
+  // Must not fire on a substring: a device merely containing "garmin" is not the
+  // same as one Strava names as a Garmin unit.
+  it('requires "Garmin" at the start, not merely present', () => {
+    expect(isGarminDevice('NotGarmin 3')).toBe(false);
+  });
+});
+
+describe('garminSourceDevice', () => {
+  it('uses the native Garmin model for a Garmin ride', () => {
+    expect(
+      garminSourceDevice({ garminActivityId: 's1', garminDeviceName: 'edge_840' })
+    ).toBe('edge_840');
+  });
+
+  it('falls back to undefined (plain "Garmin") for a Garmin ride with no model', () => {
+    expect(
+      garminSourceDevice({ garminActivityId: 's1', garminDeviceName: null })
+    ).toBeUndefined();
+  });
+
+  it('uses the Strava-reported model for a Garmin-recorded Strava ride', () => {
+    expect(
+      garminSourceDevice({ stravaDeviceName: 'Garmin Edge 840' })
+    ).toBe('Garmin Edge 840');
+    expect(formatGarminSource(garminSourceDevice({ stravaDeviceName: 'Garmin Edge 840' }))).toBe(
+      'Garmin Edge 840'
+    );
+  });
+
+  it('is undefined for a non-Garmin Strava ride', () => {
+    expect(garminSourceDevice({ stravaDeviceName: 'Wahoo ELEMNT' })).toBeUndefined();
+  });
+});
+
 describe('hasGarminData', () => {
   it('is true whenever a Garmin activity id is present', () => {
     expect(hasGarminData({ garminActivityId: 'summary-1' })).toBe(true);
+  });
+
+  // Garmin's cross-provider requirement: a Strava-imported ride recorded on a
+  // Garmin device carries Garmin data and must be attributed.
+  it('is true for a Strava ride recorded on a Garmin device', () => {
+    expect(
+      hasGarminData({ stravaActivityId: '123', stravaDeviceName: 'Garmin Edge 840' })
+    ).toBe(true);
   });
 
   // Regression guard for the real bug this replaced: getRideSource ranked
@@ -115,6 +173,11 @@ describe('hasGarminData', () => {
   it('is false for non-Garmin rides', () => {
     expect(hasGarminData({ garminActivityId: null })).toBe(false);
     expect(hasGarminData({})).toBe(false);
+    // Strava-only rides on non-Garmin hardware must stay unattributed.
+    expect(hasGarminData({ stravaActivityId: '123', stravaDeviceName: 'Wahoo ELEMNT' })).toBe(
+      false
+    );
+    expect(hasGarminData({ stravaActivityId: '123', stravaDeviceName: null })).toBe(false);
   });
 });
 

--- a/libs/shared/src/garmin/attribution.ts
+++ b/libs/shared/src/garmin/attribution.ts
@@ -203,6 +203,22 @@ export function garminSourceDevice(ride: {
 }
 
 /**
+ * A recording device worth surfacing that is NOT a Garmin unit, i.e. Strava's
+ * reported device_name for a ride recorded on something else (a Wahoo, a phone).
+ * Strava already provides these as display-ready strings, so they are returned
+ * as-is (only trimmed), unlike Garmin's snake_case tokens.
+ *
+ * Returns undefined for a Garmin device (shown as its own attribution badge via
+ * garminSourceDevice) and when Strava reported no device. Purely informational,
+ * not a compliance attribution, so render it muted, not as a provider badge.
+ */
+export function stravaRecordingDevice(ride: { stravaDeviceName?: string | null }): string | undefined {
+  const device = ride.stravaDeviceName?.trim();
+  if (!device || isGarminDevice(device)) return undefined;
+  return device;
+}
+
+/**
  * Whether a ride carries Garmin device-sourced data and therefore requires
  * attribution.
  *

--- a/libs/shared/src/garmin/attribution.ts
+++ b/libs/shared/src/garmin/attribution.ts
@@ -187,17 +187,19 @@ export function isGarminDevice(deviceName?: string | null): boolean {
  * The device model to attribute to Garmin for this ride, or `undefined` when
  * the ride carries no Garmin device-sourced data.
  *
- * Native Garmin rides use Garmin's reported model (which may be absent, so the
- * formatter falls back to plain "Garmin"). A Strava-imported ride recorded on a
- * Garmin device uses the model Strava reported. Feed the result straight into
- * formatGarminSource().
+ * Native Garmin rides use Garmin's reported model. When Garmin reports none but
+ * the same ride was also matched on Strava as a Garmin unit, we use that
+ * specific Strava-reported model rather than the plain "Garmin" fallback. A
+ * Strava-imported ride recorded on a Garmin device likewise uses the Strava
+ * model. Returns undefined only when no model is known anywhere (the formatter
+ * then renders plain "Garmin"). Feed the result straight into formatGarminSource().
  */
 export function garminSourceDevice(ride: {
   garminActivityId?: string | null;
   garminDeviceName?: string | null;
   stravaDeviceName?: string | null;
 }): string | undefined {
-  if (ride.garminActivityId) return ride.garminDeviceName ?? undefined;
+  if (ride.garminActivityId && ride.garminDeviceName) return ride.garminDeviceName;
   if (isGarminDevice(ride.stravaDeviceName)) return ride.stravaDeviceName ?? undefined;
   return undefined;
 }

--- a/libs/shared/src/garmin/attribution.ts
+++ b/libs/shared/src/garmin/attribution.ts
@@ -165,21 +165,62 @@ export function formatGarminSource(deviceName?: string | null): string {
 }
 
 /**
+ * Whether a device-model string names a Garmin device.
+ *
+ * The point is cross-provider attribution: a ride recorded on a Garmin unit,
+ * uploaded to Strava, then imported here still contains Garmin device-sourced
+ * data, and the guidelines require attribution wherever that data is present,
+ * whatever path it took to reach us. Strava reports the recorder as its full
+ * name, e.g. "Garmin Edge 840", so a leading "Garmin" is the signal.
+ *
+ * Only meaningful for a *foreign* device string such as Strava's `device_name`.
+ * Native Garmin rides are recognized by `garminActivityId`, and Garmin's own
+ * API reports models as unprefixed tokens ("edge_840"), so do not run this on
+ * `garminDeviceName`.
+ */
+export function isGarminDevice(deviceName?: string | null): boolean {
+  const device = normalizeGarminDeviceName(deviceName);
+  return device !== undefined && /^garmin\b/i.test(device);
+}
+
+/**
+ * The device model to attribute to Garmin for this ride, or `undefined` when
+ * the ride carries no Garmin device-sourced data.
+ *
+ * Native Garmin rides use Garmin's reported model (which may be absent, so the
+ * formatter falls back to plain "Garmin"). A Strava-imported ride recorded on a
+ * Garmin device uses the model Strava reported. Feed the result straight into
+ * formatGarminSource().
+ */
+export function garminSourceDevice(ride: {
+  garminActivityId?: string | null;
+  garminDeviceName?: string | null;
+  stravaDeviceName?: string | null;
+}): string | undefined {
+  if (ride.garminActivityId) return ride.garminDeviceName ?? undefined;
+  if (isGarminDevice(ride.stravaDeviceName)) return ride.stravaDeviceName ?? undefined;
+  return undefined;
+}
+
+/**
  * Whether a ride carries Garmin device-sourced data and therefore requires
  * attribution.
  *
- * Deliberately keyed on the presence of garminActivityId rather than on a
- * single "primary source" ranking: a ride matched across providers still
- * contains Garmin-sourced data, and the guidelines require attribution
- * wherever that data is present. The inverse matters just as much — the
- * guidelines forbid Garmin branding "in instances where Garmin device-sourced
- * data is not present", so this must stay false for Strava-only and manual rides.
+ * True when the ride came from Garmin directly (garminActivityId), OR when it
+ * came from another platform but was recorded on a Garmin device (Strava's
+ * device_name begins with "Garmin"). A ride matched across providers still
+ * contains Garmin-sourced data, and the guidelines require attribution wherever
+ * that data is present. The inverse matters just as much — the guidelines forbid
+ * Garmin branding "in instances where Garmin device-sourced data is not
+ * present", so this stays false for Strava-only (non-Garmin device) and manual
+ * rides.
  */
 export function hasGarminData(ride: {
   garminActivityId?: string | null;
+  stravaDeviceName?: string | null;
   // Callers pass full ride objects; the index signature keeps TypeScript's
   // excess-property check from rejecting the other provider ids.
   [key: string]: unknown;
 }): boolean {
-  return Boolean(ride.garminActivityId);
+  return Boolean(ride.garminActivityId) || isGarminDevice(ride.stravaDeviceName);
 }


### PR DESCRIPTION
## Why

Garmin's response to our production-key submission: **"If Strava data originated from a Garmin device, it must be identified as well."** The brand guidelines require attribution wherever Garmin device-sourced data is present, including a ride recorded on a Garmin unit, uploaded to Strava, then imported here. Previously such a ride showed only a **Strava** badge, because attribution keyed solely on `garminActivityId`.

## What

- **Capture** Strava's `device_name` (e.g. "Garmin Edge 840", a detailed-activity field) into the new `Ride.stravaDeviceName` column across every ingestion path:
  - Strava webhook + single-activity sync already fetch the detailed activity, so it's free there.
  - `syncStravaLatest` and the backfill route use the list endpoint (no `device_name`), so they now fetch the detail **best-effort** via `lib/strava-device.ts` (a rate-limited lookup just leaves it null; the ride still imports).
- **Attribution logic** in `@loam/shared`: new `isGarminDevice()` and `garminSourceDevice()`; `hasGarminData()` now returns true for a Strava ride whose `device_name` names a Garmin unit. Web (`rideSource`) and mobile (`garminAttribution`, `RideListItem`, `ComponentRideRow`) render the Garmin badge and "Garmin [device model]" label off these. A cross-provider ride now shows **both** Strava and Garmin.
- **GraphQL**: expose `stravaDeviceName` on `Ride` (schema + rides/componentRides operations); committed generated types regenerated for web and mobile from the local schema.
- **Migration** adds the nullable column; not backfilled, older rides fill in on their next detailed sync.

## Tests

- Shared: `isGarminDevice`, `garminSourceDevice`, and extended `hasGarminData` (32 pass).
- Web: `getRideSources`/`getRideSourceLabel` cross-provider cases (37 pass).
- API: Strava upsert paths via `sync.worker.test` (51 pass). Full API typecheck clean.

## Flow

Targets `staging` (now up to date with `main`); staging then PRs into `main`. The `normalizeGarminDeviceName` dependency from #285 is already merged to main, so this diff is the feature alone. Mobile mirror: loam-logger-mobile #63 (into main).

## ⚠️ Negative-control note

This changes what counts as a Garmin ride. The submission's negative control #24 must use a Strava ride recorded on **non-Garmin** hardware (phone/Wahoo); a Garmin-recorded Strava ride will now correctly show Garmin attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)