### PR TITLE
fix(api): route Garmin OAuth deep link by slug, not brand label

### DIFF
--- a/apps/api/src/lib/oauthCompletionPage.test.ts
+++ b/apps/api/src/lib/oauthCompletionPage.test.ts
@@ -1,0 +1,63 @@
+import { renderOAuthCompletionPage } from './oauthCompletionPage';
+
+describe('renderOAuthCompletionPage', () => {
+  it('builds the deep link path from providerSlug, not the display label', () => {
+    // Regression: the Garmin brand label "Garmin Connect™" was previously fed
+    // straight into the deep link path via provider.toLowerCase(), producing
+    // `loamlogger://oauth/garmin connect™`. The space + ™ got (double) URL
+    // encoded and matched no Expo route, dumping the user on "Unmatched Route".
+    const html = renderOAuthCompletionPage({
+      provider: 'Garmin Connect™',
+      providerSlug: 'garmin',
+      status: 'success',
+      scheme: 'loamlogger',
+      brandColor: '#007DC3',
+    });
+
+    // Path must stay `garmin` — app/oauth/garmin.tsx is what receives this.
+    expect(html).toContain('loamlogger://oauth/garmin?status=success');
+    // The display label may still appear in the copy, but never in the path.
+    expect(html).not.toContain('oauth/garmin connect');
+    expect(html).not.toContain('oauth/garmin%20connect');
+  });
+
+  it('keeps the display label in the visible page copy', () => {
+    const html = renderOAuthCompletionPage({
+      provider: 'Garmin Connect™',
+      providerSlug: 'garmin',
+      status: 'success',
+      scheme: 'loamlogger',
+      brandColor: '#007DC3',
+    });
+
+    expect(html).toContain('Garmin Connect™ Connected!');
+  });
+
+  it('honors a custom deep link scheme', () => {
+    const html = renderOAuthCompletionPage({
+      provider: 'Strava',
+      providerSlug: 'strava',
+      status: 'success',
+      scheme: 'llstaging',
+      brandColor: '#fc4c02',
+    });
+
+    expect(html).toContain('llstaging://oauth/strava?status=success');
+  });
+
+  it('appends reason and extra params to the deep link query', () => {
+    const html = renderOAuthCompletionPage({
+      provider: 'Strava',
+      providerSlug: 'strava',
+      status: 'error',
+      reason: 'token_exchange_failed',
+      scheme: 'loamlogger',
+      brandColor: '#fc4c02',
+      extraParams: { prompt: 'reauth' },
+    });
+
+    expect(html).toContain('loamlogger://oauth/strava?status=error');
+    expect(html).toContain('reason=token_exchange_failed');
+    expect(html).toContain('prompt=reauth');
+  });
+});

--- a/apps/api/src/lib/oauthCompletionPage.ts
+++ b/apps/api/src/lib/oauthCompletionPage.ts
@@ -13,16 +13,25 @@ function escapeHtml(s: string): string {
  * after an OAuth callback completes. Used by both Garmin and Strava routes.
  */
 export function renderOAuthCompletionPage(params: {
+  /** Human-readable label shown in the page copy (e.g. "Garmin Connect™"). */
   provider: string;
+  /**
+   * URL-safe routing slug for the deep link path (e.g. "garmin"). This MUST
+   * match the mobile route file at app/oauth/<slug>.tsx. Keep it separate from
+   * `provider`: brand guidelines can force the display label to contain spaces
+   * or symbols ("Garmin Connect™") that are invalid in a route segment and
+   * would land the user on the app's Unmatched Route screen.
+   */
+  providerSlug: string;
   status: string;
   reason?: string;
   scheme: string;
   brandColor: string;
   extraParams?: Record<string, string>;
 }): string {
-  const { provider, status, reason, scheme, brandColor, extraParams } = params;
+  const { provider, providerSlug, status, reason, scheme, brandColor, extraParams } = params;
 
-  const deepLinkPath = `${scheme}://oauth/${provider.toLowerCase()}`;
+  const deepLinkPath = `${scheme}://oauth/${providerSlug}`;
   const queryParams = new URLSearchParams({ status });
   if (reason) queryParams.set('reason', reason);
   if (extraParams) {

--- a/apps/api/src/routes/auth.garmin.ts
+++ b/apps/api/src/routes/auth.garmin.ts
@@ -349,8 +349,11 @@ r.get('/garmin/mobile/complete', (req: Request, res: Response) => {
   res.send(renderOAuthCompletionPage({
     // Full app name, not "Garmin" — the Garmin API Brand Guidelines forbid
     // abbreviating or truncating it when displaying the connection, and this
-    // page is part of the connect flow a brand reviewer walks through.
+    // page is part of the connect flow a brand reviewer walks through. This is
+    // display copy ONLY; the deep link path comes from providerSlug below.
     provider: 'Garmin Connect™',
+    // Must stay `garmin` — app/oauth/garmin.tsx is what receives this deep link.
+    providerSlug: 'garmin',
     status,
     reason,
     scheme,

--- a/apps/api/src/routes/auth.strava.ts
+++ b/apps/api/src/routes/auth.strava.ts
@@ -371,6 +371,7 @@ r.get('/strava/mobile/complete', (req: Request, res: Response) => {
 
   res.send(renderOAuthCompletionPage({
     provider: 'Strava',
+    providerSlug: 'strava',
     status,
     reason,
     scheme,

--- a/apps/api/src/routes/auth.suunto.ts
+++ b/apps/api/src/routes/auth.suunto.ts
@@ -404,6 +404,7 @@ r.get('/suunto/mobile/complete', (req: Request, res: Response) => {
 
   res.send(renderOAuthCompletionPage({
     provider: 'Suunto',
+    providerSlug: 'suunto',
     status,
     reason,
     scheme,

--- a/apps/api/src/routes/auth.whoop.ts
+++ b/apps/api/src/routes/auth.whoop.ts
@@ -406,6 +406,7 @@ r.get('/whoop/mobile/complete', (req: Request, res: Response) => {
 
   res.send(renderOAuthCompletionPage({
     provider: 'WHOOP',
+    providerSlug: 'whoop',
     status,
     reason,
     scheme,


### PR DESCRIPTION
## Problem

A user completed Garmin OAuth successfully but was dropped on the app's **Unmatched Route** screen instead of returning to Loam Logger. The deep link that failed:

```
loamlogger://oauth/garmin%2520connect%25E2%2584%25A2?status=success
```

Decoding the (double URL-encoded) path segment: `%2520` → space, `%25E2%2584%25A2` → `™`, i.e. the app was routed to `oauth/Garmin Connect™`. The app only has a route at `app/oauth/garmin.tsx`, so nothing matched. The `status=success` confirms the OAuth itself worked; only the redirect target was malformed.

## Root cause

`renderOAuthCompletionPage` built the deep link path from the provider **display label** via `provider.toLowerCase()`. For Strava/WHOOP/Suunto the label lowercases into a valid route, so they worked. The `garmin/attribution-brand-rules` change set Garmin's label to `"Garmin Connect™"` (brand-guideline compliance) while that same field was doubling as the routing key, producing `garmin connect™`, whose space and `™` get URL-encoded and match no route. **Garmin only.**

## Fix

- `renderOAuthCompletionPage` now takes an explicit `providerSlug` for the deep link path; `provider` is display-only copy.
- Garmin keeps the `"Garmin Connect™"` label and routes on `providerSlug: 'garmin'`.
- Strava/WHOOP/Suunto pass explicit slugs so a future label change can't silently break routing again.
- New `oauthCompletionPage.test.ts` locks the invariant that the brand label never leaks into the deep link path.

## Impact / rollout

Server-side only. Takes effect on the next Railway API deploy: **no mobile release required** and existing installs need no update. Users who hit this can just retry the Garmin connection after deploy.

## Testing

- New `oauthCompletionPage` unit tests: 4 passing.
- Existing `auth.whoop` suite (other consumer of the renderer): 65 passing.
- `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
