### PR TITLE
feat(api): idempotent addRide via client-generated mutation key

### DIFF
--- a/apps/api/prisma/migrations/20260805150000_add_ride_client_mutation_id/migration.sql
+++ b/apps/api/prisma/migrations/20260805150000_add_ride_client_mutation_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Ride" ADD COLUMN     "clientMutationId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ride_userId_clientMutationId_key" ON "Ride"("userId", "clientMutationId");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -191,6 +191,14 @@ model Ride {
   liftElevationGainMeters Float?
   liftDistanceMeters      Float?
   liftDetectorVersion     Int?
+  // Client-generated idempotency key for manual ride creation. The mobile app
+  // queues addRide while offline and retries with backoff; without this key a
+  // retry after a lost response would insert a second ride AND double-credit
+  // component hours. Scoped per user (the same UUID from two accounts is not a
+  // collision). NULL for provider-synced rides and legacy rows; Postgres treats
+  // NULLs as distinct in unique indexes, so the constraint only bites when a
+  // key is actually supplied.
+  clientMutationId        String?
   bike                    Bike?                     @relation(fields: [bikeId], references: [id])
   duplicateOf             Ride?                     @relation("DuplicateRides", fields: [duplicateOfId], references: [id], onDelete: SetNull)
   duplicates              Ride[]                    @relation("DuplicateRides")
@@ -205,6 +213,7 @@ model Ride {
   // to keep the ridesMissingWeather COUNT(*) fast once the RideWeather table fills up.
   // Prisma doesn't support partial-index predicates, so the index is managed there.
 
+  @@unique([userId, clientMutationId])
   @@index([importSessionId, bikeId])
   // Backs the userId + bikeId + startTime(range/order) access pattern shared
   // by componentRides (interactive, up to 60/min), the prediction engine's

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -137,6 +137,7 @@ jest.mock('../../lib/posthog', () => ({
 }));
 
 import { resolvers } from '../resolvers';
+import { Prisma } from '@prisma/client';
 import { prisma } from '../../lib/prisma';
 import { checkMutationRateLimit } from '../../lib/rate-limit';
 import { invalidateBikePrediction, getCachedAdvisorSummary, setCachedAdvisorSummary } from '../../services/prediction/cache';
@@ -6230,6 +6231,107 @@ describe('GraphQL Resolvers', () => {
       // No bike named, so nothing to credit or debit.
       expect(data).not.toHaveProperty('bikeId');
       expect(tx.component.updateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Mutation.addRide idempotency (clientMutationId)', () => {
+    const mutation = resolvers.Mutation.addRide;
+
+    // unownedBike keeps the resolver off the bike-lookup and hours-credit
+    // paths, so these tests isolate the idempotency behavior itself.
+    const baseInput = {
+      startTime: '2026-08-05T10:00:00.000Z',
+      durationSeconds: 3600,
+      distanceMeters: 16000,
+      elevationGainMeters: 400,
+      rideType: 'TRAIL',
+      unownedBike: true,
+    };
+
+    const makeTx = () => ({
+      ride: { create: jest.fn().mockResolvedValue({ id: 'ride-new' }) },
+    });
+
+    beforeEach(() => {
+      mockCheckMutationRateLimit.mockResolvedValue({ allowed: true, retryAfter: 0 });
+      (prisma.ride.findUnique as jest.Mock).mockReset();
+      (prisma.$transaction as jest.Mock).mockReset();
+    });
+
+    it('returns the existing ride and skips the insert when the key was already used', async () => {
+      const existing = { id: 'ride-original', clientMutationId: 'key-1' };
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue(existing);
+
+      const result = await mutation(
+        {}, { input: { ...baseInput, clientMutationId: 'key-1' } }, createMockContext('user-123') as never
+      );
+
+      expect(result).toBe(existing);
+      expect(prisma.ride.findUnique).toHaveBeenCalledWith({
+        where: { userId_clientMutationId: { userId: 'user-123', clientMutationId: 'key-1' } },
+      });
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      // The original request already fired the funnel event; a replay must not.
+      expect(mockCaptureServerEvent).not.toHaveBeenCalled();
+    });
+
+    it('stores the key on the created ride when it is fresh', async () => {
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue(null);
+      const tx = makeTx();
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation(
+        {}, { input: { ...baseInput, clientMutationId: 'key-1' } }, createMockContext('user-123') as never
+      );
+
+      expect(tx.ride.create.mock.calls[0][0].data.clientMutationId).toBe('key-1');
+    });
+
+    it('returns the winning row when two retries race past the replay check', async () => {
+      const winner = { id: 'ride-winner', clientMutationId: 'key-1' };
+      (prisma.ride.findUnique as jest.Mock)
+        .mockResolvedValueOnce(null) // replay check: nothing committed yet
+        .mockResolvedValueOnce(winner); // re-read after the unique collision
+      (prisma.$transaction as jest.Mock).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+          code: 'P2002',
+          clientVersion: 'test',
+          meta: { target: ['userId', 'clientMutationId'] },
+        })
+      );
+
+      const result = await mutation(
+        {}, { input: { ...baseInput, clientMutationId: 'key-1' } }, createMockContext('user-123') as never
+      );
+
+      expect(result).toBe(winner);
+    });
+
+    it('rethrows unique collisions that are not the idempotency key', async () => {
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue(null);
+      (prisma.$transaction as jest.Mock).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+          code: 'P2002',
+          clientVersion: 'test',
+          meta: { target: ['garminActivityId'] },
+        })
+      );
+
+      await expect(
+        mutation(
+          {}, { input: { ...baseInput, clientMutationId: 'key-1' } }, createMockContext('user-123') as never
+        )
+      ).rejects.toThrow('Unique constraint failed');
+    });
+
+    it('bypasses the idempotency path entirely when no key is supplied', async () => {
+      const tx = makeTx();
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation({}, { input: { ...baseInput } }, createMockContext('user-123') as never);
+
+      expect(prisma.ride.findUnique).not.toHaveBeenCalled();
+      expect(tx.ride.create.mock.calls[0][0].data).not.toHaveProperty('clientMutationId');
     });
   });
 });

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -1,12 +1,12 @@
 import { GraphQLError } from 'graphql';
 import type { GraphQLContext } from '../server';
 import { prisma } from '../lib/prisma';
-import { ComponentType as ComponentTypeEnum } from '@prisma/client';
+import { ComponentType as ComponentTypeEnum, Prisma } from '@prisma/client';
 import type {
-  Prisma,
   ComponentType as ComponentTypeLiteral,
   ComponentLocation,
   Bike,
+  Ride,
   Component as ComponentModel,
   UserRole,
 } from '@prisma/client';
@@ -73,6 +73,7 @@ type AddRideInput = {
   notes?: string | null;
   trailSystem?: string | null;
   location?: string | null;
+  clientMutationId?: string | null;
 };
 
 type UpdateRideInput = {
@@ -1884,6 +1885,22 @@ export const resolvers = {
           extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
         });
       }
+      // Idempotency replay check. The mobile offline queue retries addRide
+      // with the same client-generated key until it sees a response; if the
+      // first attempt committed but the response was lost, the retry must
+      // return that ride rather than insert again (which would also
+      // double-credit component hours). Checked before input validation on
+      // purpose: the original submit already passed validation, and a replay
+      // must still succeed even if state changed since (e.g. the bike was
+      // deleted, which would now fail the ownership check below).
+      const clientMutationId = cleanText(input.clientMutationId, 64);
+      if (clientMutationId) {
+        const existing = await prisma.ride.findUnique({
+          where: { userId_clientMutationId: { userId, clientMutationId } },
+        });
+        if (existing) return existing;
+      }
+
       const start = parseIso(input.startTime);
       const durationSeconds = Math.max(0, Math.floor(input.durationSeconds));
       const distanceMeters = Math.max(0, Number(input.distanceMeters));
@@ -1941,6 +1958,7 @@ export const resolvers = {
         ...(notes ? { notes } : {}),
         ...(trailSystem ? { trailSystem } : {}),
         ...(location ? { location } : {}),
+        ...(clientMutationId ? { clientMutationId } : {}),
       };
 
       const hoursDelta = durationSeconds / 3600;
@@ -1950,13 +1968,35 @@ export const resolvers = {
         await invalidateBikePrediction(userId, bikeId);
       }
 
-      const ride = await prisma.$transaction(async (tx) => {
-        const newRide = await tx.ride.create({ data: rideData });
-        if (bikeId) {
-          await incrementBikeComponentHours(tx, { userId, bikeId, hoursDelta });
+      let ride: Ride;
+      try {
+        ride = await prisma.$transaction(async (tx) => {
+          const newRide = await tx.ride.create({ data: rideData });
+          if (bikeId) {
+            await incrementBikeComponentHours(tx, { userId, bikeId, hoursDelta });
+          }
+          return newRide;
+        });
+      } catch (e) {
+        // Two retries of the same offline submit racing each other: the loser
+        // hits the (userId, clientMutationId) unique constraint after the
+        // replay check above passed. The transaction rolled back, so no hours
+        // were credited here; return the winner's ride. The analytics event
+        // and service-due check are skipped, since the winning request fired
+        // them.
+        const isReplayCollision =
+          clientMutationId &&
+          e instanceof Prisma.PrismaClientKnownRequestError &&
+          e.code === 'P2002' &&
+          (e.meta?.target as string[] | undefined)?.includes('clientMutationId');
+        if (isReplayCollision) {
+          const winner = await prisma.ride.findUnique({
+            where: { userId_clientMutationId: { userId, clientMutationId } },
+          });
+          if (winner) return winner;
         }
-        return newRide;
-      });
+        throw e;
+      }
 
       // Invalidate prediction cache after transaction
       if (bikeId) {

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -549,6 +549,11 @@ export const typeDefs = gql`
     notes: String
     trailSystem: String
     location: String
+    # Client-generated idempotency key (a UUID). When a retried submit carries
+    # the same key, the API returns the ride created by the first attempt
+    # instead of inserting a duplicate. Optional: omitting it preserves the
+    # old always-insert behavior.
+    clientMutationId: String
   }
 
   type DeleteRideResult { ok: Boolean!, id: ID! }

--- a/apps/api/src/routes/webhooks.revenuecat.test.ts
+++ b/apps/api/src/routes/webhooks.revenuecat.test.ts
@@ -42,6 +42,11 @@ jest.mock('../lib/revenuecat', () => ({
   storeToProvider: jest.fn((store: string) => store === 'APP_STORE' ? 'APPLE' : 'GOOGLE'),
 }));
 
+const mockCaptureServerEvent = jest.fn();
+jest.mock('../lib/posthog', () => ({
+  captureServerEvent: (...args: unknown[]) => mockCaptureServerEvent(...args),
+}));
+
 import router from './webhooks.revenuecat';
 import { prisma } from '../lib/prisma';
 import { sendEmailWithAudit } from '../services/email.service';
@@ -144,6 +149,19 @@ describe('POST /webhooks/revenuecat', () => {
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
+  it('should capture the funnel-terminus event on INITIAL_PURCHASE', async () => {
+    const req = createWebhookRequest('INITIAL_PURCHASE');
+    const res = createMockResponse();
+
+    await invokeHandler(handler, req, res as unknown as Response);
+
+    expect(mockCaptureServerEvent).toHaveBeenCalledWith(
+      'user-123',
+      'subscription_checkout_completed',
+      { source: 'revenuecat', store: 'APP_STORE' }
+    );
+  });
+
   it('should upgrade user on RENEWAL', async () => {
     const req = createWebhookRequest('RENEWAL', { store: 'PLAY_STORE' });
     const res = createMockResponse();
@@ -154,6 +172,16 @@ describe('POST /webhooks/revenuecat', () => {
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
+  it('should not capture a checkout event on RENEWAL or UNCANCELLATION', async () => {
+    for (const eventType of ['RENEWAL', 'UNCANCELLATION']) {
+      const req = createWebhookRequest(eventType);
+      const res = createMockResponse();
+      await invokeHandler(handler, req, res as unknown as Response);
+    }
+
+    expect(mockCaptureServerEvent).not.toHaveBeenCalled();
+  });
+
   it('should downgrade user on EXPIRATION', async () => {
     const req = createWebhookRequest('EXPIRATION');
     const res = createMockResponse();
@@ -161,6 +189,11 @@ describe('POST /webhooks/revenuecat', () => {
     await invokeHandler(handler, req, res as unknown as Response);
 
     expect(mockDowngradeUser).toHaveBeenCalledWith('user-123', 'revenuecat_webhook');
+    expect(mockCaptureServerEvent).toHaveBeenCalledWith(
+      'user-123',
+      'subscription_canceled',
+      { source: 'revenuecat', store: 'APP_STORE' }
+    );
     expect(res.status).toHaveBeenCalledWith(200);
   });
 

--- a/apps/api/src/routes/webhooks.revenuecat.ts
+++ b/apps/api/src/routes/webhooks.revenuecat.ts
@@ -7,6 +7,7 @@ import { storeToProvider } from '../lib/revenuecat';
 import { upgradeUser, downgradeUser } from '../services/subscription.service';
 import { sendEmailWithAudit } from '../services/email.service';
 import { getPaymentFailedEmailHtml, getPaymentFailedEmailSubject, PAYMENT_FAILED_TEMPLATE_VERSION } from '../templates/emails/payment-failed';
+import { captureServerEvent } from '../lib/posthog';
 
 const router = Router();
 
@@ -55,11 +56,24 @@ router.post('/', async (req: Request, res: Response) => {
         }
         const provider = storeToProvider(store || 'PLAY_STORE');
         await upgradeUser(appUserId, provider, 'revenuecat_webhook');
+        if (eventType === 'INITIAL_PURCHASE') {
+          // Mirrors the Stripe webhook's funnel terminus so IAP conversions
+          // land in the same PostHog event. Financial fields are deliberately
+          // excluded (privacy-policy scoped), matching the Stripe path.
+          captureServerEvent(appUserId, 'subscription_checkout_completed', {
+            source: 'revenuecat',
+            store: store ?? 'unknown',
+          });
+        }
         break;
       }
 
       case 'EXPIRATION':
         await downgradeUser(appUserId, 'revenuecat_webhook');
+        captureServerEvent(appUserId, 'subscription_canceled', {
+          source: 'revenuecat',
+          store: store ?? 'unknown',
+        });
         break;
 
       case 'BILLING_ISSUE':

--- a/apps/api/src/templates/emails/upgrade-confirmation.tsx
+++ b/apps/api/src/templates/emails/upgrade-confirmation.tsx
@@ -45,7 +45,7 @@ export default function UpgradeConfirmationEmail({
       </Head>
 
       <Preview>
-        Welcome to Pro: unlimited bikes, all components, advanced predictions.
+        Welcome to Pro: unlimited bikes, advanced predictions, weather on every ride.
       </Preview>
 
       <Body className="ll-body" style={styles.body}>
@@ -81,7 +81,10 @@ export default function UpgradeConfirmationEmail({
                 • <span className="ll-emph" style={styles.emph}>Unlimited bikes</span> — add every bike in your garage
               </Text>
               <Text className="ll-bullets" style={styles.bullets}>
-                • <span className="ll-emph" style={styles.emph}>All component types</span> — drivetrain, tires, wheels, dropper, headset, bottom bracket, and more
+                • <span className="ll-emph" style={styles.emph}>Rides left until service due</span>: the hours and rides each part has left, not just hours used
+              </Text>
+              <Text className="ll-bullets" style={styles.bullets}>
+                • <span className="ll-emph" style={styles.emph}>Service-due alerts</span>: a push when a part comes due, plus the weekly bike check
               </Text>
               <Text className="ll-bullets" style={styles.bullets}>
                 • <span className="ll-emph" style={styles.emph}>Predictive wear algorithm</span> — factors in elevation, distance, and trail steepness

--- a/apps/web/src/components/BillingSection.tsx
+++ b/apps/web/src/components/BillingSection.tsx
@@ -52,8 +52,8 @@ export default function BillingSection() {
                 {isFoundingRider
                   ? 'Lifetime access — thank you for your early support!'
                   : isPro
-                    ? 'Unlimited bikes and all components'
-                    : 'Upgrade for unlimited bikes and components'}
+                    ? 'Unlimited bikes and advanced predictions'
+                    : 'Upgrade for unlimited bikes and service predictions'}
               </p>
             </div>
           </div>
@@ -68,7 +68,7 @@ export default function BillingSection() {
           )}
           {!isPro && (
             <button
-              onClick={() => navigate('/pricing')}
+              onClick={() => navigate('/pricing?source=settings-billing')}
               className="flex items-center gap-1.5 rounded-lg bg-mint/15 border border-mint/30 px-3 py-1.5 text-xs font-medium text-mint transition hover:bg-mint/25"
             >
               Upgrade

--- a/apps/web/src/components/GarminWeatherRepairSection.tsx
+++ b/apps/web/src/components/GarminWeatherRepairSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useApolloClient, useMutation, useQuery } from '@apollo/client';
 import { useNavigate } from 'react-router';
-import { Mountain, Lock } from 'lucide-react';
+import { Mountain } from 'lucide-react';
 import { useUserTier } from '../hooks/useUserTier';
 import {
   BACKFILL_GARMIN_WEATHER,
@@ -37,7 +37,7 @@ export default function GarminWeatherRepairSection() {
 
   const onClick = async () => {
     if (!isPro) {
-      navigate('/pricing');
+      navigate('/pricing?source=settings-garmin-weather');
       return;
     }
     setError(null);
@@ -98,8 +98,7 @@ export default function GarminWeatherRepairSection() {
               onClick={onClick}
               className="flex items-center gap-1.5 rounded-lg border border-mint/30 bg-mint/15 px-3 py-1.5 text-xs font-medium text-mint transition hover:bg-mint/25"
             >
-              <Lock className="h-3 w-3" />
-              Pro feature
+              Included with Pro
             </button>
           )}
         </div>

--- a/apps/web/src/components/UpgradePrompt.test.tsx
+++ b/apps/web/src/components/UpgradePrompt.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { ProChip, UpsellCard } from './UpgradePrompt';
+import { UPSELL_COPY } from '../constants/upsellCopy';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const DISMISS_KEY = UPSELL_COPY.predictions.dismissKey;
+
+// The global test setup replaces localStorage with bare vi.fn() mocks; these
+// tests exercise real persistence semantics, so back the mocks with a Map.
+const store = new Map<string, string>();
+const installStorage = () => {
+  vi.mocked(window.localStorage.getItem).mockImplementation((k: string) =>
+    store.has(k) ? store.get(k)! : null
+  );
+  vi.mocked(window.localStorage.setItem).mockImplementation((k: string, v: string) => {
+    store.set(k, String(v));
+  });
+};
+
+const renderCard = (props: Partial<React.ComponentProps<typeof UpsellCard>> = {}) =>
+  render(
+    <MemoryRouter>
+      <UpsellCard feature="predictions" {...props} />
+    </MemoryRouter>
+  );
+
+describe('ProChip', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('navigates to /pricing with the given source', () => {
+    render(
+      <MemoryRouter>
+        <ProChip source="dashboard-health-row" />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByRole('button', { name: /included with pro/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/pricing?source=dashboard-health-row');
+  });
+});
+
+describe('UpsellCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store.clear();
+    installStorage();
+  });
+
+  it('renders the copy-map title and body', () => {
+    renderCard();
+    expect(screen.getByText(UPSELL_COPY.predictions.title)).toBeInTheDocument();
+    expect(screen.getByText(UPSELL_COPY.predictions.body)).toBeInTheDocument();
+  });
+
+  it('prefers the body override when provided', () => {
+    renderCard({ body: 'One part is past its service interval.' });
+    expect(screen.getByText('One part is past its service interval.')).toBeInTheDocument();
+    expect(screen.queryByText(UPSELL_COPY.predictions.body)).not.toBeInTheDocument();
+  });
+
+  it('routes to /pricing with an upsell source from the CTA', () => {
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /see pro/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/pricing?source=upsell-predictions');
+  });
+
+  it('persists dismissal and stays hidden on the next render', () => {
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(screen.queryByText(UPSELL_COPY.predictions.title)).not.toBeInTheDocument();
+
+    const { container } = renderCard();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('honors a legacy "1" dismissal when no rearmKey is given', () => {
+    store.set(DISMISS_KEY, '1');
+    const { container } = renderCard();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('re-arms a legacy dismissal when a rearm token appears', () => {
+    store.set(DISMISS_KEY, '1');
+    renderCard({ rearmKey: 'fork-1' });
+    expect(screen.getByText(UPSELL_COPY.predictions.title)).toBeInTheDocument();
+  });
+
+  it('re-arms once per new token, not once globally', () => {
+    // Dismiss while fork-1 is past interval.
+    renderCard({ rearmKey: 'fork-1' });
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+
+    // Same token: stays dismissed.
+    const same = renderCard({ rearmKey: 'fork-1' });
+    expect(same.container.firstChild).toBeNull();
+    same.unmount();
+
+    // A second, different part crosses its interval: re-arms.
+    renderCard({ rearmKey: 'fork-1,shock-2' });
+    expect(screen.getByText(UPSELL_COPY.predictions.title)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+
+    // Shrinking back to a covered subset stays dismissed.
+    const subset = renderCard({ rearmKey: 'shock-2' });
+    expect(subset.container.firstChild).toBeNull();
+  });
+
+  it('returns to the base dismissed state when the rearm condition clears', () => {
+    renderCard({ rearmKey: 'fork-1' });
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+
+    const { container } = renderCard();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('ignores stored dismissals and skips storage when persist is false', () => {
+    store.set(DISMISS_KEY, '1');
+    const onDismiss = vi.fn();
+    renderCard({ persist: false, onDismiss });
+    expect(screen.getByText(UPSELL_COPY.predictions.title)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalled();
+    // Session-only: the stored value is untouched.
+    expect(store.get(DISMISS_KEY)).toBe('1');
+  });
+});

--- a/apps/web/src/components/UpgradePrompt.tsx
+++ b/apps/web/src/components/UpgradePrompt.tsx
@@ -1,51 +1,31 @@
 import { useState } from 'react';
-import { Lock, X } from 'lucide-react';
+import { X } from 'lucide-react';
 import { useNavigate } from 'react-router';
 import { UPSELL_COPY, type UpsellFeature } from '../constants/upsellCopy';
 
-interface UpgradePromptProps {
-  message: string;
-  subtitle?: string;
-}
-
 const btn = 'rounded-lg px-4 py-2 text-sm font-medium transition';
-
-export default function UpgradePrompt({ message, subtitle }: UpgradePromptProps) {
-  const navigate = useNavigate();
-
-  return (
-    <div className="inline-flex flex-col items-center gap-3 rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 text-center">
-      <Lock className="h-5 w-5 text-amber-400" />
-      <p className="text-sm text-amber-200">{message}</p>
-      {subtitle && <p className="whitespace-pre-line text-xs text-amber-200/60">{subtitle}</p>}
-      <button
-        onClick={() => navigate('/pricing')}
-        className={`${btn} border border-white/20 text-white/80 hover:bg-white/10`}
-      >
-        Upgrade to Pro
-      </button>
-    </div>
-  );
-}
 
 /**
  * Quiet inline "Pro" chip for spots where a gated value would render.
  * No copy of its own — clicking goes to /pricing. Use at most one full
  * UpsellCard per screen; every other gated spot gets this chip.
+ *
+ * No padlock, and mint rather than amber: gating is commercial messaging,
+ * so it wears the same accent as the Upgrade button, never a warning color
+ * and never the health ramp. Mirrors the mobile ProChip.
  */
-export function ProChip({ className = '' }: { className?: string }) {
+export function ProChip({ className = '', source = 'pro-chip' }: { className?: string; source?: string }) {
   const navigate = useNavigate();
   return (
     <button
       type="button"
       onClick={(e) => {
         e.stopPropagation();
-        navigate('/pricing');
+        navigate(`/pricing?source=${encodeURIComponent(source)}`);
       }}
-      className={`inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-400 transition hover:bg-amber-500/20 ${className}`.trim()}
-      aria-label="Pro feature — see plans"
+      className={`inline-flex items-center gap-1 rounded-full border border-mint/30 bg-mint/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-mint transition hover:bg-mint/25 ${className}`.trim()}
+      aria-label="Included with Pro — see plans"
     >
-      <Lock className="h-2.5 w-2.5" />
       Pro
     </button>
   );
@@ -53,14 +33,42 @@ export function ProChip({ className = '' }: { className?: string }) {
 
 /**
  * Dismissible feature upsell card driven by the shared copy map.
- * Dismissal is persisted per feature in localStorage and respected forever.
+ * Dismissal is persisted per feature in localStorage and respected until the
+ * user's situation materially changes: pass `rearmKey` when a state change
+ * (e.g. a part going past due) justifies showing a dismissed card one more
+ * time. The dismissal stores the key it was dismissed under, so each distinct
+ * key re-arms the card at most once.
  */
-export function UpsellCard({ feature, className = '' }: { feature: UpsellFeature; className?: string }) {
+export function UpsellCard({
+  feature,
+  className = '',
+  rearmKey,
+  body,
+  persist = true,
+  onDismiss,
+}: {
+  feature: UpsellFeature;
+  className?: string;
+  rearmKey?: string;
+  body?: string;
+  /**
+   * Pass false for cards revealed by an explicit user action (e.g. clicking a
+   * gated button): the card should show every time the action is taken, so
+   * dismissal is session-only and stored dismissals are ignored.
+   */
+  persist?: boolean;
+  onDismiss?: () => void;
+}) {
   const navigate = useNavigate();
   const copy = UPSELL_COPY[feature];
+  const currentKey = rearmKey ?? '1';
   const [dismissed, setDismissed] = useState(() => {
+    if (!persist) return false;
     try {
-      return localStorage.getItem(copy.dismissKey) === '1';
+      const stored = localStorage.getItem(copy.dismissKey);
+      // Legacy dismissals stored '1'; treat them as dismissed for the base
+      // state but let a rearmKey supersede them.
+      return stored !== null && (stored === currentKey || rearmKey === undefined);
     } catch {
       return false;
     }
@@ -70,27 +78,29 @@ export function UpsellCard({ feature, className = '' }: { feature: UpsellFeature
 
   const dismiss = () => {
     setDismissed(true);
+    onDismiss?.();
+    if (!persist) return;
     try {
-      localStorage.setItem(copy.dismissKey, '1');
+      localStorage.setItem(copy.dismissKey, currentKey);
     } catch {
       // Storage unavailable — dismiss for this session only.
     }
   };
 
   return (
-    <div className={`relative rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 ${className}`.trim()}>
+    <div className={`relative rounded-2xl border border-mint/30 bg-mint/10 p-4 ${className}`.trim()}>
       <button
         type="button"
         onClick={dismiss}
-        className="absolute right-2 top-2 rounded p-1 text-amber-200/50 transition hover:text-amber-200"
+        className="absolute right-2 top-2 rounded p-1 text-muted transition hover:text-white"
         aria-label="Dismiss"
       >
         <X className="h-3.5 w-3.5" />
       </button>
-      <p className="pr-6 text-sm font-semibold text-amber-200">{copy.title}</p>
-      <p className="mt-1 pr-6 text-xs leading-relaxed text-amber-200/70">{copy.body}</p>
+      <p className="pr-6 text-sm font-semibold text-white">{copy.title}</p>
+      <p className="mt-1 pr-6 text-xs leading-relaxed text-muted">{body ?? copy.body}</p>
       <button
-        onClick={() => navigate('/pricing')}
+        onClick={() => navigate(`/pricing?source=upsell-${feature}`)}
         className={`${btn} mt-3 border border-white/20 text-white/80 hover:bg-white/10`}
       >
         See Pro

--- a/apps/web/src/components/UpgradePrompt.tsx
+++ b/apps/web/src/components/UpgradePrompt.tsx
@@ -1,7 +1,20 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { X } from 'lucide-react';
 import { useNavigate } from 'react-router';
 import { UPSELL_COPY, type UpsellFeature } from '../constants/upsellCopy';
+
+/**
+ * A dismissal stores the set of re-arm tokens it covered (legacy dismissals
+ * stored the literal '1', which participates as an ordinary token). The card
+ * is dismissed only while every current token is covered, so each NEW token
+ * (e.g. a different part crossing its service interval) re-arms the card
+ * exactly once, while shrinking or repeating token sets stay dismissed.
+ */
+function isCovered(stored: string | null, tokens: string[]): boolean {
+  if (stored === null) return false;
+  const covered = new Set(stored.split(','));
+  return tokens.every((t) => covered.has(t));
+}
 
 const btn = 'rounded-lg px-4 py-2 text-sm font-medium transition';
 
@@ -34,10 +47,9 @@ export function ProChip({ className = '', source = 'pro-chip' }: { className?: s
 /**
  * Dismissible feature upsell card driven by the shared copy map.
  * Dismissal is persisted per feature in localStorage and respected until the
- * user's situation materially changes: pass `rearmKey` when a state change
- * (e.g. a part going past due) justifies showing a dismissed card one more
- * time. The dismissal stores the key it was dismissed under, so each distinct
- * key re-arms the card at most once.
+ * user's situation materially changes: pass `rearmKey` as a comma-separated
+ * token set (e.g. the ids of parts past their service interval) and the card
+ * re-arms once per token a previous dismissal has not covered.
  */
 export function UpsellCard({
   feature,
@@ -61,27 +73,35 @@ export function UpsellCard({
 }) {
   const navigate = useNavigate();
   const copy = UPSELL_COPY[feature];
-  const currentKey = rearmKey ?? '1';
-  const [dismissed, setDismissed] = useState(() => {
+  const currentTokens = useMemo(
+    () => (rearmKey === undefined ? [] : rearmKey.split(',').filter(Boolean)),
+    [rearmKey]
+  );
+  // Computed per render (not in a mount-time initializer) so a rearmKey that
+  // arrives after data loads still re-arms the card.
+  const storedDismissed = useMemo(() => {
     if (!persist) return false;
     try {
-      const stored = localStorage.getItem(copy.dismissKey);
-      // Legacy dismissals stored '1'; treat them as dismissed for the base
-      // state but let a rearmKey supersede them.
-      return stored !== null && (stored === currentKey || rearmKey === undefined);
+      return isCovered(localStorage.getItem(copy.dismissKey), currentTokens);
     } catch {
       return false;
     }
-  });
+  }, [persist, copy.dismissKey, currentTokens]);
+  const [sessionDismissed, setSessionDismissed] = useState(false);
 
-  if (dismissed) return null;
+  if (storedDismissed || sessionDismissed) return null;
 
   const dismiss = () => {
-    setDismissed(true);
+    setSessionDismissed(true);
     onDismiss?.();
     if (!persist) return;
     try {
-      localStorage.setItem(copy.dismissKey, currentKey);
+      const covered = new Set(
+        (localStorage.getItem(copy.dismissKey) ?? '').split(',').filter(Boolean)
+      );
+      covered.add('1');
+      currentTokens.forEach((t) => covered.add(t));
+      localStorage.setItem(copy.dismissKey, Array.from(covered).join(','));
     } catch {
       // Storage unavailable — dismiss for this session only.
     }

--- a/apps/web/src/components/WeatherBackfillSection.test.tsx
+++ b/apps/web/src/components/WeatherBackfillSection.test.tsx
@@ -60,19 +60,19 @@ describe('WeatherBackfillSection', () => {
     expect(screen.getByRole('button', { name: /fetch weather/i })).toBeEnabled();
   });
 
-  it('shows a Pro feature chip for free users and routes to /pricing on click', () => {
+  it('shows an Included with Pro button for free users and routes to /pricing on click', () => {
     mockUseUserTier.mockReturnValueOnce({ isPro: false });
     renderSection();
-    const btn = screen.getByRole('button', { name: /pro feature/i });
+    const btn = screen.getByRole('button', { name: /included with pro/i });
     fireEvent.click(btn);
-    expect(mockNavigate).toHaveBeenCalledWith('/pricing');
+    expect(mockNavigate).toHaveBeenCalledWith('/pricing?source=settings-weather-backfill');
     expect(mockBackfill).not.toHaveBeenCalled();
   });
 
   it('does not call backfill mutation when a free user clicks', () => {
     mockUseUserTier.mockReturnValueOnce({ isPro: false });
     renderSection();
-    fireEvent.click(screen.getByRole('button', { name: /pro feature/i }));
+    fireEvent.click(screen.getByRole('button', { name: /included with pro/i }));
     expect(mockBackfill).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/components/WeatherBackfillSection.tsx
+++ b/apps/web/src/components/WeatherBackfillSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useApolloClient, useMutation, useQuery } from '@apollo/client';
 import { useNavigate } from 'react-router';
-import { CloudSun, Lock } from 'lucide-react';
+import { CloudSun } from 'lucide-react';
 import { useUserTier } from '../hooks/useUserTier';
 import {
   BACKFILL_WEATHER_FOR_MY_RIDES,
@@ -34,7 +34,7 @@ export default function WeatherBackfillSection() {
 
   const onClick = async () => {
     if (!isPro) {
-      navigate('/pricing');
+      navigate('/pricing?source=settings-weather-backfill');
       return;
     }
     setError(null);
@@ -107,8 +107,7 @@ export default function WeatherBackfillSection() {
               onClick={onClick}
               className="flex items-center gap-1.5 rounded-lg bg-mint/15 border border-mint/30 px-3 py-1.5 text-xs font-medium text-mint transition hover:bg-mint/25"
             >
-              <Lock className="h-3 w-3" />
-              Pro feature
+              Included with Pro
             </button>
           )}
         </div>

--- a/apps/web/src/components/dashboard/AdvisorSummaryCard.test.tsx
+++ b/apps/web/src/components/dashboard/AdvisorSummaryCard.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
 import { AdvisorSummaryCard } from './AdvisorSummaryCard';
 import type { AdvisorSummary } from '../../types/prediction';
 
@@ -26,5 +27,35 @@ describe('AdvisorSummaryCard', () => {
     expect(
       screen.getByRole('complementary', { name: /AI maintenance summary/i })
     ).toBeInTheDocument();
+  });
+
+  describe('free-tier teaser', () => {
+    it('renders the teaser with a Pro chip when summary is null and showTeaser is set', () => {
+      render(
+        <MemoryRouter>
+          <AdvisorSummaryCard summary={null} showTeaser />
+        </MemoryRouter>
+      );
+      expect(screen.getByText('AI summary')).toBeInTheDocument();
+      expect(screen.getByText(/sums up what to wrench on/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /included with pro/i })).toBeInTheDocument();
+    });
+
+    it('still collapses to nothing for a null summary without showTeaser (Pro user path)', () => {
+      // A Pro user's summary can be null (ALL_GOOD, rate limit, generation
+      // error); the teaser must never appear for them.
+      const { container } = render(<AdvisorSummaryCard summary={null} showTeaser={false} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('prefers the real summary over the teaser when both could apply', () => {
+      render(
+        <MemoryRouter>
+          <AdvisorSummaryCard summary={summary} showTeaser />
+        </MemoryRouter>
+      );
+      expect(screen.getByText(summary.text)).toBeInTheDocument();
+      expect(screen.queryByText(/sums up what to wrench on/i)).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/components/dashboard/AdvisorSummaryCard.tsx
+++ b/apps/web/src/components/dashboard/AdvisorSummaryCard.tsx
@@ -1,9 +1,17 @@
 import { Sparkles } from 'lucide-react';
 import type { AdvisorSummary } from '../../types/prediction';
 import { GarminDerivedNote } from '../attribution/GarminAttribution';
+import { ProChip } from '../UpgradePrompt';
 
 interface AdvisorSummaryCardProps {
   summary: AdvisorSummary | null;
+  /**
+   * Free tier: the API nulls the summary, so without a teaser the feature is
+   * invisible and free users never learn it exists. Pass true only for free
+   * users; a null summary for a Pro user (ALL_GOOD, rate limit, generation
+   * error) must still collapse to nothing.
+   */
+  showTeaser?: boolean;
   /**
    * Whether this bike's hours include Garmin-sourced rides. When true the card
    * names Garmin as a contributing source, which the Garmin API Brand
@@ -24,8 +32,22 @@ interface AdvisorSummaryCardProps {
  * is simply: render nothing when null and let the space collapse. No tier
  * check here — mirrors how the rest of the hero treats null predictive fields.
  */
-export function AdvisorSummaryCard({ summary, hasGarminSource = false }: AdvisorSummaryCardProps) {
-  if (!summary) return null;
+export function AdvisorSummaryCard({ summary, hasGarminSource = false, showTeaser = false }: AdvisorSummaryCardProps) {
+  if (!summary) {
+    if (!showTeaser) return null;
+    return (
+      <aside className="advisor-summary" aria-label="AI maintenance summary, included with Pro">
+        <div className="advisor-summary-label">
+          <Sparkles size={12} className="icon-left" />
+          AI summary
+          <ProChip source="dashboard-advisor-teaser" className="ml-1.5" />
+        </div>
+        <p className="advisor-summary-text text-muted">
+          Pro reads this bike's wear picture and sums up what to wrench on this week.
+        </p>
+      </aside>
+    );
+  }
 
   return (
     <aside className="advisor-summary" aria-label="AI maintenance summary">

--- a/apps/web/src/components/dashboard/ComponentHealthPanel.test.tsx
+++ b/apps/web/src/components/dashboard/ComponentHealthPanel.test.tsx
@@ -28,11 +28,17 @@ vi.mock('@apollo/client', () => ({
   useQuery: (...args: unknown[]) => mockUseQuery(...args),
 }));
 
-// Stub the upsell components — they use useNavigate, which requires a Router
+// Stub the upsell components — they use useNavigate, which requires a Router.
+// The UpsellCard stub surfaces its wiring props so the panel's re-arm logic
+// (rearmKey, dynamic body) can be asserted without the card's own behavior.
 vi.mock('../UpgradePrompt', () => ({
   default: () => null,
   ProChip: () => <span data-testid="pro-chip" />,
-  UpsellCard: () => <div data-testid="upsell-card" />,
+  UpsellCard: ({ rearmKey, body }: { rearmKey?: string; body?: string }) => (
+    <div data-testid="upsell-card" data-rearm-key={rearmKey ?? ''}>
+      {body}
+    </div>
+  ),
 }));
 
 // Factory for creating test components
@@ -769,6 +775,67 @@ describe('ComponentHealthPanel', () => {
       // CHAIN is more urgent (OVERDUE) so it sorts first
       expect(rowButtons[0]).toHaveTextContent('Chain');
       expect(rowButtons[1]).toHaveTextContent('Fork');
+    });
+  });
+
+  describe('free tier upsell re-arm wiring', () => {
+    beforeEach(() => {
+      mockUseQuery.mockReturnValue({
+        data: { me: { subscriptionTier: 'FREE', isFoundingRider: false, role: 'USER' } },
+        loading: false,
+        error: undefined,
+        refetch: vi.fn(),
+      });
+    });
+
+    afterEach(() => {
+      mockUseQuery.mockReturnValue({
+        data: { me: { subscriptionTier: 'PRO', isFoundingRider: false, role: 'USER' } },
+        loading: false,
+        error: undefined,
+        refetch: vi.fn(),
+      });
+    });
+
+    const pastInterval = (componentId: string) =>
+      createComponent({ componentId, serviceIntervalHours: 100, hoursSinceService: 120, hoursRemaining: null as unknown as number });
+    const withinInterval = (componentId: string) =>
+      createComponent({ componentId, serviceIntervalHours: 100, hoursSinceService: 40, hoursRemaining: null as unknown as number });
+
+    it('passes no rearmKey and the default body when nothing is past interval', () => {
+      render(<MemoryRouter><ComponentHealthPanel components={[withinInterval('fork')]} /></MemoryRouter>);
+
+      const card = screen.getByTestId('upsell-card');
+      expect(card).toHaveAttribute('data-rearm-key', '');
+      expect(card).not.toHaveTextContent(/past its service interval/i);
+    });
+
+    it('keys the re-arm to the past-interval component and grounds the copy in it', () => {
+      render(<MemoryRouter><ComponentHealthPanel components={[pastInterval('fork'), withinInterval('chain')]} /></MemoryRouter>);
+
+      const card = screen.getByTestId('upsell-card');
+      expect(card).toHaveAttribute('data-rearm-key', 'fork');
+      expect(card).toHaveTextContent('One part is past its service interval.');
+    });
+
+    it('joins multiple past-interval component ids and pluralizes the copy', () => {
+      render(<MemoryRouter><ComponentHealthPanel components={[pastInterval('shock'), pastInterval('fork')]} /></MemoryRouter>);
+
+      const card = screen.getByTestId('upsell-card');
+      expect(card).toHaveAttribute('data-rearm-key', 'fork,shock');
+      expect(card).toHaveTextContent('2 parts are past their service intervals.');
+    });
+
+    it('renders no upsell card for Pro users', () => {
+      mockUseQuery.mockReturnValue({
+        data: { me: { subscriptionTier: 'PRO', isFoundingRider: false, role: 'USER' } },
+        loading: false,
+        error: undefined,
+        refetch: vi.fn(),
+      });
+      render(<MemoryRouter><ComponentHealthPanel components={[pastInterval('fork')]} /></MemoryRouter>);
+
+      expect(screen.queryByTestId('upsell-card')).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/components/dashboard/ComponentHealthPanel.tsx
+++ b/apps/web/src/components/dashboard/ComponentHealthPanel.tsx
@@ -346,21 +346,25 @@ export function ComponentHealthPanel({ components, className = '', onLogService 
   );
 
   // Free tier: predictions are nulled server-side, but the raw counters
-  // survive, so "past interval" is computable here. When a part crosses its
-  // interval, re-arm the (possibly dismissed) predictions upsell once and
-  // ground its copy in the user's own data.
-  const pastIntervalCount = useMemo(
+  // survive, so "past interval" is computable here. Each part that crosses
+  // its interval re-arms the (possibly dismissed) predictions upsell once,
+  // keyed by component id, with copy grounded in the user's own data.
+  const pastIntervalIds = useMemo(
     () =>
       isFree
-        ? components.filter(
-            (c) =>
-              c.serviceIntervalHours != null &&
-              c.hoursSinceService != null &&
-              c.hoursSinceService >= c.serviceIntervalHours
-          ).length
-        : 0,
+        ? components
+            .filter(
+              (c) =>
+                c.serviceIntervalHours != null &&
+                c.hoursSinceService != null &&
+                c.hoursSinceService >= c.serviceIntervalHours
+            )
+            .map((c) => c.componentId)
+            .sort()
+        : [],
     [components, isFree]
   );
+  const pastIntervalCount = pastIntervalIds.length;
 
   // Empty state
   if (components.length === 0) {
@@ -442,7 +446,7 @@ export function ComponentHealthPanel({ components, className = '', onLogService 
         <UpsellCard
           feature="predictions"
           className="mt-4"
-          rearmKey={pastIntervalCount > 0 ? 'past-interval' : undefined}
+          rearmKey={pastIntervalCount > 0 ? pastIntervalIds.join(',') : undefined}
           body={
             pastIntervalCount > 0
               ? `${

--- a/apps/web/src/components/dashboard/ComponentHealthPanel.tsx
+++ b/apps/web/src/components/dashboard/ComponentHealthPanel.tsx
@@ -323,7 +323,7 @@ function ComponentDetailOverlay({ component, onClose, onServiceLogged, onLogServ
             {component.status == null ? (
               // Free tier: predictions (and their wear analysis) are Pro
               <p>
-                Pro estimates the rides left before this part needs service. <ProChip />
+                Pro estimates the rides left before this part needs service. <ProChip source="dashboard-wear-analysis" />
               </p>
             ) : (
               <p>No wear analysis available for this component.</p>
@@ -343,6 +343,23 @@ export function ComponentHealthPanel({ components, className = '', onLogService 
   const sortedComponents = useMemo(
     () => getSortedComponentsForHealth(components),
     [components]
+  );
+
+  // Free tier: predictions are nulled server-side, but the raw counters
+  // survive, so "past interval" is computable here. When a part crosses its
+  // interval, re-arm the (possibly dismissed) predictions upsell once and
+  // ground its copy in the user's own data.
+  const pastIntervalCount = useMemo(
+    () =>
+      isFree
+        ? components.filter(
+            (c) =>
+              c.serviceIntervalHours != null &&
+              c.hoursSinceService != null &&
+              c.hoursSinceService >= c.serviceIntervalHours
+          ).length
+        : 0,
+    [components, isFree]
   );
 
   // Empty state
@@ -392,7 +409,7 @@ export function ComponentHealthPanel({ components, className = '', onLogService 
                       {formatHours(component.hoursSinceService)} / {component.serviceIntervalHours}h
                     </span>
                     <span className="component-health-hours-secondary">
-                      {component.ridesSinceService} rides since service <ProChip />
+                      {component.ridesSinceService} rides since service <ProChip source="dashboard-health-row" />
                     </span>
                   </>
                 ) : hoursDisplay === 'total' ? (
@@ -422,7 +439,20 @@ export function ComponentHealthPanel({ components, className = '', onLogService 
       </div>
 
       {isFree && (
-        <UpsellCard feature="predictions" className="mt-4" />
+        <UpsellCard
+          feature="predictions"
+          className="mt-4"
+          rearmKey={pastIntervalCount > 0 ? 'past-interval' : undefined}
+          body={
+            pastIntervalCount > 0
+              ? `${
+                  pastIntervalCount === 1
+                    ? 'One part is past its service interval.'
+                    : `${pastIntervalCount} parts are past their service intervals.`
+                } Pro flags parts while they're still due soon, so the fix happens in the garage, not on the trail.`
+              : undefined
+          }
+        />
       )}
 
       {selectedComponent && (

--- a/apps/web/src/components/dashboard/PriorityBikeHero.tsx
+++ b/apps/web/src/components/dashboard/PriorityBikeHero.tsx
@@ -8,6 +8,7 @@ import { getBikeName } from '../../utils/formatters';
 import { StatusPill } from './StatusPill';
 import { ComponentHealthPanel } from './ComponentHealthPanel';
 import { AdvisorSummaryCard } from './AdvisorSummaryCard';
+import { useUserTier } from '../../hooks/useUserTier';
 import { CompactRideRow } from './CompactRideRow';
 import { Button } from '../ui/Button';
 
@@ -32,6 +33,7 @@ export function PriorityBikeHero({
   loading = false,
   rides = [],
 }: PriorityBikeHeroProps) {
+  const { isFree } = useUserTier();
   // Paginated rides for this bike - show 5 rides in hero
   const {
     rides: paginatedRides,
@@ -139,10 +141,11 @@ export function PriorityBikeHero({
             {/* Component Health Panel */}
             <ComponentHealthPanel components={components} onLogService={onLogService} />
 
-            {/* AI maintenance summary (Pro-only; renders nothing when null) */}
+            {/* AI maintenance summary (Pro-only; free tier gets a teaser) */}
             <AdvisorSummaryCard
               summary={predictions?.advisorSummary ?? null}
               hasGarminSource={bike?.contributingSources?.includes('garmin') ?? false}
+              showTeaser={isFree}
             />
 
             {/* Actions */}

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -74,7 +74,7 @@ export default function AppShell({ children }: { children: ReactNode }) {
                   </ProBadge>
                 ) : (
                   <NavLink
-                    to="/pricing"
+                    to="/pricing?source=navbar-free-pill"
                     className="rounded-full bg-white/10 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white/50 transition hover:bg-white/20 hover:text-white/70"
                   >
                     Free

--- a/apps/web/src/components/layout/Footer.tsx
+++ b/apps/web/src/components/layout/Footer.tsx
@@ -4,7 +4,7 @@ const productLinks = [
     { label: 'Dashboard', path: '/dashboard' },
     { label: 'My Bikes', path: '/gear' },
     { label: 'Maintenance', path: '/gear' },
-    { label: 'Pricing', path: '/pricing' },
+    { label: 'Pricing', path: '/pricing?source=app-footer' },
 ];
 
 const legalLinks = [

--- a/apps/web/src/components/marketing/MarketingFooter.tsx
+++ b/apps/web/src/components/marketing/MarketingFooter.tsx
@@ -38,6 +38,14 @@ export default function MarketingFooter() {
               </li>
               <li>
                 <Link
+                  to="/pricing?source=marketing-footer"
+                  className="text-sm text-concrete hover:text-mint transition"
+                >
+                  Pricing
+                </Link>
+              </li>
+              <li>
+                <Link
                   to="/login"
                   className="text-sm text-concrete hover:text-mint transition"
                 >

--- a/apps/web/src/constants/upsellCopy.ts
+++ b/apps/web/src/constants/upsellCopy.ts
@@ -9,8 +9,8 @@
  *   scarcity language, no "unlock" spam.
  * - One inline upsell card per screen, max. Every other gated spot gets a
  *   quiet Pro chip. Dismissed cards stay dismissed (persisted per surface),
- *   with one exception: a material state change (a part crossing its service
- *   interval) may re-arm a dismissed card once via UpsellCard's rearmKey.
+ *   with one exception: each part that crosses its service interval re-arms
+ *   a dismissed card once, keyed per part via UpsellCard's rearmKey.
  * - Never upsell inside error paths, except the bike-limit message.
  */
 import { BIKE_LIMIT_UPSELL_LINE } from '@loam/shared';

--- a/apps/web/src/constants/upsellCopy.ts
+++ b/apps/web/src/constants/upsellCopy.ts
@@ -8,7 +8,9 @@
  *   modals, no interstitials, no push-notification upsells, no urgency or
  *   scarcity language, no "unlock" spam.
  * - One inline upsell card per screen, max. Every other gated spot gets a
- *   quiet Pro chip. Dismissed cards stay dismissed (persisted per surface).
+ *   quiet Pro chip. Dismissed cards stay dismissed (persisted per surface),
+ *   with one exception: a material state change (a part crossing its service
+ *   interval) may re-arm a dismissed card once via UpsellCard's rearmKey.
  * - Never upsell inside error paths, except the bike-limit message.
  */
 import { BIKE_LIMIT_UPSELL_LINE } from '@loam/shared';

--- a/apps/web/src/pages/BikeHistory.tsx
+++ b/apps/web/src/pages/BikeHistory.tsx
@@ -281,7 +281,7 @@ export default function BikeHistory() {
                 <Button variant="outline" size="sm" onClick={() => setShowPdfUpsell(true)}>
                   <FileDown size={14} className="icon-left" />
                   Export PDF
-                  <span className="ml-1.5 rounded-full border border-amber-500/40 bg-amber-500/10 px-1.5 text-[10px] font-semibold uppercase text-amber-400">Pro</span>
+                  <span className="ml-1.5 rounded-full border border-mint/30 bg-mint/15 px-1.5 text-[10px] font-semibold uppercase text-mint">Pro</span>
                 </Button>
               )}
             </div>
@@ -289,7 +289,9 @@ export default function BikeHistory() {
 
           {showPdfUpsell && !isPro && (
             <div className="mb-4">
-              <UpsellCard feature="pdfExport" />
+              {/* Click-triggered: session-only dismissal, or a persisted
+                  dismissal would leave the Export PDF button doing nothing. */}
+              <UpsellCard feature="pdfExport" persist={false} onDismiss={() => setShowPdfUpsell(false)} />
             </div>
           )}
 

--- a/apps/web/src/pages/Gear.test.tsx
+++ b/apps/web/src/pages/Gear.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import Gear from './Gear';
+
+const mockNavigate = vi.fn();
+const mockUseUserTier = vi.fn();
+const mockMutation = vi.fn();
+
+vi.mock('@apollo/client', () => ({
+  gql: (strings: TemplateStringsArray) => strings.join(''),
+  useQuery: () => ({
+    data: { bikes: [], spareComponents: [] },
+    loading: false,
+    error: undefined,
+  }),
+  useMutation: () => [mockMutation, { loading: false }],
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('@/hooks/useUserTier', () => ({
+  useUserTier: () => mockUseUserTier(),
+}));
+
+vi.mock('@/components/gear', () => ({
+  GearPageHeader: ({ onAddBike, onAddSpare }: { onAddBike: () => void; onAddSpare: () => void }) => (
+    <div>
+      <button onClick={onAddBike}>Add Bike</button>
+      <button onClick={onAddSpare}>Add Spare</button>
+    </div>
+  ),
+  BikeOverviewCard: () => null,
+  SpareComponentsPanel: () => null,
+}));
+
+vi.mock('@/components/ui/Modal', () => ({
+  Modal: ({ isOpen, title, children }: { isOpen: boolean; title: string; children?: React.ReactNode }) =>
+    isOpen ? <div role="dialog" aria-label={title}>{children}</div> : null,
+}));
+
+vi.mock('@/components/BikeForm', () => ({
+  BikeForm: () => <div data-testid="bike-form" />,
+}));
+
+vi.mock('@/components/SpareComponentForm', () => ({
+  SpareComponentForm: () => null,
+}));
+
+vi.mock('@/components/dashboard', () => ({
+  LogServiceModal: () => null,
+}));
+
+vi.mock('@/utils/toastHelpers', () => ({
+  showBikeCreatedToast: vi.fn(),
+}));
+
+const renderGear = () =>
+  render(
+    <MemoryRouter>
+      <Gear />
+    </MemoryRouter>
+  );
+
+describe('Gear bike-limit gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockUseUserTier.mockReturnValue({ canAddBike: true });
+  });
+
+  it('opens the Add Bike form when under the bike limit', () => {
+    renderGear();
+    fireEvent.click(screen.getByRole('button', { name: 'Add Bike' }));
+
+    expect(screen.getByRole('dialog', { name: 'Add Bike' })).toBeInTheDocument();
+    expect(screen.queryByText('N+1, meet Pro.')).not.toBeInTheDocument();
+  });
+
+  it('shows the bike-limit upsell instead of the form when at the limit', () => {
+    mockUseUserTier.mockReturnValue({ canAddBike: false });
+    renderGear();
+    fireEvent.click(screen.getByRole('button', { name: 'Add Bike' }));
+
+    expect(screen.getByText('N+1, meet Pro.')).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('re-shows the upsell on every attempt even after dismissal', () => {
+    mockUseUserTier.mockReturnValue({ canAddBike: false });
+    renderGear();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Bike' }));
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(screen.queryByText('N+1, meet Pro.')).not.toBeInTheDocument();
+
+    // The card is click-triggered, so dismissal must be session-only: a
+    // persisted dismissal would leave the Add Bike button doing nothing.
+    fireEvent.click(screen.getByRole('button', { name: 'Add Bike' }));
+    expect(screen.getByText('N+1, meet Pro.')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Gear.tsx
+++ b/apps/web/src/pages/Gear.tsx
@@ -16,6 +16,8 @@ import {
   DELETE_COMPONENT,
 } from '@/graphql/gear';
 import { SpareComponentForm } from '@/components/SpareComponentForm';
+import { UpsellCard } from '@/components/UpgradePrompt';
+import { useUserTier } from '@/hooks/useUserTier';
 import { BikeOverviewCard, SpareComponentsPanel, GearPageHeader } from '@/components/gear';
 import { LogServiceModal } from '@/components/dashboard';
 import type { BikePredictionSummary } from '@/types/prediction';
@@ -169,7 +171,9 @@ export default function Gear() {
   const bikes = data?.bikes ?? [];
   const spareComponents = data?.spareComponents ?? [];
 
+  const { canAddBike } = useUserTier();
   const [showBikeModal, setShowBikeModal] = useState(false);
+  const [showBikeLimitUpsell, setShowBikeLimitUpsell] = useState(false);
   const [spareModal, setSpareModal] = useState<SpareModalState | null>(null);
   const [bikeFormError, setBikeFormError] = useState<string | null>(null);
   const [spareFormError, setSpareFormError] = useState<string | null>(null);
@@ -363,6 +367,12 @@ export default function Gear() {
       {/* Header */}
       <GearPageHeader
         onAddBike={() => {
+          // Free tier at the bike limit: don't open a form that can't
+          // succeed; show the upsell instead of a post-submit error.
+          if (!canAddBike) {
+            setShowBikeLimitUpsell(true);
+            return;
+          }
           setBikeFormError(null);
           setShowBikeModal(true);
         }}
@@ -371,6 +381,15 @@ export default function Gear() {
           setSpareModal({ mode: 'create' });
         }}
       />
+
+      {showBikeLimitUpsell && (
+        <UpsellCard
+          feature="bikeLimit"
+          className="mb-6"
+          persist={false}
+          onDismiss={() => setShowBikeLimitUpsell(false)}
+        />
+      )}
 
       {/* Error Alert */}
       {error && (

--- a/apps/web/src/pages/Pricing.tsx
+++ b/apps/web/src/pages/Pricing.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useSearchParams } from 'react-router';
 import { motion } from 'motion/react';
 import { gql, useMutation } from '@apollo/client';
 import { Check, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useUserTier } from '../hooks/useUserTier';
 import { useViewer } from '../graphql/me';
 import { posthog } from '../lib/posthog';
@@ -19,7 +19,7 @@ const CREATE_CHECKOUT = gql`
 export default function Pricing() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { tier, isPro, isFoundingRider } = useUserTier();
+  const { tier, isPro, isFoundingRider, loading: tierLoading } = useUserTier();
   const { viewer } = useViewer();
   const isAuthenticated = !!viewer;
   const [billingPeriod, setBillingPeriod] = useState<'MONTHLY' | 'ANNUAL'>('ANNUAL');
@@ -30,11 +30,19 @@ export default function Pricing() {
   // touchpoints by actual conversion, not just clicks.
   const source = searchParams.get('source') ?? 'direct';
 
+  // Fire once per visit, but only after the viewer query settles: on a cold
+  // cache (deep link, hard refresh) `tier` defaults to FREE until the query
+  // resolves, and an effect that fires on mount would permanently record the
+  // wrong tier for Pro users.
+  const viewTracked = useRef(false);
   useEffect(() => {
-    posthog.capture('pricing_page_viewed', { source, currentTier: tier });
-    // Fire once per visit; source and tier are fixed for the page's lifetime.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (tierLoading || viewTracked.current) return;
+    viewTracked.current = true;
+    posthog.capture('pricing_page_viewed', {
+      source,
+      currentTier: isAuthenticated ? tier : 'ANONYMOUS',
+    });
+  }, [tierLoading, source, tier, isAuthenticated]);
 
   const handleUpgrade = async () => {
     // The page is public: a logged-out visitor can't check out, so send them

--- a/apps/web/src/pages/Pricing.tsx
+++ b/apps/web/src/pages/Pricing.tsx
@@ -1,9 +1,10 @@
-import { useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import { motion } from 'motion/react';
 import { gql, useMutation } from '@apollo/client';
 import { Check, X } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useUserTier } from '../hooks/useUserTier';
+import { useViewer } from '../graphql/me';
 import { posthog } from '../lib/posthog';
 
 const CREATE_CHECKOUT = gql`
@@ -17,11 +18,32 @@ const CREATE_CHECKOUT = gql`
 
 export default function Pricing() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { tier, isPro, isFoundingRider } = useUserTier();
+  const { viewer } = useViewer();
+  const isAuthenticated = !!viewer;
   const [billingPeriod, setBillingPeriod] = useState<'MONTHLY' | 'ANNUAL'>('ANNUAL');
   const [createCheckout, { loading }] = useMutation(CREATE_CHECKOUT);
 
+  // Which touchpoint sent the user here (upsell card, chip, settings, footer).
+  // Every in-app link to /pricing appends ?source=… so the funnel can rank
+  // touchpoints by actual conversion, not just clicks.
+  const source = searchParams.get('source') ?? 'direct';
+
+  useEffect(() => {
+    posthog.capture('pricing_page_viewed', { source, currentTier: tier });
+    // Fire once per visit; source and tier are fixed for the page's lifetime.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const handleUpgrade = async () => {
+    // The page is public: a logged-out visitor can't check out, so send them
+    // to signup instead of silently failing the checkout mutation.
+    if (!isAuthenticated) {
+      posthog.capture('pricing_signup_redirect', { plan: billingPeriod, source });
+      navigate('/signup');
+      return;
+    }
     // Three-stage funnel:
     //   1. `checkout_session_started` — intent (fires on click)
     //   2. `checkout_session_created` — Stripe session URL returned (fires
@@ -29,12 +51,12 @@ export default function Pricing() {
     //      pre-Stripe failures: rate limits, network errors, validation)
     //   3. `subscription_checkout_completed` — payment succeeded (fires
     //      server-side from the Stripe webhook; authoritative)
-    posthog.capture('checkout_session_started', { plan: billingPeriod, currentTier: tier });
+    posthog.capture('checkout_session_started', { plan: billingPeriod, currentTier: tier, source });
     try {
       const { data } = await createCheckout({ variables: { plan: billingPeriod } });
       const url = data?.createCheckoutSession?.url;
       if (url) {
-        posthog.capture('checkout_session_created', { plan: billingPeriod, currentTier: tier });
+        posthog.capture('checkout_session_created', { plan: billingPeriod, currentTier: tier, source });
         window.location.href = url;
       }
     } catch {
@@ -57,6 +79,7 @@ export default function Pricing() {
         { text: 'Automatic ride sync', included: true },
         { text: 'Service logging & usage counts', included: true },
         { text: 'Rides left until service due', included: false },
+        { text: 'Service-due alerts & weekly bike check', included: false },
         { text: 'Ride weather tracking', included: false },
         { text: 'PDF service history export', included: false },
       ],
@@ -72,10 +95,11 @@ export default function Pricing() {
         { text: 'Unlimited bikes', included: true },
         { text: 'Rides left until service due', included: true },
         { text: 'Ride-adjusted wear predictions', included: true },
+        { text: 'AI maintenance summary per bike', included: true },
+        { text: 'Service-due alerts & weekly bike check', included: true },
         { text: 'Weather on every ride', included: true },
         { text: 'PDF service history export', included: true },
         { text: 'Import your full ride history', included: true },
-        { text: 'Priority support', included: true },
       ],
     },
   ];
@@ -180,7 +204,7 @@ export default function Pricing() {
                         disabled={loading}
                         className="w-full rounded-lg bg-amber-500 py-2 text-sm font-medium text-white transition hover:bg-amber-500/80 disabled:opacity-50"
                       >
-                        {loading ? 'Loading...' : 'Upgrade to Pro'}
+                        {loading ? 'Loading...' : isAuthenticated ? 'Upgrade to Pro' : 'Get started'}
                       </button>
                     ) : null}
                   </div>

--- a/apps/web/src/pages/Settings/sections/PreferencesSection.tsx
+++ b/apps/web/src/pages/Settings/sections/PreferencesSection.tsx
@@ -5,7 +5,7 @@ import { useCurrentUser } from '../../../hooks/useCurrentUser';
 import { usePreferences } from '../../../hooks/usePreferences';
 import { useUserTier } from '../../../hooks/useUserTier';
 import { UPDATE_USER_PREFERENCES_MUTATION } from '../../../graphql/userPreferences';
-import { ProBadge } from '../../../components/ui/ProBadge';
+import { ProChip } from '../../../components/UpgradePrompt';
 import SettingsSectionHeader from '../SettingsSectionHeader';
 import { useAutoSavePreference } from '../useAutoSavePreference';
 
@@ -106,7 +106,7 @@ export default function PreferencesSection() {
               !isPro
                 ? (e) => {
                     e.preventDefault();
-                    navigate('/pricing');
+                    navigate('/pricing?source=settings-predictive-mode');
                   }
                 : undefined
             }
@@ -121,7 +121,7 @@ export default function PreferencesSection() {
               disabled={!isPro}
             />
             Predictive (ride-adjusted)
-            {!isPro && <ProBadge className="ml-2 inline-flex items-center gap-1" />}
+            {!isPro && <ProChip className="ml-2" source="settings-predictive-mode" />}
           </label>
         </div>
         <p className="text-xs text-muted">

--- a/libs/graphql/src/generated/index.ts
+++ b/libs/graphql/src/generated/index.ts
@@ -94,6 +94,7 @@ export type AddComponentInput = {
 export type AddRideInput = {
   averageHr?: InputMaybe<Scalars['Int']['input']>;
   bikeId?: InputMaybe<Scalars['ID']['input']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   distanceMeters: Scalars['Float']['input'];
   durationSeconds: Scalars['Int']['input'];
   elevationGainMeters: Scalars['Float']['input'];
@@ -102,6 +103,7 @@ export type AddRideInput = {
   rideType: Scalars['String']['input'];
   startTime: Scalars['String']['input'];
   trailSystem?: InputMaybe<Scalars['String']['input']>;
+  unownedBike?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type AdvisorSummary = {
@@ -649,6 +651,22 @@ export type Mutation = {
   snoozeComponent: Component;
   swapComponents: SwapComponentsResult;
   triggerProviderSync: TriggerSyncResult;
+  /**
+   * Clears expoPushToken, but ONLY if it currently equals the given token:
+   * a compare-and-clear, not a blind null. expoPushToken is a single column
+   * per user, not per device, so the same account signed into two devices
+   * only ever has room for one device's token, and whichever device
+   * registers last silently wins the slot. Clearing unconditionally on
+   * logout (as updateUserPreferences with expoPushToken: null does) would
+   * let a logout on the device that already lost that race null out a
+   * different, currently-active device's token. Matching first means a
+   * stale device's logout can only ever remove its own (long since
+   * overwritten) token, never a foreign one.
+   * Returns true only if a row was actually cleared; false is not an error,
+   * it means this token was not the one on file (already cleared, or a
+   * different device holds the slot), so nothing needed to happen.
+   */
+  unregisterPushToken: Scalars['Boolean']['output'];
   updateAnalyticsOptOut: User;
   updateBike: Bike;
   updateBikeAcquisition: UpdateBikeAcquisitionResult;
@@ -848,6 +866,11 @@ export type MutationTriggerProviderSyncArgs = {
 };
 
 
+export type MutationUnregisterPushTokenArgs = {
+  token: Scalars['String']['input'];
+};
+
+
 export type MutationUpdateAnalyticsOptOutArgs = {
   optOut: Scalars['Boolean']['input'];
 };
@@ -958,6 +981,7 @@ export type Query = {
   servicePreferenceDefaults: Array<ServicePreferenceDefault>;
   sharedBikeHistory?: Maybe<SharedBikeHistory>;
   stravaGearMappings: Array<StravaGearMapping>;
+  unassignedRideCount: Scalars['Int']['output'];
   unassignedRides: UnassignedRidesPage;
   unmappedStravaGears: Array<StravaGearInfo>;
 };
@@ -1084,11 +1108,26 @@ export type Ride = {
   stravaGearId?: Maybe<Scalars['String']['output']>;
   suuntoWorkoutId?: Maybe<Scalars['String']['output']>;
   trailSystem?: Maybe<Scalars['String']['output']>;
+  /**
+   * Ridden on a bike the rider does not own: a demo, a loaner, a rental, a
+   * friend's bike. Always paired with a null bikeId, and the two are kept in
+   * sync by the server (assigning a bike clears this; setting this clears the
+   * bike). Distinguishes "not my bike" from "not assigned yet", so clients can
+   * stop prompting for a bike that is never coming. The ride still counts
+   * toward ride stats and insights; it credits no component either way.
+   */
+  unownedBike: Scalars['Boolean']['output'];
   updatedAt: Scalars['String']['output'];
   userId: Scalars['ID']['output'];
   weather?: Maybe<RideWeather>;
   whoopWorkoutId?: Maybe<Scalars['String']['output']>;
 };
+
+export enum RideSyncNotificationMode {
+  ActionNeeded = 'ACTION_NEEDED',
+  All = 'ALL',
+  Off = 'OFF'
+}
 
 export type RideTrack = {
   __typename?: 'RideTrack';
@@ -1146,6 +1185,7 @@ export type RidesFilterInput = {
   bikeId?: InputMaybe<Scalars['ID']['input']>;
   endDate?: InputMaybe<Scalars['String']['input']>;
   startDate?: InputMaybe<Scalars['String']['input']>;
+  unassigned?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ServiceEvent = {
@@ -1492,6 +1532,7 @@ export type UpdateRideInput = {
   rideType?: InputMaybe<Scalars['String']['input']>;
   startTime?: InputMaybe<Scalars['String']['input']>;
   trailSystem?: InputMaybe<Scalars['String']['input']>;
+  unownedBike?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type UpdateServiceLogInput = {
@@ -1510,6 +1551,9 @@ export type UpdateUserPreferencesInput = {
   hoursDisplayPreference?: InputMaybe<Scalars['String']['input']>;
   notifyOnRideUpload?: InputMaybe<Scalars['Boolean']['input']>;
   predictionMode?: InputMaybe<Scalars['String']['input']>;
+  rideSyncNotificationMode?: InputMaybe<RideSyncNotificationMode>;
+  timezone?: InputMaybe<Scalars['String']['input']>;
+  weeklyDigestEnabled?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type User = {
@@ -1539,6 +1583,7 @@ export type User = {
   predictionMode?: Maybe<Scalars['String']['output']>;
   /** @deprecated Referral program removed; always null */
   referralCode?: Maybe<Scalars['String']['output']>;
+  rideSyncNotificationMode: RideSyncNotificationMode;
   rides: Array<Ride>;
   ridesMissingWeather: Scalars['Int']['output'];
   role: UserRole;
@@ -1548,6 +1593,7 @@ export type User = {
   tierLimits: TierLimits;
   trailStewardshipNoticeSeenAt?: Maybe<Scalars['String']['output']>;
   weatherBreakdown: WeatherBreakdown;
+  weeklyDigestEnabled: Scalars['Boolean']['output'];
 };
 
 


### PR DESCRIPTION
## Why

The mobile app is gaining an offline outbox (ryanlecours/loam-logger-mobile#47) that retries addRide with backoff. Today a retry whose first attempt committed but whose response was lost would insert a second ride and double-credit component hours, because addRide is an unconditional insert with no idempotency anchor.

## What

- New nullable Ride.clientMutationId with @@unique([userId, clientMutationId]), mirroring the existing provider-ID unique columns. Additive migration; applies on next Railway boot via migrate deploy.
- AddRideInput.clientMutationId (optional). Omitting it preserves the old behavior exactly, so web and existing mobile builds are unaffected.
- addRide checks the key before validating (a replay must succeed even if the bike was since deleted) and returns the previously created ride. The race where two retries pass that check together is resolved by catching the P2002 unique violation and returning the winner; the loser's transaction rolled back, so no hours are double-credited and no duplicate analytics fire.
- Regenerated GraphQL types. This also picks up drift from earlier schema merges (unownedBike, unregisterPushToken, notification modes and digest fields) that skipped the codegen step.

## Testing

- 5 new resolver tests: replay short-circuit, fresh-key insert, retry race, non-idempotency P2002 rethrow, no-key bypass
- Full API suite passes; nx build and lint green

## Rollout

Safe to promote to main independently of the mobile release; the field is optional. The mobile offline PR should not ship to riders before this reaches production.

Note: this PR also carries the 6 main commits staging is currently behind on (staging was strictly behind main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)