### PR TITLE
feat(notifications): actionable-first pushes, service-due from every hour path, weekly digest

### DIFF
--- a/apps/api/prisma/migrations/20260805090000_add_notification_modes_and_digest/migration.sql
+++ b/apps/api/prisma/migrations/20260805090000_add_notification_modes_and_digest/migration.sql
@@ -1,0 +1,36 @@
+-- Ride-sync push notifications gain a three-way mode, and the weekly
+-- gear-health digest gains its columns.
+--
+-- rideSyncNotificationMode replaces notifyOnRideUpload as the source of
+-- truth for "Ride Synced" pushes:
+--   ALL           every new integration ride pushes (the original behavior)
+--   ACTION_NEEDED only rides that need a bike assigned, or the account's
+--                 first-ever synced ride
+--   OFF           no ride-sync pushes
+--
+-- Existing users are backfilled from their boolean so nobody's behavior
+-- changes with this deploy: true -> ALL, false -> OFF. The column default
+-- (ACTION_NEEDED) therefore only ever applies to accounts created after it,
+-- which is the deliberate new-user default: every push either asks for an
+-- action or marks a milestone. notifyOnRideUpload is kept and written
+-- through (mode OFF <=> false) because app versions <= 1.1.4 still toggle it.
+
+CREATE TYPE "RideSyncNotificationMode" AS ENUM ('ALL', 'ACTION_NEEDED', 'OFF');
+
+ALTER TABLE "User" ADD COLUMN "rideSyncNotificationMode" "RideSyncNotificationMode" NOT NULL DEFAULT 'ACTION_NEEDED';
+
+UPDATE "User" SET "rideSyncNotificationMode" = CASE
+  WHEN "notifyOnRideUpload" THEN 'ALL'::"RideSyncNotificationMode"
+  ELSE 'OFF'::"RideSyncNotificationMode"
+END;
+
+-- Weekly digest: opt-in, off by default. timezone is IANA, uploaded by the
+-- mobile client with the push token; the digest scheduler skips users
+-- without one rather than guessing.
+ALTER TABLE "User" ADD COLUMN "weeklyDigestEnabled" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "User" ADD COLUMN "timezone" TEXT;
+
+-- WEEKLY_DIGEST rows record "already sent this week"; RIDE_UPLOADED rows
+-- (declared since the enum's creation but never written until now) implement
+-- the ride-push burst-suppression window.
+ALTER TYPE "NotificationType" ADD VALUE 'WEEKLY_DIGEST';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -74,7 +74,36 @@ model User {
 
   // Push notification preferences
   expoPushToken      String?
+  // Legacy on/off for ride-sync pushes. Kept in sync with
+  // rideSyncNotificationMode (mode OFF <=> false) because app versions up to
+  // 1.1.4 still read and write it through updateUserPreferences; the mode
+  // column below is the source of truth and this is derived on write.
   notifyOnRideUpload Boolean @default(true)
+  // How "Ride Synced" pushes behave. ALL preserves the original behavior
+  // (every new integration ride pushes, burst-suppressed). ACTION_NEEDED
+  // pushes only when the ride needs a bike assigned or is the account's
+  // first-ever synced ride: every push carries something to act on or a
+  // milestone. Existing users were migrated from notifyOnRideUpload
+  // (true -> ALL, false -> OFF) so nobody's behavior changed; new accounts
+  // start at ACTION_NEEDED. Service-due pushes are governed separately by
+  // BikeNotificationPreference and are never affected by this mode.
+  rideSyncNotificationMode RideSyncNotificationMode @default(ACTION_NEEDED)
+  // Weekly gear-health digest ("is the bike ready for the weekend"), sent
+  // Friday morning in the user's local time. Opt-in, off by default, and
+  // Pro-gated at send time like every prediction surface.
+  weeklyDigestEnabled Boolean @default(false)
+  // IANA timezone (e.g. "America/Los_Angeles"), uploaded by mobile alongside
+  // the push token. Only read by the weekly digest scheduler; a user with a
+  // null timezone is skipped rather than guessed at, since a digest at 3am
+  // is worse than no digest.
+  timezone String?
+}
+
+// See User.rideSyncNotificationMode for semantics.
+enum RideSyncNotificationMode {
+  ALL
+  ACTION_NEEDED
+  OFF
 }
 
 model OauthToken {
@@ -858,8 +887,15 @@ model BikeNotificationPreference {
 }
 
 enum NotificationType {
+  // One row per sent "Ride Synced" push. Not a dedup key like SERVICE_DUE:
+  // these rows implement the burst-suppression window (at most one plain
+  // sync confirmation per window), so they are queried by sentAt and pruned
+  // opportunistically rather than held forever.
   RIDE_UPLOADED
   SERVICE_DUE
+  // One row per sent weekly digest; the scheduler's "already sent this week"
+  // check reads the latest row's sentAt.
+  WEEKLY_DIGEST
 }
 
 model NotificationLog {

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -5756,6 +5756,88 @@ describe('GraphQL Resolvers', () => {
     });
   });
 
+  describe('Mutation.updateRide service-due fan-out', () => {
+    const mutation = resolvers.Mutation.updateRide;
+    const { fireServiceDueForBike } = jest.requireMock<
+      typeof import('../../services/notification.service')
+    >('../../services/notification.service');
+
+    /**
+     * tx double where one component on ANOTHER bike (bike-2) holds an
+     * INCLUDE adjustment referencing the edited ride, so the canonical
+     * recompute touches bike-2 and returns it in adjustedBikeIds.
+     */
+    const makeAdjustedTx = () => ({
+      ride: {
+        update: jest.fn().mockResolvedValue({ id: 'ride-1' }),
+        aggregate: jest.fn().mockResolvedValue({ _sum: { durationSeconds: 7200 }, _count: 1 }),
+      },
+      component: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+        update: jest.fn().mockResolvedValue({}),
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'comp-other', userId: 'user-123', bikeId: 'bike-2', installedAt: null, hoursUsed: 5,
+        }),
+      },
+      serviceLog: { findFirst: jest.fn().mockResolvedValue(null) },
+      componentRideAdjustment: {
+        findMany: jest.fn()
+          // findAdjustedComponentIdsForRides: the edited ride is INCLUDEd
+          // by a component living on bike-2.
+          .mockResolvedValueOnce([{ componentId: 'comp-other' }])
+          // loadComponentAttribution's adjustment fetch.
+          .mockResolvedValue([]),
+      },
+    });
+
+    beforeEach(() => {
+      mockCheckMutationRateLimit.mockResolvedValue({ allowed: true, retryAfter: 0 });
+      (fireServiceDueForBike as jest.Mock).mockClear();
+    });
+
+    /**
+     * The hole this guards: a component on bike-2 that INCLUDEs this ride
+     * counts its duration too (computeCountedHours' INCLUDE branch). A
+     * duration increase therefore raises bike-2's hours even though the
+     * ride was never assigned to bike-2 — firing only for the ride's own
+     * bike left that threshold crossing silent.
+     */
+    it('checks cross-bike INCLUDE holders when the duration grows', async () => {
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue({
+        userId: 'user-123', durationSeconds: 3600, bikeId: 'bike-1',
+      });
+      const tx = makeAdjustedTx();
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation(
+        {}, { id: 'ride-1', input: { durationSeconds: 7200 } }, createMockContext('user-123') as never
+      );
+
+      const firedBikes = (fireServiceDueForBike as jest.Mock).mock.calls.map(
+        (c: [{ bikeId: string }]) => c[0].bikeId
+      );
+      expect(firedBikes).toContain('bike-1');
+      expect(firedBikes).toContain('bike-2');
+    });
+
+    it('stays quiet when hours only shrink and nothing is adjusted', async () => {
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue({
+        userId: 'user-123', durationSeconds: 3600, bikeId: 'bike-1',
+      });
+      const tx = makeAdjustedTx();
+      // No adjustments reference this ride.
+      tx.componentRideAdjustment.findMany = jest.fn().mockResolvedValue([]);
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation(
+        {}, { id: 'ride-1', input: { durationSeconds: 1800 } }, createMockContext('user-123') as never
+      );
+
+      // Losing hours can't make a component due.
+      expect(fireServiceDueForBike).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Mutation.updateRide unowned-bike handling', () => {
     const mutation = resolvers.Mutation.updateRide;
 
@@ -5955,6 +6037,51 @@ describe('GraphQL Resolvers', () => {
       ).rejects.toThrow('Unauthorized');
 
       expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('fires the service-due check for the target bike and any adjusted bikes', async () => {
+      const { fireServiceDueForBike } = jest.requireMock<
+        typeof import('../../services/notification.service')
+      >('../../services/notification.service');
+      (fireServiceDueForBike as jest.Mock).mockClear();
+
+      (prisma.ride.findMany as jest.Mock).mockResolvedValue([
+        { id: 'ride-1', userId: 'user-123', bikeId: null, durationSeconds: 3600 },
+      ]);
+      // One of the assigned rides is INCLUDEd by a component on bike-2, so
+      // the recompute returns it. For THIS mutation that fire should be a
+      // deduped no-op (assignment moves no hours onto bike-2), but the
+      // fan-out keeps assign and update symmetric.
+      const tx = {
+        ride: {
+          updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+          aggregate: jest.fn().mockResolvedValue({ _sum: { durationSeconds: 3600 }, _count: 1 }),
+        },
+        component: {
+          updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+          update: jest.fn().mockResolvedValue({}),
+          findUnique: jest.fn().mockResolvedValue({
+            id: 'comp-other', userId: 'user-123', bikeId: 'bike-2', installedAt: null, hoursUsed: 5,
+          }),
+        },
+        serviceLog: { findFirst: jest.fn().mockResolvedValue(null) },
+        componentRideAdjustment: {
+          findMany: jest.fn()
+            .mockResolvedValueOnce([{ componentId: 'comp-other' }])
+            .mockResolvedValue([]),
+        },
+      };
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation(
+        {}, { rideIds: ['ride-1'], bikeId: 'bike-9' }, createMockContext('user-123') as never
+      );
+
+      const firedBikes = (fireServiceDueForBike as jest.Mock).mock.calls.map(
+        (c: [{ bikeId: string }]) => c[0].bikeId
+      );
+      expect(firedBikes).toContain('bike-9');
+      expect(firedBikes).toContain('bike-2');
     });
   });
 

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -117,6 +117,7 @@ jest.mock('../../services/prediction', () => ({
 
 jest.mock('../../services/notification.service', () => ({
   clearServiceNotificationLogs: jest.fn().mockResolvedValue(undefined),
+  fireServiceDueForBike: jest.fn().mockResolvedValue(undefined),
   isValidExpoPushToken: jest.fn((token: string) => token.startsWith('ExponentPushToken[') || token.startsWith('ExpoPushToken[')),
 }));
 
@@ -3030,7 +3031,9 @@ describe('GraphQL Resolvers', () => {
       });
     });
 
-    it('should update notifyOnRideUpload', async () => {
+    it('legacy notifyOnRideUpload: false also turns the mode OFF', async () => {
+      // Old app versions only know the boolean; the mode column must follow
+      // it or the two sources of truth drift.
       const ctx = createMockContext();
       (mockPrisma.user.update as jest.Mock).mockResolvedValue({ id: 'user-123' });
 
@@ -3038,8 +3041,74 @@ describe('GraphQL Resolvers', () => {
 
       expect(mockPrisma.user.update).toHaveBeenCalledWith({
         where: { id: 'user-123' },
-        data: { notifyOnRideUpload: false },
+        data: { notifyOnRideUpload: false, rideSyncNotificationMode: 'OFF' },
       });
+    });
+
+    it('legacy notifyOnRideUpload: true lifts OFF to ALL', async () => {
+      const ctx = createMockContext();
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({ rideSyncNotificationMode: 'OFF' });
+      (mockPrisma.user.update as jest.Mock).mockResolvedValue({ id: 'user-123' });
+
+      await mutation(null, { input: { notifyOnRideUpload: true } }, ctx);
+
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-123' },
+        data: { notifyOnRideUpload: true, rideSyncNotificationMode: 'ALL' },
+      });
+    });
+
+    it('legacy notifyOnRideUpload: true preserves a stored ACTION_NEEDED', async () => {
+      // An old client's toggle renders as "on" for ACTION_NEEDED, so a save
+      // from that screen is a no-op, not a request to hear about every ride.
+      const ctx = createMockContext();
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({ rideSyncNotificationMode: 'ACTION_NEEDED' });
+      (mockPrisma.user.update as jest.Mock).mockResolvedValue({ id: 'user-123' });
+
+      await mutation(null, { input: { notifyOnRideUpload: true } }, ctx);
+
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-123' },
+        data: { notifyOnRideUpload: true },
+      });
+    });
+
+    it('rideSyncNotificationMode writes both the mode and the derived boolean', async () => {
+      const ctx = createMockContext();
+      (mockPrisma.user.update as jest.Mock).mockResolvedValue({ id: 'user-123' });
+
+      await mutation(null, { input: { rideSyncNotificationMode: 'ACTION_NEEDED' } }, ctx);
+
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-123' },
+        data: { rideSyncNotificationMode: 'ACTION_NEEDED', notifyOnRideUpload: true },
+      });
+    });
+
+    it('accepts weeklyDigestEnabled and a valid IANA timezone', async () => {
+      const ctx = createMockContext();
+      (mockPrisma.user.update as jest.Mock).mockResolvedValue({ id: 'user-123' });
+
+      await mutation(
+        null,
+        { input: { weeklyDigestEnabled: true, timezone: 'America/Denver' } },
+        ctx
+      );
+
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-123' },
+        data: { weeklyDigestEnabled: true, timezone: 'America/Denver' },
+      });
+    });
+
+    it('rejects a timezone Intl does not recognize', async () => {
+      const ctx = createMockContext();
+
+      await expect(
+        mutation(null, { input: { timezone: 'Not/AZone' } }, ctx)
+      ).rejects.toThrow('timezone is not a valid IANA timezone');
+
+      expect(mockPrisma.user.update).not.toHaveBeenCalled();
     });
 
     it('should reject expoPushToken exceeding max length', async () => {

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -17,7 +17,10 @@ import { getRideTrack } from '../lib/ride-track';
 import { invalidateBikePrediction, getCachedAdvisorSummary, setCachedAdvisorSummary } from '../services/prediction/cache';
 import { generateSummary, DEFAULT_ADVISOR_MODEL } from '../services/advisor/summarize';
 import type { BikePredictionSummary } from '../services/prediction/types';
-import { clearServiceNotificationLogs, isValidExpoPushToken } from '../services/notification.service';
+import { clearServiceNotificationLogs, fireServiceDueForBike, isValidExpoPushToken } from '../services/notification.service';
+// The canonical "still waiting on a bike" predicate; see lib/ride-predicates
+// for why this is one constant and what it deliberately excludes.
+import { UNASSIGNED_RIDE_WHERE } from '../lib/ride-predicates';
 import { getBaseInterval, BASE_INTERVALS_HOURS, DEFAULT_INTERVAL_HOURS } from '../services/prediction/config';
 import {
   getApplicableComponents,
@@ -892,24 +895,6 @@ function assertCoherentBikeFilter(filter?: RidesFilterInput | null): void {
   }
 }
 
-/**
- * The canonical "still waiting on a bike" predicate.
- *
- * `bikeId: null` on its own is NOT it. A demo, loaner or rental ride marked
- * `unownedBike` also has no bike, but by intent rather than omission, and
- * counting it as outstanding is what the flag exists to prevent.
- *
- * Kept as one constant because the two halves drifted the moment they were
- * written out by hand in more than one place: weatherBreakdown was left
- * matching on `bikeId` alone and swept unowned rides into totals that
- * `rides` and `unassignedRideCount` correctly excluded. Spread this rather
- * than restating it.
- *
- * The one copy this cannot cover is the raw SQL in
- * services/import-session-checker.service.ts, which spells the same predicate
- * out in its COUNT and has to be updated alongside.
- */
-const UNASSIGNED_RIDE_WHERE = { bikeId: null, unownedBike: false } as const;
 
 type RidesArgs = {
   take?: number;
@@ -1988,6 +1973,13 @@ export const resolvers = {
         hasBike: Boolean(bikeId),
       });
 
+      // A manual ride credits hours the same as a synced one, so it gets the
+      // same threshold check. No "Ride Synced" push, though: the rider typed
+      // this ride in themselves seconds ago.
+      if (bikeId) {
+        void fireServiceDueForBike({ userId, bikeId });
+      }
+
       return ride;
     },
     deleteRide: async (_: unknown, { id }: { id: string }, ctx: GraphQLContext) => {
@@ -2235,6 +2227,14 @@ export const resolvers = {
       );
       for (const bikeId of postInvalidate) {
         await invalidateBikePrediction(userId, bikeId);
+      }
+
+      // Hours just landed on a bike (newly assigned, or a longer duration on
+      // an assigned ride): the same threshold-crossing moment a synced ride
+      // triggers, so it gets the same check. Losing hours can't make a
+      // component due, so the shrink/unassign cases stay quiet.
+      if (nextBikeId && (bikeChanged || hoursDiff > 0)) {
+        void fireServiceDueForBike({ userId, bikeId: nextBikeId });
       }
 
       return updatedRide;
@@ -4110,7 +4110,7 @@ export const resolvers = {
 
     updateUserPreferences: async (
       _: unknown,
-      { input }: { input: { hoursDisplayPreference?: string | null; predictionMode?: string | null; distanceUnit?: string | null; expoPushToken?: string | null; notifyOnRideUpload?: boolean | null } },
+      { input }: { input: { hoursDisplayPreference?: string | null; predictionMode?: string | null; distanceUnit?: string | null; expoPushToken?: string | null; notifyOnRideUpload?: boolean | null; rideSyncNotificationMode?: 'ALL' | 'ACTION_NEEDED' | 'OFF' | null; weeklyDigestEnabled?: boolean | null; timezone?: string | null } },
       ctx: GraphQLContext
     ) => {
       const userId = requireUserId(ctx);
@@ -4122,7 +4122,7 @@ export const resolvers = {
         });
       }
 
-      const updateData: { hoursDisplayPreference?: string | null; predictionMode?: string | null; distanceUnit?: string | null; expoPushToken?: string | null; notifyOnRideUpload?: boolean } = {};
+      const updateData: { hoursDisplayPreference?: string | null; predictionMode?: string | null; distanceUnit?: string | null; expoPushToken?: string | null; notifyOnRideUpload?: boolean; rideSyncNotificationMode?: 'ALL' | 'ACTION_NEEDED' | 'OFF'; weeklyDigestEnabled?: boolean; timezone?: string | null } = {};
 
       if (input.hoursDisplayPreference !== undefined) {
         // Input length validation to prevent DoS/excessive storage
@@ -4191,8 +4191,54 @@ export const resolvers = {
         updateData.expoPushToken = input.expoPushToken;
       }
 
-      if (input.notifyOnRideUpload !== undefined && input.notifyOnRideUpload !== null) {
+      // rideSyncNotificationMode is the source of truth for ride-sync pushes;
+      // the legacy boolean is kept in sync in both directions so app versions
+      // <= 1.1.4 (which only know the toggle) and current clients never
+      // disagree about whether pushes are on.
+      if (input.rideSyncNotificationMode !== undefined && input.rideSyncNotificationMode !== null) {
+        updateData.rideSyncNotificationMode = input.rideSyncNotificationMode;
+        updateData.notifyOnRideUpload = input.rideSyncNotificationMode !== 'OFF';
+      } else if (input.notifyOnRideUpload !== undefined && input.notifyOnRideUpload !== null) {
         updateData.notifyOnRideUpload = input.notifyOnRideUpload;
+        if (!input.notifyOnRideUpload) {
+          updateData.rideSyncNotificationMode = 'OFF';
+        } else {
+          // Legacy toggle-on: only lift OFF -> ALL. A stored ACTION_NEEDED
+          // must survive an old client re-sending true (its toggle renders
+          // as "on" for that mode, so a save from that screen is a no-op,
+          // not a request to hear about every ride).
+          const current = await prisma.user.findUnique({
+            where: { id: userId },
+            select: { rideSyncNotificationMode: true },
+          });
+          if (current?.rideSyncNotificationMode === 'OFF') {
+            updateData.rideSyncNotificationMode = 'ALL';
+          }
+        }
+      }
+
+      if (input.weeklyDigestEnabled !== undefined && input.weeklyDigestEnabled !== null) {
+        updateData.weeklyDigestEnabled = input.weeklyDigestEnabled;
+      }
+
+      if (input.timezone !== undefined) {
+        if (input.timezone !== null) {
+          if (input.timezone.length > 64) {
+            throw new GraphQLError('timezone exceeds maximum length', {
+              extensions: { code: 'BAD_USER_INPUT' },
+            });
+          }
+          // The only validation that matters is the one the digest scheduler
+          // relies on: Intl must accept it. Anything else is a bad value.
+          try {
+            new Intl.DateTimeFormat('en-US', { timeZone: input.timezone });
+          } catch {
+            throw new GraphQLError('timezone is not a valid IANA timezone', {
+              extensions: { code: 'BAD_USER_INPUT' },
+            });
+          }
+        }
+        updateData.timezone = input.timezone;
       }
 
       if (Object.keys(updateData).length === 0) {
@@ -4626,6 +4672,12 @@ export const resolvers = {
       for (const affected of new Set([bikeId, ...adjustedBikeIds])) {
         await invalidateBikePrediction(userId, affected);
       }
+
+      // A bulk assignment can credit hours enough to push components past
+      // their service thresholds in one move, exactly the moment the rider
+      // is paying attention. Fire-and-forget (never throws); per-component
+      // dedup inside makes it safe even if nothing crossed.
+      void fireServiceDueForBike({ userId, bikeId });
 
       return {
         success: true,
@@ -6350,7 +6402,18 @@ export const resolvers = {
       parent.pairedComponentMigrationSeenAt?.toISOString() ?? null,
     trailStewardshipNoticeSeenAt: (parent: { trailStewardshipNoticeSeenAt?: Date | null }) =>
       parent.trailStewardshipNoticeSeenAt?.toISOString() ?? null,
-    notifyOnRideUpload: (parent: { notifyOnRideUpload?: boolean }) => parent.notifyOnRideUpload ?? true,
+    // Derived for legacy clients: the mode is the source of truth. Falls back
+    // to the kept-in-sync boolean when a caller's select omitted the mode.
+    notifyOnRideUpload: (parent: { notifyOnRideUpload?: boolean; rideSyncNotificationMode?: string }) =>
+      parent.rideSyncNotificationMode !== undefined
+        ? parent.rideSyncNotificationMode !== 'OFF'
+        : parent.notifyOnRideUpload ?? true,
+    rideSyncNotificationMode: (parent: { rideSyncNotificationMode?: string; notifyOnRideUpload?: boolean }) =>
+      parent.rideSyncNotificationMode ??
+      // Parent row predates the column being selected: derive from the
+      // boolean the same way the migration backfilled it.
+      ((parent.notifyOnRideUpload ?? true) ? 'ALL' : 'OFF'),
+    weeklyDigestEnabled: (parent: { weeklyDigestEnabled?: boolean }) => parent.weeklyDigestEnabled ?? false,
     createdAt: (parent: { createdAt: Date }) => parent.createdAt.toISOString(),
     // Scoped to the viewer's User type so the shape matches other user-owned
     // fields. GraphQL's lazy field resolution means this COUNT only runs

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -2229,12 +2229,26 @@ export const resolvers = {
         await invalidateBikePrediction(userId, bikeId);
       }
 
-      // Hours just landed on a bike (newly assigned, or a longer duration on
-      // an assigned ride): the same threshold-crossing moment a synced ride
-      // triggers, so it gets the same check. Losing hours can't make a
-      // component due, so the shrink/unassign cases stay quiet.
-      if (nextBikeId && (bikeChanged || hoursDiff > 0)) {
-        void fireServiceDueForBike({ userId, bikeId: nextBikeId });
+      // Hours may have landed on more than one bike, and every bike that
+      // gained any gets the same threshold check a synced ride triggers:
+      // - nextBikeId when the ride was newly assigned or its duration grew.
+      // - Every bike in adjustedBikeIds: a component on ANOTHER bike that
+      //   INCLUDEs this ride counts its duration too (computeCountedHours'
+      //   INCLUDE branch), so a duration increase or a startTime move into
+      //   that component's service window raises hours on a bike this ride
+      //   was never assigned to. Firing only for nextBikeId left those
+      //   crossings silent.
+      // A bike in the set whose hours only fell is a cheap no-op: candidates
+      // must cross a threshold and the per-component dedup filters repeats.
+      // The old bike (pure hour loss) is deliberately not added.
+      const serviceDueCandidates = new Set(
+        [
+          nextBikeId && (bikeChanged || hoursDiff > 0) ? nextBikeId : null,
+          ...adjustedBikeIds,
+        ].filter((b): b is string => !!b)
+      );
+      for (const candidateBikeId of serviceDueCandidates) {
+        void fireServiceDueForBike({ userId, bikeId: candidateBikeId });
       }
 
       return updatedRide;
@@ -4677,7 +4691,17 @@ export const resolvers = {
       // their service thresholds in one move, exactly the moment the rider
       // is paying attention. Fire-and-forget (never throws); per-component
       // dedup inside makes it safe even if nothing crossed.
-      void fireServiceDueForBike({ userId, bikeId });
+      //
+      // adjustedBikeIds is included for symmetry with updateRide, though for
+      // THIS mutation it should be a no-op set: assignment doesn't change
+      // ride durations, and a cross-bike component that INCLUDEs one of
+      // these rides was already counting it while unassigned
+      // (computeCountedHours' INCLUDE branch), so other bikes' hours can
+      // only stay equal or fall here. Firing anyway costs one deduped check
+      // and keeps this path correct if that invariant ever shifts.
+      for (const candidateBikeId of new Set([bikeId, ...adjustedBikeIds])) {
+        void fireServiceDueForBike({ userId, bikeId: candidateBikeId });
+      }
 
       return {
         success: true,

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -842,7 +842,34 @@ export const typeDefs = gql`
     predictionMode: String
     distanceUnit: String
     expoPushToken: String
+    # Legacy on/off for ride-sync pushes, still sent by app versions <= 1.1.4.
+    # Maps onto rideSyncNotificationMode (false -> OFF; true -> ALL, unless
+    # the stored mode is already a non-OFF value, which is preserved). New
+    # clients should send rideSyncNotificationMode instead.
     notifyOnRideUpload: Boolean
+    # How "Ride Synced" pushes behave; see the enum. Setting this also keeps
+    # the legacy boolean in sync for older clients reading it.
+    rideSyncNotificationMode: RideSyncNotificationMode
+    # Weekly Friday-morning gear-health digest. Opt-in; Pro feature at send
+    # time (a free user's toggle stores but sends nothing, mirroring how
+    # prediction surfaces degrade elsewhere).
+    weeklyDigestEnabled: Boolean
+    # IANA timezone (e.g. "America/Denver"), used only to time the weekly
+    # digest. Uploaded by mobile alongside the push token; explicit null
+    # clears it, which also stops the digest (no timezone, no send).
+    timezone: String
+  }
+
+  # Governs the "Ride Synced" push. Service-due pushes are configured
+  # per-bike (BikeNotificationPreference) and are independent of this.
+  enum RideSyncNotificationMode {
+    # Every new integration ride pushes (burst-suppressed).
+    ALL
+    # Only rides that need a bike assigned, plus the account's first-ever
+    # synced ride. Every push asks for an action or marks a milestone.
+    ACTION_NEEDED
+    # No ride-sync pushes.
+    OFF
   }
 
   # Push notification preferences
@@ -1195,7 +1222,10 @@ export const typeDefs = gql`
     pairedComponentMigrationSeenAt: String
     trailStewardshipNoticeSeenAt: String
     servicePreferences: [UserServicePreference!]!
+    # Derived for legacy clients: true iff rideSyncNotificationMode != OFF.
     notifyOnRideUpload: Boolean!
+    rideSyncNotificationMode: RideSyncNotificationMode!
+    weeklyDigestEnabled: Boolean!
     createdAt: String!
     ridesMissingWeather: Int!
     # Count of the viewer's Garmin rides stored without coordinates (a past

--- a/apps/api/src/lib/ride-predicates.ts
+++ b/apps/api/src/lib/ride-predicates.ts
@@ -1,0 +1,20 @@
+/**
+ * The canonical "still waiting on a bike" predicate.
+ *
+ * `bikeId: null` on its own is NOT it. A demo, loaner or rental ride marked
+ * `unownedBike` also has no bike, but by intent rather than omission, and
+ * counting it as outstanding is what the flag exists to prevent.
+ *
+ * Kept as one constant because the two halves drifted the moment they were
+ * written out by hand in more than one place: weatherBreakdown was left
+ * matching on `bikeId` alone and swept unowned rides into totals that
+ * `rides` and `unassignedRideCount` correctly excluded. Spread this rather
+ * than restating it.
+ *
+ * Lives in lib/ (rather than resolvers.ts, where it started) so non-GraphQL
+ * consumers — the weekly digest service — can share it without importing
+ * the resolver module. The one copy this cannot cover is the raw SQL in
+ * services/import-session-checker.service.ts, which spells the same
+ * predicate out in its COUNT and has to be updated alongside.
+ */
+export const UNASSIGNED_RIDE_WHERE = { bikeId: null, unownedBike: false } as const;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -13,6 +13,7 @@ import { startWorkers, stopWorkers } from './workers';
 import { getRedisConnection, checkRedisHealth } from './lib/redis';
 import { startEmailScheduler, stopEmailScheduler } from './services/email-scheduler.service';
 import { startImportSessionChecker, stopImportSessionChecker } from './services/import-session-checker.service';
+import { startWeeklyDigestScheduler, stopWeeklyDigestScheduler } from './services/weekly-digest.service';
 import { startOAuthCleanup, stopOAuthCleanup } from './services/oauth-cleanup.service';
 import {
   startPasswordResetCleanup,
@@ -348,6 +349,10 @@ const startServer = async () => {
   // Start import session checker (checks for idle import sessions every minute)
   startImportSessionChecker();
 
+  // Start weekly digest scheduler (sweeps opted-in users every 15 minutes,
+  // sends each their Friday-morning gear-health digest in their local time)
+  startWeeklyDigestScheduler();
+
   // Start OAuth attempt cleanup (deletes expired records hourly)
   startOAuthCleanup();
 
@@ -361,6 +366,7 @@ const startServer = async () => {
   process.on('SIGTERM', async () => {
     await stopEmailScheduler();
     await stopImportSessionChecker();
+    stopWeeklyDigestScheduler();
     stopOAuthCleanup();
     stopPasswordResetCleanup();
     await stopWorkers();

--- a/apps/api/src/services/notification.service.test.ts
+++ b/apps/api/src/services/notification.service.test.ts
@@ -6,6 +6,11 @@ jest.mock('../lib/prisma', () => ({
     },
     bike: {
       findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      count: jest.fn(),
+    },
+    ride: {
+      count: jest.fn(),
     },
     bikeNotificationPreference: {
       findUnique: jest.fn(),
@@ -13,6 +18,7 @@ jest.mock('../lib/prisma', () => ({
     notificationLog: {
       create: jest.fn(),
       createMany: jest.fn(),
+      findFirst: jest.fn(),
       findMany: jest.fn(),
       deleteMany: jest.fn(),
     },
@@ -57,6 +63,7 @@ import { prisma } from '../lib/prisma';
 import { enqueueReceiptCheck } from '../lib/queue/notification.queue';
 import {
   fireRideNotifications,
+  fireServiceDueForBike,
   notifyRideUploaded,
   checkAndNotifyServiceDue,
   clearServiceNotificationLogs,
@@ -69,12 +76,17 @@ describe('notification.service', () => {
     jest.clearAllMocks();
     mockSendPushNotificationsAsync.mockResolvedValue([{ status: 'ok', id: 'ticket-123' }]);
     (mockPrisma.notificationLog.create as jest.Mock).mockResolvedValue({});
+    // No recent ride push: the burst window is open unless a test closes it.
+    (mockPrisma.notificationLog.findFirst as jest.Mock).mockResolvedValue(null);
+    (mockPrisma.notificationLog.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
   });
 
   describe('notifyRideUploaded', () => {
+    // Whether the push should go out at all (rideSyncNotificationMode, burst
+    // window) is decided by fireRideNotifications; the opt-out and mode
+    // tests live in that describe block now.
     const baseUser = {
       expoPushToken: 'ExponentPushToken[abc123]',
-      notifyOnRideUpload: true,
       distanceUnit: 'mi' as string | null,
     };
 
@@ -87,12 +99,6 @@ describe('notification.service', () => {
       user: baseUser,
     };
 
-    it('should skip if user has notifications disabled', async () => {
-      await notifyRideUploaded({ ...baseParams, user: { ...baseUser, notifyOnRideUpload: false } });
-
-      expect(mockSendPushNotificationsAsync).not.toHaveBeenCalled();
-    });
-
     it('should send a combined upload + pick-bike notification when needsBikeAssignment is true', async () => {
       await notifyRideUploaded({ ...baseParams, bikeName: undefined, needsBikeAssignment: true });
 
@@ -103,20 +109,6 @@ describe('notification.service', () => {
           data: { screen: 'ride', rideId: 'ride-1', action: 'pickBike' },
         }),
       ]);
-    });
-
-    it('should suppress the pick-bike prompt when notifyOnRideUpload is false', async () => {
-      // The user's notification preference wins over the bike-pick prompt.
-      // Surfacing the unassigned ride is deferred to the in-app rides list
-      // rather than overriding their opt-out at the lockscreen.
-      await notifyRideUploaded({
-        ...baseParams,
-        bikeName: undefined,
-        needsBikeAssignment: true,
-        user: { ...baseUser, notifyOnRideUpload: false },
-      });
-
-      expect(mockSendPushNotificationsAsync).not.toHaveBeenCalled();
     });
 
     it('should send notification with miles when user prefers mi', async () => {
@@ -461,17 +453,19 @@ describe('notification.service', () => {
       isNewRide: true,
     };
 
+    const proUser = {
+      expoPushToken: 'ExponentPushToken[abc123]',
+      rideSyncNotificationMode: 'ALL',
+      distanceUnit: 'mi',
+      role: 'USER',
+      predictionMode: 'simple',
+      subscriptionTier: 'PRO',
+      isFoundingRider: false,
+    };
+
     beforeEach(() => {
-      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
-        expoPushToken: 'ExponentPushToken[abc123]',
-        notifyOnRideUpload: true,
-        distanceUnit: 'mi',
-        role: 'USER',
-        predictionMode: 'simple',
-        subscriptionTier: 'PRO',
-        isFoundingRider: false,
-      });
-      (mockPrisma.bike.findUnique as jest.Mock).mockResolvedValue({
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({ ...proUser });
+      (mockPrisma.bike.findFirst as jest.Mock).mockResolvedValue({
         nickname: 'Trail Bike',
         manufacturer: 'Santa Cruz',
         model: 'Hightower',
@@ -482,13 +476,8 @@ describe('notification.service', () => {
     it('skips the service-due check entirely for free users', async () => {
       // Service-due pushes carry rides/hours-remaining predictions — Pro-only.
       (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
-        expoPushToken: 'ExponentPushToken[abc123]',
-        notifyOnRideUpload: true,
-        distanceUnit: 'mi',
-        role: 'USER',
-        predictionMode: 'simple',
+        ...proUser,
         subscriptionTier: 'FREE',
-        isFoundingRider: false,
       });
       mockSendPushNotificationsAsync.mockResolvedValue([{ status: 'ok', id: 'ticket-free' }]);
 
@@ -510,11 +499,8 @@ describe('notification.service', () => {
 
     it('should return early when user has no push token', async () => {
       (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
+        ...proUser,
         expoPushToken: null,
-        notifyOnRideUpload: true,
-        distanceUnit: 'mi',
-        role: 'USER',
-        predictionMode: 'simple',
       });
 
       await fireRideNotifications(baseParams);
@@ -540,11 +526,8 @@ describe('notification.service', () => {
 
     it('should not enqueue receipt check when no tickets are produced', async () => {
       (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
-        expoPushToken: 'ExponentPushToken[abc123]',
-        notifyOnRideUpload: false,
-        distanceUnit: 'mi',
-        role: 'USER',
-        predictionMode: 'simple',
+        ...proUser,
+        rideSyncNotificationMode: 'OFF',
       });
       mockGenerateBikePredictions.mockResolvedValue(null);
 
@@ -603,6 +586,239 @@ describe('notification.service', () => {
         (call) => call[0]?.[0]?.data?.action === 'pickBike'
       );
       expect(bikePickCall).toBeUndefined();
+    });
+
+    describe('rideSyncNotificationMode', () => {
+      it('OFF sends no ride push, including the pick-bike variant', async () => {
+        // The user's opt-out wins over the bike-pick prompt. The unassigned
+        // ride still surfaces in-app (rides list + dashboard banner), so
+        // nothing is silently dropped; the lockscreen just stays quiet.
+        (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
+          ...proUser,
+          rideSyncNotificationMode: 'OFF',
+        });
+
+        await fireRideNotifications({ ...baseParams, bikeId: null, activeBikeCount: 3 });
+
+        expect(mockSendPushNotificationsAsync).not.toHaveBeenCalled();
+      });
+
+      it('OFF still runs the service-due check: silencing sync noise must not silence "fork due"', async () => {
+        (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
+          ...proUser,
+          rideSyncNotificationMode: 'OFF',
+        });
+        mockGenerateBikePredictions.mockResolvedValue({ components: [] });
+
+        await fireRideNotifications(baseParams);
+
+        expect(mockGenerateBikePredictions).toHaveBeenCalled();
+      });
+
+      it('ACTION_NEEDED skips a plain sync confirmation', async () => {
+        (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
+          ...proUser,
+          rideSyncNotificationMode: 'ACTION_NEEDED',
+        });
+        // Not the first-ever ride.
+        (mockPrisma.ride.count as jest.Mock).mockResolvedValue(12);
+
+        await fireRideNotifications(baseParams);
+
+        const rideCall = mockSendPushNotificationsAsync.mock.calls.find(
+          (call) => call[0]?.[0]?.title === 'Ride Synced'
+        );
+        expect(rideCall).toBeUndefined();
+      });
+
+      it('ACTION_NEEDED pushes when the ride needs a bike assigned', async () => {
+        (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
+          ...proUser,
+          rideSyncNotificationMode: 'ACTION_NEEDED',
+        });
+
+        await fireRideNotifications({ ...baseParams, bikeId: null, activeBikeCount: 3 });
+
+        expect(mockSendPushNotificationsAsync).toHaveBeenCalledWith([
+          expect.objectContaining({
+            data: { screen: 'ride', rideId: 'ride-1', action: 'pickBike' },
+          }),
+        ]);
+      });
+
+      it("ACTION_NEEDED pushes the account's first-ever synced ride", async () => {
+        // The "it works" moment when a provider is first connected.
+        (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
+          ...proUser,
+          rideSyncNotificationMode: 'ACTION_NEEDED',
+        });
+        (mockPrisma.ride.count as jest.Mock).mockResolvedValue(1);
+
+        await fireRideNotifications(baseParams);
+
+        const rideCall = mockSendPushNotificationsAsync.mock.calls.find(
+          (call) => call[0]?.[0]?.title === 'Ride Synced'
+        );
+        expect(rideCall).toBeDefined();
+      });
+    });
+
+    describe('burst suppression', () => {
+      it('suppresses a second ride push inside the window, pick-bike included', async () => {
+        // Multi-provider copies of one physical ride and a watch uploading a
+        // weekend at once are the same case: one push, the rest are noise.
+        // Uniform even for the pick-bike variant; the in-app banner carries
+        // multi-ride assignment.
+        (mockPrisma.notificationLog.findFirst as jest.Mock).mockResolvedValue({ id: 'recent' });
+
+        await fireRideNotifications({ ...baseParams, bikeId: null, activeBikeCount: 3 });
+
+        expect(mockSendPushNotificationsAsync).not.toHaveBeenCalled();
+      });
+
+      it('records a RIDE_UPLOADED window row only after a successful send', async () => {
+        mockSendPushNotificationsAsync.mockResolvedValue([{ status: 'ok', id: 'ticket-1' }]);
+
+        await fireRideNotifications(baseParams);
+
+        expect(mockPrisma.notificationLog.create).toHaveBeenCalledWith({
+          data: { userId: 'user-1', notificationType: 'RIDE_UPLOADED' },
+        });
+      });
+
+      it('does not record a window row when the send fails', async () => {
+        // A failed send must not burn the window: the next provider copy is
+        // then the one push the rider gets.
+        mockSendPushNotificationsAsync.mockResolvedValue([{ status: 'error', message: 'nope' }]);
+
+        await fireRideNotifications(baseParams);
+
+        expect(mockPrisma.notificationLog.create).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({ notificationType: 'RIDE_UPLOADED' }),
+          })
+        );
+      });
+
+      it('leaves the service-due push unaffected by the ride-push window', async () => {
+        (mockPrisma.notificationLog.findFirst as jest.Mock).mockResolvedValue({ id: 'recent' });
+        mockGenerateBikePredictions.mockResolvedValue({
+          components: [
+            {
+              componentId: 'comp-1',
+              componentType: 'FORK',
+              brand: 'Fox',
+              model: '36',
+              status: 'DUE_NOW',
+              hoursRemaining: 0,
+              ridesRemainingEstimate: 0,
+            },
+          ],
+        });
+        (mockPrisma.bikeNotificationPreference.findUnique as jest.Mock).mockResolvedValue({
+          serviceNotificationsEnabled: true,
+          serviceNotificationMode: 'AT_SERVICE',
+          serviceNotificationThreshold: 3,
+        });
+
+        await fireRideNotifications(baseParams);
+
+        const serviceCall = mockSendPushNotificationsAsync.mock.calls.find(
+          (call) => call[0]?.[0]?.title === 'Trail Bike - Service Due'
+        );
+        expect(serviceCall).toBeDefined();
+      });
+    });
+  });
+
+  describe('fireServiceDueForBike', () => {
+    const proUser = {
+      expoPushToken: 'ExponentPushToken[abc123]',
+      rideSyncNotificationMode: 'ALL',
+      distanceUnit: 'mi',
+      role: 'USER',
+      predictionMode: 'simple',
+      subscriptionTier: 'PRO',
+      isFoundingRider: false,
+    };
+
+    beforeEach(() => {
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({ ...proUser });
+      (mockPrisma.bike.findFirst as jest.Mock).mockResolvedValue({
+        nickname: 'Trail Bike',
+        manufacturer: 'Santa Cruz',
+        model: 'Hightower',
+      });
+      mockGenerateBikePredictions.mockResolvedValue({
+        components: [
+          {
+            componentId: 'comp-1',
+            componentType: 'FORK',
+            brand: 'Fox',
+            model: '36',
+            status: 'DUE_NOW',
+            hoursRemaining: 0,
+            ridesRemainingEstimate: 0,
+          },
+        ],
+      });
+      (mockPrisma.bikeNotificationPreference.findUnique as jest.Mock).mockResolvedValue({
+        serviceNotificationsEnabled: true,
+        serviceNotificationMode: 'AT_SERVICE',
+        serviceNotificationThreshold: 3,
+      });
+    });
+
+    it('sends the service-due push for an hour-crediting mutation', async () => {
+      // The bulk-assign / ride-edit / manual-ride path: before this existed,
+      // a rider could push a bike past its threshold via assignBikeToRides
+      // and hear nothing until their next synced ride.
+      await fireServiceDueForBike({ userId: 'user-1', bikeId: 'bike-1' });
+
+      expect(mockSendPushNotificationsAsync).toHaveBeenCalledWith([
+        expect.objectContaining({
+          title: 'Trail Bike - Service Due',
+          data: { screen: 'bike', bikeId: 'bike-1', componentId: 'comp-1' },
+        }),
+      ]);
+      expect(enqueueReceiptCheck).toHaveBeenCalledWith('user-1', ['ticket-123']);
+    });
+
+    it('never sends a ride push: this entry point is service-due only', async () => {
+      await fireServiceDueForBike({ userId: 'user-1', bikeId: 'bike-1' });
+
+      const rideCall = mockSendPushNotificationsAsync.mock.calls.find(
+        (call) => call[0]?.[0]?.title === 'Ride Synced'
+      );
+      expect(rideCall).toBeUndefined();
+    });
+
+    it('tier-gates free users like the sync path does', async () => {
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
+        ...proUser,
+        subscriptionTier: 'FREE',
+      });
+
+      await fireServiceDueForBike({ userId: 'user-1', bikeId: 'bike-1' });
+
+      expect(mockGenerateBikePredictions).not.toHaveBeenCalled();
+      expect(mockSendPushNotificationsAsync).not.toHaveBeenCalled();
+    });
+
+    it("skips a bike that isn't the user's (ownership-scoped name lookup)", async () => {
+      (mockPrisma.bike.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await fireServiceDueForBike({ userId: 'user-1', bikeId: 'bike-of-someone-else' });
+
+      expect(mockSendPushNotificationsAsync).not.toHaveBeenCalled();
+    });
+
+    it('swallows errors: a notification must never fail the mutation that triggered it', async () => {
+      (mockPrisma.user.findUnique as jest.Mock).mockRejectedValue(new Error('db down'));
+
+      await expect(
+        fireServiceDueForBike({ userId: 'user-1', bikeId: 'bike-1' })
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/apps/api/src/services/notification.service.ts
+++ b/apps/api/src/services/notification.service.ts
@@ -6,7 +6,12 @@ import { enqueueReceiptCheck } from '../lib/queue/notification.queue';
 import { generateBikePredictions } from './prediction';
 import { canSeePredictions } from '../auth/tier-access';
 import { formatComponentType } from '@loam/shared';
-import type { ServiceNotificationMode } from '@prisma/client';
+import type {
+  RideSyncNotificationMode,
+  ServiceNotificationMode,
+  SubscriptionTier,
+  UserRole,
+} from '@prisma/client';
 
 /**
  * Validates that a string is a well-formed Expo push token.
@@ -26,8 +31,13 @@ type SendPushParams = {
 /**
  * Send a push notification via Expo and return the receipt ticket ID (if successful).
  * Returns null if the send fails or the token is invalid.
+ *
+ * Exported for sibling notification services only (the weekly digest); it is
+ * the raw primitive and enforces none of the gating (preferences, dedup,
+ * burst windows) that makes the system trustworthy. Feature code should call
+ * `fireRideNotifications` / `fireServiceDueForBike`, never this.
  */
-async function sendPushNotification({ pushToken, title, body, data }: SendPushParams): Promise<string | null> {
+export async function sendPushNotification({ pushToken, title, body, data }: SendPushParams): Promise<string | null> {
   if (!Expo.isExpoPushToken(pushToken)) {
     logger.warn({ pushToken }, '[notifications] Invalid Expo push token');
     return null;
@@ -57,9 +67,62 @@ async function sendPushNotification({ pushToken, title, body, data }: SendPushPa
 
 type NotificationUser = {
   expoPushToken: string;
-  notifyOnRideUpload: boolean;
   distanceUnit: string | null;
 };
+
+/**
+ * At most one ride-sync push per user per window, regardless of why each
+ * would have fired. This is the layer where multi-provider copies of the
+ * same physical ride (up to four "Ride Synced" for one ride) and a watch
+ * uploading a weekend's activities in one burst collapse to a single push.
+ * Uniform on purpose: even the pick-bike variant obeys it, because a burst
+ * of unassigned rides used to mean a burst of pick-bike pushes, and the
+ * in-app unassigned-rides banner now carries that workload. Service-due
+ * pushes have their own per-component dedup and are unaffected.
+ */
+const RIDE_PUSH_WINDOW_MS = 30 * 60 * 1000;
+
+/** RIDE_UPLOADED window rows are only ever read within the window; anything
+ *  older is dead weight, pruned opportunistically on each send. */
+const RIDE_PUSH_ROW_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * True when a ride push went out recently enough that another would be noise.
+ *
+ * The check and the later record are not atomic; two workers ingesting
+ * provider copies of the same ride concurrently can both pass and send two
+ * pushes. That race loses nothing relative to the old behavior (which always
+ * sent both) and a claim-row scheme like SERVICE_DUE's would need a
+ * time-bucketed unique key to express "per window", so it is deliberately
+ * left as a best-effort read.
+ */
+async function isRidePushBurstSuppressed(userId: string): Promise<boolean> {
+  const recent = await prisma.notificationLog.findFirst({
+    where: {
+      userId,
+      notificationType: 'RIDE_UPLOADED',
+      sentAt: { gte: new Date(Date.now() - RIDE_PUSH_WINDOW_MS) },
+    },
+    select: { id: true },
+  });
+  return recent !== null;
+}
+
+async function recordRidePush(userId: string): Promise<void> {
+  await prisma.notificationLog.create({
+    data: { userId, notificationType: 'RIDE_UPLOADED' },
+  });
+  // Prune stale window rows so the table doesn't accrete one row per ride
+  // forever. Best-effort: a failed prune only leaves rows the window query
+  // already ignores by sentAt.
+  await prisma.notificationLog.deleteMany({
+    where: {
+      userId,
+      notificationType: 'RIDE_UPLOADED',
+      sentAt: { lt: new Date(Date.now() - RIDE_PUSH_ROW_TTL_MS) },
+    },
+  });
+}
 
 /**
  * Send a notification when a ride is synced from an integration (Strava/Garmin/Whoop/Suunto).
@@ -69,12 +132,9 @@ type NotificationUser = {
  * is set so the mobile listener deep-links straight into the bike picker on
  * the ride detail screen.
  *
- * Always gated on `notifyOnRideUpload`. The user's notification preference
- * is the source of truth — if they've opted out of ride-upload notifications
- * we don't surface the bike-pick prompt either, even though it's a one-shot
- * affordance. The unassigned ride still surfaces the next time they open the
- * app via the in-app rides list, so we're not silently dropping data on the
- * floor; we're just respecting their choice to keep the lockscreen quiet.
+ * Pure compose-and-send: whether this push should go out at all
+ * (rideSyncNotificationMode, burst window) is decided by
+ * `fireRideNotifications`, which owns the user row and the window state.
  */
 export async function notifyRideUploaded(params: {
   userId: string;
@@ -86,8 +146,6 @@ export async function notifyRideUploaded(params: {
   user: NotificationUser;
 }): Promise<string | undefined> {
   const { rideId, durationSeconds, distanceMeters, bikeName, needsBikeAssignment, user } = params;
-
-  if (!user.notifyOnRideUpload) return;
 
   const durationMin = Math.round(durationSeconds / 60);
   const isKm = user.distanceUnit === 'km';
@@ -264,9 +322,127 @@ export async function checkAndNotifyServiceDue(params: {
   return ticketId;
 }
 
+/** The user fields every notification decision needs. */
+const NOTIFICATION_USER_SELECT = {
+  expoPushToken: true,
+  rideSyncNotificationMode: true,
+  distanceUnit: true,
+  role: true,
+  predictionMode: true,
+  subscriptionTier: true,
+  isFoundingRider: true,
+} as const;
+
+type LoadedNotificationUser = {
+  expoPushToken: string | null;
+  rideSyncNotificationMode: RideSyncNotificationMode;
+  distanceUnit: string | null;
+  role: UserRole;
+  predictionMode: string | null;
+  subscriptionTier: SubscriptionTier;
+  isFoundingRider: boolean;
+};
+
+/**
+ * Tier-gate, predict, and send the service-due push for one bike.
+ * Shared by the ride-sync orchestrator and the mutation-facing
+ * `fireServiceDueForBike`. Returns the push ticket id when one was sent.
+ *
+ * Service-due pushes carry the rides/hours-remaining prediction (a Pro
+ * feature), so free users are gated out here, not at the callers.
+ */
+async function runServiceDueForBike(
+  user: LoadedNotificationUser,
+  userId: string,
+  bikeId: string,
+  bikeName: string
+): Promise<string | undefined> {
+  if (!user.expoPushToken || !canSeePredictions(user)) return;
+
+  const predictionMode = (user.predictionMode === 'predictive' ? 'predictive' : 'simple') as 'simple' | 'predictive';
+  const summary = await generateBikePredictions({
+    userId,
+    bikeId,
+    userRole: user.role,
+    predictionMode,
+    subscriptionTier: user.subscriptionTier,
+    isFoundingRider: user.isFoundingRider,
+  });
+  if (!summary?.components) return;
+
+  return checkAndNotifyServiceDue({
+    userId,
+    bikeId,
+    bikeName,
+    pushToken: user.expoPushToken,
+    predictions: summary.components,
+  });
+}
+
+async function loadBikeName(userId: string, bikeId: string): Promise<string | undefined> {
+  // Scoped to the owner so a caller bug can never push one user's bike name
+  // to another user's device.
+  const bike = await prisma.bike.findFirst({
+    where: { id: bikeId, userId },
+    select: { nickname: true, manufacturer: true, model: true },
+  });
+  if (!bike) return undefined;
+  return bike.nickname || [bike.manufacturer, bike.model].filter(Boolean).join(' ') || undefined;
+}
+
+/**
+ * Fire-and-forget service-due check for a bike whose counted hours just
+ * changed OUTSIDE the ride-sync path: bulk bike assignment, a ride edit
+ * that moved hours onto a bike, a manual ride entry.
+ *
+ * Before this existed, service-due could only fire as a side effect of an
+ * integration sync: a rider who bulk-assigned fifteen backfilled rides
+ * could push a bike straight past its service threshold in silence, and
+ * heard nothing until their NEXT synced ride happened to land on that bike.
+ * The dedup in `checkAndNotifyServiceDue` makes this safe to call from any
+ * hour-crediting path: a component already notified stays silent.
+ *
+ * Never throws.
+ */
+export async function fireServiceDueForBike(params: {
+  userId: string;
+  bikeId: string;
+}): Promise<void> {
+  const { userId, bikeId } = params;
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: NOTIFICATION_USER_SELECT,
+    });
+    if (!user?.expoPushToken) return;
+
+    const bikeName = await loadBikeName(userId, bikeId);
+    if (!bikeName) return;
+
+    const ticketId = await runServiceDueForBike(user, userId, bikeId, bikeName);
+    if (ticketId) {
+      enqueueReceiptCheck(userId, [ticketId]).catch((err) =>
+        logError('enqueueReceiptCheck', err)
+      );
+    }
+  } catch (error) {
+    logError('fireServiceDueForBike', error);
+  }
+}
+
 /**
  * Fire-and-forget: send ride upload notification and check service due notifications.
  * Errors are logged but never thrown to avoid blocking the caller.
+ *
+ * Whether the "Ride Synced" push goes out is decided by
+ * `rideSyncNotificationMode`:
+ *   ALL           every new integration ride, minus burst suppression
+ *   ACTION_NEEDED only rides needing a bike pick, plus the account's
+ *                 first-ever synced ride (the "it works" moment when a
+ *                 provider is first connected)
+ *   OFF           never
+ * All ride pushes share one burst window (`RIDE_PUSH_WINDOW_MS`); the
+ * service-due push is governed by per-bike preferences, not by this mode.
  */
 export async function fireRideNotifications(params: {
   userId: string;
@@ -296,30 +472,12 @@ export async function fireRideNotifications(params: {
     // Single user query for all notification needs
     const user = await prisma.user.findUnique({
       where: { id: userId },
-      select: {
-        expoPushToken: true,
-        notifyOnRideUpload: true,
-        distanceUnit: true,
-        role: true,
-        predictionMode: true,
-        subscriptionTier: true,
-        isFoundingRider: true,
-      },
+      select: NOTIFICATION_USER_SELECT,
     });
 
     if (!user?.expoPushToken) return;
 
-    // Get bike name if assigned
-    let bikeName: string | undefined;
-    if (bikeId) {
-      const bike = await prisma.bike.findUnique({
-        where: { id: bikeId },
-        select: { nickname: true, manufacturer: true, model: true },
-      });
-      if (bike) {
-        bikeName = bike.nickname || [bike.manufacturer, bike.model].filter(Boolean).join(' ') || undefined;
-      }
-    }
+    const bikeName = bikeId ? await loadBikeName(userId, bikeId) : undefined;
 
     const ticketIds: string[] = [];
 
@@ -333,40 +491,49 @@ export async function fireRideNotifications(params: {
       !bikeId &&
       (providedBikeCount ?? (await prisma.bike.count({ where: { userId, status: 'ACTIVE' } }))) > 1;
 
-    const rideTicketId = await notifyRideUploaded({
-      userId, rideId, durationSeconds, distanceMeters, bikeName,
-      needsBikeAssignment,
-      user: {
-        expoPushToken: user.expoPushToken,
-        notifyOnRideUpload: user.notifyOnRideUpload,
-        distanceUnit: user.distanceUnit,
-      },
-    });
-    if (rideTicketId) ticketIds.push(rideTicketId);
-
-    // Service due check (only if ride is assigned to a bike). Service-due
-    // pushes carry the rides/hours-remaining prediction — a Pro feature —
-    // so free users receive only the ride-upload notification.
-    if (bikeId && bikeName && canSeePredictions(user)) {
-      const predictionMode = (user.predictionMode === 'predictive' ? 'predictive' : 'simple') as 'simple' | 'predictive';
-      const summary = await generateBikePredictions({
-        userId,
-        bikeId,
-        userRole: user.role,
-        predictionMode,
-        subscriptionTier: user.subscriptionTier,
-        isFoundingRider: user.isFoundingRider,
-      });
-      if (summary?.components) {
-        const serviceTicketId = await checkAndNotifyServiceDue({
-          userId,
-          bikeId,
-          bikeName,
-          pushToken: user.expoPushToken,
-          predictions: summary.components,
-        });
-        if (serviceTicketId) ticketIds.push(serviceTicketId);
+    const mode = user.rideSyncNotificationMode;
+    let sendRidePush = false;
+    if (mode !== 'OFF') {
+      if (needsBikeAssignment || mode === 'ALL') {
+        sendRidePush = true;
+      } else {
+        // ACTION_NEEDED: the one non-actionable push that still earns its
+        // place is the account's first-ever synced ride, the moment that
+        // proves the integration works. count === 1 is the ride we are
+        // holding right now.
+        const rideCount = await prisma.ride.count({ where: { userId } });
+        sendRidePush = rideCount === 1;
       }
+      // One window for every ride push, whatever justified it. A burst of
+      // unassigned rides means one pick-bike push, not one per ride; the
+      // in-app unassigned-rides banner carries the rest.
+      if (sendRidePush && (await isRidePushBurstSuppressed(userId))) {
+        sendRidePush = false;
+      }
+    }
+
+    if (sendRidePush) {
+      const rideTicketId = await notifyRideUploaded({
+        userId, rideId, durationSeconds, distanceMeters, bikeName,
+        needsBikeAssignment,
+        user: {
+          expoPushToken: user.expoPushToken,
+          distanceUnit: user.distanceUnit,
+        },
+      });
+      if (rideTicketId) {
+        ticketIds.push(rideTicketId);
+        await recordRidePush(userId);
+      }
+    }
+
+    // Service due check (only if ride is assigned to a bike). Deliberately
+    // independent of rideSyncNotificationMode: silencing sync confirmations
+    // must not silence "your fork is due", which has its own per-bike
+    // preference and per-component dedup.
+    if (bikeId && bikeName) {
+      const serviceTicketId = await runServiceDueForBike(user, userId, bikeId, bikeName);
+      if (serviceTicketId) ticketIds.push(serviceTicketId);
     }
 
     // Enqueue delayed receipt check for all tickets from this ride

--- a/apps/api/src/services/weekly-digest.service.test.ts
+++ b/apps/api/src/services/weekly-digest.service.test.ts
@@ -1,0 +1,247 @@
+// Mock dependencies before imports
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    user: { findMany: jest.fn() },
+    bike: { findMany: jest.fn() },
+    ride: { count: jest.fn() },
+    notificationLog: { create: jest.fn(), findFirst: jest.fn() },
+  },
+}));
+
+jest.mock('../lib/logger', () => ({
+  logError: jest.fn(),
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('../lib/redis', () => ({
+  getRedisConnection: jest.fn(),
+  isRedisReady: jest.fn(() => false),
+}));
+
+jest.mock('../lib/queue/notification.queue', () => ({
+  enqueueReceiptCheck: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockGenerateBikePredictions = jest.fn();
+jest.mock('./prediction', () => ({
+  generateBikePredictions: (...args: unknown[]) => mockGenerateBikePredictions(...args),
+}));
+
+const mockSendPushNotification = jest.fn();
+jest.mock('./notification.service', () => ({
+  sendPushNotification: (...args: unknown[]) => mockSendPushNotification(...args),
+}));
+
+import { prisma } from '../lib/prisma';
+import { enqueueReceiptCheck } from '../lib/queue/notification.queue';
+import { buildDigestBody, maybeSendDigestForUser, runWeeklyDigestSweep } from './weekly-digest.service';
+import type { SubscriptionTier, UserRole } from '@prisma/client';
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+const proUser = {
+  id: 'user-1',
+  expoPushToken: 'ExponentPushToken[abc123]',
+  timezone: 'UTC',
+  role: 'USER' as UserRole,
+  predictionMode: 'simple',
+  subscriptionTier: 'PRO' as SubscriptionTier,
+  isFoundingRider: false,
+};
+
+/** 2026-08-07 is a Friday; 08:30 UTC is inside the send hour for tz UTC. */
+const FRIDAY_8AM_UTC = new Date('2026-08-07T08:30:00Z');
+/** Same instant is 01:30 in Los Angeles — outside the send window there. */
+const LA_TZ = 'America/Los_Angeles';
+
+const bike = (id: string, nickname: string) => ({ id, nickname, manufacturer: 'M', model: 'X' });
+const pred = (componentId: string, componentType: string, status: string) => ({
+  componentId,
+  componentType,
+  brand: 'B',
+  model: 'M',
+  status,
+  hoursRemaining: 1,
+  ridesRemainingEstimate: 1,
+});
+
+describe('weekly-digest.service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSendPushNotification.mockResolvedValue('ticket-1');
+    (mockPrisma.notificationLog.findFirst as jest.Mock).mockResolvedValue(null);
+    (mockPrisma.notificationLog.create as jest.Mock).mockResolvedValue({});
+    (mockPrisma.ride.count as jest.Mock).mockResolvedValue(0);
+  });
+
+  describe('buildDigestBody', () => {
+    it('returns null with no active bikes — nothing worth waking a phone for', async () => {
+      (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([]);
+
+      expect(await buildDigestBody(proUser)).toBeNull();
+    });
+
+    it('answers the core question directly when everything is healthy', async () => {
+      (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([
+        bike('b1', 'Smuggler'),
+        bike('b2', 'TYEE'),
+        bike('b3', 'JACKAL'),
+      ]);
+      mockGenerateBikePredictions.mockResolvedValue({ components: [pred('c1', 'FORK', 'ALL_GOOD')] });
+
+      expect(await buildDigestBody(proUser)).toBe('All 3 bikes good to go');
+    });
+
+    it('names the single bike in the all-good case', async () => {
+      (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([bike('b1', 'Smuggler')]);
+      mockGenerateBikePredictions.mockResolvedValue({ components: [] });
+
+      expect(await buildDigestBody(proUser)).toBe('Smuggler good to go');
+    });
+
+    it('leads with the worst bike and truncates to two bikes and two components', async () => {
+      (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([
+        bike('b1', 'Mild'),
+        bike('b2', 'Bad'),
+        bike('b3', 'AlsoDue'),
+      ]);
+      mockGenerateBikePredictions
+        // b1: one due-soon issue
+        .mockResolvedValueOnce({ components: [pred('c1', 'CHAIN', 'DUE_SOON')] })
+        // b2: overdue + due now + due soon — worst bike, 3 issues
+        .mockResolvedValueOnce({
+          components: [
+            pred('c2', 'FORK', 'OVERDUE'),
+            pred('c3', 'BRAKE_PAD', 'DUE_NOW'),
+            pred('c4', 'SHOCK', 'DUE_SOON'),
+          ],
+        })
+        // b3: due now
+        .mockResolvedValueOnce({ components: [pred('c5', 'CASSETTE', 'DUE_NOW')] });
+
+      const body = await buildDigestBody(proUser);
+
+      // Worst bike leads, its list truncates at two, third bike collapses
+      // into the counter.
+      expect(body).toContain('Bad: fork overdue, brake pad due now, +1 more');
+      expect(body?.indexOf('Bad')).toBeLessThan(body!.indexOf('AlsoDue'));
+      expect(body).toContain('1 more bike needs work');
+      expect(body).not.toContain('Mild:');
+    });
+
+    it('appends the unassigned-rides fragment when rides are waiting on a bike', async () => {
+      (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([bike('b1', 'Smuggler')]);
+      mockGenerateBikePredictions.mockResolvedValue({ components: [] });
+      (mockPrisma.ride.count as jest.Mock).mockResolvedValue(3);
+
+      expect(await buildDigestBody(proUser)).toBe('Smuggler good to go · 3 rides need a bike');
+    });
+
+    it('counts unassigned rides with the canonical predicate (unowned excluded)', async () => {
+      (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([bike('b1', 'Smuggler')]);
+      mockGenerateBikePredictions.mockResolvedValue({ components: [] });
+
+      await buildDigestBody(proUser);
+
+      expect(mockPrisma.ride.count).toHaveBeenCalledWith({
+        where: { userId: 'user-1', bikeId: null, unownedBike: false },
+      });
+    });
+  });
+
+  describe('maybeSendDigestForUser', () => {
+    beforeEach(() => {
+      (mockPrisma.bike.findMany as jest.Mock).mockResolvedValue([bike('b1', 'Smuggler')]);
+      mockGenerateBikePredictions.mockResolvedValue({ components: [] });
+    });
+
+    it('sends inside the local Friday-8am window and records the log', async () => {
+      await maybeSendDigestForUser(proUser, FRIDAY_8AM_UTC);
+
+      expect(mockSendPushNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Weekend bike check',
+          body: 'Smuggler good to go',
+          data: { screen: 'dashboard' },
+        })
+      );
+      expect(mockPrisma.notificationLog.create).toHaveBeenCalledWith({
+        data: { userId: 'user-1', notificationType: 'WEEKLY_DIGEST' },
+      });
+      expect(enqueueReceiptCheck).toHaveBeenCalledWith('user-1', ['ticket-1']);
+    });
+
+    it('does not send outside the window — 8:30 UTC is 1:30am in Los Angeles', async () => {
+      await maybeSendDigestForUser({ ...proUser, timezone: LA_TZ }, FRIDAY_8AM_UTC);
+
+      expect(mockSendPushNotification).not.toHaveBeenCalled();
+    });
+
+    it('does not send twice in one week', async () => {
+      (mockPrisma.notificationLog.findFirst as jest.Mock).mockResolvedValue({ id: 'sent' });
+
+      await maybeSendDigestForUser(proUser, FRIDAY_8AM_UTC);
+
+      expect(mockSendPushNotification).not.toHaveBeenCalled();
+    });
+
+    it('skips free users — the digest is a prediction surface', async () => {
+      await maybeSendDigestForUser(
+        { ...proUser, subscriptionTier: 'FREE' as SubscriptionTier },
+        FRIDAY_8AM_UTC
+      );
+
+      expect(mockSendPushNotification).not.toHaveBeenCalled();
+    });
+
+    it('skips users with an invalid stored timezone instead of throwing', async () => {
+      await maybeSendDigestForUser({ ...proUser, timezone: 'Not/AZone' }, FRIDAY_8AM_UTC);
+
+      expect(mockSendPushNotification).not.toHaveBeenCalled();
+    });
+
+    it('does not record a log when the send fails, so the next sweep retries', async () => {
+      mockSendPushNotification.mockResolvedValue(null);
+
+      await maybeSendDigestForUser(proUser, FRIDAY_8AM_UTC);
+
+      expect(mockPrisma.notificationLog.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('runWeeklyDigestSweep', () => {
+    it('one failing user does not cost the users after them their digest', async () => {
+      (mockPrisma.user.findMany as jest.Mock).mockResolvedValue([
+        { ...proUser, id: 'user-bad' },
+        { ...proUser, id: 'user-good' },
+      ]);
+      (mockPrisma.bike.findMany as jest.Mock)
+        .mockRejectedValueOnce(new Error('db hiccup'))
+        .mockResolvedValue([bike('b1', 'Smuggler')]);
+      mockGenerateBikePredictions.mockResolvedValue({ components: [] });
+
+      await runWeeklyDigestSweep(FRIDAY_8AM_UTC);
+
+      expect(mockSendPushNotification).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.notificationLog.create).toHaveBeenCalledWith({
+        data: { userId: 'user-good', notificationType: 'WEEKLY_DIGEST' },
+      });
+    });
+
+    it('only queries opted-in users with a token and a timezone', async () => {
+      (mockPrisma.user.findMany as jest.Mock).mockResolvedValue([]);
+
+      await runWeeklyDigestSweep(FRIDAY_8AM_UTC);
+
+      expect(mockPrisma.user.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            weeklyDigestEnabled: true,
+            expoPushToken: { not: null },
+            timezone: { not: null },
+          },
+        })
+      );
+    });
+  });
+});

--- a/apps/api/src/services/weekly-digest.service.ts
+++ b/apps/api/src/services/weekly-digest.service.ts
@@ -1,0 +1,311 @@
+import { prisma } from '../lib/prisma';
+import { logError, logger } from '../lib/logger';
+import { getRedisConnection, isRedisReady } from '../lib/redis';
+import { enqueueReceiptCheck } from '../lib/queue/notification.queue';
+import { UNASSIGNED_RIDE_WHERE } from '../lib/ride-predicates';
+import { sendPushNotification } from './notification.service';
+import { generateBikePredictions } from './prediction';
+import { canSeePredictions } from '../auth/tier-access';
+import { formatComponentType } from '@loam/shared';
+import type { SubscriptionTier, UserRole } from '@prisma/client';
+
+/**
+ * Weekly gear-health digest.
+ *
+ * One push, Friday 8am in the rider's local time, answering the product's
+ * core question before the weekend: "Is the bike I want to ride good to go,
+ * or what needs to be done to get it good to go?"
+ *
+ * Deliberate properties, all load-bearing:
+ * - Opt-in and off by default. This is the only push in the system that is
+ *   not a direct consequence of something the rider did, so it must be asked
+ *   for, never assumed.
+ * - Pro-gated at send time (`canSeePredictions`), like every other surface
+ *   that shows predictions.
+ * - Skips riders with no stored timezone rather than guessing. A digest at
+ *   3am teaches a rider to disable notifications; no digest teaches nothing.
+ * - The all-good week still sends ("All 3 bikes good to go"). Unlike the
+ *   event-driven pushes, where silence means nothing is wrong, a rider who
+ *   opted into a weekly check is owed the answer either way — an opt-in
+ *   digest that only ever brings bad news reads as nagging, not as a check.
+ * - Statuses come straight from predictions, independent of each bike's
+ *   BikeNotificationPreference. Those thresholds tune the event-driven
+ *   service-due push; the digest is a summary of state, not an alert.
+ */
+
+const DIGEST_TITLE = 'Weekend bike check';
+/** Friday, matching Intl's en-US short weekday form. */
+const DIGEST_LOCAL_WEEKDAY = 'Fri';
+/** Send during the 08:00–08:59 local hour. */
+const DIGEST_LOCAL_HOUR = 8;
+/**
+ * Sweep every 15 minutes: several chances to catch each user's local 8am
+ * hour, close enough to 8:00 to still read as "morning".
+ */
+const SWEEP_INTERVAL_MS = 15 * 60 * 1000;
+/**
+ * "Already sent this week" window. Six days rather than seven so DST shifts
+ * and sweep-timing drift can never skip a week outright.
+ */
+const SENT_WINDOW_MS = 6 * 24 * 60 * 60 * 1000;
+
+const LOCK_KEY = 'lock:weekly-digest:global';
+const LOCK_TTL_SECONDS = 10 * 60;
+
+/** Severity order for picking what leads the body. */
+const STATUS_RANK: Record<string, number> = { OVERDUE: 0, DUE_NOW: 1, DUE_SOON: 2 };
+const STATUS_WORD: Record<string, string> = {
+  OVERDUE: 'overdue',
+  DUE_NOW: 'due now',
+  DUE_SOON: 'due soon',
+};
+
+type DigestUser = {
+  id: string;
+  expoPushToken: string | null;
+  timezone: string | null;
+  role: UserRole;
+  predictionMode: string | null;
+  subscriptionTier: SubscriptionTier;
+  isFoundingRider: boolean;
+};
+
+/**
+ * The rider's local weekday and hour, or null when the stored timezone is
+ * invalid (the resolver validates writes, but a bad value must degrade to
+ * "skip", never to a throw that kills the sweep for everyone after them).
+ */
+function localParts(timezone: string, now: Date): { weekday: string; hour: number } | null {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      weekday: 'short',
+      hour: 'numeric',
+      hour12: false,
+    }).formatToParts(now);
+    const weekday = parts.find((p) => p.type === 'weekday')?.value;
+    const hourRaw = parts.find((p) => p.type === 'hour')?.value;
+    if (!weekday || hourRaw === undefined) return null;
+    // Intl renders midnight as "24" in some hour12:false locales; normalize.
+    const hour = Number(hourRaw) % 24;
+    return Number.isNaN(hour) ? null : { weekday, hour };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compose the digest body for one user, or null when there is nothing worth
+ * sending (no active bikes).
+ *
+ * Shape: at most two bikes named with at most two components each, then
+ * counts. "Smuggler: fork overdue, chain due soon · TYEE: brake pads due
+ * now · 2 more bikes need work · 3 rides need a bike". Copy reuses the
+ * dashboard's own vocabulary ("need work", "need a bike", "good to go") so
+ * the push and the screen it opens describe the world identically.
+ */
+export async function buildDigestBody(user: DigestUser): Promise<string | null> {
+  const bikes = await prisma.bike.findMany({
+    where: { userId: user.id, status: 'ACTIVE' },
+    select: { id: true, nickname: true, manufacturer: true, model: true },
+  });
+  if (bikes.length === 0) return null;
+
+  const predictionMode = (user.predictionMode === 'predictive' ? 'predictive' : 'simple') as 'simple' | 'predictive';
+
+  type BikeIssues = {
+    name: string;
+    /** Sorted worst-first. */
+    issues: { componentType: string; status: string }[];
+  };
+  const bikesWithIssues: BikeIssues[] = [];
+
+  for (const bike of bikes) {
+    const name = bike.nickname || [bike.manufacturer, bike.model].filter(Boolean).join(' ') || 'Bike';
+    const summary = await generateBikePredictions({
+      userId: user.id,
+      bikeId: bike.id,
+      userRole: user.role,
+      predictionMode,
+      subscriptionTier: user.subscriptionTier,
+      isFoundingRider: user.isFoundingRider,
+    });
+    const issues = (summary?.components ?? [])
+      .filter((c) => c.status !== 'ALL_GOOD' && c.status in STATUS_RANK)
+      .sort((a, b) => STATUS_RANK[a.status] - STATUS_RANK[b.status])
+      .map((c) => ({ componentType: c.componentType, status: c.status }));
+    if (issues.length > 0) {
+      bikesWithIssues.push({ name, issues });
+    }
+  }
+
+  const unassignedCount = await prisma.ride.count({
+    where: { userId: user.id, ...UNASSIGNED_RIDE_WHERE },
+  });
+
+  const fragments: string[] = [];
+
+  if (bikesWithIssues.length === 0) {
+    if (bikes.length === 1) {
+      const only = bikes[0];
+      const name = only.nickname || [only.manufacturer, only.model].filter(Boolean).join(' ') || 'Your bike';
+      fragments.push(`${name} good to go`);
+    } else {
+      fragments.push(`All ${bikes.length} bikes good to go`);
+    }
+  } else {
+    // Worst bike first: lead with the strongest reason the push exists.
+    bikesWithIssues.sort(
+      (a, b) => STATUS_RANK[a.issues[0].status] - STATUS_RANK[b.issues[0].status]
+    );
+    const MAX_BIKES = 2;
+    const MAX_COMPONENTS = 2;
+    for (const bike of bikesWithIssues.slice(0, MAX_BIKES)) {
+      const listed = bike.issues
+        .slice(0, MAX_COMPONENTS)
+        .map((i) => `${formatComponentType(i.componentType, null, { case: 'lower' })} ${STATUS_WORD[i.status]}`)
+        .join(', ');
+      const extra = bike.issues.length - MAX_COMPONENTS;
+      fragments.push(extra > 0 ? `${bike.name}: ${listed}, +${extra} more` : `${bike.name}: ${listed}`);
+    }
+    const moreBikes = bikesWithIssues.length - MAX_BIKES;
+    if (moreBikes > 0) {
+      fragments.push(`${moreBikes} more ${moreBikes === 1 ? 'bike needs' : 'bikes need'} work`);
+    }
+  }
+
+  if (unassignedCount > 0) {
+    fragments.push(`${unassignedCount} ${unassignedCount === 1 ? 'ride needs' : 'rides need'} a bike`);
+  }
+
+  return fragments.join(' · ');
+}
+
+/** Decide-and-send for one candidate. Exported for tests. */
+export async function maybeSendDigestForUser(user: DigestUser, now: Date): Promise<void> {
+  if (!user.expoPushToken || !user.timezone) return;
+  if (!canSeePredictions(user)) return;
+
+  const local = localParts(user.timezone, now);
+  if (!local || local.weekday !== DIGEST_LOCAL_WEEKDAY || local.hour !== DIGEST_LOCAL_HOUR) return;
+
+  const alreadySent = await prisma.notificationLog.findFirst({
+    where: {
+      userId: user.id,
+      notificationType: 'WEEKLY_DIGEST',
+      sentAt: { gte: new Date(now.getTime() - SENT_WINDOW_MS) },
+    },
+    select: { id: true },
+  });
+  if (alreadySent) return;
+
+  const body = await buildDigestBody(user);
+  if (!body) return;
+
+  const ticketId = await sendPushNotification({
+    pushToken: user.expoPushToken,
+    title: DIGEST_TITLE,
+    body,
+    data: { screen: 'dashboard' },
+  });
+  if (!ticketId) return;
+
+  await prisma.notificationLog.create({
+    data: { userId: user.id, notificationType: 'WEEKLY_DIGEST' },
+  });
+  enqueueReceiptCheck(user.id, [ticketId]).catch((err) => logError('enqueueReceiptCheck', err));
+
+  logger.info({ userId: user.id }, '[weekly-digest] Digest sent');
+}
+
+/** One sweep over every opted-in user. Exported for tests. */
+export async function runWeeklyDigestSweep(now: Date = new Date()): Promise<void> {
+  const candidates = await prisma.user.findMany({
+    where: {
+      weeklyDigestEnabled: true,
+      expoPushToken: { not: null },
+      timezone: { not: null },
+    },
+    select: {
+      id: true,
+      expoPushToken: true,
+      timezone: true,
+      role: true,
+      predictionMode: true,
+      subscriptionTier: true,
+      isFoundingRider: true,
+    },
+  });
+
+  for (const user of candidates) {
+    try {
+      await maybeSendDigestForUser(user, now);
+    } catch (error) {
+      // One rider's bad data must not cost everyone after them their digest.
+      logError('weeklyDigest:user', error);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler plumbing — mirrors import-session-checker.service.ts: a plain
+// interval whose body takes a Redis lock so multiple API instances don't
+// double-send, and skips (rather than risks it) when Redis is down.
+// ---------------------------------------------------------------------------
+
+let sweepInterval: NodeJS.Timeout | null = null;
+let isSweeping = false;
+
+async function lockedSweep(): Promise<void> {
+  if (isSweeping) return;
+
+  if (!isRedisReady()) {
+    logger.warn('[weekly-digest] Redis unavailable, skipping sweep to prevent double-sends');
+    return;
+  }
+
+  const lockValue = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  try {
+    const redis = getRedisConnection();
+    const acquired = await redis.set(LOCK_KEY, lockValue, 'EX', LOCK_TTL_SECONDS, 'NX');
+    if (acquired !== 'OK') return;
+  } catch (error) {
+    logError('weeklyDigest:lock', error);
+    return;
+  }
+
+  isSweeping = true;
+  try {
+    await runWeeklyDigestSweep();
+  } catch (error) {
+    logError('weeklyDigest:sweep', error);
+  } finally {
+    isSweeping = false;
+    // Atomic check-and-delete so an expired-and-reacquired lock is never
+    // released out from under another instance.
+    try {
+      const redis = getRedisConnection();
+      await redis.eval(
+        `if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end`,
+        1,
+        LOCK_KEY,
+        lockValue
+      );
+    } catch (error) {
+      logError('weeklyDigest:unlock', error);
+    }
+  }
+}
+
+export function startWeeklyDigestScheduler(): void {
+  if (sweepInterval) return;
+  sweepInterval = setInterval(() => void lockedSweep(), SWEEP_INTERVAL_MS);
+  logger.info('[weekly-digest] Scheduler started');
+}
+
+export function stopWeeklyDigestScheduler(): void {
+  if (sweepInterval) {
+    clearInterval(sweepInterval);
+    sweepInterval = null;
+  }
+}


### PR DESCRIPTION
## Why

The push system had exactly two notification types, inverted in priority. "Ride Synced" fired on every new integration ride (up to four times for one physical ride when multiple providers deliver copies), while "{Bike} - Service Due", the push that answers the product's core question, could only fire as a passenger on an integration sync. A rider who bulk-assigned fifteen backfilled rides could push a bike straight past its service threshold and hear nothing until their next synced ride happened to land on it.

The redesign rule: every push either asks for an action, marks a milestone, or is a summary the rider explicitly opted into. No streaks, no re-engagement, no marketing pushes. Quiet is a feature.

## What

**Three-way ride-sync mode** (`User.rideSyncNotificationMode`):

| Mode | Behavior |
|---|---|
| `ALL` | Every new integration ride (the original behavior) |
| `ACTION_NEEDED` | Only rides needing a bike assigned, plus the account's first-ever synced ride |
| `OFF` | Never |

The migration backfills existing users from `notifyOnRideUpload` (true to ALL, false to OFF) so **nobody's behavior changes with this deploy**; the ACTION_NEEDED column default applies only to accounts created after it. The legacy boolean stays two-way-synced for app versions <= 1.1.4, with one subtlety covered by tests: an old client re-sending `true` lifts OFF to ALL but does not stomp a stored ACTION_NEEDED, because that client's toggle renders "on" for that mode and a save from that screen is a no-op, not a request to hear about every ride. `User.notifyOnRideUpload` is now derived from the mode.

**Burst suppression.** All ride pushes share one 30-minute window, recorded via the previously dead `RIDE_UPLOADED` NotificationLog value (rows are pruned opportunistically after 24h). Multi-provider copies of one ride and a watch uploading a weekend at once now produce one push. Deliberately uniform, pick-bike variant included: a burst of unassigned rides used to mean a burst of pick-bike pushes, and the in-app unassigned-rides banner carries that workload now. The check-then-record pair is not atomic; the worst case of the race is two pushes where today's behavior always sent both, and the comment says so.

**Service-due from every hour-crediting path.** New `fireServiceDueForBike` entry point, called by `assignBikeToRides`, `updateRide` (bike gained or duration grew), and manual `addRide`. Shares the tier gate, per-bike preferences, and per-component dedup with the sync path, so it is safe to call from any mutation. Losing hours never triggers it (a shrink can't make a component due). Service-due remains fully independent of the ride-sync mode: silencing sync noise must not silence "your fork is due".

**Weekly digest ("Weekend bike check").** Opt-in, off by default, Pro-gated at send time, Friday 8am in the rider's stored IANA timezone. Skips users with no stored timezone rather than guessing (a 3am digest teaches a rider to disable notifications). Summarizes every active bike in the dashboard's own vocabulary ("need work", "good to go", "rides need a bike"), truncating to two bikes and two components, worst first. The all-good week still sends: a rider who asked for a weekly answer is owed it either way. Swept every 15 minutes under a Redis lock (mirrors import-session-checker), deduped by a six-day NotificationLog window so DST shifts can't skip a week.

**Refactor:** `UNASSIGNED_RIDE_WHERE` moves from resolvers.ts to `lib/ride-predicates.ts` so the digest service can share it without importing the resolver module.

## Migration

`20260805090000_add_notification_modes_and_digest`: one enum type, three User columns (mode with backfill UPDATE, `weeklyDigestEnabled`, `timezone`), one enum value added to `NotificationType`. Additive; the backfill preserves current behavior for every existing row.

## New GraphQL surface

- `UpdateUserPreferencesInput`: `rideSyncNotificationMode`, `weeklyDigestEnabled`, `timezone` (Intl-validated, explicit null clears)
- `User`: `rideSyncNotificationMode!`, `weeklyDigestEnabled!`

## Testing

- Full suite green: **1867 passed / 91 suites** (67 net new tests).
- New coverage: mode gating (including OFF suppressing pick-bike but not service-due), burst window (send/suppress/record-only-on-success), first-ever-ride milestone, `fireServiceDueForBike` (send, tier gate, ownership-scoped bike lookup, never-throws), legacy boolean mapping in all three directions, timezone validation, digest body composition, local-time windowing, weekly dedup, and sweep isolation (one failing user doesn't cost the rest their digest).
- Lint clean (3 pre-existing warnings); typecheck at the known `@loam/shared` baseline.

## Caveats

- **Nothing has been exercised against a running server.** No push has actually been sent; verification is unit tests, typecheck, and lint.
- The client half is loam-logger-mobile's `feat/notification-system` (stacked on #64 there); this PR must deploy first.
- Web still has no notification preferences UI; the new mode is settable from mobile only.
- Known follow-ups deliberately not in this PR: Android notification silhouette icon, per-type Android channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)