### PR TITLE
Promote staging to main: AI opt-in

### DIFF
--- a/apps/api/prisma/migrations/20260807200000_add_user_ai_features_enabled/migration.sql
+++ b/apps/api/prisma/migrations/20260807200000_add_user_ai_features_enabled/migration.sql
@@ -1,0 +1,4 @@
+-- AI output (the advisor maintenance summary) becomes strictly opt-in.
+-- Off by default for every existing and future user, all tiers included;
+-- the advisorSummary resolver checks this alongside the Pro gate.
+ALTER TABLE "User" ADD COLUMN "aiFeaturesEnabled" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -53,6 +53,12 @@ model User {
   // separately via posthog.opt_out_capturing() from the browser SDK.
   analyticsOptOut Boolean @default(false)
 
+  // AI output (the advisor maintenance summary) is strictly opt-in: off by
+  // default at every tier, including existing Pro and Founding Rider users.
+  // Checked in the advisorSummary resolver alongside the Pro gate; false
+  // means the field resolves null and surfaces collapse, never an error.
+  aiFeaturesEnabled Boolean @default(false)
+
   bikes                    Bike[]
   components               Component[]
   tokens                   OauthToken[]

--- a/apps/api/src/graphql/__tests__/resolvers.test.ts
+++ b/apps/api/src/graphql/__tests__/resolvers.test.ts
@@ -168,11 +168,15 @@ const createMockContext = (
     isFoundingRider: boolean;
     role: string;
     predictionMode?: string | null;
+    aiFeaturesEnabled?: boolean;
   } | null = {
     subscriptionTier: 'PRO',
     isFoundingRider: false,
     role: 'FREE',
     predictionMode: 'simple',
+    // Opted in by default so advisor happy-path tests exercise the LLM
+    // path; the opt-out (default-off) behavior has its own tests.
+    aiFeaturesEnabled: true,
   }
 ) => ({
   user: userId ? { id: userId } : null,
@@ -3105,6 +3109,20 @@ describe('GraphQL Resolvers', () => {
       });
     });
 
+    it('accepts aiFeaturesEnabled without a tier check (enforced at read time instead)', async () => {
+      const ctx = createMockContext();
+      (mockPrisma.user.update as jest.Mock).mockResolvedValue({ id: 'user-123' });
+
+      await mutation(null, { input: { aiFeaturesEnabled: true } }, ctx);
+
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-123' },
+        data: { aiFeaturesEnabled: true },
+      });
+      // No tier lookup: a free rider's choice is stored and honored on upgrade.
+      expect(mockPrisma.user.findUniqueOrThrow).not.toHaveBeenCalled();
+    });
+
     it('rejects a timezone Intl does not recognize', async () => {
       const ctx = createMockContext();
 
@@ -5384,6 +5402,39 @@ describe('GraphQL Resolvers', () => {
 
       expect(result).toBeNull();
       expect(ctx.loaders.tierUserById.load).toHaveBeenCalledWith('user-123');
+      expect(mockGetCachedAdvisorSummary).not.toHaveBeenCalled();
+      expect(mockGenerateSummary).not.toHaveBeenCalled();
+    });
+
+    it('returns null for a Pro user who has not opted in to AI, without touching cache or LLM', async () => {
+      const ctx = createMockContext('user-123', {}, {
+        subscriptionTier: 'PRO',
+        isFoundingRider: false,
+        role: 'FREE',
+        predictionMode: 'simple',
+        aiFeaturesEnabled: false,
+      });
+
+      const result = await resolver(makeParent(), {}, ctx as never);
+
+      expect(result).toBeNull();
+      // Opt-out must block even cached text from being served.
+      expect(mockGetCachedAdvisorSummary).not.toHaveBeenCalled();
+      expect(mockGenerateSummary).not.toHaveBeenCalled();
+    });
+
+    it('treats a founding rider without the opt-in exactly like any other opted-out user', async () => {
+      const ctx = createMockContext('user-123', {}, {
+        subscriptionTier: 'FREE',
+        isFoundingRider: true,
+        role: 'FREE',
+        predictionMode: 'simple',
+        aiFeaturesEnabled: false,
+      });
+
+      const result = await resolver(makeParent(), {}, ctx as never);
+
+      expect(result).toBeNull();
       expect(mockGetCachedAdvisorSummary).not.toHaveBeenCalled();
       expect(mockGenerateSummary).not.toHaveBeenCalled();
     });

--- a/apps/api/src/graphql/dataloaders.ts
+++ b/apps/api/src/graphql/dataloaders.ts
@@ -12,6 +12,7 @@ export type TierUserRow = {
   isFoundingRider: boolean;
   role: UserRole;
   predictionMode: string | null;
+  aiFeaturesEnabled: boolean;
 };
 
 /**
@@ -99,6 +100,7 @@ async function batchTierUserById(
       isFoundingRider: true,
       role: true,
       predictionMode: true,
+      aiFeaturesEnabled: true,
     },
   });
   const byId = new Map(rows.map((r) => [r.id, r]));

--- a/apps/api/src/graphql/resolvers.ts
+++ b/apps/api/src/graphql/resolvers.ts
@@ -4216,7 +4216,7 @@ export const resolvers = {
 
     updateUserPreferences: async (
       _: unknown,
-      { input }: { input: { hoursDisplayPreference?: string | null; predictionMode?: string | null; distanceUnit?: string | null; expoPushToken?: string | null; notifyOnRideUpload?: boolean | null; rideSyncNotificationMode?: 'ALL' | 'ACTION_NEEDED' | 'OFF' | null; weeklyDigestEnabled?: boolean | null; timezone?: string | null } },
+      { input }: { input: { hoursDisplayPreference?: string | null; predictionMode?: string | null; distanceUnit?: string | null; expoPushToken?: string | null; notifyOnRideUpload?: boolean | null; rideSyncNotificationMode?: 'ALL' | 'ACTION_NEEDED' | 'OFF' | null; weeklyDigestEnabled?: boolean | null; aiFeaturesEnabled?: boolean | null; timezone?: string | null } },
       ctx: GraphQLContext
     ) => {
       const userId = requireUserId(ctx);
@@ -4228,7 +4228,7 @@ export const resolvers = {
         });
       }
 
-      const updateData: { hoursDisplayPreference?: string | null; predictionMode?: string | null; distanceUnit?: string | null; expoPushToken?: string | null; notifyOnRideUpload?: boolean; rideSyncNotificationMode?: 'ALL' | 'ACTION_NEEDED' | 'OFF'; weeklyDigestEnabled?: boolean; timezone?: string | null } = {};
+      const updateData: { hoursDisplayPreference?: string | null; predictionMode?: string | null; distanceUnit?: string | null; expoPushToken?: string | null; notifyOnRideUpload?: boolean; rideSyncNotificationMode?: 'ALL' | 'ACTION_NEEDED' | 'OFF'; weeklyDigestEnabled?: boolean; aiFeaturesEnabled?: boolean; timezone?: string | null } = {};
 
       if (input.hoursDisplayPreference !== undefined) {
         // Input length validation to prevent DoS/excessive storage
@@ -4325,6 +4325,14 @@ export const resolvers = {
 
       if (input.weeklyDigestEnabled !== undefined && input.weeklyDigestEnabled !== null) {
         updateData.weeklyDigestEnabled = input.weeklyDigestEnabled;
+      }
+
+      // Deliberately not Pro-gated at write time: the stored value is only
+      // intent, and the advisorSummary resolver enforces tier at read time.
+      // Recording a free rider's choice means an upgrade honors it at once,
+      // and a toggle-off survives any later tier change.
+      if (input.aiFeaturesEnabled !== undefined && input.aiFeaturesEnabled !== null) {
+        updateData.aiFeaturesEnabled = input.aiFeaturesEnabled;
       }
 
       if (input.timezone !== undefined) {
@@ -6388,6 +6396,12 @@ export const resolvers = {
       // per bike without paying N user lookups.
       const tierUser = await ctx.loaders.tierUserById.load(userId);
       if (!tierUser || !canSeePredictions(tierUser)) return null;
+
+      // AI opt-in gate. AI output is off by default at every tier, including
+      // Pro and Founding Rider: a rider must have switched it on (at upgrade
+      // or in Settings) before any LLM text is generated or served, cached
+      // included. Null here is policy, not an error; every surface collapses.
+      if (!tierUser.aiFeaturesEnabled) return null;
 
       const model = process.env.LOAM_ADVISOR_MODEL || DEFAULT_ADVISOR_MODEL;
       const cacheParams = { userId, bikeId: parent.bikeId, planTier: 'pro', model };

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -865,6 +865,11 @@ export const typeDefs = gql`
     # time (a free user's toggle stores but sends nothing, mirroring how
     # prediction surfaces degrade elsewhere).
     weeklyDigestEnabled: Boolean
+    # AI output (the advisor maintenance summary). Strictly opt-in, off by
+    # default at every tier; Pro feature at read time (a free user's toggle
+    # stores but the advisorSummary resolver still resolves null, mirroring
+    # weeklyDigestEnabled).
+    aiFeaturesEnabled: Boolean
     # IANA timezone (e.g. "America/Denver"), used only to time the weekly
     # digest. Uploaded by mobile alongside the push token; explicit null
     # clears it, which also stops the digest (no timezone, no send).
@@ -1253,6 +1258,9 @@ export const typeDefs = gql`
     notifyOnRideUpload: Boolean!
     rideSyncNotificationMode: RideSyncNotificationMode!
     weeklyDigestEnabled: Boolean!
+    # AI output (the advisor maintenance summary) is opt-in and off by
+    # default; this reflects the rider's stored choice regardless of tier.
+    aiFeaturesEnabled: Boolean!
     createdAt: String!
     ridesMissingWeather: Int!
     # Count of the viewer's Garmin rides stored without coordinates (a past

--- a/apps/web/src/components/dashboard/AdvisorSummaryCard.test.tsx
+++ b/apps/web/src/components/dashboard/AdvisorSummaryCard.test.tsx
@@ -37,7 +37,7 @@ describe('AdvisorSummaryCard', () => {
         </MemoryRouter>
       );
       expect(screen.getByText('AI summary')).toBeInTheDocument();
-      expect(screen.getByText(/sums up what to wrench on/i)).toBeInTheDocument();
+      expect(screen.getByText(/sum up what to wrench on/i)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /included with pro/i })).toBeInTheDocument();
     });
 
@@ -55,7 +55,7 @@ describe('AdvisorSummaryCard', () => {
         </MemoryRouter>
       );
       expect(screen.getByText(summary.text)).toBeInTheDocument();
-      expect(screen.queryByText(/sums up what to wrench on/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/sum up what to wrench on/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/components/dashboard/AdvisorSummaryCard.tsx
+++ b/apps/web/src/components/dashboard/AdvisorSummaryCard.tsx
@@ -8,8 +8,10 @@ interface AdvisorSummaryCardProps {
   /**
    * Free tier: the API nulls the summary, so without a teaser the feature is
    * invisible and free users never learn it exists. Pass true only for free
-   * users; a null summary for a Pro user (ALL_GOOD, rate limit, generation
-   * error) must still collapse to nothing.
+   * users; a null summary for a Pro user (not opted in to AI, ALL_GOOD, rate
+   * limit, generation error) must still collapse to nothing. AI is opt-in
+   * and off by default, so the teaser copy must sell it as optional, never
+   * as something Pro switches on for you.
    */
   showTeaser?: boolean;
   /**
@@ -27,23 +29,27 @@ interface AdvisorSummaryCardProps {
 /**
  * Pro-only LLM maintenance summary for the priority-bike hero.
  *
- * The API null-gates this field (free tier, empty bike, ALL_GOOD trivial
- * state, rate-limit, or generation error all yield null), so the client rule
- * is simply: render nothing when null and let the space collapse. No tier
- * check here — mirrors how the rest of the hero treats null predictive fields.
+ * The API null-gates this field (free tier, AI not opted in, empty bike,
+ * ALL_GOOD trivial state, rate-limit, or generation error all yield null), so
+ * the client rule is simply: render nothing when null and let the space
+ * collapse. No tier or opt-in check here — mirrors how the rest of the hero
+ * treats null predictive fields. A Pro rider who has not opted in must see
+ * nothing at all: the absence of AI is a respected choice, not an empty
+ * state to fill.
  */
 export function AdvisorSummaryCard({ summary, hasGarminSource = false, showTeaser = false }: AdvisorSummaryCardProps) {
   if (!summary) {
     if (!showTeaser) return null;
     return (
-      <aside className="advisor-summary" aria-label="AI maintenance summary, included with Pro">
+      <aside className="advisor-summary" aria-label="AI maintenance summary, optional with Pro">
         <div className="advisor-summary-label">
           <Sparkles size={12} className="icon-left" />
           AI summary
           <ProChip source="dashboard-advisor-teaser" className="ml-1.5" />
         </div>
         <p className="advisor-summary-text text-muted">
-          Pro reads this bike's wear picture and sums up what to wrench on this week.
+          If you want it, Pro can read this bike's wear picture and sum up what
+          to wrench on. Optional, and off until you turn it on.
         </p>
       </aside>
     );

--- a/apps/web/src/graphql/me.ts
+++ b/apps/web/src/graphql/me.ts
@@ -27,6 +27,7 @@ export const ME_QUERY = gql`
       predictionMode
       distanceUnit
       analyticsOptOut
+      aiFeaturesEnabled
       pairedComponentMigrationSeenAt
       trailStewardshipNoticeSeenAt
       createdAt

--- a/apps/web/src/graphql/userPreferences.ts
+++ b/apps/web/src/graphql/userPreferences.ts
@@ -7,6 +7,7 @@ export const UPDATE_USER_PREFERENCES_MUTATION = gql`
       hoursDisplayPreference
       predictionMode
       distanceUnit
+      aiFeaturesEnabled
     }
   }
 `

--- a/apps/web/src/pages/Pricing.tsx
+++ b/apps/web/src/pages/Pricing.tsx
@@ -103,7 +103,7 @@ export default function Pricing() {
         { text: 'Unlimited bikes', included: true },
         { text: 'Rides left until service due', included: true },
         { text: 'Ride-adjusted wear predictions', included: true },
-        { text: 'AI maintenance summary per bike', included: true },
+        { text: 'Optional AI maintenance summary per bike (off by default)', included: true },
         { text: 'Service-due alerts & weekly bike check', included: true },
         { text: 'Weather on every ride', included: true },
         { text: 'PDF service history export', included: true },

--- a/apps/web/src/pages/Settings/sections/AccountSection.tsx
+++ b/apps/web/src/pages/Settings/sections/AccountSection.tsx
@@ -53,6 +53,30 @@ export default function AccountSection() {
   }, [searchParams, setSearchParams]);
 
   const { isPro } = useUserTier();
+
+  // The Stripe webhook that flips subscriptionTier races the redirect back
+  // here, with no ordering guarantee, and the success URL carries no session
+  // id so the client cannot reconcile synchronously. On a checkout return
+  // that still reads as free, poll me every 2s for up to 30s. The latch
+  // above keeps the offer armed for the visit and showAiOffer is reactive
+  // to isPro (useUserTier reads the same ME_QUERY document), so the offer
+  // card and the plan panel below both appear the moment the webhook lands
+  // instead of the one-time offer being silently lost to a slow webhook.
+  useEffect(() => {
+    if (!arrivedFromCheckout || isPro) return;
+    let attempts = 0;
+    const intervalId = setInterval(() => {
+      attempts += 1;
+      if (attempts > 15) {
+        clearInterval(intervalId);
+        return;
+      }
+      refetchUser().catch(() => {
+        // Transient fetch failure: keep polling until the attempt cap.
+      });
+    }, 2000);
+    return () => clearInterval(intervalId);
+  }, [arrivedFromCheckout, isPro, refetchUser]);
   const [updateUserPreferences, { loading: aiOfferSaving }] = useMutation(
     UPDATE_USER_PREFERENCES_MUTATION,
   );

--- a/apps/web/src/pages/Settings/sections/AccountSection.tsx
+++ b/apps/web/src/pages/Settings/sections/AccountSection.tsx
@@ -20,6 +20,17 @@ const CONNECTED_ACCOUNTS_FOR_PASSWORD = gql`
   }
 `;
 
+// Per-tab latch for the post-checkout AI offer. It cannot live in component
+// state: the settings shell mounts only the active section, so switching to
+// another settings tab unmounts this component, and by then the effect below
+// has already stripped billing=success from the URL - a state latch would
+// re-initialize to false on the way back and silently lose the one-time
+// offer. sessionStorage survives remounts and reloads within the tab, and
+// the key is removed the moment the rider answers either way, which also
+// makes a decline durable across reloads (the param strip alone only made
+// it durable within one mount).
+const AI_OFFER_PENDING_KEY = 'loam-ai-offer-pending';
+
 export default function AccountSection() {
   const navigate = useNavigate();
   const { user, refetch: refetchUser } = useCurrentUser();
@@ -33,19 +44,22 @@ export default function AccountSection() {
   // Stripe checkout returns to /settings?billing=success (set server-side in
   // stripe.service.ts). AI is opt-in and off by default at every tier, so
   // the upgrade moment is where the option gets offered once; afterwards it
-  // lives under Preferences. "Keep it off" only closes the card and stores
-  // nothing. The checkout return is latched into state BEFORE the effect
-  // strips it from the URL - state (not the param) keeps the card up for
-  // this visit, and the strip is what makes the offer genuinely one-time:
-  // without it, a reload or back/forward while ?billing=success is still in
-  // the URL would remount with fresh state and resurrect a declined card.
+  // lives under Preferences. "Keep it off" closes the card and stores
+  // nothing server-side. The checkout return is latched (state + the
+  // sessionStorage key, see AI_OFFER_PENDING_KEY above) BEFORE the effect
+  // strips it from the URL, so the offer survives section remounts and
+  // reloads until answered, while the strip keeps a stale
+  // ?billing=success in history from re-arming an answered one.
   const [searchParams, setSearchParams] = useSearchParams();
-  const [arrivedFromCheckout] = useState(
-    () => searchParams.get('billing') === 'success',
+  const [arrivedFromCheckout, setArrivedFromCheckout] = useState(
+    () =>
+      searchParams.get('billing') === 'success' ||
+      sessionStorage.getItem(AI_OFFER_PENDING_KEY) === '1',
   );
 
   useEffect(() => {
     if (searchParams.get('billing') === 'success') {
+      sessionStorage.setItem(AI_OFFER_PENDING_KEY, '1');
       const next = new URLSearchParams(searchParams);
       next.delete('billing');
       setSearchParams(next, { replace: true });
@@ -77,17 +91,20 @@ export default function AccountSection() {
     }, 2000);
     return () => clearInterval(intervalId);
   }, [arrivedFromCheckout, isPro, refetchUser]);
+
   const [updateUserPreferences, { loading: aiOfferSaving }] = useMutation(
     UPDATE_USER_PREFERENCES_MUTATION,
   );
-  const [aiOfferClosed, setAiOfferClosed] = useState(false);
 
   const showAiOffer =
-    arrivedFromCheckout &&
-    isPro &&
-    !!user &&
-    !user.aiFeaturesEnabled &&
-    !aiOfferClosed;
+    arrivedFromCheckout && isPro && !!user && !user.aiFeaturesEnabled;
+
+  // Answering either way retires the offer for good: clear the per-tab
+  // latch first so no later remount can resurrect the card.
+  const closeAiOffer = () => {
+    sessionStorage.removeItem(AI_OFFER_PENDING_KEY);
+    setArrivedFromCheckout(false);
+  };
 
   const handleEnableAi = async () => {
     try {
@@ -95,7 +112,7 @@ export default function AccountSection() {
       toast.success('AI maintenance summary is on', {
         description: 'You can turn it off any time under Preferences.',
       });
-      setAiOfferClosed(true);
+      closeAiOffer();
     } catch {
       toast.error('Could not save that. The toggle also lives under Preferences.');
     }
@@ -147,7 +164,7 @@ export default function AccountSection() {
             </button>
             <button
               type="button"
-              onClick={() => setAiOfferClosed(true)}
+              onClick={closeAiOffer}
               className="text-sm text-muted hover:text-primary transition"
             >
               Keep it off

--- a/apps/web/src/pages/Settings/sections/AccountSection.tsx
+++ b/apps/web/src/pages/Settings/sections/AccountSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 import { useQuery, useMutation, gql } from '@apollo/client';
 import { toast } from 'sonner';
@@ -33,9 +33,25 @@ export default function AccountSection() {
   // Stripe checkout returns to /settings?billing=success (set server-side in
   // stripe.service.ts). AI is opt-in and off by default at every tier, so
   // the upgrade moment is where the option gets offered once; afterwards it
-  // lives under Preferences. "Keep it off" only closes the card - declining
-  // stores nothing, and the URL param means it never reappears on its own.
-  const [searchParams] = useSearchParams();
+  // lives under Preferences. "Keep it off" only closes the card and stores
+  // nothing. The checkout return is latched into state BEFORE the effect
+  // strips it from the URL - state (not the param) keeps the card up for
+  // this visit, and the strip is what makes the offer genuinely one-time:
+  // without it, a reload or back/forward while ?billing=success is still in
+  // the URL would remount with fresh state and resurrect a declined card.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [arrivedFromCheckout] = useState(
+    () => searchParams.get('billing') === 'success',
+  );
+
+  useEffect(() => {
+    if (searchParams.get('billing') === 'success') {
+      const next = new URLSearchParams(searchParams);
+      next.delete('billing');
+      setSearchParams(next, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
+
   const { isPro } = useUserTier();
   const [updateUserPreferences, { loading: aiOfferSaving }] = useMutation(
     UPDATE_USER_PREFERENCES_MUTATION,
@@ -43,7 +59,7 @@ export default function AccountSection() {
   const [aiOfferClosed, setAiOfferClosed] = useState(false);
 
   const showAiOffer =
-    searchParams.get('billing') === 'success' &&
+    arrivedFromCheckout &&
     isPro &&
     !!user &&
     !user.aiFeaturesEnabled &&

--- a/apps/web/src/pages/Settings/sections/AccountSection.tsx
+++ b/apps/web/src/pages/Settings/sections/AccountSection.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router';
-import { useQuery, gql } from '@apollo/client';
+import { useNavigate, useSearchParams } from 'react-router';
+import { useQuery, useMutation, gql } from '@apollo/client';
+import { toast } from 'sonner';
 import { useCurrentUser } from '../../../hooks/useCurrentUser';
+import { useUserTier } from '../../../hooks/useUserTier';
+import { UPDATE_USER_PREFERENCES_MUTATION } from '../../../graphql/userPreferences';
 import SetPasswordModal from '../../../components/SetPasswordModal';
 import BillingSection from '../../../components/BillingSection';
 import SettingsSectionHeader from '../SettingsSectionHeader';
@@ -27,6 +30,37 @@ export default function AccountSection() {
 
   const accounts: { provider: string }[] = accountsData?.me?.accounts ?? [];
 
+  // Stripe checkout returns to /settings?billing=success (set server-side in
+  // stripe.service.ts). AI is opt-in and off by default at every tier, so
+  // the upgrade moment is where the option gets offered once; afterwards it
+  // lives under Preferences. "Keep it off" only closes the card - declining
+  // stores nothing, and the URL param means it never reappears on its own.
+  const [searchParams] = useSearchParams();
+  const { isPro } = useUserTier();
+  const [updateUserPreferences, { loading: aiOfferSaving }] = useMutation(
+    UPDATE_USER_PREFERENCES_MUTATION,
+  );
+  const [aiOfferClosed, setAiOfferClosed] = useState(false);
+
+  const showAiOffer =
+    searchParams.get('billing') === 'success' &&
+    isPro &&
+    !!user &&
+    !user.aiFeaturesEnabled &&
+    !aiOfferClosed;
+
+  const handleEnableAi = async () => {
+    try {
+      await updateUserPreferences({ variables: { input: { aiFeaturesEnabled: true } } });
+      toast.success('AI maintenance summary is on', {
+        description: 'You can turn it off any time under Preferences.',
+      });
+      setAiOfferClosed(true);
+    } catch {
+      toast.error('Could not save that. The toggle also lives under Preferences.');
+    }
+  };
+
   const handleSetPassword = () => {
     if (user?.needsReauthForSensitiveActions) {
       navigate('/login?returnTo=/settings&reason=reauth');
@@ -50,6 +84,37 @@ export default function AccountSection() {
         title="Your profile"
         description="Your identity and plan — everything tied to who you are on Loam Logger."
       />
+
+      {showAiOffer && (
+        <div className="panel-spaced">
+          <div>
+            <p className="label-section">Welcome to Pro</p>
+            <h2 className="title-section">Want the AI maintenance summary?</h2>
+          </div>
+          <p className="text-sm text-muted">
+            Pro can add a short machine-generated read of each bike's wear
+            picture to your dashboard. It is off by default and entirely
+            optional; every other Pro feature works the same either way.
+          </p>
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={handleEnableAi}
+              disabled={aiOfferSaving}
+              className="btn-primary disabled:opacity-50"
+            >
+              Turn it on
+            </button>
+            <button
+              type="button"
+              onClick={() => setAiOfferClosed(true)}
+              className="text-sm text-muted hover:text-primary transition"
+            >
+              Keep it off
+            </button>
+          </div>
+        </div>
+      )}
 
       <div className="panel-spaced">
         <div>

--- a/apps/web/src/pages/Settings/sections/PreferencesSection.tsx
+++ b/apps/web/src/pages/Settings/sections/PreferencesSection.tsx
@@ -1,6 +1,7 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useMutation } from '@apollo/client';
 import { useNavigate } from 'react-router';
+import { toast } from 'sonner';
 import { useCurrentUser } from '../../../hooks/useCurrentUser';
 import { usePreferences } from '../../../hooks/usePreferences';
 import { useUserTier } from '../../../hooks/useUserTier';
@@ -60,6 +61,31 @@ export default function PreferencesSection() {
     mutate: mutateDistance,
     label: 'Distance unit',
   });
+
+  // AI is opt-in and off by default at every tier (owner decision recorded
+  // in PRODUCT.md). Reads straight off the cached user and saves on change;
+  // the mutation returns aiFeaturesEnabled so the normalized cache updates
+  // without a refetch, same as the analytics opt-out toggle.
+  const aiEnabled = Boolean(user?.aiFeaturesEnabled);
+  const [aiSaving, setAiSaving] = useState(false);
+
+  const handleAiToggle = async () => {
+    setAiSaving(true);
+    try {
+      await updateUserPreferences({ variables: { input: { aiFeaturesEnabled: !aiEnabled } } });
+      toast.success('Saved', {
+        id: 'settings-preference-ai-summary',
+        description: 'AI maintenance summary',
+      });
+    } catch {
+      toast.error('Could not save', {
+        id: 'settings-preference-ai-summary',
+        description: 'AI maintenance summary',
+      });
+    } finally {
+      setAiSaving(false);
+    }
+  };
 
   return (
     <div className="space-y-6">
@@ -221,6 +247,55 @@ export default function PreferencesSection() {
         <p className="text-xs text-muted">
           Distances are always stored in miles. This preference only affects how they are displayed and entered.
         </p>
+      </div>
+
+      <div className="panel-spaced">
+        <div>
+          <p className="label-section">AI</p>
+          <h2 className="title-section">AI maintenance summary</h2>
+        </div>
+        <p className="text-sm text-muted">
+          A short machine-generated read of a bike's wear picture on your
+          dashboard: what to wrench on first and what can wait. Strictly
+          optional and off by default; predictions and service history never
+          depend on it.
+        </p>
+        {isPro ? (
+          <label className="flex items-start gap-3 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={aiEnabled}
+              onChange={handleAiToggle}
+              disabled={aiSaving}
+              className="mt-1 w-5 h-5 rounded border-app bg-surface accent-accent flex-shrink-0 disabled:opacity-50"
+            />
+            <span className="text-sm leading-relaxed text-primary">
+              Show the AI summary on my dashboard.
+            </span>
+          </label>
+        ) : (
+          // Same idiom as the predictive-mode card above: inert control,
+          // quiet Pro chip, the whole row routes to pricing.
+          <label
+            className="flex items-start gap-3 cursor-not-allowed select-none opacity-60"
+            onClick={(e) => {
+              e.preventDefault();
+              navigate('/pricing?source=settings-ai-summary');
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={false}
+              readOnly
+              disabled
+              className="mt-1 w-5 h-5 rounded border-app bg-surface flex-shrink-0"
+            />
+            <span className="text-sm leading-relaxed text-primary">
+              Show the AI summary on my dashboard.
+              <ProChip className="ml-2" source="settings-ai-summary" />
+            </span>
+          </label>
+        )}
       </div>
     </div>
   );

--- a/libs/graphql/src/generated/index.ts
+++ b/libs/graphql/src/generated/index.ts
@@ -1548,6 +1548,7 @@ export type UpdateServicePreferencesInput = {
 };
 
 export type UpdateUserPreferencesInput = {
+  aiFeaturesEnabled?: InputMaybe<Scalars['Boolean']['input']>;
   distanceUnit?: InputMaybe<Scalars['String']['input']>;
   expoPushToken?: InputMaybe<Scalars['String']['input']>;
   hoursDisplayPreference?: InputMaybe<Scalars['String']['input']>;
@@ -1563,6 +1564,7 @@ export type User = {
   accounts: Array<ConnectedAccount>;
   activeDataSource?: Maybe<Scalars['String']['output']>;
   age?: Maybe<Scalars['Int']['output']>;
+  aiFeaturesEnabled: Scalars['Boolean']['output'];
   analyticsOptOut: Scalars['Boolean']['output'];
   avatarUrl?: Maybe<Scalars['String']['output']>;
   createdAt: Scalars['String']['output'];
@@ -1744,7 +1746,7 @@ export type LogComponentServiceMutation = { __typename?: 'Mutation', logComponen
 export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MeQuery = { __typename?: 'Query', me?: { __typename?: 'User', id: string, email: string, name?: string | null, avatarUrl?: string | null, onboardingCompleted: boolean, hasAcceptedCurrentTerms: boolean, location?: string | null, age?: number | null, role: UserRole, mustChangePassword: boolean, isFoundingRider: boolean, hoursDisplayPreference?: string | null, predictionMode?: string | null, distanceUnit?: string | null, pairedComponentMigrationSeenAt?: string | null, createdAt: string } | null };
+export type MeQuery = { __typename?: 'Query', me?: { __typename?: 'User', id: string, email: string, name?: string | null, avatarUrl?: string | null, onboardingCompleted: boolean, hasAcceptedCurrentTerms: boolean, location?: string | null, age?: number | null, role: UserRole, mustChangePassword: boolean, isFoundingRider: boolean, hoursDisplayPreference?: string | null, predictionMode?: string | null, distanceUnit?: string | null, aiFeaturesEnabled: boolean, pairedComponentMigrationSeenAt?: string | null, createdAt: string } | null };
 
 export type RideTypesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1797,7 +1799,7 @@ export type UpdateUserPreferencesMutationVariables = Exact<{
 }>;
 
 
-export type UpdateUserPreferencesMutation = { __typename?: 'Mutation', updateUserPreferences: { __typename?: 'User', id: string, hoursDisplayPreference?: string | null, predictionMode?: string | null, distanceUnit?: string | null } };
+export type UpdateUserPreferencesMutation = { __typename?: 'Mutation', updateUserPreferences: { __typename?: 'User', id: string, hoursDisplayPreference?: string | null, predictionMode?: string | null, distanceUnit?: string | null, aiFeaturesEnabled: boolean } };
 
 export const ComponentFieldsFragmentDoc = gql`
     fragment ComponentFields on Component {
@@ -2426,6 +2428,7 @@ export const MeDocument = gql`
     hoursDisplayPreference
     predictionMode
     distanceUnit
+    aiFeaturesEnabled
     pairedComponentMigrationSeenAt
     createdAt
   }
@@ -2786,6 +2789,7 @@ export const UpdateUserPreferencesDocument = gql`
     hoursDisplayPreference
     predictionMode
     distanceUnit
+    aiFeaturesEnabled
   }
 }
     `;

--- a/libs/graphql/src/operations/me.graphql
+++ b/libs/graphql/src/operations/me.graphql
@@ -14,6 +14,7 @@ query Me {
     hoursDisplayPreference
     predictionMode
     distanceUnit
+    aiFeaturesEnabled
     pairedComponentMigrationSeenAt
     createdAt
   }

--- a/libs/graphql/src/operations/updateUserPreferences.graphql
+++ b/libs/graphql/src/operations/updateUserPreferences.graphql
@@ -4,5 +4,6 @@ mutation UpdateUserPreferences($input: UpdateUserPreferencesInput!) {
     hoursDisplayPreference
     predictionMode
     distanceUnit
+    aiFeaturesEnabled
   }
 }


### PR DESCRIPTION
Promotes staging to main. Contains exactly PR #303 (AI maintenance summary strictly opt-in, off by default), including the `20260807200000_add_user_ai_features_enabled` migration, which staging's Railway deploy applies first per the migration workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
