### PR TITLE
Release: scoped push-token clearing (API)

### DIFF
--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -3254,6 +3254,29 @@ describe('GraphQL Resolvers', () => {
       expect(mockPrisma.user.updateMany).not.toHaveBeenCalled();
     });
 
+    it('rejects an over-length token, matching updateUserPreferences', async () => {
+      const ctx = createMockContext('user-123');
+
+      await expect(
+        mutation(null, { token: 'a'.repeat(201) }, ctx)
+      ).rejects.toThrow('token exceeds maximum length');
+
+      expect(mockPrisma.user.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('accepts a malformed-but-short token and simply matches nothing', async () => {
+      // Format is deliberately NOT validated on this removal path: a bad
+      // token matches no row and returns false, which is already correct,
+      // and rejecting would only make a legitimate cleanup fail (including
+      // for a token stored under an older Expo format).
+      const ctx = createMockContext('user-123');
+      (mockPrisma.user.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+
+      const result = await mutation(null, { token: 'not-an-expo-token' }, ctx);
+
+      expect(result).toBe(false);
+    });
+
     it('requires authentication', async () => {
       const ctx = createMockContext(null);
 

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -60,6 +60,7 @@ jest.mock('../../lib/prisma', () => ({
     },
     user: {
       update: jest.fn(),
+      updateMany: jest.fn(),
       findUnique: jest.fn(),
       findUniqueOrThrow: jest.fn().mockResolvedValue({ subscriptionTier: 'PRO', isFoundingRider: false, needsDowngradeSelection: false }),
     },
@@ -3182,6 +3183,85 @@ describe('GraphQL Resolvers', () => {
       await mutation(null, { input: { predictionMode: 'predictive' } }, ctx);
 
       expect(mockPrisma.user.update).toHaveBeenCalled();
+    });
+  });
+
+  describe('unregisterPushToken', () => {
+    const mutation = resolvers.Mutation.unregisterPushToken;
+
+    beforeEach(() => {
+      mockCheckMutationRateLimit.mockResolvedValue({ allowed: true, retryAfter: 0 });
+    });
+
+    /**
+     * The bug this mutation exists to prevent: expoPushToken is one column
+     * per USER, not per device. Two devices signed into the same account
+     * share that single slot, and whichever registers last silently wins
+     * it. A blind `updateUserPreferences(expoPushToken: null)` on logout
+     * would let the device that already lost that race null out the OTHER,
+     * currently-active device's token. The where-clause match is what
+     * prevents it: the update only touches the row if the stored token
+     * still equals the caller's own.
+     */
+    it('clears the token only when it matches what is stored', async () => {
+      const ctx = createMockContext('user-123');
+      (mockPrisma.user.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      const result = await mutation(null, { token: 'ExponentPushToken[mine]' }, ctx);
+
+      expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
+        where: { id: 'user-123', expoPushToken: 'ExponentPushToken[mine]' },
+        data: { expoPushToken: null },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('leaves a different device\'s token untouched and returns false', async () => {
+      // The stored value is some OTHER device's token (it already won the
+      // slot); updateMany's where-clause matches zero rows, so nothing is
+      // cleared. This is the exact scenario a blind null would have broken.
+      const ctx = createMockContext('user-123');
+      (mockPrisma.user.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+
+      const result = await mutation(null, { token: 'ExponentPushToken[stale]' }, ctx);
+
+      expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
+        where: { id: 'user-123', expoPushToken: 'ExponentPushToken[stale]' },
+        data: { expoPushToken: null },
+      });
+      expect(result).toBe(false);
+    });
+
+    it('scopes the match to the authenticated user', async () => {
+      const ctx = createMockContext('user-456');
+      (mockPrisma.user.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await mutation(null, { token: 'ExponentPushToken[abc]' }, ctx);
+
+      expect(mockPrisma.user.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ id: 'user-456' }) })
+      );
+    });
+
+    it('rejects when the rate limit is exceeded', async () => {
+      const ctx = createMockContext('user-123');
+      mockCheckMutationRateLimit.mockResolvedValue({ allowed: false, retryAfter: 30 });
+
+      await expect(
+        mutation(null, { token: 'ExponentPushToken[abc]' }, ctx)
+      ).rejects.toThrow('Rate limit exceeded');
+
+      expect(mockPrisma.user.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('requires authentication', async () => {
+      const ctx = createMockContext(null);
+
+      await expect(
+        mutation(null, { token: 'ExponentPushToken[abc]' }, ctx)
+      ).rejects.toThrow();
+
+      expect(mockPrisma.user.updateMany).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -4269,6 +4269,43 @@ export const resolvers = {
       return updatedUser;
     },
 
+    /**
+     * Compare-and-clear for expoPushToken. See the schema doc for why this
+     * can't be a blind null: the column is one value per USER, not one per
+     * device, so the same account signed into two devices only ever has
+     * room for one device's token — whichever registers last silently wins
+     * the slot. A blind clear on logout would let the device that already
+     * lost that race null out a different, currently-active device's token.
+     * Matching first means a stale device's logout can only ever remove its
+     * OWN (long since overwritten) token, never a foreign one.
+     */
+    unregisterPushToken: async (
+      _: unknown,
+      { token }: { token: string },
+      ctx: GraphQLContext
+    ) => {
+      const userId = requireUserId(ctx);
+
+      const rateLimit = await checkMutationRateLimit('unregisterPushToken', userId);
+      if (!rateLimit.allowed) {
+        throw new GraphQLError(`Rate limit exceeded. Try again in ${rateLimit.retryAfter} seconds.`, {
+          extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
+        });
+      }
+
+      // updateMany + a where-clause match, not findUnique-then-update: the
+      // match check and the clear are one atomic statement, so two devices
+      // racing this call can never both observe "yes it's mine" and step on
+      // each other. A false return isn't an error — it means this token
+      // wasn't the one on file (already cleared, or a different device has
+      // since claimed the slot), and there is nothing to unregister.
+      const result = await prisma.user.updateMany({
+        where: { id: userId, expoPushToken: token },
+        data: { expoPushToken: null },
+      });
+      return result.count > 0;
+    },
+
     updateAnalyticsOptOut: async (
       _: unknown,
       { optOut }: { optOut: boolean },

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -4273,7 +4273,7 @@ export const resolvers = {
      * Compare-and-clear for expoPushToken. See the schema doc for why this
      * can't be a blind null: the column is one value per USER, not one per
      * device, so the same account signed into two devices only ever has
-     * room for one device's token — whichever registers last silently wins
+     * room for one device's token, and whichever registers last silently wins
      * the slot. A blind clear on logout would let the device that already
      * lost that race null out a different, currently-active device's token.
      * Matching first means a stale device's logout can only ever remove its
@@ -4293,10 +4293,26 @@ export const resolvers = {
         });
       }
 
+      // Same 200-char cap updateUserPreferences applies to this field. It
+      // bounds the value going into the WHERE clause; nothing here is ever
+      // persisted, so this is a resource guard rather than data validation.
+      //
+      // Deliberately NOT also running isValidExpoPushToken, which that path
+      // does. Format validation protects the column on write; on a removal
+      // path it protects nothing and can only turn a legitimate cleanup into
+      // a hard error. A malformed token simply matches no row and returns
+      // false, which is already the correct answer. Being liberal here also
+      // means a token stored under an older Expo format stays removable.
+      if (token.length > 200) {
+        throw new GraphQLError('token exceeds maximum length', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
       // updateMany + a where-clause match, not findUnique-then-update: the
       // match check and the clear are one atomic statement, so two devices
       // racing this call can never both observe "yes it's mine" and step on
-      // each other. A false return isn't an error — it means this token
+      // each other. A false return isn't an error: it means this token
       // wasn't the one on file (already cleared, or a different device has
       // since claimed the slot), and there is nothing to unregister.
       const result = await prisma.user.updateMany({

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -1126,6 +1126,22 @@ export const typeDefs = gql`
     bulkUpdateComponentBaselines(input: BulkUpdateBaselinesInput!): [Component!]!
     acceptTerms(input: AcceptTermsInput!): AcceptTermsResult!
     updateUserPreferences(input: UpdateUserPreferencesInput!): User!
+    """
+    Clears expoPushToken, but ONLY if it currently equals the given token:
+    a compare-and-clear, not a blind null. expoPushToken is a single column
+    per user, not per device, so the same account signed into two devices
+    only ever has room for one device's token, and whichever device
+    registers last silently wins the slot. Clearing unconditionally on
+    logout (as updateUserPreferences with expoPushToken: null does) would
+    let a logout on the device that already lost that race null out a
+    different, currently-active device's token. Matching first means a
+    stale device's logout can only ever remove its own (long since
+    overwritten) token, never a foreign one.
+    Returns true only if a row was actually cleared; false is not an error,
+    it means this token was not the one on file (already cleared, or a
+    different device holds the slot), so nothing needed to happen.
+    """
+    unregisterPushToken(token: String!): Boolean!
     updateAnalyticsOptOut(optOut: Boolean!): User!
     acknowledgeImportOverlay(importSessionId: ID!): AcknowledgeResult!
     assignBikeToRides(rideIds: [ID!]!, bikeId: ID!): BulkAssignResult!

--- a/apps/api/src/lib/queue/notification.queue.ts
+++ b/apps/api/src/lib/queue/notification.queue.ts
@@ -18,6 +18,18 @@ export type NotificationJobName = 'checkReceipts';
 export type NotificationJobData = {
   userId: string;
   ticketIds: string[];
+  /**
+   * The push token these tickets were sent to. Lets the receipt worker
+   * compare-and-clear on DeviceNotRegistered instead of blindly nulling
+   * User.expoPushToken, which is one column per user rather than per
+   * device: a dead token's receipt arriving after another device has
+   * claimed the slot would otherwise wipe that live device's token.
+   *
+   * Optional only for jobs enqueued before this field existed. Those are
+   * drained within the 15-minute receipt delay of a deploy, and the worker
+   * skips the clear rather than falling back to the unsafe blind write.
+   */
+  pushToken?: string;
 };
 
 let notificationQueue: Queue<NotificationJobData, void, NotificationJobName> | null = null;
@@ -45,13 +57,17 @@ export function getNotificationQueue(): Queue<NotificationJobData, void, Notific
  * Enqueue a delayed job to check Expo push notification receipts.
  * Expo recommends waiting ~15 minutes before polling for receipts.
  */
-export async function enqueueReceiptCheck(userId: string, ticketIds: string[]): Promise<void> {
+export async function enqueueReceiptCheck(
+  userId: string,
+  ticketIds: string[],
+  pushToken?: string
+): Promise<void> {
   if (ticketIds.length === 0) return;
 
   const queue = getNotificationQueue();
 
   try {
-    await queue.add('checkReceipts', { userId, ticketIds }, { delay: RECEIPT_CHECK_DELAY_MS });
+    await queue.add('checkReceipts', { userId, ticketIds, pushToken }, { delay: RECEIPT_CHECK_DELAY_MS });
     logger.debug({ userId, ticketCount: ticketIds.length }, '[NotificationQueue] Enqueued receipt check');
   } catch (err) {
     logger.warn({ userId, error: err }, '[NotificationQueue] Failed to enqueue receipt check (non-fatal)');

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -111,6 +111,9 @@ export const MUTATION_RATE_LIMITS = {
   oauthStart: { windowSeconds: 600, maxRequests: 10 },
   /** updateUserPreferences: max 20 requests per minute per user */
   updateUserPreferences: { windowSeconds: 60, maxRequests: 20 },
+  /** unregisterPushToken: max 20 requests per minute per user (one call per
+   *  logout; matches updateUserPreferences since it's a peer of that path) */
+  unregisterPushToken: { windowSeconds: 60, maxRequests: 20 },
   /** updateAnalyticsOptOut: max 10 toggles per hour per user. Users rarely flip
    *  this — a tight cap bounds cache-invalidation abuse without impacting
    *  legitimate usage. */

--- a/apps/api/src/services/notification.service.test.ts
+++ b/apps/api/src/services/notification.service.test.ts
@@ -521,7 +521,7 @@ describe('notification.service', () => {
 
       await fireRideNotifications(baseParams);
 
-      expect(enqueueReceiptCheck).toHaveBeenCalledWith('user-1', expect.arrayContaining([expect.any(String)]));
+      expect(enqueueReceiptCheck).toHaveBeenCalledWith('user-1', expect.arrayContaining([expect.any(String)]), 'ExponentPushToken[abc123]');
     });
 
     it('should not enqueue receipt check when no tickets are produced', async () => {
@@ -781,7 +781,7 @@ describe('notification.service', () => {
           data: { screen: 'bike', bikeId: 'bike-1', componentId: 'comp-1' },
         }),
       ]);
-      expect(enqueueReceiptCheck).toHaveBeenCalledWith('user-1', ['ticket-123']);
+      expect(enqueueReceiptCheck).toHaveBeenCalledWith('user-1', ['ticket-123'], 'ExponentPushToken[abc123]');
     });
 
     it('never sends a ride push: this entry point is service-due only', async () => {

--- a/apps/api/src/services/notification.service.ts
+++ b/apps/api/src/services/notification.service.ts
@@ -421,7 +421,7 @@ export async function fireServiceDueForBike(params: {
 
     const ticketId = await runServiceDueForBike(user, userId, bikeId, bikeName);
     if (ticketId) {
-      enqueueReceiptCheck(userId, [ticketId]).catch((err) =>
+      enqueueReceiptCheck(userId, [ticketId], user.expoPushToken).catch((err) =>
         logError('enqueueReceiptCheck', err)
       );
     }
@@ -536,9 +536,12 @@ export async function fireRideNotifications(params: {
       if (serviceTicketId) ticketIds.push(serviceTicketId);
     }
 
-    // Enqueue delayed receipt check for all tickets from this ride
+    // Enqueue delayed receipt check for all tickets from this ride. The
+    // token rides along so a DeviceNotRegistered receipt can be matched
+    // against it rather than blindly clearing whatever is stored 15 minutes
+    // from now.
     if (ticketIds.length > 0) {
-      enqueueReceiptCheck(userId, ticketIds).catch((err) =>
+      enqueueReceiptCheck(userId, ticketIds, user.expoPushToken).catch((err) =>
         logError('enqueueReceiptCheck', err)
       );
     }

--- a/apps/api/src/services/weekly-digest.service.test.ts
+++ b/apps/api/src/services/weekly-digest.service.test.ts
@@ -168,7 +168,7 @@ describe('weekly-digest.service', () => {
       expect(mockPrisma.notificationLog.create).toHaveBeenCalledWith({
         data: { userId: 'user-1', notificationType: 'WEEKLY_DIGEST' },
       });
-      expect(enqueueReceiptCheck).toHaveBeenCalledWith('user-1', ['ticket-1']);
+      expect(enqueueReceiptCheck).toHaveBeenCalledWith('user-1', ['ticket-1'], 'ExponentPushToken[abc123]');
     });
 
     it('does not send outside the window — 8:30 UTC is 1:30am in Los Angeles', async () => {

--- a/apps/api/src/services/weekly-digest.service.ts
+++ b/apps/api/src/services/weekly-digest.service.ts
@@ -213,7 +213,9 @@ export async function maybeSendDigestForUser(user: DigestUser, now: Date): Promi
   await prisma.notificationLog.create({
     data: { userId: user.id, notificationType: 'WEEKLY_DIGEST' },
   });
-  enqueueReceiptCheck(user.id, [ticketId]).catch((err) => logError('enqueueReceiptCheck', err));
+  enqueueReceiptCheck(user.id, [ticketId], user.expoPushToken).catch((err) =>
+    logError('enqueueReceiptCheck', err)
+  );
 
   logger.info({ userId: user.id }, '[weekly-digest] Digest sent');
 }

--- a/apps/api/src/workers/notification.worker.test.ts
+++ b/apps/api/src/workers/notification.worker.test.ts
@@ -2,6 +2,7 @@ jest.mock('../lib/prisma', () => ({
   prisma: {
     user: {
       update: jest.fn(),
+      updateMany: jest.fn(),
     },
   },
 }));
@@ -42,6 +43,7 @@ function createMockJob(data: NotificationJobData): Job<NotificationJobData, void
 describe('notification.worker', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (mockPrisma.user.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
   });
 
   it('should not write to DB when all receipts are ok', async () => {
@@ -58,7 +60,65 @@ describe('notification.worker', () => {
     expect(mockPrisma.user.update).not.toHaveBeenCalled();
   });
 
-  it('should clear push token on DeviceNotRegistered', async () => {
+  it('should clear push token on DeviceNotRegistered, matching on the token sent', async () => {
+    mockGetPushNotificationReceiptsAsync.mockResolvedValue({
+      'ticket-1': {
+        status: 'error',
+        message: 'The device is not registered',
+        details: { error: 'DeviceNotRegistered' },
+      },
+    });
+
+    await processReceiptCheck(createMockJob({
+      userId: 'user-1',
+      ticketIds: ['ticket-1'],
+      pushToken: 'ExponentPushToken[dead]',
+    }));
+
+    // Compare-and-clear, not a blind null: the where clause pins the clear
+    // to the token these tickets were actually sent to.
+    expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
+      where: { id: 'user-1', expoPushToken: 'ExponentPushToken[dead]' },
+      data: { expoPushToken: null },
+    });
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The race this guards. Receipts are polled ~15 minutes after the send, so
+   * another device on the same account can easily have registered in the
+   * meantime and claimed the single expoPushToken slot. Blindly nulling on
+   * a dead device's DeviceNotRegistered would kill push on that live device.
+   * The where-clause match makes it a no-op instead.
+   */
+  it('leaves a newer device token intact when the dead token no longer matches', async () => {
+    mockGetPushNotificationReceiptsAsync.mockResolvedValue({
+      'ticket-1': {
+        status: 'error',
+        message: 'The device is not registered',
+        details: { error: 'DeviceNotRegistered' },
+      },
+    });
+    // Another device already claimed the slot, so zero rows match.
+    (mockPrisma.user.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+
+    await processReceiptCheck(createMockJob({
+      userId: 'user-1',
+      ticketIds: ['ticket-1'],
+      pushToken: 'ExponentPushToken[dead]',
+    }));
+
+    expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
+      where: { id: 'user-1', expoPushToken: 'ExponentPushToken[dead]' },
+      data: { expoPushToken: null },
+    });
+  });
+
+  it('skips the clear entirely for a legacy job carrying no pushToken', async () => {
+    // Jobs enqueued before pushToken existed on the payload drain within one
+    // receipt delay of a deploy. Skipping is deliberate: falling back to the
+    // blind write would reintroduce exactly the bug this guards against. The
+    // dead token survives until the next send fails with the token attached.
     mockGetPushNotificationReceiptsAsync.mockResolvedValue({
       'ticket-1': {
         status: 'error',
@@ -72,10 +132,8 @@ describe('notification.worker', () => {
       ticketIds: ['ticket-1'],
     }));
 
-    expect(mockPrisma.user.update).toHaveBeenCalledWith({
-      where: { id: 'user-1' },
-      data: { expoPushToken: null },
-    });
+    expect(mockPrisma.user.updateMany).not.toHaveBeenCalled();
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
   });
 
   it('should not clear push token on non-DeviceNotRegistered errors', async () => {
@@ -112,10 +170,11 @@ describe('notification.worker', () => {
     await processReceiptCheck(createMockJob({
       userId: 'user-1',
       ticketIds: ['ticket-1', 'ticket-2'],
+      pushToken: 'ExponentPushToken[dead]',
     }));
 
     // Token should only be cleared once despite multiple DeviceNotRegistered receipts
-    expect(mockPrisma.user.update).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.user.updateMany).toHaveBeenCalledTimes(1);
   });
 
   it('should rethrow when Expo receipt fetch fails (for BullMQ retry)', async () => {

--- a/apps/api/src/workers/notification.worker.ts
+++ b/apps/api/src/workers/notification.worker.ts
@@ -16,7 +16,7 @@ import type { NotificationJobData, NotificationJobName } from '../lib/queue/noti
  * to stop attempting future sends.
  */
 export async function processReceiptCheck(job: Job<NotificationJobData, void, NotificationJobName>): Promise<void> {
-  const { userId, ticketIds } = job.data;
+  const { userId, ticketIds, pushToken } = job.data;
 
   logger.debug({ userId, ticketCount: ticketIds.length }, '[NotificationWorker] Checking receipts');
 
@@ -42,14 +42,38 @@ export async function processReceiptCheck(job: Job<NotificationJobData, void, No
         '[NotificationWorker] Push delivery failed'
       );
 
-      // DeviceNotRegistered means the token is permanently invalid — clear it
+      // DeviceNotRegistered means this token is permanently invalid: the
+      // app was uninstalled or notification permission was revoked.
       if (receipt.details?.error === 'DeviceNotRegistered') {
         if (!tokenCleared) {
-          logger.info({ userId }, '[NotificationWorker] Clearing invalid push token (DeviceNotRegistered)');
-          await prisma.user.update({
-            where: { id: userId },
-            data: { expoPushToken: null },
-          });
+          // Compare-and-clear, never a blind null. User.expoPushToken is one
+          // column per user rather than per device, so two devices on one
+          // account share a single slot and the last to register wins it.
+          // These receipts are ~15 minutes stale by design, which is ample
+          // time for another device to have claimed the slot; nulling
+          // unconditionally would silently kill push on that live device
+          // because a DIFFERENT, now-dead device's receipt came back.
+          // Matching on the token these tickets were actually sent to means
+          // we can only ever clear the dead one.
+          if (!pushToken) {
+            // Job predates pushToken being on the payload. Skip rather than
+            // fall back to the unsafe blind write: the cost is one dead
+            // token surviving until the next send fails, whose receipt job
+            // will carry the token and clear it properly.
+            logger.warn(
+              { userId },
+              '[NotificationWorker] DeviceNotRegistered on a legacy job with no pushToken; skipping clear'
+            );
+          } else {
+            const result = await prisma.user.updateMany({
+              where: { id: userId, expoPushToken: pushToken },
+              data: { expoPushToken: null },
+            });
+            logger.info(
+              { userId, cleared: result.count > 0 },
+              '[NotificationWorker] DeviceNotRegistered; cleared push token if still current'
+            );
+          }
           tokenCleared = true;
         }
       }


### PR DESCRIPTION
Promotes `staging` to `main`. Contains [#293](https://github.com/ryanlecours/loam-logger/pull/293) and nothing else.

## What's in it

A regression fix for the logout flow introduced alongside the notification system, plus the same bug found at a second call site.

**The bug.** `User.expoPushToken` is one column per user, not per device. The same account signed into two devices only ever has room for one device's token, and whichever registers last silently wins the slot. Two code paths were nulling that column unconditionally:

1. **Logout** (via `updateUserPreferences(expoPushToken: null)`). Log out on the phone, and if the tablet's token happened to be the one stored, the tablet silently stops receiving push.
2. **The receipt worker**, on a `DeviceNotRegistered` receipt. Arguably the worse of the two: receipts are polled ~15 minutes after the send *by design*, which is ample time for another device to have claimed the slot, so a dead device's receipt could null out a live device's token.

**The fix.** New `unregisterPushToken(token: String!): Boolean!` mutation doing a compare-and-clear rather than a blind null:

```ts
prisma.user.updateMany({
  where: { id: userId, expoPushToken: token },
  data: { expoPushToken: null },
})
```

The match and the clear are one atomic statement, so a caller can only ever remove its own (possibly already-overwritten) token, never one belonging to a device it doesn't recognize. `false` is the expected "a different device holds the slot" answer, not an error.

The receipt worker gets the same treatment: the token used for a send is now threaded through `NotificationJobData` so the worker can scope its clear identically. All three `enqueueReceiptCheck` call sites already had the token in hand, so this is a parameter rather than a lookup. Jobs enqueued before the field existed carry no token and skip the clear rather than falling back to the unsafe write, costing at most one dead token surviving until the next send fails with a token attached.

Also caps `unregisterPushToken`'s input length at 200 chars, matching the sibling field's validation on `updateUserPreferences`. Format is deliberately *not* validated on this removal path: it protects nothing there and could only turn a legitimate cleanup into a hard error.

## Scope check

**API only** — no `apps/web` files touched, and **no migration** (the fix is query-shape, not schema).

## Risk

Low and strictly corrective. The two changed write paths become narrower (conditional instead of unconditional); nothing new is written. The only behavioral change beyond the fix is that a `DeviceNotRegistered` receipt on an in-flight legacy job no longer clears a token, which self-heals on the next failed send.

## Testing

- Full API suite green on the merge commit: **1879 passed / 91 suites**.
- New coverage: compare-and-clear match/no-match, user scoping, rate limiting, auth, length rejection, malformed-token-returns-false, plus the worker's live-token-survives-a-dead-receipt race and the legacy-job skip.
- Lint clean (3 pre-existing warnings); typecheck at the known `@loam/shared` baseline.
- **Not exercised against a running server or a real Expo send.** Verification is unit tests, typecheck, and lint.

## Sequencing

Unblocks [loam-logger-mobile#65](https://github.com/ryanlecours/loam-logger-mobile/pull/65), whose logout flow calls `unregisterPushToken`. That PR needs this merged **and deployed** before it can ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)