### PR TITLE
Promote staging to main: idempotent addRide

### DIFF
--- a/apps/api/prisma/migrations/20260805150000_add_ride_client_mutation_id/migration.sql
+++ b/apps/api/prisma/migrations/20260805150000_add_ride_client_mutation_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Ride" ADD COLUMN     "clientMutationId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ride_userId_clientMutationId_key" ON "Ride"("userId", "clientMutationId");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -191,6 +191,14 @@ model Ride {
   liftElevationGainMeters Float?
   liftDistanceMeters      Float?
   liftDetectorVersion     Int?
+  // Client-generated idempotency key for manual ride creation. The mobile app
+  // queues addRide while offline and retries with backoff; without this key a
+  // retry after a lost response would insert a second ride AND double-credit
+  // component hours. Scoped per user (the same UUID from two accounts is not a
+  // collision). NULL for provider-synced rides and legacy rows; Postgres treats
+  // NULLs as distinct in unique indexes, so the constraint only bites when a
+  // key is actually supplied.
+  clientMutationId        String?
   bike                    Bike?                     @relation(fields: [bikeId], references: [id])
   duplicateOf             Ride?                     @relation("DuplicateRides", fields: [duplicateOfId], references: [id], onDelete: SetNull)
   duplicates              Ride[]                    @relation("DuplicateRides")
@@ -205,6 +213,7 @@ model Ride {
   // to keep the ridesMissingWeather COUNT(*) fast once the RideWeather table fills up.
   // Prisma doesn't support partial-index predicates, so the index is managed there.
 
+  @@unique([userId, clientMutationId])
   @@index([importSessionId, bikeId])
   // Backs the userId + bikeId + startTime(range/order) access pattern shared
   // by componentRides (interactive, up to 60/min), the prediction engine's

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -137,6 +137,7 @@ jest.mock('../../lib/posthog', () => ({
 }));
 
 import { resolvers } from '../resolvers';
+import { Prisma } from '@prisma/client';
 import { prisma } from '../../lib/prisma';
 import { checkMutationRateLimit } from '../../lib/rate-limit';
 import { invalidateBikePrediction, getCachedAdvisorSummary, setCachedAdvisorSummary } from '../../services/prediction/cache';
@@ -6230,6 +6231,107 @@ describe('GraphQL Resolvers', () => {
       // No bike named, so nothing to credit or debit.
       expect(data).not.toHaveProperty('bikeId');
       expect(tx.component.updateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Mutation.addRide idempotency (clientMutationId)', () => {
+    const mutation = resolvers.Mutation.addRide;
+
+    // unownedBike keeps the resolver off the bike-lookup and hours-credit
+    // paths, so these tests isolate the idempotency behavior itself.
+    const baseInput = {
+      startTime: '2026-08-05T10:00:00.000Z',
+      durationSeconds: 3600,
+      distanceMeters: 16000,
+      elevationGainMeters: 400,
+      rideType: 'TRAIL',
+      unownedBike: true,
+    };
+
+    const makeTx = () => ({
+      ride: { create: jest.fn().mockResolvedValue({ id: 'ride-new' }) },
+    });
+
+    beforeEach(() => {
+      mockCheckMutationRateLimit.mockResolvedValue({ allowed: true, retryAfter: 0 });
+      (prisma.ride.findUnique as jest.Mock).mockReset();
+      (prisma.$transaction as jest.Mock).mockReset();
+    });
+
+    it('returns the existing ride and skips the insert when the key was already used', async () => {
+      const existing = { id: 'ride-original', clientMutationId: 'key-1' };
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue(existing);
+
+      const result = await mutation(
+        {}, { input: { ...baseInput, clientMutationId: 'key-1' } }, createMockContext('user-123') as never
+      );
+
+      expect(result).toBe(existing);
+      expect(prisma.ride.findUnique).toHaveBeenCalledWith({
+        where: { userId_clientMutationId: { userId: 'user-123', clientMutationId: 'key-1' } },
+      });
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      // The original request already fired the funnel event; a replay must not.
+      expect(mockCaptureServerEvent).not.toHaveBeenCalled();
+    });
+
+    it('stores the key on the created ride when it is fresh', async () => {
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue(null);
+      const tx = makeTx();
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation(
+        {}, { input: { ...baseInput, clientMutationId: 'key-1' } }, createMockContext('user-123') as never
+      );
+
+      expect(tx.ride.create.mock.calls[0][0].data.clientMutationId).toBe('key-1');
+    });
+
+    it('returns the winning row when two retries race past the replay check', async () => {
+      const winner = { id: 'ride-winner', clientMutationId: 'key-1' };
+      (prisma.ride.findUnique as jest.Mock)
+        .mockResolvedValueOnce(null) // replay check: nothing committed yet
+        .mockResolvedValueOnce(winner); // re-read after the unique collision
+      (prisma.$transaction as jest.Mock).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+          code: 'P2002',
+          clientVersion: 'test',
+          meta: { target: ['userId', 'clientMutationId'] },
+        })
+      );
+
+      const result = await mutation(
+        {}, { input: { ...baseInput, clientMutationId: 'key-1' } }, createMockContext('user-123') as never
+      );
+
+      expect(result).toBe(winner);
+    });
+
+    it('rethrows unique collisions that are not the idempotency key', async () => {
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue(null);
+      (prisma.$transaction as jest.Mock).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+          code: 'P2002',
+          clientVersion: 'test',
+          meta: { target: ['garminActivityId'] },
+        })
+      );
+
+      await expect(
+        mutation(
+          {}, { input: { ...baseInput, clientMutationId: 'key-1' } }, createMockContext('user-123') as never
+        )
+      ).rejects.toThrow('Unique constraint failed');
+    });
+
+    it('bypasses the idempotency path entirely when no key is supplied', async () => {
+      const tx = makeTx();
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation({}, { input: { ...baseInput } }, createMockContext('user-123') as never);
+
+      expect(prisma.ride.findUnique).not.toHaveBeenCalled();
+      expect(tx.ride.create.mock.calls[0][0].data).not.toHaveProperty('clientMutationId');
     });
   });
 });

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -1,12 +1,12 @@
 import { GraphQLError } from 'graphql';
 import type { GraphQLContext } from '../server';
 import { prisma } from '../lib/prisma';
-import { ComponentType as ComponentTypeEnum } from '@prisma/client';
+import { ComponentType as ComponentTypeEnum, Prisma } from '@prisma/client';
 import type {
-  Prisma,
   ComponentType as ComponentTypeLiteral,
   ComponentLocation,
   Bike,
+  Ride,
   Component as ComponentModel,
   UserRole,
 } from '@prisma/client';
@@ -73,6 +73,7 @@ type AddRideInput = {
   notes?: string | null;
   trailSystem?: string | null;
   location?: string | null;
+  clientMutationId?: string | null;
 };
 
 type UpdateRideInput = {
@@ -1884,6 +1885,22 @@ export const resolvers = {
           extensions: { code: 'RATE_LIMITED', retryAfter: rateLimit.retryAfter },
         });
       }
+      // Idempotency replay check. The mobile offline queue retries addRide
+      // with the same client-generated key until it sees a response; if the
+      // first attempt committed but the response was lost, the retry must
+      // return that ride rather than insert again (which would also
+      // double-credit component hours). Checked before input validation on
+      // purpose: the original submit already passed validation, and a replay
+      // must still succeed even if state changed since (e.g. the bike was
+      // deleted, which would now fail the ownership check below).
+      const clientMutationId = cleanText(input.clientMutationId, 64);
+      if (clientMutationId) {
+        const existing = await prisma.ride.findUnique({
+          where: { userId_clientMutationId: { userId, clientMutationId } },
+        });
+        if (existing) return existing;
+      }
+
       const start = parseIso(input.startTime);
       const durationSeconds = Math.max(0, Math.floor(input.durationSeconds));
       const distanceMeters = Math.max(0, Number(input.distanceMeters));
@@ -1941,6 +1958,7 @@ export const resolvers = {
         ...(notes ? { notes } : {}),
         ...(trailSystem ? { trailSystem } : {}),
         ...(location ? { location } : {}),
+        ...(clientMutationId ? { clientMutationId } : {}),
       };
 
       const hoursDelta = durationSeconds / 3600;
@@ -1950,13 +1968,35 @@ export const resolvers = {
         await invalidateBikePrediction(userId, bikeId);
       }
 
-      const ride = await prisma.$transaction(async (tx) => {
-        const newRide = await tx.ride.create({ data: rideData });
-        if (bikeId) {
-          await incrementBikeComponentHours(tx, { userId, bikeId, hoursDelta });
+      let ride: Ride;
+      try {
+        ride = await prisma.$transaction(async (tx) => {
+          const newRide = await tx.ride.create({ data: rideData });
+          if (bikeId) {
+            await incrementBikeComponentHours(tx, { userId, bikeId, hoursDelta });
+          }
+          return newRide;
+        });
+      } catch (e) {
+        // Two retries of the same offline submit racing each other: the loser
+        // hits the (userId, clientMutationId) unique constraint after the
+        // replay check above passed. The transaction rolled back, so no hours
+        // were credited here; return the winner's ride. The analytics event
+        // and service-due check are skipped, since the winning request fired
+        // them.
+        const isReplayCollision =
+          clientMutationId &&
+          e instanceof Prisma.PrismaClientKnownRequestError &&
+          e.code === 'P2002' &&
+          (e.meta?.target as string[] | undefined)?.includes('clientMutationId');
+        if (isReplayCollision) {
+          const winner = await prisma.ride.findUnique({
+            where: { userId_clientMutationId: { userId, clientMutationId } },
+          });
+          if (winner) return winner;
         }
-        return newRide;
-      });
+        throw e;
+      }
 
       // Invalidate prediction cache after transaction
       if (bikeId) {

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -549,6 +549,11 @@ export const typeDefs = gql`
     notes: String
     trailSystem: String
     location: String
+    # Client-generated idempotency key (a UUID). When a retried submit carries
+    # the same key, the API returns the ride created by the first attempt
+    # instead of inserting a duplicate. Optional: omitting it preserves the
+    # old always-insert behavior.
+    clientMutationId: String
   }
 
   type DeleteRideResult { ok: Boolean!, id: ID! }

--- a/libs/graphql/src/generated/index.ts
+++ b/libs/graphql/src/generated/index.ts
@@ -94,6 +94,7 @@ export type AddComponentInput = {
 export type AddRideInput = {
   averageHr?: InputMaybe<Scalars['Int']['input']>;
   bikeId?: InputMaybe<Scalars['ID']['input']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   distanceMeters: Scalars['Float']['input'];
   durationSeconds: Scalars['Int']['input'];
   elevationGainMeters: Scalars['Float']['input'];
@@ -102,6 +103,7 @@ export type AddRideInput = {
   rideType: Scalars['String']['input'];
   startTime: Scalars['String']['input'];
   trailSystem?: InputMaybe<Scalars['String']['input']>;
+  unownedBike?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type AdvisorSummary = {
@@ -649,6 +651,22 @@ export type Mutation = {
   snoozeComponent: Component;
   swapComponents: SwapComponentsResult;
   triggerProviderSync: TriggerSyncResult;
+  /**
+   * Clears expoPushToken, but ONLY if it currently equals the given token:
+   * a compare-and-clear, not a blind null. expoPushToken is a single column
+   * per user, not per device, so the same account signed into two devices
+   * only ever has room for one device's token, and whichever device
+   * registers last silently wins the slot. Clearing unconditionally on
+   * logout (as updateUserPreferences with expoPushToken: null does) would
+   * let a logout on the device that already lost that race null out a
+   * different, currently-active device's token. Matching first means a
+   * stale device's logout can only ever remove its own (long since
+   * overwritten) token, never a foreign one.
+   * Returns true only if a row was actually cleared; false is not an error,
+   * it means this token was not the one on file (already cleared, or a
+   * different device holds the slot), so nothing needed to happen.
+   */
+  unregisterPushToken: Scalars['Boolean']['output'];
   updateAnalyticsOptOut: User;
   updateBike: Bike;
   updateBikeAcquisition: UpdateBikeAcquisitionResult;
@@ -848,6 +866,11 @@ export type MutationTriggerProviderSyncArgs = {
 };
 
 
+export type MutationUnregisterPushTokenArgs = {
+  token: Scalars['String']['input'];
+};
+
+
 export type MutationUpdateAnalyticsOptOutArgs = {
   optOut: Scalars['Boolean']['input'];
 };
@@ -958,6 +981,7 @@ export type Query = {
   servicePreferenceDefaults: Array<ServicePreferenceDefault>;
   sharedBikeHistory?: Maybe<SharedBikeHistory>;
   stravaGearMappings: Array<StravaGearMapping>;
+  unassignedRideCount: Scalars['Int']['output'];
   unassignedRides: UnassignedRidesPage;
   unmappedStravaGears: Array<StravaGearInfo>;
 };
@@ -1084,11 +1108,26 @@ export type Ride = {
   stravaGearId?: Maybe<Scalars['String']['output']>;
   suuntoWorkoutId?: Maybe<Scalars['String']['output']>;
   trailSystem?: Maybe<Scalars['String']['output']>;
+  /**
+   * Ridden on a bike the rider does not own: a demo, a loaner, a rental, a
+   * friend's bike. Always paired with a null bikeId, and the two are kept in
+   * sync by the server (assigning a bike clears this; setting this clears the
+   * bike). Distinguishes "not my bike" from "not assigned yet", so clients can
+   * stop prompting for a bike that is never coming. The ride still counts
+   * toward ride stats and insights; it credits no component either way.
+   */
+  unownedBike: Scalars['Boolean']['output'];
   updatedAt: Scalars['String']['output'];
   userId: Scalars['ID']['output'];
   weather?: Maybe<RideWeather>;
   whoopWorkoutId?: Maybe<Scalars['String']['output']>;
 };
+
+export enum RideSyncNotificationMode {
+  ActionNeeded = 'ACTION_NEEDED',
+  All = 'ALL',
+  Off = 'OFF'
+}
 
 export type RideTrack = {
   __typename?: 'RideTrack';
@@ -1146,6 +1185,7 @@ export type RidesFilterInput = {
   bikeId?: InputMaybe<Scalars['ID']['input']>;
   endDate?: InputMaybe<Scalars['String']['input']>;
   startDate?: InputMaybe<Scalars['String']['input']>;
+  unassigned?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ServiceEvent = {
@@ -1492,6 +1532,7 @@ export type UpdateRideInput = {
   rideType?: InputMaybe<Scalars['String']['input']>;
   startTime?: InputMaybe<Scalars['String']['input']>;
   trailSystem?: InputMaybe<Scalars['String']['input']>;
+  unownedBike?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type UpdateServiceLogInput = {
@@ -1510,6 +1551,9 @@ export type UpdateUserPreferencesInput = {
   hoursDisplayPreference?: InputMaybe<Scalars['String']['input']>;
   notifyOnRideUpload?: InputMaybe<Scalars['Boolean']['input']>;
   predictionMode?: InputMaybe<Scalars['String']['input']>;
+  rideSyncNotificationMode?: InputMaybe<RideSyncNotificationMode>;
+  timezone?: InputMaybe<Scalars['String']['input']>;
+  weeklyDigestEnabled?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type User = {
@@ -1539,6 +1583,7 @@ export type User = {
   predictionMode?: Maybe<Scalars['String']['output']>;
   /** @deprecated Referral program removed; always null */
   referralCode?: Maybe<Scalars['String']['output']>;
+  rideSyncNotificationMode: RideSyncNotificationMode;
   rides: Array<Ride>;
   ridesMissingWeather: Scalars['Int']['output'];
   role: UserRole;
@@ -1548,6 +1593,7 @@ export type User = {
   tierLimits: TierLimits;
   trailStewardshipNoticeSeenAt?: Maybe<Scalars['String']['output']>;
   weatherBreakdown: WeatherBreakdown;
+  weeklyDigestEnabled: Scalars['Boolean']['output'];
 };
 
 


### PR DESCRIPTION
Promotes #297 to production: nullable Ride.clientMutationId with a per-user unique constraint, the optional AddRideInput.clientMutationId field, replay/race handling in the addRide resolver, and the regenerated GraphQL types (including catch-up drift from earlier merges that skipped codegen).

The migration is additive and applies on Railway boot via migrate deploy.

This unblocks the mobile offline release (ryanlecours/loam-logger-mobile#67), which must not ship to riders before this reaches production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)