### PR TITLE
fix: sliding mobile sessions, remove the 7-day forced logout

### DIFF
--- a/apps/api/prisma/migrations/20260807120000_add_mobile_session/migration.sql
+++ b/apps/api/prisma/migrations/20260807120000_add_mobile_session/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "MobileSession" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "currentJti" TEXT NOT NULL,
+    "previousJti" TEXT,
+    "rotatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "MobileSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MobileSession_userId_idx" ON "MobileSession"("userId");
+
+-- AddForeignKey
+ALTER TABLE "MobileSession" ADD CONSTRAINT "MobileSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260807120000_add_mobile_session/migration.sql
+++ b/apps/api/prisma/migrations/20260807120000_add_mobile_session/migration.sql
@@ -9,12 +9,16 @@ CREATE TABLE "MobileSession" (
     "lastUsedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "expiresAt" TIMESTAMP(3) NOT NULL,
     "revokedAt" TIMESTAMP(3),
+    "legacyTokenHash" TEXT,
 
     CONSTRAINT "MobileSession_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateIndex
 CREATE INDEX "MobileSession_userId_idx" ON "MobileSession"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MobileSession_legacyTokenHash_key" ON "MobileSession"("legacyTokenHash");
 
 -- AddForeignKey
 ALTER TABLE "MobileSession" ADD CONSTRAINT "MobileSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -122,6 +122,12 @@ model MobileSession {
   // Sliding: pushed forward on every successful refresh.
   expiresAt   DateTime
   revokedAt   DateTime?
+  // sha256 of the pre-session legacy refresh token this session was
+  // upgraded from; null for sessions born at login. The unique index makes
+  // the upgrade one-shot: a legacy token leaked before the sessions deploy
+  // can mint at most one session, and replaying it after that trips reuse
+  // detection instead of minting fresh year-long sessions forever.
+  legacyTokenHash String? @unique
   user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -71,6 +71,7 @@ model User {
   notificationLogs         NotificationLog[]
   passwordResetTokens      PasswordResetToken[]
   componentRideAdjustments ComponentRideAdjustment[]
+  mobileSessions           MobileSession[]
 
   // Push notification preferences
   expoPushToken      String?
@@ -97,6 +98,33 @@ model User {
   // null timezone is skipped rather than guessed at, since a digest at 3am
   // is worse than no digest.
   timezone String?
+}
+
+// One row per mobile device sign-in. Refresh tokens carry this row's id
+// (sid) plus a one-time jti; a refresh is honored only when the presented
+// jti matches currentJti (or previousJti inside the retry grace window,
+// because a device that never received the rotation response legitimately
+// retries with the old token). A jti matching neither is evidence the token
+// leaked and was replayed: the session is revoked on the spot. This is what
+// makes the long sliding refresh window safe: leaked tokens are detectable
+// and individual devices are revocable, without touching the stateless
+// access-token path (still signature + sessionTokenVersion only).
+model MobileSession {
+  id          String    @id @default(uuid())
+  userId      String
+  currentJti  String
+  // The jti this session rotated away from, honored briefly (see
+  // REFRESH_ROTATION_GRACE_MS) so a lost response is not misread as theft.
+  previousJti String?
+  rotatedAt   DateTime  @default(now())
+  createdAt   DateTime  @default(now())
+  lastUsedAt  DateTime  @default(now())
+  // Sliding: pushed forward on every successful refresh.
+  expiresAt   DateTime
+  revokedAt   DateTime?
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 // See User.rideSyncNotificationMode for semantics.

--- a/apps/api/src/auth/mobile-apple.route.test.ts
+++ b/apps/api/src/auth/mobile-apple.route.test.ts
@@ -52,6 +52,8 @@ jest.mock('../lib/rate-limit', () => ({
 jest.mock('../lib/prisma', () => ({
   prisma: {
     user: { findUnique: jest.fn() },
+    // issueMobileTokens creates a MobileSession row for every token pair.
+    mobileSession: { create: jest.fn().mockResolvedValue({ id: 'session-1' }) },
   },
 }));
 

--- a/apps/api/src/auth/mobile-refresh.route.test.ts
+++ b/apps/api/src/auth/mobile-refresh.route.test.ts
@@ -281,6 +281,27 @@ describe('POST /mobile/refresh', () => {
     expect(res.status).toHaveBeenCalledWith(401);
     expect(mockUpgradeLegacySession).not.toHaveBeenCalled();
   });
+
+  it('refuses to redeem an unsubscribe token for a session', async () => {
+    // Same secret, no typ, no sid/jti, 90-day lifetime: without the
+    // claim-shape allowlist this payload walked straight into the
+    // legacy-upgrade branch and came back as a year-long session, turning
+    // every emailed unsubscribe link into an account-takeover credential.
+    const iat = Math.floor(Date.now() / 1000);
+    mockVerifyToken.mockReturnValue({
+      uid: 'user-1',
+      purpose: 'unsubscribe',
+      iat,
+      exp: iat + 90 * 24 * 60 * 60,
+    });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'an-unsubscribe-token' } } as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(mockUpgradeLegacySession).not.toHaveBeenCalled();
+    expect(mockRotateMobileSession).not.toHaveBeenCalled();
+  });
 });
 
 describe('POST /mobile/logout', () => {

--- a/apps/api/src/auth/mobile-refresh.route.test.ts
+++ b/apps/api/src/auth/mobile-refresh.route.test.ts
@@ -338,6 +338,21 @@ describe('POST /mobile/logout', () => {
     expect(res.json).toHaveBeenCalledWith({ ok: true });
   });
 
+  it('never revokes on a non-refresh token, even one carrying a sid-shaped field', async () => {
+    // Defense-in-depth mirroring the refresh route: today only refresh
+    // tokens carry sid, but that is a structural accident. If some future
+    // SESSION_SECRET-signed token grew a same-named claim, this endpoint
+    // must not start revoking sessions on its behalf.
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', typ: 'access', sid: 'sid-forged' });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'an-access-token' } } as Request, res as Response);
+
+    expect(mockRevokeMobileSession).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ ok: true });
+  });
+
   it('returns 400 when the refresh token is missing', async () => {
     const res = createMockResponse();
 

--- a/apps/api/src/auth/mobile-refresh.route.test.ts
+++ b/apps/api/src/auth/mobile-refresh.route.test.ts
@@ -40,6 +40,10 @@ jest.mock('./ensureUserFromApple', () => ({ ensureUserFromApple: jest.fn() }));
 jest.mock('./appleTokenVerifier', () => ({ verifyAppleIdentityToken: jest.fn() }));
 
 jest.mock('./token', () => ({
+  // Real isRefreshTokenPayload/isAccessTokenPayload: the tests below feed
+  // realistically-shaped payloads through the actual type predicates, so a
+  // regression in that logic fails here, not just in token.test.ts.
+  ...jest.requireActual('./token'),
   generateAccessToken: jest.fn().mockReturnValue('new_access_token'),
   generateRefreshToken: jest.fn().mockReturnValue('new_refresh_token'),
   verifyToken: jest.fn(),
@@ -129,7 +133,7 @@ describe('POST /mobile/refresh', () => {
   });
 
   it('rotates a session-bound token and returns the new pair', async () => {
-    mockVerifyToken.mockReturnValue({ uid: 'user-1', email: USER.email, v: 0, sid: 'sid-1', jti: 'jti-1' });
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', email: USER.email, v: 0, typ: 'refresh', sid: 'sid-1', jti: 'jti-1' });
     mockRotateMobileSession.mockResolvedValue({ ok: true, jti: 'jti-2' });
     const res = createMockResponse();
 
@@ -147,7 +151,7 @@ describe('POST /mobile/refresh', () => {
   });
 
   it('returns 401 and reports when a spent token is replayed', async () => {
-    mockVerifyToken.mockReturnValue({ uid: 'user-1', v: 0, sid: 'sid-1', jti: 'jti-stolen' });
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', v: 0, typ: 'refresh', sid: 'sid-1', jti: 'jti-stolen' });
     mockRotateMobileSession.mockResolvedValue({ ok: false, reason: 'reuse-detected' });
     const res = createMockResponse();
 
@@ -161,7 +165,7 @@ describe('POST /mobile/refresh', () => {
   });
 
   it('returns 401 for a revoked session without Sentry noise', async () => {
-    mockVerifyToken.mockReturnValue({ uid: 'user-1', v: 0, sid: 'sid-1', jti: 'jti-1' });
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', v: 0, typ: 'refresh', sid: 'sid-1', jti: 'jti-1' });
     mockRotateMobileSession.mockResolvedValue({ ok: false, reason: 'revoked' });
     const res = createMockResponse();
 
@@ -172,7 +176,8 @@ describe('POST /mobile/refresh', () => {
   });
 
   it('upgrades a legacy sid-less token to a session instead of rejecting it', async () => {
-    mockVerifyToken.mockReturnValue({ uid: 'user-1', email: USER.email, v: 0 });
+    const iat = Math.floor(Date.now() / 1000);
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', email: USER.email, v: 0, iat, exp: iat + 7 * 24 * 60 * 60 });
     mockCreateMobileSession.mockResolvedValue({ sid: 'sid-new', jti: 'jti-new' });
     const res = createMockResponse();
 
@@ -187,7 +192,7 @@ describe('POST /mobile/refresh', () => {
   });
 
   it('still rejects tokens invalidated by a sessionTokenVersion bump', async () => {
-    mockVerifyToken.mockReturnValue({ uid: 'user-1', v: 0, sid: 'sid-1', jti: 'jti-1' });
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', v: 0, typ: 'refresh', sid: 'sid-1', jti: 'jti-1' });
     mockUserFindUnique.mockResolvedValue({ ...USER, sessionTokenVersion: 1 });
     const res = createMockResponse();
 
@@ -205,6 +210,31 @@ describe('POST /mobile/refresh', () => {
 
     expect(res.status).toHaveBeenCalledWith(401);
   });
+
+  // Access tokens verify with the same secret and, like legacy refresh
+  // tokens, carry no sid/jti. Without the typ gate, a leaked 15-minute
+  // access token POSTed here would be upgraded into a 365-day session.
+  it('refuses to upgrade an access token into a refresh session', async () => {
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', email: USER.email, v: 0, typ: 'access' });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'an-access-token' } } as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(mockCreateMobileSession).not.toHaveBeenCalled();
+    expect(mockRotateMobileSession).not.toHaveBeenCalled();
+  });
+
+  it('refuses a legacy-shaped token whose signed lifetime says access token', async () => {
+    const iat = Math.floor(Date.now() / 1000);
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', v: 0, iat, exp: iat + 15 * 60 });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'legacy-access' } } as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(mockCreateMobileSession).not.toHaveBeenCalled();
+  });
 });
 
 describe('POST /mobile/logout', () => {
@@ -220,7 +250,7 @@ describe('POST /mobile/logout', () => {
   });
 
   it('revokes the session named by a valid token', async () => {
-    mockVerifyToken.mockReturnValue({ uid: 'user-1', sid: 'sid-1', jti: 'jti-1' });
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', typ: 'refresh', sid: 'sid-1', jti: 'jti-1' });
     const res = createMockResponse();
 
     await invokeHandler(handler, { body: { refreshToken: 'rt' } } as Request, res as Response);

--- a/apps/api/src/auth/mobile-refresh.route.test.ts
+++ b/apps/api/src/auth/mobile-refresh.route.test.ts
@@ -54,9 +54,11 @@ jest.mock('./session-issuer', () => ({
 }));
 
 jest.mock('./mobile-session', () => ({
-  createMobileSession: jest.fn(),
+  // Real hashLegacyToken so tests can compute the same hash the route does.
+  ...jest.requireActual('./mobile-session'),
   rotateMobileSession: jest.fn(),
   revokeMobileSession: jest.fn(),
+  upgradeLegacySession: jest.fn(),
 }));
 
 jest.mock('./recent-auth', () => ({
@@ -72,12 +74,14 @@ import * as Sentry from '@sentry/node';
 import router from './mobile.route';
 import { prisma } from '../lib/prisma';
 import { generateRefreshToken, verifyToken } from './token';
-import { createMobileSession, rotateMobileSession, revokeMobileSession } from './mobile-session';
+import { checkAuthRateLimit } from '../lib/rate-limit';
+import { rotateMobileSession, revokeMobileSession, upgradeLegacySession, hashLegacyToken } from './mobile-session';
 
 const mockUserFindUnique = prisma.user.findUnique as jest.Mock;
 const mockVerifyToken = verifyToken as jest.Mock;
 const mockGenerateRefreshToken = generateRefreshToken as jest.Mock;
-const mockCreateMobileSession = createMobileSession as jest.Mock;
+const mockCheckAuthRateLimit = checkAuthRateLimit as jest.Mock;
+const mockUpgradeLegacySession = upgradeLegacySession as jest.Mock;
 const mockRotateMobileSession = rotateMobileSession as jest.Mock;
 const mockRevokeMobileSession = revokeMobileSession as jest.Mock;
 
@@ -150,16 +154,30 @@ describe('POST /mobile/refresh', () => {
     });
   });
 
-  it('returns 401 and reports when a spent token is replayed', async () => {
+  it('returns 401 and reports the stolen-chain signature when a spent token is replayed', async () => {
     mockVerifyToken.mockReturnValue({ uid: 'user-1', v: 0, typ: 'refresh', sid: 'sid-1', jti: 'jti-stolen' });
-    mockRotateMobileSession.mockResolvedValue({ ok: false, reason: 'reuse-detected' });
+    mockRotateMobileSession.mockResolvedValue({ ok: false, reason: 'reuse-detected', detail: 'spent-previous' });
     const res = createMockResponse();
 
     await invokeHandler(handler, { body: { refreshToken: 'rt' } } as Request, res as Response);
 
     expect(res.status).toHaveBeenCalledWith(401);
     expect(Sentry.captureMessage).toHaveBeenCalledWith(
-      'Mobile refresh token reuse detected',
+      'Mobile refresh token reuse detected (spent token replayed)',
+      expect.anything()
+    );
+  });
+
+  it('reports an unknown jti under its own signal, distinct from spent-token replay', async () => {
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', v: 0, typ: 'refresh', sid: 'sid-1', jti: 'jti-mystery' });
+    mockRotateMobileSession.mockResolvedValue({ ok: false, reason: 'reuse-detected', detail: 'unknown-jti' });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'rt' } } as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Mobile refresh token with unknown jti (client token corruption or theft)',
       expect.anything()
     );
   });
@@ -175,20 +193,48 @@ describe('POST /mobile/refresh', () => {
     expect(Sentry.captureMessage).not.toHaveBeenCalled();
   });
 
-  it('upgrades a legacy sid-less token to a session instead of rejecting it', async () => {
+  it('upgrades a legacy sid-less token to a session, keyed by the token hash', async () => {
     const iat = Math.floor(Date.now() / 1000);
     mockVerifyToken.mockReturnValue({ uid: 'user-1', email: USER.email, v: 0, iat, exp: iat + 7 * 24 * 60 * 60 });
-    mockCreateMobileSession.mockResolvedValue({ sid: 'sid-new', jti: 'jti-new' });
+    mockUpgradeLegacySession.mockResolvedValue({ ok: true, sid: 'sid-new', jti: 'jti-new' });
     const res = createMockResponse();
 
     await invokeHandler(handler, { body: { refreshToken: 'legacy' } } as Request, res as Response);
 
-    expect(mockCreateMobileSession).toHaveBeenCalledWith('user-1');
+    expect(mockUpgradeLegacySession).toHaveBeenCalledWith('user-1', hashLegacyToken('legacy'));
     expect(mockRotateMobileSession).not.toHaveBeenCalled();
     expect(mockGenerateRefreshToken).toHaveBeenCalledWith(
       expect.objectContaining({ sid: 'sid-new', jti: 'jti-new' })
     );
     expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('returns 401 and reports when a legacy token is replayed after its upgrade', async () => {
+    const iat = Math.floor(Date.now() / 1000);
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', v: 0, iat, exp: iat + 7 * 24 * 60 * 60 });
+    mockUpgradeLegacySession.mockResolvedValue({ ok: false, reason: 'reuse-detected' });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'legacy-replayed' } } as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Mobile legacy refresh token replayed after upgrade',
+      expect.anything()
+    );
+  });
+
+  it('returns 429 when the per-user refresh rate limit trips, before any DB work', async () => {
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', v: 0, typ: 'refresh', sid: 'sid-1', jti: 'jti-1' });
+    mockCheckAuthRateLimit.mockResolvedValueOnce({ allowed: false, retryAfter: 60 });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'rt' } } as Request, res as Response);
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith('token-refresh', 'user-1');
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(mockRotateMobileSession).not.toHaveBeenCalled();
+    expect(mockUserFindUnique).not.toHaveBeenCalled();
   });
 
   it('still rejects tokens invalidated by a sessionTokenVersion bump', async () => {
@@ -221,7 +267,7 @@ describe('POST /mobile/refresh', () => {
     await invokeHandler(handler, { body: { refreshToken: 'an-access-token' } } as Request, res as Response);
 
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(mockCreateMobileSession).not.toHaveBeenCalled();
+    expect(mockUpgradeLegacySession).not.toHaveBeenCalled();
     expect(mockRotateMobileSession).not.toHaveBeenCalled();
   });
 
@@ -233,7 +279,7 @@ describe('POST /mobile/refresh', () => {
     await invokeHandler(handler, { body: { refreshToken: 'legacy-access' } } as Request, res as Response);
 
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(mockCreateMobileSession).not.toHaveBeenCalled();
+    expect(mockUpgradeLegacySession).not.toHaveBeenCalled();
   });
 });
 
@@ -277,5 +323,17 @@ describe('POST /mobile/logout', () => {
     await invokeHandler(handler, { body: {} } as Request, res as Response);
 
     expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 429 when the per-user logout rate limit trips, without revoking', async () => {
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', typ: 'refresh', sid: 'sid-1', jti: 'jti-1' });
+    mockCheckAuthRateLimit.mockResolvedValueOnce({ allowed: false, retryAfter: 60 });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'rt' } } as Request, res as Response);
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith('token-logout', 'user-1');
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(mockRevokeMobileSession).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/auth/mobile-refresh.route.test.ts
+++ b/apps/api/src/auth/mobile-refresh.route.test.ts
@@ -1,0 +1,251 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+// Mock dependencies BEFORE importing the router
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../lib/rate-limit', () => ({
+  checkAuthRateLimit: jest.fn().mockResolvedValue({ allowed: true }),
+  checkMutationRateLimit: jest.fn().mockResolvedValue({ allowed: true }),
+}));
+
+jest.mock('../lib/logger', () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+  createLogger: () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() }),
+}));
+
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+jest.mock('google-auth-library', () => ({
+  OAuth2Client: jest.fn().mockImplementation(() => ({
+    verifyIdToken: jest.fn(),
+  })),
+}));
+
+jest.mock('./ensureUserFromGoogle', () => ({ ensureUserFromGoogle: jest.fn() }));
+jest.mock('./ensureUserFromApple', () => ({ ensureUserFromApple: jest.fn() }));
+jest.mock('./appleTokenVerifier', () => ({ verifyAppleIdentityToken: jest.fn() }));
+
+jest.mock('./token', () => ({
+  generateAccessToken: jest.fn().mockReturnValue('new_access_token'),
+  generateRefreshToken: jest.fn().mockReturnValue('new_refresh_token'),
+  verifyToken: jest.fn(),
+}));
+
+jest.mock('./session-issuer', () => ({
+  issueMobileTokens: jest.fn(),
+}));
+
+jest.mock('./mobile-session', () => ({
+  createMobileSession: jest.fn(),
+  rotateMobileSession: jest.fn(),
+  revokeMobileSession: jest.fn(),
+}));
+
+jest.mock('./recent-auth', () => ({
+  updateLastAuthAt: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../services/password-notification.service', () => ({
+  sendPasswordAddedNotification: jest.fn(),
+  sendPasswordChangedNotification: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/node';
+import router from './mobile.route';
+import { prisma } from '../lib/prisma';
+import { generateRefreshToken, verifyToken } from './token';
+import { createMobileSession, rotateMobileSession, revokeMobileSession } from './mobile-session';
+
+const mockUserFindUnique = prisma.user.findUnique as jest.Mock;
+const mockVerifyToken = verifyToken as jest.Mock;
+const mockGenerateRefreshToken = generateRefreshToken as jest.Mock;
+const mockCreateMobileSession = createMobileSession as jest.Mock;
+const mockRotateMobileSession = rotateMobileSession as jest.Mock;
+const mockRevokeMobileSession = revokeMobileSession as jest.Mock;
+
+interface RouteLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: RequestHandler }>;
+  };
+}
+
+function getHandler(path: string, method: string): RequestHandler | undefined {
+  const routerStack = (router as unknown as { stack: RouteLayer[] }).stack;
+  const layer = routerStack.find(
+    (l) => l.route?.path === path && l.route?.methods?.[method]
+  );
+  const handlers = layer?.route?.stack;
+  return handlers?.[handlers.length - 1]?.handle;
+}
+
+async function invokeHandler(
+  h: RequestHandler | undefined,
+  req: Request,
+  res: Response
+): Promise<void> {
+  if (!h) throw new Error('Handler not found');
+  await h(req, res, jest.fn() as NextFunction);
+}
+
+function createMockResponse(): Partial<Response> & { status: jest.Mock; json: jest.Mock; send: jest.Mock; setHeader: jest.Mock } {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+  };
+}
+
+const USER = { id: 'user-1', email: 'rider@example.com', sessionTokenVersion: 0 };
+
+describe('POST /mobile/refresh', () => {
+  let handler: RequestHandler | undefined;
+
+  beforeAll(() => {
+    handler = getHandler('/mobile/refresh', 'post');
+    if (!handler) throw new Error('Handler not found for /mobile/refresh');
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUserFindUnique.mockResolvedValue(USER);
+    mockGenerateRefreshToken.mockReturnValue('new_refresh_token');
+  });
+
+  it('rotates a session-bound token and returns the new pair', async () => {
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', email: USER.email, v: 0, sid: 'sid-1', jti: 'jti-1' });
+    mockRotateMobileSession.mockResolvedValue({ ok: true, jti: 'jti-2' });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'rt' } } as Request, res as Response);
+
+    expect(mockRotateMobileSession).toHaveBeenCalledWith('sid-1', 'jti-1');
+    expect(mockGenerateRefreshToken).toHaveBeenCalledWith(
+      expect.objectContaining({ uid: 'user-1', sid: 'sid-1', jti: 'jti-2' })
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      accessToken: 'new_access_token',
+      refreshToken: 'new_refresh_token',
+    });
+  });
+
+  it('returns 401 and reports when a spent token is replayed', async () => {
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', v: 0, sid: 'sid-1', jti: 'jti-stolen' });
+    mockRotateMobileSession.mockResolvedValue({ ok: false, reason: 'reuse-detected' });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'rt' } } as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Mobile refresh token reuse detected',
+      expect.anything()
+    );
+  });
+
+  it('returns 401 for a revoked session without Sentry noise', async () => {
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', v: 0, sid: 'sid-1', jti: 'jti-1' });
+    mockRotateMobileSession.mockResolvedValue({ ok: false, reason: 'revoked' });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'rt' } } as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('upgrades a legacy sid-less token to a session instead of rejecting it', async () => {
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', email: USER.email, v: 0 });
+    mockCreateMobileSession.mockResolvedValue({ sid: 'sid-new', jti: 'jti-new' });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'legacy' } } as Request, res as Response);
+
+    expect(mockCreateMobileSession).toHaveBeenCalledWith('user-1');
+    expect(mockRotateMobileSession).not.toHaveBeenCalled();
+    expect(mockGenerateRefreshToken).toHaveBeenCalledWith(
+      expect.objectContaining({ sid: 'sid-new', jti: 'jti-new' })
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('still rejects tokens invalidated by a sessionTokenVersion bump', async () => {
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', v: 0, sid: 'sid-1', jti: 'jti-1' });
+    mockUserFindUnique.mockResolvedValue({ ...USER, sessionTokenVersion: 1 });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'rt' } } as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(mockRotateMobileSession).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 for an unverifiable token', async () => {
+    mockVerifyToken.mockReturnValue(null);
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'garbage' } } as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+});
+
+describe('POST /mobile/logout', () => {
+  let handler: RequestHandler | undefined;
+
+  beforeAll(() => {
+    handler = getHandler('/mobile/logout', 'post');
+    if (!handler) throw new Error('Handler not found for /mobile/logout');
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('revokes the session named by a valid token', async () => {
+    mockVerifyToken.mockReturnValue({ uid: 'user-1', sid: 'sid-1', jti: 'jti-1' });
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'rt' } } as Request, res as Response);
+
+    expect(mockRevokeMobileSession).toHaveBeenCalledWith('sid-1', 'user-1');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('succeeds without revoking when the token is expired or malformed', async () => {
+    mockVerifyToken.mockReturnValue(null);
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: { refreshToken: 'expired' } } as Request, res as Response);
+
+    expect(mockRevokeMobileSession).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('returns 400 when the refresh token is missing', async () => {
+    const res = createMockResponse();
+
+    await invokeHandler(handler, { body: {} } as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/apps/api/src/auth/mobile-session.test.ts
+++ b/apps/api/src/auth/mobile-session.test.ts
@@ -3,7 +3,6 @@ jest.mock('../lib/prisma', () => ({
     mobileSession: {
       create: jest.fn(),
       findUnique: jest.fn(),
-      update: jest.fn(),
       updateMany: jest.fn(),
     },
   },
@@ -20,7 +19,6 @@ import {
 
 const mockCreate = prisma.mobileSession.create as jest.Mock;
 const mockFindUnique = prisma.mobileSession.findUnique as jest.Mock;
-const mockUpdate = prisma.mobileSession.update as jest.Mock;
 const mockUpdateMany = prisma.mobileSession.updateMany as jest.Mock;
 
 function liveSession(overrides: Record<string, unknown> = {}) {
@@ -61,69 +59,101 @@ describe('createMobileSession', () => {
 });
 
 describe('rotateMobileSession', () => {
-  it('rotates on the current jti: new jti, presented becomes previous, expiry slides', async () => {
-    mockFindUnique.mockResolvedValue(liveSession());
-    mockUpdate.mockResolvedValue({});
+  it('rotates via a single conditional write on the presented jti (no read-then-write race)', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 1 });
 
     const before = Date.now();
     const result = await rotateMobileSession('sid-1', 'jti-current');
 
     expect(result).toEqual({ ok: true, jti: expect.any(String) });
-    const data = mockUpdate.mock.calls[0][0].data;
-    expect(data.currentJti).not.toBe('jti-current');
-    expect(data.previousJti).toBe('jti-current');
-    expect(data.expiresAt.getTime()).toBeGreaterThanOrEqual(before + MOBILE_REFRESH_TTL_MS);
+    const call = mockUpdateMany.mock.calls[0][0];
+    // The atomicity lives in this where clause: the rotation only lands if
+    // the presented jti is still current at write time.
+    expect(call.where).toEqual({
+      id: 'sid-1',
+      currentJti: 'jti-current',
+      revokedAt: null,
+      expiresAt: { gt: expect.any(Date) },
+    });
+    expect(call.data.currentJti).not.toBe('jti-current');
+    expect(call.data.previousJti).toBe('jti-current');
+    expect(call.data.expiresAt.getTime()).toBeGreaterThanOrEqual(before + MOBILE_REFRESH_TTL_MS);
+    expect(mockFindUnique).not.toHaveBeenCalled();
   });
 
-  it('honors the previous jti inside the grace window (lost-response retry)', async () => {
+  it('hands a race loser the winning rotation instead of rotating again', async () => {
+    // Two refreshes raced with the same jti; the winner already rotated
+    // currentJti to 'jti-winner' with previousJti = the presented one.
+    mockUpdateMany.mockResolvedValueOnce({ count: 0 }).mockResolvedValue({ count: 1 });
     mockFindUnique.mockResolvedValue(
-      liveSession({ rotatedAt: new Date(Date.now() - REFRESH_ROTATION_GRACE_MS / 2) }),
+      liveSession({
+        currentJti: 'jti-winner',
+        previousJti: 'jti-raced',
+        rotatedAt: new Date(Date.now() - 1_000),
+      }),
     );
-    mockUpdate.mockResolvedValue({});
 
-    const result = await rotateMobileSession('sid-1', 'jti-previous');
+    const result = await rotateMobileSession('sid-1', 'jti-raced');
 
-    expect(result.ok).toBe(true);
+    // Same jti the winner received: whichever response the device stores
+    // last, it holds a live token.
+    expect(result).toEqual({ ok: true, jti: 'jti-winner' });
+    // The follow-up write slides expiry only; rotating here would clobber
+    // the winner's jti and orphan the other device response.
+    const slide = mockUpdateMany.mock.calls[1][0];
+    expect(slide.data.currentJti).toBeUndefined();
+    expect(slide.data.expiresAt).toEqual(expect.any(Date));
+  });
+
+  it('re-issues the current jti defensively if the conditional write missed while still current', async () => {
+    mockUpdateMany.mockResolvedValueOnce({ count: 0 }).mockResolvedValue({ count: 1 });
+    mockFindUnique.mockResolvedValue(liveSession());
+
+    const result = await rotateMobileSession('sid-1', 'jti-current');
+
+    expect(result).toEqual({ ok: true, jti: 'jti-current' });
   });
 
   it('revokes the session when the previous jti is replayed after the grace window', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 0 });
     mockFindUnique.mockResolvedValue(
       liveSession({ rotatedAt: new Date(Date.now() - REFRESH_ROTATION_GRACE_MS - 1_000) }),
     );
-    mockUpdate.mockResolvedValue({});
 
     const result = await rotateMobileSession('sid-1', 'jti-previous');
 
     expect(result).toEqual({ ok: false, reason: 'reuse-detected' });
-    expect(mockUpdate).toHaveBeenCalledWith({
-      where: { id: 'sid-1' },
+    expect(mockUpdateMany).toHaveBeenLastCalledWith({
+      where: { id: 'sid-1', revokedAt: null },
       data: { revokedAt: expect.any(Date) },
     });
   });
 
   it('revokes the session when the jti matches nothing in the chain', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 0 });
     mockFindUnique.mockResolvedValue(liveSession());
-    mockUpdate.mockResolvedValue({});
 
     const result = await rotateMobileSession('sid-1', 'jti-from-another-era');
 
     expect(result).toEqual({ ok: false, reason: 'reuse-detected' });
-    expect(mockUpdate).toHaveBeenCalledWith({
-      where: { id: 'sid-1' },
+    expect(mockUpdateMany).toHaveBeenLastCalledWith({
+      where: { id: 'sid-1', revokedAt: null },
       data: { revokedAt: expect.any(Date) },
     });
   });
 
   it('rejects a revoked session without touching it', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 0 });
     mockFindUnique.mockResolvedValue(liveSession({ revokedAt: new Date() }));
 
     const result = await rotateMobileSession('sid-1', 'jti-current');
 
     expect(result).toEqual({ ok: false, reason: 'revoked' });
-    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockUpdateMany).toHaveBeenCalledTimes(1);
   });
 
   it('rejects an expired session', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 0 });
     mockFindUnique.mockResolvedValue(
       liveSession({ expiresAt: new Date(Date.now() - 1_000) }),
     );
@@ -131,10 +161,11 @@ describe('rotateMobileSession', () => {
     const result = await rotateMobileSession('sid-1', 'jti-current');
 
     expect(result).toEqual({ ok: false, reason: 'expired' });
-    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockUpdateMany).toHaveBeenCalledTimes(1);
   });
 
   it('rejects an unknown session id', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 0 });
     mockFindUnique.mockResolvedValue(null);
 
     const result = await rotateMobileSession('sid-missing', 'jti-current');

--- a/apps/api/src/auth/mobile-session.test.ts
+++ b/apps/api/src/auth/mobile-session.test.ts
@@ -1,0 +1,157 @@
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    mobileSession: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from '../lib/prisma';
+import {
+  MOBILE_REFRESH_TTL_MS,
+  REFRESH_ROTATION_GRACE_MS,
+  createMobileSession,
+  rotateMobileSession,
+  revokeMobileSession,
+} from './mobile-session';
+
+const mockCreate = prisma.mobileSession.create as jest.Mock;
+const mockFindUnique = prisma.mobileSession.findUnique as jest.Mock;
+const mockUpdate = prisma.mobileSession.update as jest.Mock;
+const mockUpdateMany = prisma.mobileSession.updateMany as jest.Mock;
+
+function liveSession(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'sid-1',
+    userId: 'user-1',
+    currentJti: 'jti-current',
+    previousJti: 'jti-previous',
+    rotatedAt: new Date(Date.now() - 5_000),
+    createdAt: new Date(Date.now() - 100_000),
+    lastUsedAt: new Date(Date.now() - 5_000),
+    expiresAt: new Date(Date.now() + MOBILE_REFRESH_TTL_MS),
+    revokedAt: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('createMobileSession', () => {
+  it('creates a row with a sliding expiry and returns its sid and jti', async () => {
+    mockCreate.mockImplementation(({ data }) =>
+      Promise.resolve({ id: 'sid-new', ...data }),
+    );
+
+    const before = Date.now();
+    const result = await createMobileSession('user-1');
+
+    expect(result.sid).toBe('sid-new');
+    expect(result.jti).toEqual(expect.any(String));
+    const data = mockCreate.mock.calls[0][0].data;
+    expect(data.userId).toBe('user-1');
+    expect(data.currentJti).toBe(result.jti);
+    expect(data.expiresAt.getTime()).toBeGreaterThanOrEqual(before + MOBILE_REFRESH_TTL_MS);
+  });
+});
+
+describe('rotateMobileSession', () => {
+  it('rotates on the current jti: new jti, presented becomes previous, expiry slides', async () => {
+    mockFindUnique.mockResolvedValue(liveSession());
+    mockUpdate.mockResolvedValue({});
+
+    const before = Date.now();
+    const result = await rotateMobileSession('sid-1', 'jti-current');
+
+    expect(result).toEqual({ ok: true, jti: expect.any(String) });
+    const data = mockUpdate.mock.calls[0][0].data;
+    expect(data.currentJti).not.toBe('jti-current');
+    expect(data.previousJti).toBe('jti-current');
+    expect(data.expiresAt.getTime()).toBeGreaterThanOrEqual(before + MOBILE_REFRESH_TTL_MS);
+  });
+
+  it('honors the previous jti inside the grace window (lost-response retry)', async () => {
+    mockFindUnique.mockResolvedValue(
+      liveSession({ rotatedAt: new Date(Date.now() - REFRESH_ROTATION_GRACE_MS / 2) }),
+    );
+    mockUpdate.mockResolvedValue({});
+
+    const result = await rotateMobileSession('sid-1', 'jti-previous');
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('revokes the session when the previous jti is replayed after the grace window', async () => {
+    mockFindUnique.mockResolvedValue(
+      liveSession({ rotatedAt: new Date(Date.now() - REFRESH_ROTATION_GRACE_MS - 1_000) }),
+    );
+    mockUpdate.mockResolvedValue({});
+
+    const result = await rotateMobileSession('sid-1', 'jti-previous');
+
+    expect(result).toEqual({ ok: false, reason: 'reuse-detected' });
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'sid-1' },
+      data: { revokedAt: expect.any(Date) },
+    });
+  });
+
+  it('revokes the session when the jti matches nothing in the chain', async () => {
+    mockFindUnique.mockResolvedValue(liveSession());
+    mockUpdate.mockResolvedValue({});
+
+    const result = await rotateMobileSession('sid-1', 'jti-from-another-era');
+
+    expect(result).toEqual({ ok: false, reason: 'reuse-detected' });
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'sid-1' },
+      data: { revokedAt: expect.any(Date) },
+    });
+  });
+
+  it('rejects a revoked session without touching it', async () => {
+    mockFindUnique.mockResolvedValue(liveSession({ revokedAt: new Date() }));
+
+    const result = await rotateMobileSession('sid-1', 'jti-current');
+
+    expect(result).toEqual({ ok: false, reason: 'revoked' });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an expired session', async () => {
+    mockFindUnique.mockResolvedValue(
+      liveSession({ expiresAt: new Date(Date.now() - 1_000) }),
+    );
+
+    const result = await rotateMobileSession('sid-1', 'jti-current');
+
+    expect(result).toEqual({ ok: false, reason: 'expired' });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown session id', async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    const result = await rotateMobileSession('sid-missing', 'jti-current');
+
+    expect(result).toEqual({ ok: false, reason: 'not-found' });
+  });
+});
+
+describe('revokeMobileSession', () => {
+  it('scopes the revocation to the owning user and unrevoked rows', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+
+    await revokeMobileSession('sid-1', 'user-1');
+
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { id: 'sid-1', userId: 'user-1', revokedAt: null },
+      data: { revokedAt: expect.any(Date) },
+    });
+  });
+});

--- a/apps/api/src/auth/mobile-session.test.ts
+++ b/apps/api/src/auth/mobile-session.test.ts
@@ -15,6 +15,8 @@ import {
   createMobileSession,
   rotateMobileSession,
   revokeMobileSession,
+  upgradeLegacySession,
+  hashLegacyToken,
 } from './mobile-session';
 
 const mockCreate = prisma.mobileSession.create as jest.Mock;
@@ -122,7 +124,7 @@ describe('rotateMobileSession', () => {
 
     const result = await rotateMobileSession('sid-1', 'jti-previous');
 
-    expect(result).toEqual({ ok: false, reason: 'reuse-detected' });
+    expect(result).toEqual({ ok: false, reason: 'reuse-detected', detail: 'spent-previous' });
     expect(mockUpdateMany).toHaveBeenLastCalledWith({
       where: { id: 'sid-1', revokedAt: null },
       data: { revokedAt: expect.any(Date) },
@@ -135,7 +137,7 @@ describe('rotateMobileSession', () => {
 
     const result = await rotateMobileSession('sid-1', 'jti-from-another-era');
 
-    expect(result).toEqual({ ok: false, reason: 'reuse-detected' });
+    expect(result).toEqual({ ok: false, reason: 'reuse-detected', detail: 'unknown-jti' });
     expect(mockUpdateMany).toHaveBeenLastCalledWith({
       where: { id: 'sid-1', revokedAt: null },
       data: { revokedAt: expect.any(Date) },
@@ -171,6 +173,93 @@ describe('rotateMobileSession', () => {
     const result = await rotateMobileSession('sid-missing', 'jti-current');
 
     expect(result).toEqual({ ok: false, reason: 'not-found' });
+  });
+});
+
+describe('upgradeLegacySession', () => {
+  const HASH = hashLegacyToken('legacy-token-bytes');
+
+  function upgradedSession(overrides: Record<string, unknown> = {}) {
+    return liveSession({
+      previousJti: null,
+      legacyTokenHash: HASH,
+      rotatedAt: new Date(Date.now() - 5_000),
+      ...overrides,
+    });
+  }
+
+  it('claims an unclaimed legacy token by creating a session bound to its hash', async () => {
+    mockFindUnique.mockResolvedValue(null);
+    mockCreate.mockImplementation(({ data }) => Promise.resolve({ id: 'sid-new', ...data }));
+
+    const result = await upgradeLegacySession('user-1', HASH);
+
+    expect(result).toEqual({ ok: true, sid: 'sid-new', jti: expect.any(String) });
+    expect(mockCreate.mock.calls[0][0].data.legacyTokenHash).toBe(HASH);
+  });
+
+  it('re-issues the session pair on a lost-response retry (never rotated, within grace)', async () => {
+    mockFindUnique.mockResolvedValue(upgradedSession());
+
+    const result = await upgradeLegacySession('user-1', HASH);
+
+    expect(result).toEqual({ ok: true, sid: 'sid-1', jti: 'jti-current' });
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('revokes the claimed session when the legacy token is replayed after the device rotated', async () => {
+    mockFindUnique.mockResolvedValue(upgradedSession({ previousJti: 'jti-rotated-once' }));
+
+    const result = await upgradeLegacySession('user-1', HASH);
+
+    expect(result).toEqual({ ok: false, reason: 'reuse-detected' });
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { id: 'sid-1', revokedAt: null },
+      data: { revokedAt: expect.any(Date) },
+    });
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('revokes the claimed session when replayed outside the grace window', async () => {
+    mockFindUnique.mockResolvedValue(
+      upgradedSession({ rotatedAt: new Date(Date.now() - REFRESH_ROTATION_GRACE_MS - 1_000) }),
+    );
+
+    const result = await upgradeLegacySession('user-1', HASH);
+
+    expect(result).toEqual({ ok: false, reason: 'reuse-detected' });
+  });
+
+  it('refuses an already-revoked claim without minting anything', async () => {
+    mockFindUnique.mockResolvedValue(upgradedSession({ revokedAt: new Date() }));
+
+    const result = await upgradeLegacySession('user-1', HASH);
+
+    expect(result).toEqual({ ok: false, reason: 'reuse-detected' });
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('resolves a concurrent-upgrade race against the winning row', async () => {
+    // Both racers see the token unclaimed; the loser's create hits the
+    // unique index and must settle against the winner's session.
+    mockFindUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(upgradedSession({ currentJti: 'jti-winner' }));
+    mockCreate.mockRejectedValue(new Error('Unique constraint failed on legacyTokenHash'));
+
+    const result = await upgradeLegacySession('user-1', HASH);
+
+    expect(result).toEqual({ ok: true, sid: 'sid-1', jti: 'jti-winner' });
+  });
+});
+
+describe('hashLegacyToken', () => {
+  it('is deterministic and shaped like sha256 hex', () => {
+    expect(hashLegacyToken('abc')).toBe(hashLegacyToken('abc'));
+    expect(hashLegacyToken('abc')).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashLegacyToken('abc')).not.toBe(hashLegacyToken('abd'));
   });
 });
 

--- a/apps/api/src/auth/mobile-session.test.ts
+++ b/apps/api/src/auth/mobile-session.test.ts
@@ -4,6 +4,7 @@ jest.mock('../lib/prisma', () => ({
       create: jest.fn(),
       findUnique: jest.fn(),
       updateMany: jest.fn(),
+      deleteMany: jest.fn(),
     },
   },
 }));
@@ -17,6 +18,7 @@ import {
   revokeMobileSession,
   upgradeLegacySession,
   hashLegacyToken,
+  deleteDefunctMobileSessions,
 } from './mobile-session';
 
 const mockCreate = prisma.mobileSession.create as jest.Mock;
@@ -252,6 +254,23 @@ describe('upgradeLegacySession', () => {
     const result = await upgradeLegacySession('user-1', HASH);
 
     expect(result).toEqual({ ok: true, sid: 'sid-1', jti: 'jti-winner' });
+  });
+});
+
+describe('deleteDefunctMobileSessions', () => {
+  it('deletes only rows revoked or expired before the retention cutoff', async () => {
+    const mockDeleteMany = prisma.mobileSession.deleteMany as jest.Mock;
+    mockDeleteMany.mockResolvedValue({ count: 7 });
+
+    const before = Date.now();
+    const deleted = await deleteDefunctMobileSessions(30);
+
+    expect(deleted).toBe(7);
+    const where = mockDeleteMany.mock.calls[0][0].where;
+    const cutoffMs = 30 * 24 * 60 * 60 * 1000;
+    expect(where.OR).toHaveLength(2);
+    expect(where.OR[0].revokedAt.lt.getTime()).toBeLessThanOrEqual(before - cutoffMs + 1_000);
+    expect(where.OR[1].expiresAt.lt.getTime()).toBeLessThanOrEqual(before - cutoffMs + 1_000);
   });
 });
 

--- a/apps/api/src/auth/mobile-session.ts
+++ b/apps/api/src/auth/mobile-session.ts
@@ -49,38 +49,29 @@ export type RotationResult =
 /**
  * Validate a presented refresh jti against its session and, when valid,
  * rotate to a new jti and slide the expiry forward.
+ *
+ * Concurrency: refreshes for one session can race (a foreground trigger
+ * and a background timer double-firing, or a retry after a slow but
+ * successful response). A read-validate-write here would let both racers
+ * pass validation and the loser's freshly-minted jti would never be
+ * persisted — so the loser's device presents an orphaned jti next time and
+ * gets revoked as a "thief," recreating the spurious logout this table
+ * exists to prevent. Instead: an atomic conditional write claims the
+ * rotation, and every racer that loses the claim is handed the SAME
+ * current jti the winner produced. Rotation is idempotent per presented
+ * token, so the device ends up holding a live token no matter which
+ * response arrives last.
  */
 export async function rotateMobileSession(
   sid: string,
   presentedJti: string,
 ): Promise<RotationResult> {
   const now = new Date();
-  const session = await prisma.mobileSession.findUnique({ where: { id: sid } });
-  if (!session) return { ok: false, reason: 'not-found' };
-  if (session.revokedAt) return { ok: false, reason: 'revoked' };
-  if (session.expiresAt < now) return { ok: false, reason: 'expired' };
-
-  const isCurrent = presentedJti === session.currentJti;
-  const isPreviousInGrace =
-    presentedJti === session.previousJti &&
-    now.getTime() - session.rotatedAt.getTime() < REFRESH_ROTATION_GRACE_MS;
-
-  if (!isCurrent && !isPreviousInGrace) {
-    // A spent jti outside the grace window means two parties hold tokens
-    // from this session's chain — the legitimate device and whoever
-    // replayed this one. There is no way to tell which caller is which, so
-    // kill the session; the legitimate device re-authenticates once, the
-    // stolen chain dies with it.
-    await prisma.mobileSession.update({
-      where: { id: sid },
-      data: { revokedAt: now },
-    });
-    return { ok: false, reason: 'reuse-detected' };
-  }
-
   const jti = randomUUID();
-  await prisma.mobileSession.update({
-    where: { id: sid },
+
+  // Atomic fast path: rotate iff the presented jti is still current.
+  const rotated = await prisma.mobileSession.updateMany({
+    where: { id: sid, currentJti: presentedJti, revokedAt: null, expiresAt: { gt: now } },
     data: {
       currentJti: jti,
       previousJti: presentedJti,
@@ -89,7 +80,44 @@ export async function rotateMobileSession(
       expiresAt: new Date(now.getTime() + MOBILE_REFRESH_TTL_MS),
     },
   });
-  return { ok: true, jti };
+  if (rotated.count === 1) return { ok: true, jti };
+
+  // The conditional write matched nothing; read to find out why.
+  const session = await prisma.mobileSession.findUnique({ where: { id: sid } });
+  if (!session) return { ok: false, reason: 'not-found' };
+  if (session.revokedAt) return { ok: false, reason: 'revoked' };
+  if (session.expiresAt < now) return { ok: false, reason: 'expired' };
+
+  const lostRaceInGrace =
+    presentedJti === session.previousJti &&
+    now.getTime() - session.rotatedAt.getTime() < REFRESH_ROTATION_GRACE_MS;
+  // Defensive only: nothing ever writes an old jti back to currentJti, so
+  // a failed conditional write with the presented jti still current should
+  // be unreachable — but if it happens, the caller holds a valid token and
+  // must not be punished for our race handling.
+  const stillCurrent = presentedJti === session.currentJti;
+
+  if (lostRaceInGrace || stillCurrent) {
+    // Do NOT rotate again — that would clobber the winner's jti and shift
+    // the orphaned-token problem one rotation down. Re-issue the current
+    // jti and slide the expiry as any successful refresh does.
+    await prisma.mobileSession.updateMany({
+      where: { id: sid, revokedAt: null },
+      data: { lastUsedAt: now, expiresAt: new Date(now.getTime() + MOBILE_REFRESH_TTL_MS) },
+    });
+    return { ok: true, jti: session.currentJti };
+  }
+
+  // A spent jti outside the grace window means two parties hold tokens
+  // from this session's chain — the legitimate device and whoever replayed
+  // this one. There is no way to tell which caller is which, so kill the
+  // session; the legitimate device re-authenticates once, the stolen chain
+  // dies with it.
+  await prisma.mobileSession.updateMany({
+    where: { id: sid, revokedAt: null },
+    data: { revokedAt: now },
+  });
+  return { ok: false, reason: 'reuse-detected' };
 }
 
 /**

--- a/apps/api/src/auth/mobile-session.ts
+++ b/apps/api/src/auth/mobile-session.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { prisma } from '../lib/prisma';
 
 // Server-side state for mobile refresh tokens. The tokens themselves are
@@ -44,7 +44,16 @@ export async function createMobileSession(userId: string): Promise<NewMobileSess
 
 export type RotationResult =
   | { ok: true; jti: string }
-  | { ok: false; reason: 'not-found' | 'revoked' | 'expired' | 'reuse-detected' };
+  | { ok: false; reason: 'not-found' | 'revoked' | 'expired' }
+  /**
+   * `detail` separates the two ways reuse fires so their alerts can differ:
+   * 'spent-previous' (the session's own previous jti replayed after grace)
+   * is the classic stolen-chain signature, while 'unknown-jti' can also be
+   * a client bug that corrupted or lost the stored token. Both revoke, but
+   * conflating their alerts would train people to ignore the real one if
+   * client bugs ever get noisy.
+   */
+  | { ok: false; reason: 'reuse-detected'; detail: 'spent-previous' | 'unknown-jti' };
 
 /**
  * Validate a presented refresh jti against its session and, when valid,
@@ -117,7 +126,88 @@ export async function rotateMobileSession(
     where: { id: sid, revokedAt: null },
     data: { revokedAt: now },
   });
-  return { ok: false, reason: 'reuse-detected' };
+  const detail = presentedJti === session.previousJti ? 'spent-previous' : 'unknown-jti';
+  return { ok: false, reason: 'reuse-detected', detail };
+}
+
+/** Stable identity for a legacy (pre-session) refresh token. */
+export function hashLegacyToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export type LegacyUpgradeResult =
+  | { ok: true; sid: string; jti: string }
+  | { ok: false; reason: 'reuse-detected' };
+
+/**
+ * One-shot upgrade of a legacy sid-less refresh token to a session.
+ *
+ * The unique legacyTokenHash column is what makes it one-shot. Legacy
+ * tokens are stateless, so without this a single token could be replayed
+ * throughout the 7-day migration window and mint an unlimited number of
+ * independent year-long sessions — converting anything leaked BEFORE the
+ * sessions deploy from a credential with a hard 7-day ceiling into an
+ * indefinitely renewable one. With it, the first presentation claims the
+ * token; a replay gets the same treatment as a spent jti: the claimed
+ * session is revoked and the caller gets reuse-detected.
+ *
+ * The lost-response case gets the same grace rotation retries get: until
+ * the session's first real rotation (previousJti null) and within
+ * REFRESH_ROTATION_GRACE_MS, re-presenting the legacy token re-issues the
+ * session's current pair, because a device whose upgrade response was lost
+ * has nothing else to present. The client retries failed refreshes on a
+ * ~10s cadence, well inside the window.
+ */
+export async function upgradeLegacySession(
+  userId: string,
+  legacyTokenHash: string,
+): Promise<LegacyUpgradeResult> {
+  const now = new Date();
+
+  // Evaluate an already-claimed token; null means unclaimed.
+  const evaluateExisting = async (): Promise<LegacyUpgradeResult | null> => {
+    const existing = await prisma.mobileSession.findUnique({ where: { legacyTokenHash } });
+    if (!existing) return null;
+    if (existing.userId !== userId || existing.revokedAt || existing.expiresAt < now) {
+      return { ok: false, reason: 'reuse-detected' };
+    }
+    const neverRotated = existing.previousJti === null;
+    const withinGrace = now.getTime() - existing.rotatedAt.getTime() < REFRESH_ROTATION_GRACE_MS;
+    if (neverRotated && withinGrace) {
+      return { ok: true, sid: existing.id, jti: existing.currentJti };
+    }
+    // The upgrading device has moved on (rotated) or too much time has
+    // passed: this presentation comes from a second holder of the token.
+    await prisma.mobileSession.updateMany({
+      where: { id: existing.id, revokedAt: null },
+      data: { revokedAt: now },
+    });
+    return { ok: false, reason: 'reuse-detected' };
+  };
+
+  const claimed = await evaluateExisting();
+  if (claimed) return claimed;
+
+  try {
+    const jti = randomUUID();
+    const session = await prisma.mobileSession.create({
+      data: {
+        userId,
+        currentJti: jti,
+        legacyTokenHash,
+        lastUsedAt: now,
+        expiresAt: new Date(now.getTime() + MOBILE_REFRESH_TTL_MS),
+      },
+    });
+    return { ok: true, sid: session.id, jti };
+  } catch (err) {
+    // Unique violation: a concurrent upgrade with the same token won the
+    // create. Evaluate against the winner's row; anything else is a real
+    // error and propagates.
+    const raced = await evaluateExisting();
+    if (raced) return raced;
+    throw err;
+  }
 }
 
 /**

--- a/apps/api/src/auth/mobile-session.ts
+++ b/apps/api/src/auth/mobile-session.ts
@@ -1,0 +1,106 @@
+import { randomUUID } from 'crypto';
+import { prisma } from '../lib/prisma';
+
+// Server-side state for mobile refresh tokens. The tokens themselves are
+// still stateless JWTs, but each one names a MobileSession row (sid) and a
+// one-time rotation id (jti). That pairing is what makes the long sliding
+// refresh window defensible: a leaked token stops being an invisible
+// year-long bearer credential, because replaying a spent jti revokes the
+// session on the spot, and any individual device can be revoked without
+// bumping the user's global sessionTokenVersion.
+
+/** Sliding session lifetime; pushed forward on every successful refresh. */
+export const MOBILE_REFRESH_TTL_MS = 365 * 24 * 60 * 60 * 1000;
+
+/**
+ * How long the previous jti stays honored after a rotation. A device that
+ * never received the rotation response (trail dead zone, timeout) retries
+ * with the token it still holds — the one just rotated away from. Reading
+ * that retry as theft would revoke the session and recreate the exact
+ * mid-ride logout this work exists to kill, so a short grace window
+ * distinguishes "lost response" from "replayed weeks later."
+ */
+export const REFRESH_ROTATION_GRACE_MS = 60_000;
+
+export interface NewMobileSession {
+  sid: string;
+  jti: string;
+}
+
+/** One row per device sign-in; also the upgrade path for legacy tokens. */
+export async function createMobileSession(userId: string): Promise<NewMobileSession> {
+  const jti = randomUUID();
+  const now = new Date();
+  const session = await prisma.mobileSession.create({
+    data: {
+      userId,
+      currentJti: jti,
+      lastUsedAt: now,
+      expiresAt: new Date(now.getTime() + MOBILE_REFRESH_TTL_MS),
+    },
+  });
+  return { sid: session.id, jti };
+}
+
+export type RotationResult =
+  | { ok: true; jti: string }
+  | { ok: false; reason: 'not-found' | 'revoked' | 'expired' | 'reuse-detected' };
+
+/**
+ * Validate a presented refresh jti against its session and, when valid,
+ * rotate to a new jti and slide the expiry forward.
+ */
+export async function rotateMobileSession(
+  sid: string,
+  presentedJti: string,
+): Promise<RotationResult> {
+  const now = new Date();
+  const session = await prisma.mobileSession.findUnique({ where: { id: sid } });
+  if (!session) return { ok: false, reason: 'not-found' };
+  if (session.revokedAt) return { ok: false, reason: 'revoked' };
+  if (session.expiresAt < now) return { ok: false, reason: 'expired' };
+
+  const isCurrent = presentedJti === session.currentJti;
+  const isPreviousInGrace =
+    presentedJti === session.previousJti &&
+    now.getTime() - session.rotatedAt.getTime() < REFRESH_ROTATION_GRACE_MS;
+
+  if (!isCurrent && !isPreviousInGrace) {
+    // A spent jti outside the grace window means two parties hold tokens
+    // from this session's chain — the legitimate device and whoever
+    // replayed this one. There is no way to tell which caller is which, so
+    // kill the session; the legitimate device re-authenticates once, the
+    // stolen chain dies with it.
+    await prisma.mobileSession.update({
+      where: { id: sid },
+      data: { revokedAt: now },
+    });
+    return { ok: false, reason: 'reuse-detected' };
+  }
+
+  const jti = randomUUID();
+  await prisma.mobileSession.update({
+    where: { id: sid },
+    data: {
+      currentJti: jti,
+      previousJti: presentedJti,
+      rotatedAt: now,
+      lastUsedAt: now,
+      expiresAt: new Date(now.getTime() + MOBILE_REFRESH_TTL_MS),
+    },
+  });
+  return { ok: true, jti };
+}
+
+/**
+ * Revoke one session. Scoped to the owning user so a forged sid in an
+ * otherwise-valid token cannot revoke someone else's session. Idempotent:
+ * revoking an already-revoked or missing session is a no-op, because logout
+ * must never fail retroactively.
+ */
+export async function revokeMobileSession(sid: string, userId: string): Promise<void> {
+  await prisma.mobileSession.updateMany({
+    where: { id: sid, userId, revokedAt: null },
+    data: { revokedAt: new Date() },
+  });
+}

--- a/apps/api/src/auth/mobile-session.ts
+++ b/apps/api/src/auth/mobile-session.ts
@@ -211,6 +211,28 @@ export async function upgradeLegacySession(
 }
 
 /**
+ * Delete rows that stopped mattering a while ago: sessions revoked, or
+ * expired, more than `olderThanDays` days back. The retention window keeps
+ * recent revocations around for incident forensics (a reuse-detection
+ * event is exactly when you want to inspect the row). Deleting an old
+ * revoked row cannot re-open its one-shot legacy claim: legacy tokens all
+ * expire within 7 days of the sessions deploy, far inside any sane
+ * retention, so by deletion time the token that hash guarded is dead.
+ */
+export async function deleteDefunctMobileSessions(olderThanDays: number): Promise<number> {
+  const cutoff = new Date(Date.now() - olderThanDays * 24 * 60 * 60 * 1000);
+  const result = await prisma.mobileSession.deleteMany({
+    where: {
+      OR: [
+        { revokedAt: { lt: cutoff } },
+        { expiresAt: { lt: cutoff } },
+      ],
+    },
+  });
+  return result.count;
+}
+
+/**
  * Revoke one session. Scoped to the owning user so a forged sid in an
  * otherwise-valid token cannot revoke someone else's session. Idempotent:
  * revoking an already-revoked or missing session is a no-op, because logout

--- a/apps/api/src/auth/mobile-signup.route.test.ts
+++ b/apps/api/src/auth/mobile-signup.route.test.ts
@@ -58,6 +58,8 @@ jest.mock('../lib/prisma', () => ({
   prisma: {
     // getSessionTokenVersion (via issueMobileTokens) reads this; undefined → version 0.
     user: { findUnique: jest.fn() },
+    // issueMobileTokens creates a MobileSession row for every token pair.
+    mobileSession: { create: jest.fn().mockResolvedValue({ id: 'session-1' }) },
   },
 }));
 

--- a/apps/api/src/auth/mobile.route.ts
+++ b/apps/api/src/auth/mobile.route.ts
@@ -9,7 +9,7 @@ import { validateEmailFormat } from './email.utils';
 import { verifyPassword, validatePassword, hashPassword } from './password.utils';
 import { generateAccessToken, generateRefreshToken, verifyToken, isRefreshTokenPayload } from './token';
 import { issueMobileTokens } from './session-issuer';
-import { createMobileSession, rotateMobileSession, revokeMobileSession } from './mobile-session';
+import { rotateMobileSession, revokeMobileSession, upgradeLegacySession, hashLegacyToken } from './mobile-session';
 import { updateLastAuthAt } from './recent-auth';
 import { prisma } from '../lib/prisma';
 import { checkAuthRateLimit, checkMutationRateLimit } from '../lib/rate-limit';
@@ -438,6 +438,16 @@ router.post('/mobile/refresh', express.json(), async (req, res) => {
       return sendUnauthorized(res, 'Invalid or expired refresh token');
     }
 
+    // Per-user, not per-IP: the uid is signature-verified by this point (so
+    // junk floods never reach here), a valid-signature flood is inherently
+    // per-user, and carrier-grade NAT would make an IP key throttle
+    // innocent riders. This caps the DB writes each refresh performs.
+    const rateLimit = await checkAuthRateLimit('token-refresh', payload.uid);
+    if (!rateLimit.allowed) {
+      logger.warn({ uid: payload.uid, retryAfter: rateLimit.retryAfter, route: 'mobile/refresh' }, 'Refresh 429: rate limited');
+      return sendTooManyRequests(res, 'Too many refresh attempts. Please try again later.', rateLimit.retryAfter);
+    }
+
     // Verify user still exists
     const user = await prisma.user.findUnique({
       where: { id: payload.uid },
@@ -468,14 +478,18 @@ router.post('/mobile/refresh', express.json(), async (req, res) => {
       const rotation = await rotateMobileSession(payload.sid, payload.jti);
       if (!rotation.ok) {
         if (rotation.reason === 'reuse-detected') {
-          // Someone presented a token this session already rotated away
-          // from. Loud on purpose: this is the one signal that a refresh
-          // token leaked.
-          logger.warn({ userId: user.id, sid: payload.sid, route: 'mobile/refresh' }, 'Refresh 401: spent token replayed, session revoked');
-          Sentry.captureMessage('Mobile refresh token reuse detected', {
+          // Loud on purpose: this is the one signal that a refresh token
+          // leaked. Two distinct Sentry messages so a noisy client bug
+          // (unknown jti from a corrupted/lost stored token) cannot bury
+          // the classic stolen-chain signature (spent jti replayed).
+          const message = rotation.detail === 'spent-previous'
+            ? 'Mobile refresh token reuse detected (spent token replayed)'
+            : 'Mobile refresh token with unknown jti (client token corruption or theft)';
+          logger.warn({ userId: user.id, sid: payload.sid, detail: rotation.detail, route: 'mobile/refresh' }, 'Refresh 401: reuse detected, session revoked');
+          Sentry.captureMessage(message, {
             level: 'warning',
             tags: { route: 'mobile/refresh' },
-            extra: { userId: user.id, sid: payload.sid },
+            extra: { userId: user.id, sid: payload.sid, detail: rotation.detail },
           });
         } else {
           logger.info({ userId: user.id, sid: payload.sid, reason: rotation.reason, route: 'mobile/refresh' }, 'Refresh 401: session not usable');
@@ -486,12 +500,24 @@ router.post('/mobile/refresh', express.json(), async (req, res) => {
       jti = rotation.jti;
     } else {
       // Legacy token from before sessions existed (7-day TTL, no sid).
-      // Upgrade it in place instead of forcing a re-login: mint a session
-      // now and hand back a session-bound pair. Legacy tokens age out of
-      // circulation entirely within 7 days of this deploy.
-      const session = await createMobileSession(user.id);
-      sid = session.sid;
-      jti = session.jti;
+      // Upgrade it in place instead of forcing a re-login — but exactly
+      // once: the token's hash is recorded on the session it creates, so a
+      // replay cannot mint additional sessions. Without that, anything
+      // leaked before the sessions deploy would convert from a credential
+      // with a hard 7-day ceiling into an indefinitely renewable one.
+      // Legacy tokens age out of circulation within 7 days of deploy.
+      const upgrade = await upgradeLegacySession(user.id, hashLegacyToken(refreshToken));
+      if (!upgrade.ok) {
+        logger.warn({ userId: user.id, route: 'mobile/refresh' }, 'Refresh 401: legacy token replayed after upgrade, session revoked');
+        Sentry.captureMessage('Mobile legacy refresh token replayed after upgrade', {
+          level: 'warning',
+          tags: { route: 'mobile/refresh' },
+          extra: { userId: user.id },
+        });
+        return sendUnauthorized(res, 'Refresh token has been revoked');
+      }
+      sid = upgrade.sid;
+      jti = upgrade.jti;
     }
 
     // Generate new access token stamped with the current token version
@@ -537,8 +563,15 @@ router.post('/mobile/logout', express.json(), async (req, res) => {
 
     const payload = verifyToken(refreshToken);
     // An expired or malformed token has no live session worth revoking;
-    // treat as an already-complete logout rather than an error.
+    // treat as an already-complete logout rather than an error. Only the
+    // sid path does DB work, so only it is rate limited (per user, same
+    // rationale as token-refresh).
     if (payload?.sid) {
+      const rateLimit = await checkAuthRateLimit('token-logout', payload.uid);
+      if (!rateLimit.allowed) {
+        logger.warn({ uid: payload.uid, retryAfter: rateLimit.retryAfter, route: 'mobile/logout' }, 'Logout 429: rate limited');
+        return sendTooManyRequests(res, 'Too many requests. Please try again later.', rateLimit.retryAfter);
+      }
       await revokeMobileSession(payload.sid, payload.uid);
       auditLogger.info({ userId: payload.uid, sid: payload.sid }, 'Mobile session revoked by logout');
     }

--- a/apps/api/src/auth/mobile.route.ts
+++ b/apps/api/src/auth/mobile.route.ts
@@ -9,6 +9,7 @@ import { validateEmailFormat } from './email.utils';
 import { verifyPassword, validatePassword, hashPassword } from './password.utils';
 import { generateAccessToken, generateRefreshToken, verifyToken } from './token';
 import { issueMobileTokens } from './session-issuer';
+import { createMobileSession, rotateMobileSession, revokeMobileSession } from './mobile-session';
 import { updateLastAuthAt } from './recent-auth';
 import { prisma } from '../lib/prisma';
 import { checkAuthRateLimit, checkMutationRateLimit } from '../lib/rate-limit';
@@ -445,6 +446,44 @@ router.post('/mobile/refresh', express.json(), async (req, res) => {
       return sendUnauthorized(res, 'Refresh token has been revoked');
     }
 
+    // Rotate within the token's server-side session. Each successful
+    // refresh mints a new jti and slides the session expiry forward, so an
+    // actively-used app never hits refresh expiry (the fixed-expiry version
+    // of this route logged riders out 7 days after login, including
+    // mid-ride). Presenting a spent jti revokes the session: that is the
+    // reuse-detection that makes the long sliding window safe.
+    let sid: string;
+    let jti: string;
+    if (payload.sid && payload.jti) {
+      const rotation = await rotateMobileSession(payload.sid, payload.jti);
+      if (!rotation.ok) {
+        if (rotation.reason === 'reuse-detected') {
+          // Someone presented a token this session already rotated away
+          // from. Loud on purpose: this is the one signal that a refresh
+          // token leaked.
+          logger.warn({ userId: user.id, sid: payload.sid, route: 'mobile/refresh' }, 'Refresh 401: spent token replayed, session revoked');
+          Sentry.captureMessage('Mobile refresh token reuse detected', {
+            level: 'warning',
+            tags: { route: 'mobile/refresh' },
+            extra: { userId: user.id, sid: payload.sid },
+          });
+        } else {
+          logger.info({ userId: user.id, sid: payload.sid, reason: rotation.reason, route: 'mobile/refresh' }, 'Refresh 401: session not usable');
+        }
+        return sendUnauthorized(res, 'Refresh token has been revoked');
+      }
+      sid = payload.sid;
+      jti = rotation.jti;
+    } else {
+      // Legacy token from before sessions existed (7-day TTL, no sid).
+      // Upgrade it in place instead of forcing a re-login: mint a session
+      // now and hand back a session-bound pair. Legacy tokens age out of
+      // circulation entirely within 7 days of this deploy.
+      const session = await createMobileSession(user.id);
+      sid = session.sid;
+      jti = session.jti;
+    }
+
     // Generate new access token stamped with the current token version
     const accessToken = generateAccessToken({
       uid: user.id,
@@ -452,16 +491,16 @@ router.post('/mobile/refresh', express.json(), async (req, res) => {
       v: user.sessionTokenVersion,
     });
 
-    // Rotate the refresh token too: each successful refresh restarts the
-    // session window, so an actively-used app never hits refresh expiry
-    // (the fixed-expiry version of this route logged riders out 7 days
-    // after login, including mid-ride). The mobile client stores
-    // `refreshToken` from this response when present; older builds that
-    // ignore it simply keep their original fixed-window token.
+    // The mobile client stores `refreshToken` from this response when
+    // present; older builds that ignore it keep their previous token, which
+    // stays honored as this session's previousJti only briefly — those
+    // builds fall back to fixed-window behavior and re-login at expiry.
     const rotatedRefreshToken = generateRefreshToken({
       uid: user.id,
       email: user.email,
       v: user.sessionTokenVersion,
+      sid,
+      jti,
     });
 
     res.status(200).json({ accessToken, refreshToken: rotatedRefreshToken });
@@ -469,6 +508,36 @@ router.post('/mobile/refresh', express.json(), async (req, res) => {
     logger.error({ err: e, route: 'mobile/refresh' }, '[MobileAuth] Token refresh failed');
     Sentry.captureException(e, { tags: { route: 'mobile/refresh' } });
     return sendInternalError(res, 'Token refresh failed');
+  }
+});
+
+/**
+ * POST /auth/mobile/logout
+ * Revoke the refresh token's server-side session. Best-effort from the
+ * client (a rider logging out in a dead zone must still log out locally),
+ * so the endpoint is idempotent and succeeds even when there is nothing
+ * left to revoke.
+ */
+router.post('/mobile/logout', express.json(), async (req, res) => {
+  try {
+    const { refreshToken } = req.body as { refreshToken?: string };
+    if (!refreshToken) {
+      return sendBadRequest(res, 'Missing refreshToken', 'MISSING_TOKEN');
+    }
+
+    const payload = verifyToken(refreshToken);
+    // An expired or malformed token has no live session worth revoking;
+    // treat as an already-complete logout rather than an error.
+    if (payload?.sid) {
+      await revokeMobileSession(payload.sid, payload.uid);
+      auditLogger.info({ userId: payload.uid, sid: payload.sid }, 'Mobile session revoked by logout');
+    }
+
+    return res.status(200).json({ ok: true });
+  } catch (e) {
+    logger.error({ err: e, route: 'mobile/logout' }, '[MobileAuth] Logout failed');
+    Sentry.captureException(e, { tags: { route: 'mobile/logout' } });
+    return sendInternalError(res, 'Logout failed');
   }
 });
 

--- a/apps/api/src/auth/mobile.route.ts
+++ b/apps/api/src/auth/mobile.route.ts
@@ -563,10 +563,14 @@ router.post('/mobile/logout', express.json(), async (req, res) => {
 
     const payload = verifyToken(refreshToken);
     // An expired or malformed token has no live session worth revoking;
-    // treat as an already-complete logout rather than an error. Only the
-    // sid path does DB work, so only it is rate limited (per user, same
-    // rationale as token-refresh).
-    if (payload?.sid) {
+    // treat as an already-complete logout rather than an error. The
+    // isRefreshTokenPayload gate matches the refresh route: today only
+    // refresh tokens carry sid, but that is a structural accident, and if
+    // any future SESSION_SECRET-signed token grew a same-named field this
+    // endpoint would silently start revoking sessions on its behalf. Only
+    // the revocation path does DB work, so only it is rate limited (per
+    // user, same rationale as token-refresh).
+    if (payload && isRefreshTokenPayload(payload) && payload.sid) {
       const rateLimit = await checkAuthRateLimit('token-logout', payload.uid);
       if (!rateLimit.allowed) {
         logger.warn({ uid: payload.uid, retryAfter: rateLimit.retryAfter, route: 'mobile/logout' }, 'Logout 429: rate limited');

--- a/apps/api/src/auth/mobile.route.ts
+++ b/apps/api/src/auth/mobile.route.ts
@@ -7,7 +7,7 @@ import { verifyAppleIdentityToken, type AppleVerifyErrorDetail } from './appleTo
 import { normalizeEmail, getClientIp } from './utils';
 import { validateEmailFormat } from './email.utils';
 import { verifyPassword, validatePassword, hashPassword } from './password.utils';
-import { generateAccessToken, verifyToken } from './token';
+import { generateAccessToken, generateRefreshToken, verifyToken } from './token';
 import { issueMobileTokens } from './session-issuer';
 import { updateLastAuthAt } from './recent-auth';
 import { prisma } from '../lib/prisma';
@@ -452,7 +452,19 @@ router.post('/mobile/refresh', express.json(), async (req, res) => {
       v: user.sessionTokenVersion,
     });
 
-    res.status(200).json({ accessToken });
+    // Rotate the refresh token too: each successful refresh restarts the
+    // session window, so an actively-used app never hits refresh expiry
+    // (the fixed-expiry version of this route logged riders out 7 days
+    // after login, including mid-ride). The mobile client stores
+    // `refreshToken` from this response when present; older builds that
+    // ignore it simply keep their original fixed-window token.
+    const rotatedRefreshToken = generateRefreshToken({
+      uid: user.id,
+      email: user.email,
+      v: user.sessionTokenVersion,
+    });
+
+    res.status(200).json({ accessToken, refreshToken: rotatedRefreshToken });
   } catch (e) {
     logger.error({ err: e, route: 'mobile/refresh' }, '[MobileAuth] Token refresh failed');
     Sentry.captureException(e, { tags: { route: 'mobile/refresh' } });

--- a/apps/api/src/auth/mobile.route.ts
+++ b/apps/api/src/auth/mobile.route.ts
@@ -7,7 +7,7 @@ import { verifyAppleIdentityToken, type AppleVerifyErrorDetail } from './appleTo
 import { normalizeEmail, getClientIp } from './utils';
 import { validateEmailFormat } from './email.utils';
 import { verifyPassword, validatePassword, hashPassword } from './password.utils';
-import { generateAccessToken, generateRefreshToken, verifyToken } from './token';
+import { generateAccessToken, generateRefreshToken, verifyToken, isRefreshTokenPayload } from './token';
 import { issueMobileTokens } from './session-issuer';
 import { createMobileSession, rotateMobileSession, revokeMobileSession } from './mobile-session';
 import { updateLastAuthAt } from './recent-auth';
@@ -425,6 +425,16 @@ router.post('/mobile/refresh', express.json(), async (req, res) => {
     if (!payload) {
       // Stale / malformed token is the common case here — info, not warn.
       logger.info({ reason: 'invalid-or-expired', route: 'mobile/refresh' }, 'Refresh 401: token invalid or expired');
+      return sendUnauthorized(res, 'Invalid or expired refresh token');
+    }
+
+    // The signature only proves WE minted the token, not that it is a
+    // refresh token: access tokens and web session cookies share the same
+    // secret. Without this check, a leaked 15-minute access token could be
+    // traded here for a year-long session. The real client never does
+    // this, so warn: it is either a bug or someone probing.
+    if (!isRefreshTokenPayload(payload)) {
+      logger.warn({ uid: payload.uid, typ: payload.typ, route: 'mobile/refresh' }, 'Refresh 401: non-refresh token presented');
       return sendUnauthorized(res, 'Invalid or expired refresh token');
     }
 

--- a/apps/api/src/auth/session-issuer.ts
+++ b/apps/api/src/auth/session-issuer.ts
@@ -2,6 +2,7 @@ import type { Response } from 'express';
 import { prisma } from '../lib/prisma';
 import { setSessionCookie } from './session';
 import { generateAccessToken, generateRefreshToken } from './token';
+import { createMobileSession } from './mobile-session';
 
 /**
  * Fetch the user's current sessionTokenVersion. Used to stamp tokens at issue time
@@ -34,15 +35,18 @@ export type MobileTokenPair = {
 
 /**
  * Issue a mobile access + refresh token pair stamped with the user's current
- * sessionTokenVersion.
+ * sessionTokenVersion. Every pair starts a MobileSession row: the refresh
+ * token is bound to it via sid/jti, which is what lets the refresh route
+ * rotate with reuse detection and lets a single device be revoked.
  */
 export async function issueMobileTokens(user: {
   id: string;
   email: string;
 }): Promise<MobileTokenPair> {
   const v = await getSessionTokenVersion(user.id);
+  const { sid, jti } = await createMobileSession(user.id);
   return {
     accessToken: generateAccessToken({ uid: user.id, email: user.email, v }),
-    refreshToken: generateRefreshToken({ uid: user.id, email: user.email, v }),
+    refreshToken: generateRefreshToken({ uid: user.id, email: user.email, v, sid, jti }),
   };
 }

--- a/apps/api/src/auth/session.test.ts
+++ b/apps/api/src/auth/session.test.ts
@@ -7,6 +7,9 @@ process.env = { ...originalEnv, SESSION_SECRET: 'test-secret' };
 // Mock dependencies BEFORE importing session.ts
 jest.mock('jsonwebtoken');
 jest.mock('./token', () => ({
+  // Real isAccessTokenPayload: bearer tests exercise the actual token-type
+  // gate, so payloads below carry the typ claim real tokens have.
+  ...jest.requireActual('./token'),
   extractBearerToken: jest.fn(),
   verifyToken: jest.fn(),
 }));
@@ -222,7 +225,7 @@ describe('attachUser — cookie session (web)', () => {
 
 describe('attachUser — bearer token (mobile)', () => {
   it('attaches sessionUser when bearer token is valid and version matches', async () => {
-    const payload = { uid: 'user_1', email: 'a@b.com', v: 2 };
+    const payload = { uid: 'user_1', email: 'a@b.com', v: 2, typ: 'access' };
     mockExtractBearerToken.mockReturnValue('mobile-access-token');
     mockVerifyToken.mockReturnValue(payload);
     mockUserFindUnique.mockResolvedValue({ sessionTokenVersion: 2 });
@@ -234,7 +237,7 @@ describe('attachUser — bearer token (mobile)', () => {
   });
 
   it('rejects a bearer token whose v is stale (mobile device still holding pre-reset token)', async () => {
-    const stalePayload = { uid: 'user_1', v: 0 };
+    const stalePayload = { uid: 'user_1', v: 0, typ: 'access' };
     mockExtractBearerToken.mockReturnValue('stale-mobile-token');
     mockVerifyToken.mockReturnValue(stalePayload);
     mockUserFindUnique.mockResolvedValue({ sessionTokenVersion: 1 });
@@ -243,6 +246,20 @@ describe('attachUser — bearer token (mobile)', () => {
     await runAttachUser(req);
 
     expect(req.sessionUser).toBeUndefined();
+  });
+
+  it('does not attach a user for a refresh token in the Authorization header', async () => {
+    // A refresh token verifies with the same secret; accepting it here
+    // would make it a year-long access credential that never passes
+    // through rotation or reuse detection.
+    mockExtractBearerToken.mockReturnValue('a-refresh-token');
+    mockVerifyToken.mockReturnValue({ uid: 'user_1', v: 0, typ: 'refresh', sid: 'sid-1', jti: 'jti-1' });
+    const req = makeReq();
+
+    await runAttachUser(req);
+
+    expect(req.sessionUser).toBeUndefined();
+    expect(mockUserFindUnique).not.toHaveBeenCalled();
   });
 
   it('does not attach a user when bearer token itself is invalid', async () => {

--- a/apps/api/src/auth/session.ts
+++ b/apps/api/src/auth/session.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import * as Sentry from '@sentry/node';
-import { extractBearerToken, verifyToken } from './token';
+import { extractBearerToken, verifyToken, isAccessTokenPayload } from './token';
 import { prisma } from '../lib/prisma';
 import { logger } from '../lib/logger';
 
@@ -109,7 +109,10 @@ export async function attachUser(req: Request, _res: Response, next: NextFunctio
     const bearerToken = extractBearerToken(req);
     if (bearerToken) {
       const user = verifyToken(bearerToken);
-      if (user && (await isTokenVersionCurrent(user))) {
+      // Access tokens only. A refresh token here would be a year-long
+      // credential that never passes through rotation or reuse detection,
+      // defeating the point of short-lived access tokens entirely.
+      if (user && isAccessTokenPayload(user) && (await isTokenVersionCurrent(user))) {
         req.sessionUser = user;
       }
     }

--- a/apps/api/src/auth/token.test.ts
+++ b/apps/api/src/auth/token.test.ts
@@ -108,6 +108,27 @@ describe('isRefreshTokenPayload / isAccessTokenPayload', () => {
     expect(isAccessTokenPayload(webCookie)).toBe(false);
   });
 
+  it('never types an unsubscribe token as either mobile token', () => {
+    // The account-takeover shape: {uid, purpose}, 90-day expiry, signed
+    // with the same secret, embedded in every marketing email. A pure
+    // lifetime heuristic typed this as a refresh token, letting anyone
+    // holding an unsubscribe link mint a real session at /mobile/refresh.
+    const unsubscribe = {
+      uid: 'u',
+      purpose: 'unsubscribe',
+      iat: now,
+      exp: now + 90 * 24 * 60 * 60,
+    } as never;
+    expect(isRefreshTokenPayload(unsubscribe)).toBe(false);
+    expect(isAccessTokenPayload(unsubscribe)).toBe(false);
+  });
+
+  it('never types a payload carrying any unknown claim (allowlist, not blocklist)', () => {
+    const future = { uid: 'u', scope: 'anything', iat: now, exp: now + 7 * 24 * 60 * 60 } as never;
+    expect(isRefreshTokenPayload(future)).toBe(false);
+    expect(isAccessTokenPayload(future)).toBe(false);
+  });
+
   it('rejects payloads with no typ and no usable lifetime', () => {
     expect(isRefreshTokenPayload({ uid: 'u' })).toBe(false);
     expect(isAccessTokenPayload({ uid: 'u' })).toBe(false);

--- a/apps/api/src/auth/token.test.ts
+++ b/apps/api/src/auth/token.test.ts
@@ -10,7 +10,14 @@ jest.mock('jsonwebtoken');
 const mockedJwt = jwt as jest.Mocked<typeof jwt>;
 
 // Now import the module under test
-import { generateAccessToken, generateRefreshToken, verifyToken, extractBearerToken } from './token';
+import {
+  generateAccessToken,
+  generateRefreshToken,
+  verifyToken,
+  extractBearerToken,
+  isRefreshTokenPayload,
+  isAccessTokenPayload,
+} from './token';
 
 afterAll(() => {
   process.env = originalEnv;
@@ -21,13 +28,13 @@ describe('generateAccessToken', () => {
     jest.clearAllMocks();
   });
 
-  it('should generate access token with 15m expiry', () => {
+  it('should generate access token with 15m expiry and an access typ claim', () => {
     mockedJwt.sign.mockReturnValue('access_token' as never);
 
     const result = generateAccessToken({ uid: 'user123', email: 'test@example.com' });
 
     expect(mockedJwt.sign).toHaveBeenCalledWith(
-      { uid: 'user123', email: 'test@example.com' },
+      { uid: 'user123', email: 'test@example.com', typ: 'access' },
       'test-secret',
       { expiresIn: '15m' }
     );
@@ -40,7 +47,7 @@ describe('generateAccessToken', () => {
     const result = generateAccessToken({ uid: 'user123' });
 
     expect(mockedJwt.sign).toHaveBeenCalledWith(
-      { uid: 'user123' },
+      { uid: 'user123', typ: 'access' },
       'test-secret',
       { expiresIn: '15m' }
     );
@@ -53,17 +60,57 @@ describe('generateRefreshToken', () => {
     jest.clearAllMocks();
   });
 
-  it('should generate refresh token with 365d expiry', () => {
+  it('should generate refresh token with 365d expiry and a refresh typ claim', () => {
     mockedJwt.sign.mockReturnValue('refresh_token' as never);
 
     const result = generateRefreshToken({ uid: 'user123', email: 'test@example.com' });
 
     expect(mockedJwt.sign).toHaveBeenCalledWith(
-      { uid: 'user123', email: 'test@example.com' },
+      { uid: 'user123', email: 'test@example.com', typ: 'refresh' },
       'test-secret',
       { expiresIn: '365d' }
     );
     expect(result).toBe('refresh_token');
+  });
+});
+
+// The two token kinds share a signing secret, so these predicates are the
+// only thing standing between "leaked 15-minute access token" and "minted
+// year-long refresh session" (and the reverse). Legacy tokens without a typ
+// claim are typed by signed lifetime; web session cookies (same secret,
+// 7-day lifetime) are excluded by their authAt claim.
+describe('isRefreshTokenPayload / isAccessTokenPayload', () => {
+  const now = 1_700_000_000;
+
+  it('trusts an explicit typ claim in both directions', () => {
+    expect(isRefreshTokenPayload({ uid: 'u', typ: 'refresh' })).toBe(true);
+    expect(isRefreshTokenPayload({ uid: 'u', typ: 'access' })).toBe(false);
+    expect(isAccessTokenPayload({ uid: 'u', typ: 'access' })).toBe(true);
+    expect(isAccessTokenPayload({ uid: 'u', typ: 'refresh' })).toBe(false);
+  });
+
+  it('ignores lifetime when typ is present (a forged short refresh is still a refresh)', () => {
+    expect(isAccessTokenPayload({ uid: 'u', typ: 'refresh', iat: now, exp: now + 60 })).toBe(false);
+  });
+
+  it('types legacy tokens by signed lifetime', () => {
+    const legacyAccess = { uid: 'u', iat: now, exp: now + 15 * 60 };
+    const legacyRefresh = { uid: 'u', iat: now, exp: now + 7 * 24 * 60 * 60 };
+    expect(isAccessTokenPayload(legacyAccess)).toBe(true);
+    expect(isRefreshTokenPayload(legacyAccess)).toBe(false);
+    expect(isRefreshTokenPayload(legacyRefresh)).toBe(true);
+    expect(isAccessTokenPayload(legacyRefresh)).toBe(false);
+  });
+
+  it('never types a web session cookie as either mobile token', () => {
+    const webCookie = { uid: 'u', authAt: now * 1000, iat: now, exp: now + 7 * 24 * 60 * 60 } as never;
+    expect(isRefreshTokenPayload(webCookie)).toBe(false);
+    expect(isAccessTokenPayload(webCookie)).toBe(false);
+  });
+
+  it('rejects payloads with no typ and no usable lifetime', () => {
+    expect(isRefreshTokenPayload({ uid: 'u' })).toBe(false);
+    expect(isAccessTokenPayload({ uid: 'u' })).toBe(false);
   });
 });
 

--- a/apps/api/src/auth/token.test.ts
+++ b/apps/api/src/auth/token.test.ts
@@ -53,7 +53,7 @@ describe('generateRefreshToken', () => {
     jest.clearAllMocks();
   });
 
-  it('should generate refresh token with 7d expiry', () => {
+  it('should generate refresh token with 365d expiry', () => {
     mockedJwt.sign.mockReturnValue('refresh_token' as never);
 
     const result = generateRefreshToken({ uid: 'user123', email: 'test@example.com' });
@@ -61,7 +61,7 @@ describe('generateRefreshToken', () => {
     expect(mockedJwt.sign).toHaveBeenCalledWith(
       { uid: 'user123', email: 'test@example.com' },
       'test-secret',
-      { expiresIn: '7d' }
+      { expiresIn: '365d' }
     );
     expect(result).toBe('refresh_token');
   });

--- a/apps/api/src/auth/token.ts
+++ b/apps/api/src/auth/token.ts
@@ -3,15 +3,30 @@ import jwt from 'jsonwebtoken';
 
 const { SESSION_SECRET } = process.env;
 
+export type TokenType = 'access' | 'refresh';
+
 export type TokenPayload = {
   uid: string;
   email?: string;
   /** User's sessionTokenVersion at token issue time — used to revoke tokens after password reset */
   v?: number;
+  /**
+   * Which kind of token this is. Both kinds are signed with the same
+   * SESSION_SECRET, so without this claim they are interchangeable: an
+   * access token POSTed to /mobile/refresh would mint a year-long refresh
+   * session, and a refresh token in an Authorization header would act as a
+   * year-long access token that never touches rotation or reuse detection.
+   * Optional only because tokens issued before the claim existed lack it;
+   * those are typed by lifetime instead (see isRefreshTokenPayload).
+   */
+  typ?: TokenType;
   /** Refresh tokens only: MobileSession row id this token belongs to */
   sid?: string;
   /** Refresh tokens only: one-time rotation id, matched against MobileSession.currentJti */
   jti?: string;
+  /** Stamped by jwt.sign; present on any verified payload. */
+  iat?: number;
+  exp?: number;
 };
 
 /**
@@ -22,7 +37,7 @@ export function generateAccessToken(payload: TokenPayload): string {
   if (!SESSION_SECRET) {
     throw new Error('SESSION_SECRET environment variable is not set');
   }
-  return jwt.sign(payload, SESSION_SECRET, { expiresIn: '15m' });
+  return jwt.sign({ ...payload, typ: 'access' }, SESSION_SECRET, { expiresIn: '15m' });
 }
 
 /**
@@ -45,7 +60,42 @@ export function generateRefreshToken(payload: TokenPayload): string {
   if (!SESSION_SECRET) {
     throw new Error('SESSION_SECRET environment variable is not set');
   }
-  return jwt.sign(payload, SESSION_SECRET, { expiresIn: '365d' });
+  return jwt.sign({ ...payload, typ: 'refresh' }, SESSION_SECRET, { expiresIn: '365d' });
+}
+
+// Legacy tokens (issued before the typ claim) are typed by their signed
+// lifetime: access tokens lived 15 minutes, refresh tokens 7 days. One hour
+// splits those cleanly. Web session cookies share the secret and a 7-day
+// lifetime, so they would pass the duration test; they are excluded by their
+// authAt claim, which mobile tokens never carry. The legacy fallbacks below
+// can be deleted once every pre-typ token has expired (7 days after the typ
+// deploy; legacy access tokens die in 15 minutes).
+const LEGACY_ACCESS_MAX_LIFETIME_S = 60 * 60;
+
+function signedLifetimeSeconds(payload: TokenPayload): number | null {
+  return typeof payload.iat === 'number' && typeof payload.exp === 'number'
+    ? payload.exp - payload.iat
+    : null;
+}
+
+function isWebSessionShaped(payload: TokenPayload): boolean {
+  return (payload as { authAt?: unknown }).authAt !== undefined;
+}
+
+/** True iff this verified payload was issued as a mobile refresh token. */
+export function isRefreshTokenPayload(payload: TokenPayload): boolean {
+  if (payload.typ !== undefined) return payload.typ === 'refresh';
+  if (isWebSessionShaped(payload)) return false;
+  const lifetime = signedLifetimeSeconds(payload);
+  return lifetime !== null && lifetime > LEGACY_ACCESS_MAX_LIFETIME_S;
+}
+
+/** True iff this verified payload was issued as a mobile access token. */
+export function isAccessTokenPayload(payload: TokenPayload): boolean {
+  if (payload.typ !== undefined) return payload.typ === 'access';
+  if (isWebSessionShaped(payload)) return false;
+  const lifetime = signedLifetimeSeconds(payload);
+  return lifetime !== null && lifetime <= LEGACY_ACCESS_MAX_LIFETIME_S;
 }
 
 /**

--- a/apps/api/src/auth/token.ts
+++ b/apps/api/src/auth/token.ts
@@ -8,6 +8,10 @@ export type TokenPayload = {
   email?: string;
   /** User's sessionTokenVersion at token issue time — used to revoke tokens after password reset */
   v?: number;
+  /** Refresh tokens only: MobileSession row id this token belongs to */
+  sid?: string;
+  /** Refresh tokens only: one-time rotation id, matched against MobileSession.currentJti */
+  jti?: string;
 };
 
 /**
@@ -29,9 +33,13 @@ export function generateAccessToken(payload: TokenPayload): string {
  * token on every successful refresh, so the session window slides: a rider
  * who opens the app at least once a year is never logged out. Riding is
  * seasonal (a whole winter off is normal), and a mid-ride logout can cost a
- * recording, so expiry is not a safety net worth that price. Revocation is
- * handled by sessionTokenVersion (bumped on password reset/change), which
- * kills all outstanding tokens for the user immediately regardless of TTL.
+ * recording, so expiry is not a safety net worth that price.
+ *
+ * The long TTL is safe because these tokens are not pure bearer
+ * credentials: each is bound to a MobileSession row (sid + one-time jti,
+ * see mobile-session.ts), giving per-device revocation and reuse detection
+ * when a spent token is replayed. sessionTokenVersion (bumped on password
+ * reset/change) additionally kills all of a user's tokens at once.
  */
 export function generateRefreshToken(payload: TokenPayload): string {
   if (!SESSION_SECRET) {

--- a/apps/api/src/auth/token.ts
+++ b/apps/api/src/auth/token.ts
@@ -22,14 +22,22 @@ export function generateAccessToken(payload: TokenPayload): string {
 }
 
 /**
- * Generate a long-lived refresh token (7 days)
+ * Generate a long-lived refresh token (365 days)
  * Used for obtaining new access tokens without re-authenticating
+ *
+ * The TTL is deliberately long and the mobile refresh route rotates the
+ * token on every successful refresh, so the session window slides: a rider
+ * who opens the app at least once a year is never logged out. Riding is
+ * seasonal (a whole winter off is normal), and a mid-ride logout can cost a
+ * recording, so expiry is not a safety net worth that price. Revocation is
+ * handled by sessionTokenVersion (bumped on password reset/change), which
+ * kills all outstanding tokens for the user immediately regardless of TTL.
  */
 export function generateRefreshToken(payload: TokenPayload): string {
   if (!SESSION_SECRET) {
     throw new Error('SESSION_SECRET environment variable is not set');
   }
-  return jwt.sign(payload, SESSION_SECRET, { expiresIn: '7d' });
+  return jwt.sign(payload, SESSION_SECRET, { expiresIn: '365d' });
 }
 
 /**

--- a/apps/api/src/auth/token.ts
+++ b/apps/api/src/auth/token.ts
@@ -65,12 +65,23 @@ export function generateRefreshToken(payload: TokenPayload): string {
 
 // Legacy tokens (issued before the typ claim) are typed by their signed
 // lifetime: access tokens lived 15 minutes, refresh tokens 7 days. One hour
-// splits those cleanly. Web session cookies share the secret and a 7-day
-// lifetime, so they would pass the duration test; they are excluded by their
-// authAt claim, which mobile tokens never carry. The legacy fallbacks below
-// can be deleted once every pre-typ token has expired (7 days after the typ
-// deploy; legacy access tokens die in 15 minutes).
+// splits those cleanly. The legacy fallbacks below can be deleted once every
+// pre-typ mobile token has expired (7 days after the typ deploy; legacy
+// access tokens die in 15 minutes).
 const LEGACY_ACCESS_MAX_LIFETIME_S = 60 * 60;
+
+// The exact claims a legacy mobile token can carry: what
+// generateAccessToken/generateRefreshToken signed ({uid, email?, v?}) plus
+// jwt.sign's own timestamps. The lifetime heuristic is trusted ONLY for
+// payloads with exactly this shape — any other claim means the token is
+// some other SESSION_SECRET-signed artifact (a web session cookie's authAt,
+// an unsubscribe link's purpose, or whatever gets minted next) and must
+// never be typed as a mobile credential. This is an allowlist rather than a
+// blocklist of known cousins because the failure mode is severe: the
+// unsubscribe token ({uid, purpose}, 90-day expiry, embedded in every
+// marketing email) passed a pure lifetime test and could be redeemed at
+// /mobile/refresh for a fully-authenticated year-long session.
+const LEGACY_MOBILE_TOKEN_CLAIMS = new Set(['uid', 'email', 'v', 'iat', 'exp']);
 
 function signedLifetimeSeconds(payload: TokenPayload): number | null {
   return typeof payload.iat === 'number' && typeof payload.exp === 'number'
@@ -78,14 +89,14 @@ function signedLifetimeSeconds(payload: TokenPayload): number | null {
     : null;
 }
 
-function isWebSessionShaped(payload: TokenPayload): boolean {
-  return (payload as { authAt?: unknown }).authAt !== undefined;
+function isLegacyMobileShaped(payload: TokenPayload): boolean {
+  return Object.keys(payload).every((key) => LEGACY_MOBILE_TOKEN_CLAIMS.has(key));
 }
 
 /** True iff this verified payload was issued as a mobile refresh token. */
 export function isRefreshTokenPayload(payload: TokenPayload): boolean {
   if (payload.typ !== undefined) return payload.typ === 'refresh';
-  if (isWebSessionShaped(payload)) return false;
+  if (!isLegacyMobileShaped(payload)) return false;
   const lifetime = signedLifetimeSeconds(payload);
   return lifetime !== null && lifetime > LEGACY_ACCESS_MAX_LIFETIME_S;
 }
@@ -93,7 +104,7 @@ export function isRefreshTokenPayload(payload: TokenPayload): boolean {
 /** True iff this verified payload was issued as a mobile access token. */
 export function isAccessTokenPayload(payload: TokenPayload): boolean {
   if (payload.typ !== undefined) return payload.typ === 'access';
-  if (isWebSessionShaped(payload)) return false;
+  if (!isLegacyMobileShaped(payload)) return false;
   const lifetime = signedLifetimeSeconds(payload);
   return lifetime !== null && lifetime <= LEGACY_ACCESS_MAX_LIFETIME_S;
 }

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -273,6 +273,15 @@ export const AUTH_RATE_LIMITS = {
   'forgot-password': { windowSeconds: 60, maxRequests: 5 },
   /** shared-history: max 30 requests per minute per IP (public bike-share pages; prevents scripted scraping of known slugs — slug entropy already defeats brute-force enumeration) */
   'shared-history': { windowSeconds: 60, maxRequests: 30 },
+  /** token-refresh: max 10 per minute per USER (not IP: carrier-grade NAT
+   *  puts many riders behind one IP, and the uid is already
+   *  signature-verified by the time this runs, so junk floods never get
+   *  here). Legitimate cadence is ~4/hour/device; 10/min absorbs races and
+   *  retries while capping the DB writes each refresh performs. */
+  'token-refresh': { windowSeconds: 60, maxRequests: 10 },
+  /** token-logout: max 10 per minute per USER (same keying rationale as
+   *  token-refresh; each call is one conditional DB write) */
+  'token-logout': { windowSeconds: 60, maxRequests: 10 },
 } as const;
 
 export type AuthRateLimitType = keyof typeof AUTH_RATE_LIMITS;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -19,6 +19,10 @@ import {
   startPasswordResetCleanup,
   stopPasswordResetCleanup,
 } from './services/password-reset-cleanup.service';
+import {
+  startMobileSessionCleanup,
+  stopMobileSessionCleanup,
+} from './services/mobile-session-cleanup.service';
 import { rootLogger, logger } from './lib/logger';
 import { validateEncryptionKey } from './lib/crypto';
 import { flushPostHog } from './lib/posthog';
@@ -359,6 +363,9 @@ const startServer = async () => {
   // Start password reset token cleanup (deletes tokens expired >7d ago, daily)
   startPasswordResetCleanup();
 
+  // Start mobile session cleanup (deletes sessions revoked/expired >30d ago, daily)
+  startMobileSessionCleanup();
+
   app.listen(PORT, HOST, () => {
     logger.info({ port: PORT }, 'LoamLogger backend running (GraphQL at /graphql)');
   });
@@ -369,6 +376,7 @@ const startServer = async () => {
     stopWeeklyDigestScheduler();
     stopOAuthCleanup();
     stopPasswordResetCleanup();
+    stopMobileSessionCleanup();
     await stopWorkers();
     await Sentry.flush(2000).catch(() => {});
     await flushPostHog();

--- a/apps/api/src/services/mobile-session-cleanup.service.ts
+++ b/apps/api/src/services/mobile-session-cleanup.service.ts
@@ -1,0 +1,48 @@
+import { deleteDefunctMobileSessions } from '../auth/mobile-session';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('mobile-session-cleanup');
+
+// Sessions churn slowly (one row per device sign-in, 365-day sliding
+// expiry), so a daily sweep is plenty; the table would otherwise grow
+// unbounded from revoked sessions, expired sessions, and one-shot
+// legacy-upgrade rows.
+const CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+// Keep revoked/expired rows for 30 days before deletion: a reuse-detection
+// revocation is precisely the row you want available while investigating.
+const DEFUNCT_OLDER_THAN_DAYS = 30;
+
+let cleanupInterval: NodeJS.Timeout | null = null;
+
+async function runCleanup(): Promise<void> {
+  try {
+    const deleted = await deleteDefunctMobileSessions(DEFUNCT_OLDER_THAN_DAYS);
+    if (deleted > 0) {
+      log.info({ deleted }, 'Cleaned up defunct mobile sessions');
+    }
+  } catch (err) {
+    log.error({ err }, 'Mobile session cleanup failed');
+  }
+}
+
+export function startMobileSessionCleanup(): void {
+  if (cleanupInterval) {
+    log.info('Already running');
+    return;
+  }
+
+  log.info('Starting mobile session cleanup (daily)');
+  // Run once immediately so a fresh deploy doesn't wait a full interval
+  // before pruning the table.
+  void runCleanup();
+  cleanupInterval = setInterval(runCleanup, CLEANUP_INTERVAL_MS);
+}
+
+export function stopMobileSessionCleanup(): void {
+  if (cleanupInterval) {
+    clearInterval(cleanupInterval);
+    cleanupInterval = null;
+    log.info('Stopped mobile session cleanup');
+  }
+}


### PR DESCRIPTION
## Summary

Mobile refresh tokens carried a hard 7-day expiry and /auth/mobile/refresh never rotated them, so every rider was logged out exactly a week after signing in, wherever that moment landed. For one rider it landed 50 minutes into a GPS recording and cancelled it. Apps in this space keep users signed in indefinitely; now Loam Logger does too, and the long window is backed by server-side sessions rather than being a bare bearer credential.

### Sliding sessions

- Refresh token TTL: 7d to 365d. Riding is seasonal; a winter off the bike should not end a session.
- /auth/mobile/refresh rotates the refresh token on every successful refresh, restarting the window each time. Any rider active at least once a year stays signed in.
- The mobile client already stores the rotated token when the response includes one, so no coordinated app release is needed.

### Device-scoped sessions with reuse detection

A 365-day stateless token would otherwise be a year-long undetectable bearer credential (there was no jti, no server-side store, and rotation without reuse detection adds no security). This PR adds the state that makes the long window defensible:

- New MobileSession table: one row per device sign-in, carrying the current rotation id (jti), the previous one, and a sliding expiry.
- Refresh tokens are bound to their session via sid + jti claims. A refresh is honored only for the current jti, or the previous jti within a 60s grace window (a device that never received the rotation response legitimately retries with the old token; reading that as theft would recreate the mid-ride logout through the security path).
- Rotation is atomic: a single conditional write keyed on the presented jti claims the rotation, and a refresh that loses the race is handed the winner's current jti instead of rotating again. Without this, two near-simultaneous refreshes would both pass a read-then-write validation, the loser's jti would never be persisted, and its next refresh would be revoked as reuse.
- Presenting any other spent jti is reuse detection: the session is revoked immediately, logged loudly, and reported to Sentry. This is the signal that a refresh token leaked, which did not exist before.
- POST /auth/mobile/logout revokes the session server-side (idempotent, tolerant of dead tokens, and gated on isRefreshTokenPayload like the refresh route rather than relying on only refresh tokens carrying a sid claim). The mobile client calls it best-effort on sign-out (ryanlecours/loam-logger-mobile#70).
- A daily cleanup service deletes sessions revoked or expired more than 30 days ago, so revoked rows, expired rows, and one-shot legacy-upgrade rows do not accumulate unboundedly; the 30-day retention keeps recent revocations available for reuse-detection forensics and outlives the legacy window, so pruning cannot re-open a one-shot claim.
- Legacy sid-less tokens are upgraded to a session on their next refresh instead of rejected, so existing users migrate with no forced logout; they age out of circulation within 7 days of deploy. The upgrade is one-shot: a sha256 of the legacy token is recorded on the session it creates (unique index), so a token leaked before this deploy can claim at most one session, and replaying it after that revokes the claimed session and reports, instead of minting unlimited fresh year-long sessions through the migration window.
- Reuse detection reports under distinct Sentry signals: spent-jti-replayed (the classic stolen-chain signature), unknown-jti (could also be client token corruption), and legacy-token-replayed, so a noisy client bug cannot bury a real theft alert.
- /auth/mobile/refresh and /auth/mobile/logout are rate limited at 10/min per user (per-user rather than per-IP: the uid is signature-verified before the check, and carrier NAT would make IP keys throttle innocent riders).
- sessionTokenVersion revocation is unchanged: password reset/change still kills all of a user's tokens at once.

### Token typing (access vs refresh)

SESSION_SECRET signs three token families (mobile access/refresh, web session cookies, email-unsubscribe links), and nothing in the payloads distinguished them; with a 365-day refresh TTL that becomes privilege escalation from any of them (a leaked 15-minute access token upgraded into a year-long refresh session via the legacy branch; a refresh token used directly as a year-long bearer access token that bypasses rotation and reuse detection; and most severely, an emailed unsubscribe token, {uid, purpose}, 90-day expiry, redeemable at /auth/mobile/refresh for a fully authenticated session, i.e. account takeover from a forwarded email or a link-prefetching mail scanner). Both mobile tokens now carry a typ claim: /auth/mobile/refresh rejects non-refresh tokens, and the bearer path in attachUser accepts only access tokens. Legacy pre-typ tokens are typed by signed lifetime (access lived 15m, refresh 7d, split at 1h), but only for payloads whose claims exactly match the mobile-token shape, an allowlist rather than a blocklist: the web cookie's authAt, the unsubscribe token's purpose, and any future claim all disqualify a payload from being treated as a mobile credential.

Pairs with the client-side resilience fix in ryanlecours/loam-logger-mobile#70, which stops transient refresh failures (trail dead zones, deploy-window 5xx) from being treated as revoked sessions.

## Deployment notes

- Includes a Prisma migration (MobileSession table); it applies automatically on Railway boot via prisma migrate deploy.
- Existing tokens are upgraded in place on first refresh, so there is no forced logout at rollout.
- The legacy lifetime-based typing fallbacks can be deleted once pre-typ tokens age out, 7 days after deploy.
- Recommended follow-up: sign unsubscribe tokens (and any future non-authentication JWT) with their own secret instead of SESSION_SECRET. Links are not credentials; separate key material removes this confusion class permanently.

## Test plan

- 207 auth tests pass across 17 suites, including unit tests for the rotation state machine (atomic conditional rotation, race-loser re-issue, grace window, reuse revocation, expiry), the token-type predicates (typ claim, legacy lifetime heuristic, web-cookie exclusion), and route tests for refresh (rotation, reuse reporting, legacy upgrade, access-token refusal, version bump) and logout (revocation, idempotency); attachUser tests cover the refresh-as-bearer refusal
- Full API suite green: 1929 tests across 93 suites
- api lint and typecheck clean; prisma schema validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
