### PR TITLE
docs(notifications): correct the legacy-client version boundary to 1.1.3

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -76,7 +76,7 @@ model User {
   expoPushToken      String?
   // Legacy on/off for ride-sync pushes. Kept in sync with
   // rideSyncNotificationMode (mode OFF <=> false) because app versions up to
-  // 1.1.4 still read and write it through updateUserPreferences; the mode
+  // 1.1.3 still read and write it through updateUserPreferences; the mode
   // column below is the source of truth and this is derived on write.
   notifyOnRideUpload Boolean @default(true)
   // How "Ride Synced" pushes behave. ALL preserves the original behavior

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -4207,7 +4207,7 @@ export const resolvers = {
 
       // rideSyncNotificationMode is the source of truth for ride-sync pushes;
       // the legacy boolean is kept in sync in both directions so app versions
-      // <= 1.1.4 (which only know the toggle) and current clients never
+      // <= 1.1.3 (which only know the toggle) and current clients never
       // disagree about whether pushes are on.
       if (input.rideSyncNotificationMode !== undefined && input.rideSyncNotificationMode !== null) {
         updateData.rideSyncNotificationMode = input.rideSyncNotificationMode;

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -842,7 +842,7 @@ export const typeDefs = gql`
     predictionMode: String
     distanceUnit: String
     expoPushToken: String
-    # Legacy on/off for ride-sync pushes, still sent by app versions <= 1.1.4.
+    # Legacy on/off for ride-sync pushes, still sent by app versions <= 1.1.3.
     # Maps onto rideSyncNotificationMode (false -> OFF; true -> ALL, unless
     # the stored mode is already a non-OFF value, which is preserved). New
     # clients should send rideSyncNotificationMode instead.


### PR DESCRIPTION
Comment-only, 3 lines. No behavior change, no migration.

## Why

Three comments document which app versions still send the legacy `notifyOnRideUpload` boolean rather than `rideSyncNotificationMode`, and all three said **`<= 1.1.4`**. That was correct when written: the mobile client was going to ship the new mode as 1.1.5.

It's since been decided that mobile stays at **1.1.4** — that version was bumped but never built or submitted (releases are manual), so the notification work ships as part of the same release rather than earning its own version. The only 1.1.4 that will ever exist in the wild is the one that sends `rideSyncNotificationMode`, which makes **1.1.3** the actual legacy boundary.

## Why it's worth a PR

These comments are precisely what a future reader consults when deciding whether the legacy boolean can finally be dropped. Off by one version, they'd argue for keeping a dead field alive a release longer than necessary. Cheap to fix now, annoying to discover later.

Sites corrected:
- `prisma/schema.prisma` — `User.notifyOnRideUpload` doc comment
- `src/graphql/schema.ts` — `UpdateUserPreferencesInput.notifyOnRideUpload` description
- `src/graphql/resolvers.ts` — the two-way-mapping comment in `updateUserPreferences`

## Testing

Full suite green (**1879 passed / 91 suites**), typecheck at the known `@loam/shared` baseline, `prisma generate` clean. All unchanged from before, as expected for a comment-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)