### PR TITLE
Release: unassigned-ride resolution and unowned-bike support (API)

### DIFF
--- a/apps/api/prisma/migrations/20260804210000_add_ride_unowned_bike/migration.sql
+++ b/apps/api/prisma/migrations/20260804210000_add_ride_unowned_bike/migration.sql
@@ -1,0 +1,15 @@
+-- Marks a ride as ridden on a bike the rider does not own: a demo, a loaner, a
+-- rental, a friend's bike. Always paired with a NULL bikeId.
+--
+-- Adds no behavior to the component-hour math. A ride with no bikeId already
+-- credits no component (syncBikeComponentHours no-ops when bikeId is null on
+-- both sides), so this column records intent rather than changing accounting.
+-- Its job is to separate "not my bike" from "not assigned yet": without it the
+-- two are indistinguishable, and an unowned ride is counted by
+-- unassignedRideCount and prompted forever by "N rides need a bike".
+--
+-- NOT NULL with a false default, so every existing row keeps today's meaning
+-- (unassigned rides stay unassigned and stay prompted). No backfill: the rider
+-- is the only one who knows which of their unassigned rides were on someone
+-- else's bike.
+ALTER TABLE "Ride" ADD COLUMN "unownedBike" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -122,6 +122,17 @@ model Ride {
   trailSystem             String?
   duplicateOfId           String?
   isDuplicate             Boolean                   @default(false)
+  // Ridden on a bike the rider does not own: a demo, a loaner, a rental, a
+  // friend's bike. Always paired with a NULL bikeId, and the resolvers keep the
+  // two in sync (assigning a bike clears this; setting this clears the bike).
+  //
+  // The wear math needs no special case for it: with no bikeId the ride already
+  // credits no component. What this column adds is intent. Without it an
+  // unowned ride is indistinguishable from one still waiting to be assigned, so
+  // it would be counted by unassignedRideCount and nagged forever by the
+  // "N rides need a bike" prompt. The ride still counts toward ride stats,
+  // streaks and insights, because the rider did ride it.
+  unownedBike             Boolean                   @default(false)
   // Garmin Activity Summary `deviceName`. Required by the Garmin API Brand
   // Guidelines: every surface showing Garmin data must attribute
   // "Garmin [device model]". NULL is expected and legal — rides imported

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -4820,6 +4820,40 @@ describe('GraphQL Resolvers', () => {
       expect(groupByCall.where.ride.bikeId).toBe('bike-mine');
     });
 
+    /**
+     * Regression: this resolver spelled the unassigned predicate out by hand as
+     * `bikeId: null` alone, so a demo or loaner ride the rider had already
+     * marked `unownedBike` was swept into these totals while the identical
+     * filter excluded it from `rides` and `unassignedRideCount`. One filter
+     * value meant two different things depending on where it was sent.
+     */
+    it('excludes unowned-bike rides from the unassigned filter, like Query.rides does', async () => {
+      mockGroupBy.mockResolvedValueOnce([]);
+      mockRideCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+
+      await resolver({ id: 'user-123' }, { filter: { unassigned: true } }, createMockContext() as never);
+
+      const rideWhere = mockGroupBy.mock.calls[0][0].where.ride;
+      expect(rideWhere.bikeId).toBeNull();
+      expect(rideWhere.unownedBike).toBe(false);
+      // The two count queries read the same clause object.
+      expect(mockRideCount.mock.calls[1][0].where).toEqual(
+        expect.objectContaining({ bikeId: null, unownedBike: false })
+      );
+    });
+
+    it('rejects a filter setting both bikeId and unassigned', async () => {
+      await expect(
+        resolver(
+          { id: 'user-123' },
+          { filter: { bikeId: 'bike-mine', unassigned: true } },
+          createMockContext() as never
+        )
+      ).rejects.toThrow('Filter cannot set both `bikeId` and `unassigned: true`');
+
+      expect(mockGroupBy).not.toHaveBeenCalled();
+    });
+
     it('logs and skips an unknown condition value (schema drift safety)', async () => {
       // If a future migration adds a WeatherCondition enum value before the
       // resolver's local `breakdown` object is updated, the groupBy result

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -2115,6 +2115,72 @@ describe('GraphQL Resolvers', () => {
       );
       expect(result).toEqual(mockRides);
     });
+
+    it('should select only rides with no bike when unassigned is set', async () => {
+      const ctx = createMockContext('user-123');
+      mockPrisma.ride.findMany.mockResolvedValue([] as never);
+
+      await query({}, { take: 10, filter: { unassigned: true } }, ctx as never);
+
+      // No ownership check to make: the clause is already scoped to the viewer.
+      // `unownedBike: false` keeps demo and loaner rides out — they have no
+      // bike by intent, not because the rider still owes an answer.
+      expect(mockPrisma.bike.findUnique).not.toHaveBeenCalled();
+      expect(mockPrisma.ride.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: 'user-123', bikeId: null, unownedBike: false },
+        })
+      );
+    });
+
+    it('should ignore unassigned:false rather than filtering on it', async () => {
+      const ctx = createMockContext('user-123');
+      mockPrisma.ride.findMany.mockResolvedValue([] as never);
+
+      await query({}, { take: 10, filter: { unassigned: false } }, ctx as never);
+
+      expect(mockPrisma.ride.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: 'user-123' },
+        })
+      );
+    });
+
+    it('should reject a filter setting both bikeId and unassigned', async () => {
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        query({}, { take: 10, filter: { bikeId: 'bike-1', unassigned: true } }, ctx as never)
+      ).rejects.toThrow('Filter cannot set both `bikeId` and `unassigned: true`');
+
+      // Rejected before any read, so a contradictory filter can never be
+      // silently resolved one way or the other.
+      expect(mockPrisma.bike.findUnique).not.toHaveBeenCalled();
+      expect(mockPrisma.ride.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Query.unassignedRideCount', () => {
+    const query = resolvers.Query.unassignedRideCount;
+
+    it("should count the viewer's rides that have no bike", async () => {
+      const ctx = createMockContext('user-123');
+      mockPrisma.ride.count.mockResolvedValue(4 as never);
+
+      const result = await query({}, {}, ctx as never);
+
+      expect(mockPrisma.ride.count).toHaveBeenCalledWith({
+        where: { userId: 'user-123', bikeId: null, unownedBike: false },
+      });
+      expect(result).toBe(4);
+    });
+
+    it('should throw when unauthenticated', async () => {
+      const ctx = createMockContext(null);
+
+      await expect(query({}, {}, ctx as never)).rejects.toThrow();
+      expect(mockPrisma.ride.count).not.toHaveBeenCalled();
+    });
   });
 
   // =========================================================================
@@ -5584,6 +5650,109 @@ describe('GraphQL Resolvers', () => {
       const invalidatedBikes = mockInvalidate.mock.calls.map((c: unknown[]) => c[1]);
       expect(invalidatedBikes).toContain('bike-1');
       expect(invalidatedBikes).toContain('bike-2');
+    });
+  });
+
+  describe('Mutation.updateRide unowned-bike handling', () => {
+    const mutation = resolvers.Mutation.updateRide;
+
+    /** tx double covering the writes updateRide performs. */
+    const makeTx = () => ({
+      ride: {
+        update: jest.fn().mockResolvedValue({ id: 'ride-1' }),
+        aggregate: jest.fn().mockResolvedValue({ _sum: { durationSeconds: 0 }, _count: 0 }),
+      },
+      component: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+        update: jest.fn().mockResolvedValue({}),
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+      serviceLog: { findFirst: jest.fn().mockResolvedValue(null) },
+      componentRideAdjustment: { findMany: jest.fn().mockResolvedValue([]) },
+    });
+
+    beforeEach(() => {
+      mockCheckMutationRateLimit.mockResolvedValue({ allowed: true, retryAfter: 0 });
+    });
+
+    /**
+     * The case that actually moves numbers. A rider who mis-assigned a demo
+     * ride to their own bike inflated that bike's component wear; marking it
+     * unowned has to hand those hours back, not merely set a flag.
+     */
+    it('detaches the bike and returns its hours when a ride is marked unowned', async () => {
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue({
+        userId: 'user-123', durationSeconds: 3600, bikeId: 'bike-1',
+      });
+      const tx = makeTx();
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation(
+        {}, { id: 'ride-1', input: { unownedBike: true } }, createMockContext('user-123') as never
+      );
+
+      expect(tx.ride.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ bikeId: null, unownedBike: true }),
+        })
+      );
+      // One hour comes back off bike-1's components.
+      expect(tx.component.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ userId: 'user-123', bikeId: 'bike-1' }),
+          data: { hoursUsed: { decrement: 1 } },
+        })
+      );
+    });
+
+    it('clears the unowned flag when a bike is assigned', async () => {
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue({
+        userId: 'user-123', durationSeconds: 3600, bikeId: null,
+      });
+      (prisma.bike.findUnique as jest.Mock).mockResolvedValue({ userId: 'user-123' });
+      const tx = makeTx();
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation(
+        {}, { id: 'ride-1', input: { bikeId: 'bike-9' } }, createMockContext('user-123') as never
+      );
+
+      expect(tx.ride.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ bikeId: 'bike-9', unownedBike: false }),
+        })
+      );
+    });
+
+    it('rejects an input setting both a bikeId and unownedBike', async () => {
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue({
+        userId: 'user-123', durationSeconds: 3600, bikeId: null,
+      });
+      (prisma.bike.findUnique as jest.Mock).mockResolvedValue({ userId: 'user-123' });
+
+      await expect(
+        mutation(
+          {},
+          { id: 'ride-1', input: { bikeId: 'bike-9', unownedBike: true } },
+          createMockContext('user-123') as never
+        )
+      ).rejects.toThrow('A ride cannot have both a bikeId and unownedBike: true');
+    });
+
+    it('leaves the flag alone when the input does not mention it', async () => {
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue({
+        userId: 'user-123', durationSeconds: 3600, bikeId: 'bike-1',
+      });
+      const tx = makeTx();
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation(
+        {}, { id: 'ride-1', input: { notes: 'chunky' } }, createMockContext('user-123') as never
+      );
+
+      const data = tx.ride.update.mock.calls[0][0].data;
+      expect(data).not.toHaveProperty('unownedBike');
+      expect(data).not.toHaveProperty('bikeId');
     });
   });
 });

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -5789,4 +5789,148 @@ describe('GraphQL Resolvers', () => {
       expect(data).not.toHaveProperty('bikeId');
     });
   });
+
+  describe('Mutation.assignBikeToRides', () => {
+    const mutation = resolvers.Mutation.assignBikeToRides;
+
+    const makeTx = () => ({
+      ride: {
+        updateMany: jest.fn().mockResolvedValue({ count: 2 }),
+        aggregate: jest.fn().mockResolvedValue({ _sum: { durationSeconds: 0 }, _count: 0 }),
+      },
+      component: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+        update: jest.fn().mockResolvedValue({}),
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+      serviceLog: { findFirst: jest.fn().mockResolvedValue(null) },
+      componentRideAdjustment: { findMany: jest.fn().mockResolvedValue([]) },
+    });
+
+    beforeEach(() => {
+      mockCheckMutationRateLimit.mockResolvedValue({ allowed: true, retryAfter: 0 });
+      (prisma.bike.findUnique as jest.Mock).mockResolvedValue({ userId: 'user-123' });
+    });
+
+    it('clears unownedBike on the rides it assigns', async () => {
+      (prisma.ride.findMany as jest.Mock).mockResolvedValue([
+        { id: 'ride-1', userId: 'user-123', bikeId: null, durationSeconds: 3600 },
+        { id: 'ride-2', userId: 'user-123', bikeId: null, durationSeconds: 1800 },
+      ]);
+      const tx = makeTx();
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation(
+        {},
+        { rideIds: ['ride-1', 'ride-2'], bikeId: 'bike-9' },
+        createMockContext('user-123') as never
+      );
+
+      expect(tx.ride.updateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['ride-1', 'ride-2'] } },
+        data: { bikeId: 'bike-9', unownedBike: false },
+      });
+      // 1.5h total credited to the target bike's components.
+      expect(tx.component.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ userId: 'user-123', bikeId: 'bike-9' }),
+          data: { hoursUsed: { increment: 1.5 } },
+        })
+      );
+    });
+
+    /**
+     * Documents a deliberate asymmetry rather than asserting a guard that
+     * isn't there: eligibility is "has no bike", so a ride previously marked
+     * unowned CAN be reclaimed in bulk, and doing so clears the flag. That
+     * matches updateRide, and in practice these rides never reach here because
+     * `unassignedRides` excludes them from the client's selection. Callers
+     * assembling their own rideIds (the pending web mass-assign modal) have to
+     * preserve that filtering themselves.
+     */
+    it('reclaims a ride previously marked unowned, clearing the flag', async () => {
+      (prisma.ride.findMany as jest.Mock).mockResolvedValue([
+        { id: 'ride-demo', userId: 'user-123', bikeId: null, durationSeconds: 3600 },
+      ]);
+      const tx = makeTx();
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation(
+        {}, { rideIds: ['ride-demo'], bikeId: 'bike-9' }, createMockContext('user-123') as never
+      );
+
+      expect(tx.ride.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { bikeId: 'bike-9', unownedBike: false } })
+      );
+    });
+
+    it('refuses to reassign a ride that already has a bike', async () => {
+      (prisma.ride.findMany as jest.Mock).mockResolvedValue([
+        { id: 'ride-1', userId: 'user-123', bikeId: 'bike-existing', durationSeconds: 3600 },
+      ]);
+
+      await expect(
+        mutation({}, { rideIds: ['ride-1'], bikeId: 'bike-9' }, createMockContext('user-123') as never)
+      ).rejects.toThrow('One or more rides already have a bike assigned');
+
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("refuses to assign another user's ride", async () => {
+      (prisma.ride.findMany as jest.Mock).mockResolvedValue([
+        { id: 'ride-1', userId: 'someone-else', bikeId: null, durationSeconds: 3600 },
+      ]);
+
+      await expect(
+        mutation({}, { rideIds: ['ride-1'], bikeId: 'bike-9' }, createMockContext('user-123') as never)
+      ).rejects.toThrow('Unauthorized');
+
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Mutation.updateRide unowned-bike trailing case', () => {
+    const mutation = resolvers.Mutation.updateRide;
+
+    const makeTx = () => ({
+      ride: {
+        update: jest.fn().mockResolvedValue({ id: 'ride-1' }),
+        aggregate: jest.fn().mockResolvedValue({ _sum: { durationSeconds: 0 }, _count: 0 }),
+      },
+      component: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+        update: jest.fn().mockResolvedValue({}),
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+      serviceLog: { findFirst: jest.fn().mockResolvedValue(null) },
+      componentRideAdjustment: { findMany: jest.fn().mockResolvedValue([]) },
+    });
+
+    beforeEach(() => {
+      mockCheckMutationRateLimit.mockResolvedValue({ allowed: true, retryAfter: 0 });
+    });
+
+    /**
+     * Un-marking a ride the rider had called someone else's. It goes back to
+     * plain unassigned rather than onto a bike, so no hours move and the
+     * "N rides need a bike" prompt correctly picks it up again.
+     */
+    it('clears the flag without moving hours when unownedBike is set false', async () => {
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue({
+        userId: 'user-123', durationSeconds: 3600, bikeId: null,
+      });
+      const tx = makeTx();
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation(
+        {}, { id: 'ride-1', input: { unownedBike: false } }, createMockContext('user-123') as never
+      );
+
+      const data = tx.ride.update.mock.calls[0][0].data;
+      expect(data.unownedBike).toBe(false);
+      // No bike named, so nothing to credit or debit.
+      expect(data).not.toHaveProperty('bikeId');
+      expect(tx.component.updateMany).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -892,6 +892,25 @@ function assertCoherentBikeFilter(filter?: RidesFilterInput | null): void {
   }
 }
 
+/**
+ * The canonical "still waiting on a bike" predicate.
+ *
+ * `bikeId: null` on its own is NOT it. A demo, loaner or rental ride marked
+ * `unownedBike` also has no bike, but by intent rather than omission, and
+ * counting it as outstanding is what the flag exists to prevent.
+ *
+ * Kept as one constant because the two halves drifted the moment they were
+ * written out by hand in more than one place: weatherBreakdown was left
+ * matching on `bikeId` alone and swept unowned rides into totals that
+ * `rides` and `unassignedRideCount` correctly excluded. Spread this rather
+ * than restating it.
+ *
+ * The one copy this cannot cover is the raw SQL in
+ * services/import-session-checker.service.ts, which spells the same predicate
+ * out in its COUNT and has to be updated alongside.
+ */
+const UNASSIGNED_RIDE_WHERE = { bikeId: null, unownedBike: false } as const;
+
 type RidesArgs = {
   take?: number;
   after?: string | null;
@@ -1061,12 +1080,9 @@ export const resolvers = {
       }
 
       // Rides still waiting on a bike. Needs no ownership check of its own:
-      // the clause is already scoped to the viewer's userId. Rides the rider
-      // marked as someone else's bike are excluded — they have no bike by
-      // intent, and listing them here would ask a question already answered.
+      // the clause is already scoped to the viewer's userId.
       if (filter?.unassigned) {
-        whereClause.bikeId = null;
-        whereClause.unownedBike = false;
+        Object.assign(whereClause, UNASSIGNED_RIDE_WHERE);
       }
 
       return prisma.ride.findMany({
@@ -1227,7 +1243,7 @@ export const resolvers = {
 
       // Get current unassigned count (may have changed since session completed)
       const currentUnassignedCount = await prisma.ride.count({
-        where: { importSessionId: session.id, bikeId: null, unownedBike: false },
+        where: { importSessionId: session.id, ...UNASSIGNED_RIDE_WHERE },
       });
 
       return {
@@ -1267,7 +1283,7 @@ export const resolvers = {
 
       const [rides, totalCount] = await Promise.all([
         prisma.ride.findMany({
-          where: { importSessionId, bikeId: null, unownedBike: false },
+          where: { importSessionId, ...UNASSIGNED_RIDE_WHERE },
           orderBy: { startTime: 'desc' },
           take: limit + 1, // Fetch one extra to check if there's more
           ...(after ? { skip: 1, cursor: { id: after } } : {}),
@@ -1281,7 +1297,7 @@ export const resolvers = {
             rideType: true,
           },
         }),
-        prisma.ride.count({ where: { importSessionId, bikeId: null, unownedBike: false } }),
+        prisma.ride.count({ where: { importSessionId, ...UNASSIGNED_RIDE_WHERE } }),
       ]);
 
       const hasMore = rides.length > limit;
@@ -1306,9 +1322,10 @@ export const resolvers = {
      */
     unassignedRideCount: async (_: unknown, __: unknown, ctx: GraphQLContext) => {
       const userId = requireUserId(ctx);
-      // `unownedBike: false` is what stops this from nagging forever. A demo or
-      // loaner ride also has no bikeId, but it is finished business.
-      return prisma.ride.count({ where: { userId, bikeId: null, unownedBike: false } });
+      // The `unownedBike: false` half of the predicate is what stops this from
+      // nagging forever: a demo or loaner ride also has no bikeId, but it is
+      // finished business.
+      return prisma.ride.count({ where: { userId, ...UNASSIGNED_RIDE_WHERE } });
     },
 
     calibrationState: async (_: unknown, __: unknown, ctx: GraphQLContext) => {
@@ -6387,8 +6404,12 @@ export const resolvers = {
         rideWhere.bikeId = filter.bikeId;
       }
 
+      // Same predicate as Query.rides, from the same constant. Spelled out by
+      // hand this drifted: it matched on bikeId alone, so a demo or loaner
+      // ride still landed in these totals while being excluded everywhere
+      // else the identical filter was sent.
       if (filter?.unassigned) {
-        rideWhere.bikeId = null;
+        Object.assign(rideWhere, UNASSIGNED_RIDE_WHERE);
       }
 
       const [grouped, pending, totalRides] = await Promise.all([

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -66,6 +66,7 @@ type AddRideInput = {
   averageHr?: number | null;
   rideType: string;
   bikeId?: string | null;
+  unownedBike?: boolean | null;
   notes?: string | null;
   trailSystem?: string | null;
   location?: string | null;
@@ -79,6 +80,7 @@ type UpdateRideInput = {
   averageHr?: number | null;
   rideType?: string | null;
   bikeId?: string | null;
+  unownedBike?: boolean | null;
   notes?: string | null;
   trailSystem?: string | null;
   location?: string | null;
@@ -873,7 +875,22 @@ type RidesFilterInput = {
   startDate?: string | null;
   endDate?: string | null;
   bikeId?: string | null;
+  unassigned?: boolean | null;
 };
+
+/**
+ * `unassigned: true` and `bikeId` select disjoint sets, so a filter carrying
+ * both is a caller mistake rather than something to quietly resolve one way.
+ * Shared by every consumer of RidesFilterInput so the input means the same
+ * thing wherever it is accepted.
+ */
+function assertCoherentBikeFilter(filter?: RidesFilterInput | null): void {
+  if (filter?.unassigned && filter.bikeId) {
+    throw new GraphQLError('Filter cannot set both `bikeId` and `unassigned: true`', {
+      extensions: { code: 'BAD_USER_INPUT' },
+    });
+  }
+}
 
 type RidesArgs = {
   take?: number;
@@ -1009,6 +1026,7 @@ export const resolvers = {
     rides: async (_: unknown, { take = 1000, after, filter }: RidesArgs, ctx: GraphQLContext) => {
       if (!ctx.user?.id) throw new Error('Unauthorized');
       const limit = Math.min(10000, Math.max(1, take));
+      assertCoherentBikeFilter(filter);
 
       const whereClause: Prisma.RideWhereInput = {
         userId: ctx.user.id,
@@ -1040,6 +1058,15 @@ export const resolvers = {
         }
 
         whereClause.bikeId = filter.bikeId;
+      }
+
+      // Rides still waiting on a bike. Needs no ownership check of its own:
+      // the clause is already scoped to the viewer's userId. Rides the rider
+      // marked as someone else's bike are excluded — they have no bike by
+      // intent, and listing them here would ask a question already answered.
+      if (filter?.unassigned) {
+        whereClause.bikeId = null;
+        whereClause.unownedBike = false;
       }
 
       return prisma.ride.findMany({
@@ -1200,7 +1227,7 @@ export const resolvers = {
 
       // Get current unassigned count (may have changed since session completed)
       const currentUnassignedCount = await prisma.ride.count({
-        where: { importSessionId: session.id, bikeId: null },
+        where: { importSessionId: session.id, bikeId: null, unownedBike: false },
       });
 
       return {
@@ -1240,7 +1267,7 @@ export const resolvers = {
 
       const [rides, totalCount] = await Promise.all([
         prisma.ride.findMany({
-          where: { importSessionId, bikeId: null },
+          where: { importSessionId, bikeId: null, unownedBike: false },
           orderBy: { startTime: 'desc' },
           take: limit + 1, // Fetch one extra to check if there's more
           ...(after ? { skip: 1, cursor: { id: after } } : {}),
@@ -1254,7 +1281,7 @@ export const resolvers = {
             rideType: true,
           },
         }),
-        prisma.ride.count({ where: { importSessionId, bikeId: null } }),
+        prisma.ride.count({ where: { importSessionId, bikeId: null, unownedBike: false } }),
       ]);
 
       const hasMore = rides.length > limit;
@@ -1268,6 +1295,20 @@ export const resolvers = {
         totalCount,
         hasMore,
       };
+    },
+
+    /**
+     * Unassigned rides across the rider's whole history, not scoped to an
+     * import session the way `unassignedRides` is. A ride with no bike credits
+     * its duration to no component at all, so this is the size of the gap
+     * between what the rider actually rode and what their service predictions
+     * are computed from.
+     */
+    unassignedRideCount: async (_: unknown, __: unknown, ctx: GraphQLContext) => {
+      const userId = requireUserId(ctx);
+      // `unownedBike: false` is what stops this from nagging forever. A demo or
+      // loaner ride also has no bikeId, but it is finished business.
+      return prisma.ride.count({ where: { userId, bikeId: null, unownedBike: false } });
     },
 
     calibrationState: async (_: unknown, __: unknown, ctx: GraphQLContext) => {
@@ -1840,8 +1881,17 @@ export const resolvers = {
       const location = cleanText(input.location, MAX_LABEL_LEN);
       const rideType = cleanText(input.rideType, 32); // required; validated below
       const requestedBikeId = input.bikeId ?? null;
+      const unownedBike = input.unownedBike === true;
 
       if (!rideType) throw new Error('rideType is required');
+
+      // A ride is either on one of the rider's bikes or on a bike they don't
+      // own. Contradictory input is rejected rather than resolved silently.
+      if (unownedBike && requestedBikeId) {
+        throw new GraphQLError('A ride cannot have both a bikeId and unownedBike: true', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
 
       let bikeId: string | null = null;
       if (requestedBikeId) {
@@ -1851,8 +1901,10 @@ export const resolvers = {
         });
         if (!ownedBike || ownedBike.userId !== userId) throw new Error('Bike not found');
         bikeId = requestedBikeId;
-      } else {
-        // If no bike specified, auto-assign if user has exactly one bike
+      } else if (!unownedBike) {
+        // If no bike specified, auto-assign if user has exactly one bike.
+        // Skipped for an unowned ride: the rider has already said it was not
+        // theirs, so guessing their only bike would credit it hours it never did.
         const userBikes = await prisma.bike.findMany({
           where: { userId },
           select: { id: true },
@@ -1871,6 +1923,7 @@ export const resolvers = {
         averageHr,
         rideType,
         ...(bikeId ? { bikeId } : {}),
+        ...(unownedBike ? { unownedBike: true } : {}),
         ...(notes ? { notes } : {}),
         ...(trailSystem ? { trailSystem } : {}),
         ...(location ? { location } : {}),
@@ -2036,6 +2089,35 @@ export const resolvers = {
         }
       }
 
+      // A ride is either on one of the rider's bikes or on a bike they don't
+      // own. Contradictory input is rejected rather than resolved silently,
+      // matching addRide and the rides filter.
+      if (input.unownedBike === true && input.bikeId) {
+        throw new GraphQLError('A ride cannot have both a bikeId and unownedBike: true', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      let unownedUpdate: boolean | undefined =
+        input.unownedBike === undefined || input.unownedBike === null
+          ? undefined
+          : input.unownedBike === true;
+
+      // Marking a ride unowned detaches whatever bike it was on. Clearing the
+      // bike here (rather than only setting the flag) is what makes the
+      // decrement below run, handing that bike's components back the hours
+      // they were never owed.
+      if (unownedUpdate === true && nextBikeId !== null) {
+        bikeUpdate = null;
+        nextBikeId = null;
+      }
+
+      // Assigning a real bike is the rider saying the ride was theirs after
+      // all, so the flag comes off with it.
+      if (bikeUpdate) {
+        unownedUpdate = false;
+      }
+
       const data: Prisma.RideUpdateInput = {
         ...(start !== undefined && { startTime: start }), // Date (no null)
         ...(durationUpdate !== undefined && {
@@ -2052,6 +2134,7 @@ export const resolvers = {
         }),
         ...(rideType !== undefined && { rideType }), // string only; omit if empty/undefined
         ...(bikeUpdate !== undefined && { bikeId: bikeUpdate }), // nullable
+        ...(unownedUpdate !== undefined && { unownedBike: unownedUpdate }),
         ...(notes !== undefined ? { notes: notes as string | null } : {}),
         ...(trailSystem !== undefined ? { trailSystem: trailSystem as string | null } : {}),
         ...(location !== undefined ? { location: location as string | null } : {}),
@@ -4480,10 +4563,12 @@ export const resolvers = {
 
       // Update rides and components in a transaction
       const adjustedBikeIds = await prisma.$transaction(async (tx) => {
-        // Assign bike to all rides
+        // Assign bike to all rides. Clearing unownedBike alongside keeps the
+        // two in sync the same way updateRide does: naming a bike is the rider
+        // saying the ride was theirs.
         await tx.ride.updateMany({
           where: { id: { in: rideIds } },
-          data: { bikeId },
+          data: { bikeId, unownedBike: false },
         });
 
         // Add hours to bike's components
@@ -6265,7 +6350,7 @@ export const resolvers = {
     // to bucket by condition.
     weatherBreakdown: async (
       parent: { id: string },
-      { filter }: { filter?: { startDate?: string | null; endDate?: string | null; bikeId?: string | null } | null },
+      { filter }: { filter?: RidesFilterInput | null },
       ctx: GraphQLContext
     ) => {
       // Weather is Pro-only: free users get a zeroed breakdown (non-null
@@ -6278,6 +6363,8 @@ export const resolvers = {
           totalRides: 0,
         };
       }
+
+      assertCoherentBikeFilter(filter);
 
       const rideWhere: Prisma.RideWhereInput = { userId: parent.id };
 
@@ -6298,6 +6385,10 @@ export const resolvers = {
           });
         }
         rideWhere.bikeId = filter.bikeId;
+      }
+
+      if (filter?.unassigned) {
+        rideWhere.bikeId = null;
       }
 
       const [grouped, pending, totalRides] = await Promise.all([

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -1322,6 +1322,18 @@ export const resolvers = {
      */
     unassignedRideCount: async (_: unknown, __: unknown, ctx: GraphQLContext) => {
       const userId = requireUserId(ctx);
+
+      // Limited like its sibling unassignedRides. Nothing polls this today, so
+      // the ceiling is headroom rather than a constraint; it is here because
+      // the query is a COUNT over the rider's whole Ride table and a client
+      // that starts polling should not have to remember to add it.
+      const rateLimit = await checkQueryRateLimit('unassignedRideCount', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(`Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`, {
+          extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
+        });
+      }
+
       // The `unownedBike: false` half of the predicate is what stops this from
       // nagging forever: a demo or loaner ride also has no bikeId, but it is
       // finished business.
@@ -4562,6 +4574,17 @@ export const resolvers = {
         throw new Error('One or more rides not found');
       }
 
+      // Eligibility is "has no bike", deliberately not "has no bike and was
+      // never marked unowned". A ride the rider marked as someone else's is
+      // therefore reclaimable in bulk, and naming a bike clears the flag, which
+      // matches updateRide's single-ride semantics: an explicit assignment is
+      // the rider saying the ride was theirs after all.
+      //
+      // In practice these rides are not offered here — `unassignedRides`, which
+      // seeds the client's selection, excludes them. Callers that build their
+      // own rideIds list (the web mass-assign modal) should keep doing the
+      // same, so a bulk action can't quietly overturn a per-ride answer the
+      // rider already gave.
       for (const ride of rides) {
         if (ride.userId !== userId) {
           throw new Error('Unauthorized');

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -169,6 +169,15 @@ export const typeDefs = gql`
     averageHr: Int
     rideType: String!
     bikeId: ID
+    """
+    Ridden on a bike the rider does not own: a demo, a loaner, a rental, a
+    friend's bike. Always paired with a null bikeId, and the two are kept in
+    sync by the server (assigning a bike clears this; setting this clears the
+    bike). Distinguishes "not my bike" from "not assigned yet", so clients can
+    stop prompting for a bike that is never coming. The ride still counts
+    toward ride stats and insights; it credits no component either way.
+    """
+    unownedBike: Boolean!
     notes: String
     trailSystem: String
     location: String
@@ -516,6 +525,10 @@ export const typeDefs = gql`
     averageHr: Int
     rideType: String
     bikeId: ID
+    # Setting this true clears bikeId (and returns that bike's hours); assigning
+    # a bikeId clears this. Sending a bikeId and unownedBike: true together is a
+    # BAD_USER_INPUT error rather than one silently winning.
+    unownedBike: Boolean
     notes: String
     trailSystem: String
     location: String
@@ -529,6 +542,10 @@ export const typeDefs = gql`
     averageHr: Int
     rideType: String!
     bikeId: ID
+    # Logging a ride on a bike the rider does not own. Suppresses the
+    # sole-bike auto-assign that an omitted bikeId would otherwise trigger.
+    # Cannot be combined with a bikeId.
+    unownedBike: Boolean
     notes: String
     trailSystem: String
     location: String
@@ -1195,6 +1212,12 @@ export const typeDefs = gql`
     startDate: String
     endDate: String
     bikeId: ID
+    # Only rides with no bike assigned. Garmin never reports gear, so on a
+    # multi-bike account every Garmin ride lands unassigned and accrues no
+    # component wear until the rider picks a bike; this is how the clients
+    # list those rides. Mutually exclusive with bikeId: sending both is a
+    # BAD_USER_INPUT error rather than a silently-ignored filter.
+    unassigned: Boolean
   }
 
   enum ComponentInstallEventType {
@@ -1295,6 +1318,11 @@ export const typeDefs = gql`
     unmappedStravaGears: [StravaGearInfo!]!
     importNotificationState: ImportNotificationState
     unassignedRides(importSessionId: ID!, take: Int = 50, after: ID): UnassignedRidesPage!
+    # How many of the viewer's rides have no bike assigned, across their whole
+    # history rather than a single import session. Drives the dashboard prompt
+    # to go assign them; those rides' hours are credited to no component until
+    # they are.
+    unassignedRideCount: Int!
     calibrationState: CalibrationState
     servicePreferenceDefaults: [ServicePreferenceDefault!]!
     bikeNotes(bikeId: ID!, take: Int = 20, after: ID): BikeNotesPage!

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -138,6 +138,12 @@ export const MUTATION_RATE_LIMITS = {
 export const QUERY_RATE_LIMITS = {
   /** unassignedRides: max 60 requests per minute per user (supports ~1 req/sec polling) */
   unassignedRides: { windowSeconds: 60, maxRequests: 60 },
+  /** unassignedRideCount: max 60 requests per minute per user. Not polled today
+   *  (dashboard mount, tab focus and pull-to-refresh), so this is headroom
+   *  rather than a constraint — it exists because the query is a COUNT over a
+   *  rider's whole Ride table and its sibling unassignedRides is limited the
+   *  same way. A client that starts polling it inherits the protection. */
+  unassignedRideCount: { windowSeconds: 60, maxRequests: 60 },
   /** importNotificationState: max 30 requests per minute per user (supports 30s polling) */
   importNotificationState: { windowSeconds: 60, maxRequests: 30 },
   /** rideTrack: max 60 requests per minute per user (map open + post-request polling) */

--- a/apps/api/src/services/import-session-checker.service.ts
+++ b/apps/api/src/services/import-session-checker.service.ts
@@ -214,7 +214,9 @@ async function checkIdleSessions(): Promise<void> {
               "completedAt" = ${now},
               "unassignedRideCount" = (
                 SELECT COUNT(*) FROM "Ride"
-                WHERE "importSessionId" = ${session.id} AND "bikeId" IS NULL
+                WHERE "importSessionId" = ${session.id}
+                  AND "bikeId" IS NULL
+                  AND "unownedBike" = false
               ),
               "updatedAt" = ${now}
             WHERE id = ${session.id} AND status = 'running'

--- a/apps/api/src/workers/backfill.worker.test.ts
+++ b/apps/api/src/workers/backfill.worker.test.ts
@@ -209,6 +209,12 @@ describe('processBackfillJob (via worker processor)', () => {
       (mockPrisma.importSession.findFirst as jest.Mock).mockResolvedValue(null);
       (mockPrisma.ride.findUnique as jest.Mock).mockResolvedValue(null);
       (mockPrisma.ride.upsert as jest.Mock).mockResolvedValue({});
+      // Multi-bike account by default (the case where Garmin's lack of gear
+      // reporting leaves the ride unassigned). Tests that care override it.
+      (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([
+        { id: 'bike-1' },
+        { id: 'bike-2' },
+      ]);
       mockDeriveLocationAsync.mockResolvedValue({ title: 'Test Location' });
       mockShouldApplyAutoLocation.mockReturnValue(undefined);
     });
@@ -267,6 +273,118 @@ describe('processBackfillJob (via worker processor)', () => {
           }),
         })
       );
+    });
+
+    /**
+     * Garmin never reports which bike was ridden, so the sole-active-bike guess
+     * is the only assignment a callback-delivered ride can get at ingest. This
+     * path used to omit bikeId from `create` entirely, which left every
+     * backfilled and every manually-updated Garmin activity unassigned even for
+     * a rider who owns one bike, and an unassigned ride credits its hours to no
+     * component at all.
+     */
+    it('assigns the sole active bike when the rider has exactly one', async () => {
+      (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([{ id: 'only-bike' }]);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([
+          {
+            summaryId: 'activity-solo',
+            activityType: 'cycling',
+            startTimeInSeconds: 1706123456,
+            durationInSeconds: 3600,
+          },
+        ]),
+      } as never);
+
+      await processBackfillJob({
+        name: 'processCallback',
+        id: 'job-123',
+        data: {
+          userId: 'user-123',
+          provider: 'garmin',
+          callbackURL: 'https://apis.garmin.com/callback/xyz',
+        },
+      });
+
+      expect(mockPrisma.bike.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: 'user-123', status: 'ACTIVE' } })
+      );
+      expect(mockPrisma.ride.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ bikeId: 'only-bike' }),
+        })
+      );
+    });
+
+    it('leaves the ride unassigned when the rider has more than one active bike', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([
+          {
+            summaryId: 'activity-multi',
+            activityType: 'cycling',
+            startTimeInSeconds: 1706123456,
+            durationInSeconds: 3600,
+          },
+        ]),
+      } as never);
+
+      await processBackfillJob({
+        name: 'processCallback',
+        id: 'job-123',
+        data: {
+          userId: 'user-123',
+          provider: 'garmin',
+          callbackURL: 'https://apis.garmin.com/callback/xyz',
+        },
+      });
+
+      expect(mockPrisma.ride.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ bikeId: null }),
+        })
+      );
+    });
+
+    /**
+     * A re-delivery must not revert a bike the rider assigned by hand. Garmin
+     * re-sends an activity whenever it is edited in Garmin Connect, so this is
+     * a routine event, not an edge case.
+     */
+    it('never carries bikeId in the update payload', async () => {
+      (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([{ id: 'only-bike' }]);
+      (mockPrisma.ride.findUnique as jest.Mock).mockResolvedValue({
+        location: null,
+        bikeId: 'rider-picked-bike',
+        durationSeconds: 3600,
+      });
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([
+          {
+            summaryId: 'activity-resend',
+            activityType: 'cycling',
+            startTimeInSeconds: 1706123456,
+            durationInSeconds: 3600,
+          },
+        ]),
+      } as never);
+
+      await processBackfillJob({
+        name: 'processCallback',
+        id: 'job-123',
+        data: {
+          userId: 'user-123',
+          provider: 'garmin',
+          callbackURL: 'https://apis.garmin.com/callback/xyz',
+        },
+      });
+
+      const upsertArg = (mockPrisma.ride.upsert as jest.Mock).mock.calls[0][0];
+      expect(upsertArg.update).not.toHaveProperty('bikeId');
     });
 
     /**
@@ -983,6 +1101,10 @@ describe('Activity metric conversions', () => {
     mockGetValidGarminToken.mockResolvedValue('valid-token');
     (mockPrisma.importSession.findFirst as jest.Mock).mockResolvedValue(null);
     (mockPrisma.ride.findUnique as jest.Mock).mockResolvedValue(null);
+    (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([
+      { id: 'bike-1' },
+      { id: 'bike-2' },
+    ]);
     mockDeriveLocationAsync.mockResolvedValue({ title: 'Test Location' });
     mockShouldApplyAutoLocation.mockReturnValue(undefined);
   });

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -781,6 +781,22 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
     select: { id: true },
   });
 
+  // Auto-assign the bike when the rider has exactly one active one, matching
+  // `upsertGarminActivity` in sync.worker.ts. Garmin never tags gear, so this
+  // sole-bike inference is the only assignment a callback-delivered ride can
+  // get on ingest. Omitting it here meant every backfilled and every
+  // manually-updated Garmin activity landed unassigned even for a rider who
+  // owns one bike, and its duration then reached no components at all
+  // (syncBikeComponentHours is a no-op when bikeId is null on both sides).
+  //
+  // Resolved once per batch, not per activity: the bike set cannot change
+  // mid-callback and the loop below runs for every activity in the payload.
+  const activeBikes = await prisma.bike.findMany({
+    where: { userId, status: 'ACTIVE' },
+    select: { id: true },
+  });
+  const soleActiveBikeId = activeBikes.length === 1 ? activeBikes[0].id : null;
+
   let processedActivityCount = 0;
 
   for (const activity of activities) {
@@ -875,6 +891,10 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
           notes: activity.activityName ?? null,
           location: autoLocation?.title ?? null,
           importSessionId: runningSession?.id ?? null,
+          // Create-only, exactly as in sync.worker.ts: `update` never carries
+          // bikeId, so a re-delivery of an activity the rider has since
+          // assigned by hand cannot revert it to the sole-bike guess.
+          bikeId: soleActiveBikeId,
           startLat,
           startLng,
           garminDeviceName: garminDeviceName ?? null,

--- a/apps/api/src/workers/backfill.worker.ts
+++ b/apps/api/src/workers/backfill.worker.ts
@@ -789,8 +789,15 @@ async function processGarminCallback(userId: string, callbackURL: string): Promi
   // owns one bike, and its duration then reached no components at all
   // (syncBikeComponentHours is a no-op when bikeId is null on both sides).
   //
-  // Resolved once per batch, not per activity: the bike set cannot change
-  // mid-callback and the loop below runs for every activity in the payload.
+  // Resolved once per batch rather than per activity, because the loop below
+  // awaits geocoding and several writes for every activity in the payload.
+  //
+  // That makes it a snapshot, not a guarantee: a rider who adds or archives a
+  // bike while a batch is in flight leaves the rest of that batch reading a
+  // stale count. Accepted rather than fixed. The window is a single callback,
+  // it only matters at the exactly-one-bike boundary, and the cost of being
+  // wrong is one ride assigned to the sole bike or left unassigned, both of
+  // which the rider can correct from the ride itself.
   const activeBikes = await prisma.bike.findMany({
     where: { userId, status: 'ACTIVE' },
     select: { id: true },


### PR DESCRIPTION
Promotes `staging` to `main`. Contains [#289](https://github.com/ryanlecours/loam-logger/pull/289) and nothing else.

## What's in it

**The problem.** Garmin never reports gear, so on a multi-bike account every synced Garmin ride arrives with no bike, and a ride with no bike credits its duration to no component. Service predictions therefore read healthier than the bike actually is. The only in-app route to fix that on mobile was a push-notification deep link, so a missed or dismissed push stranded the ride permanently.

**Surfacing it.** `unassigned` on `RidesFilterInput` and a new `unassignedRideCount` query, so clients can find and count these rides across a rider's whole history rather than a single import session. `bikeId` and `unassigned` select disjoint sets, so sending both is a `BAD_USER_INPUT` error rather than one silently winning.

**Answering it.** `Ride.unownedBike` for a demo, loaner, rental, or a friend's bike. It needs no special case in the hour accounting (a null `bikeId` already credits nothing); it records intent, separating "not my bike" from "not assigned yet" so the prompt can go quiet honestly instead of via a dismiss button. Assigning a bike clears the flag; marking a ride unowned detaches the bike and hands its hours back.

**An ingestion bug.** `processGarminCallback` omitted `bikeId` from its `create` block entirely, so every backfilled and manually-updated Garmin activity landed unassigned **even for riders who own exactly one bike**, where the webhook path would have assigned it.

## Migration

`20260804210000_add_ride_unowned_bike` adds one `NOT NULL DEFAULT false` boolean to `Ride`. Additive, no backfill, no data rewritten, so every existing row keeps today's meaning. Railway runs `prisma migrate deploy` before server start, so it applies on boot.

## Scope check

**API only.** No `apps/web` files are touched. `LinkBikeModal` and `MassAssignBikeModal` still have no "not my bike" option, so after this deploys the flag is settable from mobile only. Web is a known follow-up, and `assignBikeToRides` carries a comment about the filtering the mass-assign modal will need to preserve.

## Risk

Additive throughout: one nullable-by-default column, one new query, one new optional filter field, one new optional input field. No existing behavior changes except the Garmin callback now assigning a sole active bike where it previously assigned nothing, which is the bug fix.

The one thing worth watching after deploy is `unassignedRideCount` on accounts with deep ride histories. It is a `COUNT` backed by the existing `@@index([userId, bikeId, startTime])` and is rate-limited to 60/min per user.

## Testing

- Full API suite green on the merge commit: **1836 passed / 90 suites**.
- Lint clean (3 pre-existing warnings, none in touched files); typecheck shows only the unresolved `@loam/shared` errors already present on `main`.
- Not exercised against a running app or database. Verification is unit tests, typecheck, and lint only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)