### PR TITLE
feat(api): accept GPS start coordinates on addRide, enqueue weather

### DIFF
--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -122,8 +122,10 @@ jest.mock('../../services/notification.service', () => ({
   isValidExpoPushToken: jest.fn((token: string) => token.startsWith('ExponentPushToken[') || token.startsWith('ExpoPushToken[')),
 }));
 
+// Resolves rather than bare jest.fn(): addRide fire-and-forgets the enqueue
+// with .catch() chained, so the mock must return a promise.
 jest.mock('../../lib/queue/weather.queue', () => ({
-  enqueueWeatherJob: jest.fn(),
+  enqueueWeatherJob: jest.fn().mockResolvedValue({ enqueued: true }),
 }));
 
 // Prevent captureServerEvent calls from firing real PostHog events during
@@ -6332,6 +6334,81 @@ describe('GraphQL Resolvers', () => {
 
       expect(prisma.ride.findUnique).not.toHaveBeenCalled();
       expect(tx.ride.create.mock.calls[0][0].data).not.toHaveProperty('clientMutationId');
+    });
+  });
+
+  describe('Mutation.addRide start coordinates (in-app recording)', () => {
+    const mutation = resolvers.Mutation.addRide;
+    const { enqueueWeatherJob } = jest.requireMock<{
+      enqueueWeatherJob: jest.Mock;
+    }>('../../lib/queue/weather.queue');
+
+    const baseInput = {
+      startTime: '2026-08-05T10:00:00.000Z',
+      durationSeconds: 3600,
+      distanceMeters: 16000,
+      elevationGainMeters: 400,
+      rideType: 'TRAIL',
+      unownedBike: true,
+    };
+
+    const makeTx = () => ({
+      ride: { create: jest.fn().mockResolvedValue({ id: 'ride-new' }) },
+    });
+
+    beforeEach(() => {
+      mockCheckMutationRateLimit.mockResolvedValue({ allowed: true, retryAfter: 0 });
+      (prisma.$transaction as jest.Mock).mockReset();
+    });
+
+    it('stores both coordinates and enqueues weather enrichment', async () => {
+      const tx = makeTx();
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation(
+        {},
+        { input: { ...baseInput, startLat: 47.6062, startLng: -122.3321 } },
+        createMockContext('user-123') as never
+      );
+
+      const data = tx.ride.create.mock.calls[0][0].data;
+      expect(data.startLat).toBe(47.6062);
+      expect(data.startLng).toBe(-122.3321);
+      expect(enqueueWeatherJob).toHaveBeenCalledWith({ rideId: 'ride-new' });
+    });
+
+    it('skips weather and stores nothing when no coordinates are sent', async () => {
+      const tx = makeTx();
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation({}, { input: { ...baseInput } }, createMockContext('user-123') as never);
+
+      const data = tx.ride.create.mock.calls[0][0].data;
+      expect(data).not.toHaveProperty('startLat');
+      expect(data).not.toHaveProperty('startLng');
+      expect(enqueueWeatherJob).not.toHaveBeenCalled();
+    });
+
+    it('rejects a lone coordinate', async () => {
+      await expect(
+        mutation(
+          {},
+          { input: { ...baseInput, startLat: 47.6062 } },
+          createMockContext('user-123') as never
+        )
+      ).rejects.toThrow('startLat and startLng must be provided together');
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('rejects out-of-range coordinates', async () => {
+      await expect(
+        mutation(
+          {},
+          { input: { ...baseInput, startLat: 91, startLng: 0 } },
+          createMockContext('user-123') as never
+        )
+      ).rejects.toThrow('startLat/startLng out of range');
+      expect(prisma.$transaction).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -6410,5 +6410,57 @@ describe('GraphQL Resolvers', () => {
       ).rejects.toThrow('startLat/startLng out of range');
       expect(prisma.$transaction).not.toHaveBeenCalled();
     });
+
+    it('accepts the exact range boundary (90, -180)', async () => {
+      const tx = makeTx();
+      (prisma.$transaction as jest.Mock).mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+      await mutation(
+        {},
+        { input: { ...baseInput, startLat: 90, startLng: -180 } },
+        createMockContext('user-123') as never
+      );
+
+      const data = tx.ride.create.mock.calls[0][0].data;
+      expect(data.startLat).toBe(90);
+      expect(data.startLng).toBe(-180);
+    });
+
+    it('rejects the (0, 0) no-fix sentinel', async () => {
+      await expect(
+        mutation(
+          {},
+          { input: { ...baseInput, startLat: 0, startLng: 0 } },
+          createMockContext('user-123') as never
+        )
+      ).rejects.toThrow('startLat/startLng of (0, 0) is not a valid fix');
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(enqueueWeatherJob).not.toHaveBeenCalled();
+    });
+
+    it('skips the weather enqueue on an idempotent replay with coordinates', async () => {
+      (prisma.ride.findUnique as jest.Mock).mockResolvedValue({
+        id: 'ride-original',
+        clientMutationId: 'key-1',
+      });
+
+      const result = await mutation(
+        {},
+        {
+          input: {
+            ...baseInput,
+            clientMutationId: 'key-1',
+            startLat: 47.6062,
+            startLng: -122.3321,
+          },
+        },
+        createMockContext('user-123') as never
+      );
+
+      expect(result).toEqual(expect.objectContaining({ id: 'ride-original' }));
+      // The original request enqueued weather; the replay must not re-fire it.
+      expect(enqueueWeatherJob).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -74,6 +74,8 @@ type AddRideInput = {
   trailSystem?: string | null;
   location?: string | null;
   clientMutationId?: string | null;
+  startLat?: number | null;
+  startLng?: number | null;
 };
 
 type UpdateRideInput = {
@@ -1924,6 +1926,33 @@ export const resolvers = {
         });
       }
 
+      // GPS start coordinate (in-app recording). Both or neither, range
+      // checked: the weather worker and lift detection key off these columns,
+      // and a lone or out-of-range coordinate would poison them silently.
+      const hasStartLat = typeof input.startLat === 'number';
+      const hasStartLng = typeof input.startLng === 'number';
+      if (hasStartLat !== hasStartLng) {
+        throw new GraphQLError('startLat and startLng must be provided together', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+      let startLat: number | null = null;
+      let startLng: number | null = null;
+      if (hasStartLat && hasStartLng) {
+        startLat = Number(input.startLat);
+        startLng = Number(input.startLng);
+        if (
+          !Number.isFinite(startLat) ||
+          !Number.isFinite(startLng) ||
+          Math.abs(startLat) > 90 ||
+          Math.abs(startLng) > 180
+        ) {
+          throw new GraphQLError('startLat/startLng out of range', {
+            extensions: { code: 'BAD_USER_INPUT' },
+          });
+        }
+      }
+
       let bikeId: string | null = null;
       if (requestedBikeId) {
         const ownedBike = await prisma.bike.findUnique({
@@ -1959,6 +1988,7 @@ export const resolvers = {
         ...(trailSystem ? { trailSystem } : {}),
         ...(location ? { location } : {}),
         ...(clientMutationId ? { clientMutationId } : {}),
+        ...(startLat !== null && startLng !== null ? { startLat, startLng } : {}),
       };
 
       const hoursDelta = durationSeconds / 3600;
@@ -2015,9 +2045,18 @@ export const resolvers = {
 
       // A manual ride credits hours the same as a synced one, so it gets the
       // same threshold check. No "Ride Synced" push, though: the rider typed
-      // this ride in themselves seconds ago.
+      // this ride in themselves seconds ago (or just finished recording it
+      // in-app, which is the same situation).
       if (bikeId) {
         void fireServiceDueForBike({ userId, bikeId });
+      }
+
+      // With a start coordinate the ride gets the same weather enrichment a
+      // provider-synced ride does. Fire-and-forget like the provider paths;
+      // the job is idempotent per ride (static jobId) and the worker skips
+      // rides whose weather already exists.
+      if (startLat !== null && startLng !== null) {
+        enqueueWeatherJob({ rideId: ride.id }).catch(() => {});
       }
 
       return ride;

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -2052,11 +2052,13 @@ export const resolvers = {
       }
 
       // With a start coordinate the ride gets the same weather enrichment a
-      // provider-synced ride does. Fire-and-forget like the provider paths;
-      // the job is idempotent per ride (static jobId) and the worker skips
-      // rides whose weather already exists.
+      // provider-synced ride does. Fire-and-forget like the provider paths,
+      // logged like them too: an enqueue failure (Redis hiccup) must not fail
+      // the ride, but it must not vanish either, since nothing retries it.
       if (startLat !== null && startLng !== null) {
-        enqueueWeatherJob({ rideId: ride.id }).catch(() => {});
+        enqueueWeatherJob({ rideId: ride.id }).catch((err) =>
+          logError(`addRide weather enqueue ${ride.id}`, err),
+        );
       }
 
       return ride;

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -1951,6 +1951,17 @@ export const resolvers = {
             extensions: { code: 'BAD_USER_INPUT' },
           });
         }
+        // Exactly (0, 0) is treated as "no GPS fix yet", not a place: some
+        // mobile location stacks emit it as a sentinel before acquisition,
+        // and no ride starts at that open-ocean intersection. The recorder
+        // filters it client-side too; this is the backstop that keeps a
+        // slipped sentinel from storing bogus coords and fetching weather
+        // for the Gulf of Guinea.
+        if (startLat === 0 && startLng === 0) {
+          throw new GraphQLError('startLat/startLng of (0, 0) is not a valid fix', {
+            extensions: { code: 'BAD_USER_INPUT' },
+          });
+        }
       }
 
       let bikeId: string | null = null;

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -554,6 +554,12 @@ export const typeDefs = gql`
     # instead of inserting a duplicate. Optional: omitting it preserves the
     # old always-insert behavior.
     clientMutationId: String
+    # Where the ride started, from the phone's GPS (in-app recording) or any
+    # future coordinate-bearing source. Both or neither; a lone coordinate is
+    # rejected. Presence unlocks the enrichment provider rides already get:
+    # weather now, lift detection once a track is uploaded.
+    startLat: Float
+    startLng: Float
   }
 
   type DeleteRideResult { ok: Boolean!, id: ID! }

--- a/libs/graphql/src/generated/index.ts
+++ b/libs/graphql/src/generated/index.ts
@@ -101,6 +101,8 @@ export type AddRideInput = {
   location?: InputMaybe<Scalars['String']['input']>;
   notes?: InputMaybe<Scalars['String']['input']>;
   rideType: Scalars['String']['input'];
+  startLat?: InputMaybe<Scalars['Float']['input']>;
+  startLng?: InputMaybe<Scalars['Float']['input']>;
   startTime: Scalars['String']['input'];
   trailSystem?: InputMaybe<Scalars['String']['input']>;
   unownedBike?: InputMaybe<Scalars['Boolean']['input']>;


### PR DESCRIPTION
First backend slice of #252 (in-app GPS ride recording, mobile scope in ryanlecours/loam-logger-mobile#48).

## What

- AddRideInput gains optional startLat/startLng. Validated as a pair (a lone coordinate is a BAD_USER_INPUT error) with range checks, because the weather worker and lift detection both key off these columns and a silently stored bad coordinate would poison them.
- addRide writes the pair to the existing Ride.startLat/startLng columns (this path never set them before) and enqueues weather enrichment exactly like the provider ingest paths do: fire-and-forget, idempotent per ride via the queue's static jobId, worker skips rides that already have weather.
- Idempotent replays skip the enqueue; the original request fired it.
- Regenerated GraphQL types.

## Why this shape

This one field pair is the keystone for the recording pipeline: weather works immediately, and lift detection plus rideTrack FETCHABLE logic light up once the track upload endpoint lands (next #252 slice). No migration needed; the columns have existed since the Strava work.

## Testing

Four new resolver tests (pair stored + weather enqueued, absent pair skips both, lone coordinate rejected, out-of-range rejected). Full API suite, lint, and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)